### PR TITLE
Fix: keep dark mode in sync with OS changes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,8 +13,18 @@ export const metadata: Metadata = {
 const manrope = Manrope({ subsets: ['latin'] });
 const themeScript = `(() => {
   try {
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    document.documentElement.classList.toggle('dark', prefersDark);
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const apply = (matches) => {
+      document.documentElement.classList.toggle('dark', matches);
+    };
+
+    apply(media.matches);
+
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', (event) => apply(event.matches));
+    } else if (typeof media.addListener === 'function') {
+      media.addListener((event) => apply(event.matches));
+    }
   } catch {
     // No-op: if matchMedia is unavailable, default to light mode.
   }

--- a/tests/e2e/dark-mode.spec.ts
+++ b/tests/e2e/dark-mode.spec.ts
@@ -26,4 +26,38 @@ test.describe('dark mode', () => {
       )
       .toBe(false);
   });
+
+  test('updates the `.dark` class when OS preference changes', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    await expect
+      .poll(async () => {
+        return page.evaluate(() =>
+          document.documentElement.classList.contains('dark'),
+        );
+      })
+      .toBe(true);
+
+    await page.emulateMedia({ colorScheme: 'light' });
+
+    await expect
+      .poll(async () => {
+        return page.evaluate(() =>
+          document.documentElement.classList.contains('dark'),
+        );
+      })
+      .toBe(false);
+
+    await page.emulateMedia({ colorScheme: 'dark' });
+
+    await expect
+      .poll(async () => {
+        return page.evaluate(() =>
+          document.documentElement.classList.contains('dark'),
+        );
+      })
+      .toBe(true);
+  });
 });


### PR DESCRIPTION
Adds an OS color-scheme change listener to the theme bootstrap script so the .dark class updates during a session. Includes Playwright regression coverage.