### PR TITLE
Add subscription upsert + lookup (DEBT-003)

### DIFF
--- a/docs/debt/debt-003-missing-subscription-update-method.md
+++ b/docs/debt/debt-003-missing-subscription-update-method.md
@@ -1,8 +1,9 @@
 # DEBT-003: SubscriptionRepository Missing update() Method
 
-**Status:** Open
+**Status:** Resolved
 **Priority:** P1
 **Date:** 2026-01-31
+**Resolved:** 2026-02-01
 
 ## Summary
 
@@ -47,3 +48,13 @@ interface SubscriptionRepository {
 - Drizzle implementation handles insert-or-update semantics
 - Stripe subscription ID lookup enabled for webhook processing
 - Integration tests cover upsert behavior
+
+## Resolution
+
+- Added `SubscriptionUpsertInput`, `SubscriptionRepository.upsert()`, and `SubscriptionRepository.findByStripeSubscriptionId()` to `src/application/ports/repositories.ts`.
+- Implemented `findByStripeSubscriptionId()` + `upsert()` in `src/adapters/repositories/drizzle-subscription-repository.ts`:
+  - Upsert is keyed by `userId` (1 row per user per SSOT).
+  - Stores `stripeSubscriptionId` and mapped `priceId` (from domain `plan` + adapter config).
+  - Maps Postgres unique-constraint violations to `ApplicationError('CONFLICT', ...)`.
+- Added integration test coverage in `tests/integration/repositories.integration.test.ts`.
+- Updated `FakeSubscriptionRepository` to implement the new port methods.

--- a/docs/specs/spec-004-application-ports.md
+++ b/docs/specs/spec-004-application-ports.md
@@ -125,10 +125,11 @@ export type WebhookEventResult = {
   processed: boolean;
   subscriptionUpdate?: {
     userId: string; // internal UUID
+    stripeSubscriptionId: string; // opaque external id
+    plan: SubscriptionPlan; // domain plan (monthly/annual)
     status: SubscriptionStatus;
     currentPeriodEnd: Date;
     cancelAtPeriodEnd: boolean;
-    priceId: string; // persisted for audit/debug (not a domain concept)
   };
 };
 
@@ -157,7 +158,7 @@ export interface PaymentGateway {
 
 ```ts
 import type { Attempt, Bookmark, PracticeSession, Question, Subscription, Tag } from '@/src/domain/entities';
-import type { QuestionDifficulty } from '@/src/domain/value-objects';
+import type { QuestionDifficulty, SubscriptionPlan, SubscriptionStatus } from '@/src/domain/value-objects';
 
 export interface QuestionRepository {
   findPublishedById(id: string): Promise<Question | null>;
@@ -222,8 +223,19 @@ export interface TagRepository {
   listAll(): Promise<readonly Tag[]>;
 }
 
+export type SubscriptionUpsertInput = {
+  userId: string;
+  stripeSubscriptionId: string; // opaque external id
+  plan: SubscriptionPlan; // domain plan (monthly/annual)
+  status: SubscriptionStatus;
+  currentPeriodEnd: Date;
+  cancelAtPeriodEnd: boolean;
+};
+
 export interface SubscriptionRepository {
   findByUserId(userId: string): Promise<Subscription | null>;
+  findByStripeSubscriptionId(stripeSubscriptionId: string): Promise<Subscription | null>;
+  upsert(input: SubscriptionUpsertInput): Promise<void>;
 }
 
 export interface StripeCustomerRepository {

--- a/docs/specs/spec-009-payment-gateway.md
+++ b/docs/specs/spec-009-payment-gateway.md
@@ -82,10 +82,11 @@ If Stripe does not return a `session.url`, throw `ApplicationError('STRIPE_ERROR
 
 - For subscription events, `subscriptionUpdate` MUST include:
   - `userId` (internal UUID from metadata)
+  - `stripeSubscriptionId`
+  - `plan` (domain plan mapped from Stripe price id)
   - `status`
   - `currentPeriodEnd`
   - `cancelAtPeriodEnd`
-  - `priceId` (persisted for audit/debug; not a domain concept)
 
 If required fields are missing (e.g., no `user_id` metadata), treat this as a processing error and let the webhook/controller mark the event as failed (do not silently ignore).
 

--- a/src/adapters/repositories/drizzle-subscription-repository.test.ts
+++ b/src/adapters/repositories/drizzle-subscription-repository.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it } from 'vitest';
+import { ApplicationError } from '@/src/application/errors';
+import { DrizzleSubscriptionRepository } from './drizzle-subscription-repository';
+
+describe('DrizzleSubscriptionRepository', () => {
+  it('maps Stripe price ids to domain plan when loading subscriptions', async () => {
+    const db = {
+      query: {
+        stripeSubscriptions: {
+          findFirst: async () => ({
+            id: 'sub_row_1',
+            userId: 'user_1',
+            stripeSubscriptionId: 'sub_123',
+            status: 'active',
+            priceId: 'price_monthly',
+            currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
+            cancelAtPeriodEnd: false,
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+          }),
+        },
+      },
+      insert: () => {
+        throw new Error('unexpected insert');
+      },
+    } as const;
+
+    const priceIds = {
+      monthly: 'price_monthly',
+      annual: 'price_annual',
+    } as const;
+
+    type RepoDb = ConstructorParameters<
+      typeof DrizzleSubscriptionRepository
+    >[0];
+    const repo = new DrizzleSubscriptionRepository(
+      db as unknown as RepoDb,
+      priceIds,
+    );
+
+    await expect(repo.findByUserId('user_1')).resolves.toMatchObject({
+      userId: 'user_1',
+      plan: 'monthly',
+      status: 'active',
+    });
+  });
+
+  it('throws INTERNAL_ERROR when a stored subscription has an unknown priceId', async () => {
+    const db = {
+      query: {
+        stripeSubscriptions: {
+          findFirst: async () => ({
+            id: 'sub_row_1',
+            userId: 'user_1',
+            stripeSubscriptionId: 'sub_123',
+            status: 'active',
+            priceId: 'price_unknown',
+            currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
+            cancelAtPeriodEnd: false,
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+          }),
+        },
+      },
+      insert: () => {
+        throw new Error('unexpected insert');
+      },
+    } as const;
+
+    const priceIds = {
+      monthly: 'price_monthly',
+      annual: 'price_annual',
+    } as const;
+
+    type RepoDb = ConstructorParameters<
+      typeof DrizzleSubscriptionRepository
+    >[0];
+    const repo = new DrizzleSubscriptionRepository(
+      db as unknown as RepoDb,
+      priceIds,
+    );
+
+    await expect(repo.findByUserId('user_1')).rejects.toBeInstanceOf(
+      ApplicationError,
+    );
+    await expect(repo.findByUserId('user_1')).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+    });
+  });
+
+  it('upserts subscriptions by userId and maps plan → priceId', async () => {
+    const onConflictDoUpdate = async () => {};
+    const values = (input: unknown) => ({
+      onConflictDoUpdate: async (conflict: unknown) => {
+        expect(input).toMatchObject({
+          userId: 'user_1',
+          stripeSubscriptionId: 'sub_123',
+          status: 'active',
+          priceId: 'price_monthly',
+          cancelAtPeriodEnd: false,
+        });
+        expect(conflict).toMatchObject({
+          target: expect.anything(),
+        });
+        return onConflictDoUpdate;
+      },
+    });
+
+    const db = {
+      insert: () => ({ values }),
+      query: {
+        stripeSubscriptions: {
+          findFirst: async () => null,
+        },
+      },
+    } as const;
+
+    const priceIds = {
+      monthly: 'price_monthly',
+      annual: 'price_annual',
+    } as const;
+
+    type RepoDb = ConstructorParameters<
+      typeof DrizzleSubscriptionRepository
+    >[0];
+    const repo = new DrizzleSubscriptionRepository(
+      db as unknown as RepoDb,
+      priceIds,
+    );
+
+    await expect(
+      repo.upsert({
+        userId: 'user_1',
+        stripeSubscriptionId: 'sub_123',
+        plan: 'monthly',
+        status: 'active',
+        currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
+        cancelAtPeriodEnd: false,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws CONFLICT when the DB reports a unique-constraint violation during upsert', async () => {
+    const db = {
+      insert: () => ({
+        values: () => ({
+          onConflictDoUpdate: async () => {
+            throw { cause: { code: '23505' } };
+          },
+        }),
+      }),
+      query: {
+        stripeSubscriptions: {
+          findFirst: async () => null,
+        },
+      },
+    } as const;
+
+    const priceIds = {
+      monthly: 'price_monthly',
+      annual: 'price_annual',
+    } as const;
+
+    type RepoDb = ConstructorParameters<
+      typeof DrizzleSubscriptionRepository
+    >[0];
+    const repo = new DrizzleSubscriptionRepository(
+      db as unknown as RepoDb,
+      priceIds,
+    );
+
+    await expect(
+      repo.upsert({
+        userId: 'user_1',
+        stripeSubscriptionId: 'sub_123',
+        plan: 'monthly',
+        status: 'active',
+        currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
+        cancelAtPeriodEnd: false,
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+
+  it('throws INTERNAL_ERROR on unexpected database failures during upsert', async () => {
+    const db = {
+      insert: () => ({
+        values: () => ({
+          onConflictDoUpdate: async () => {
+            throw new Error('db down');
+          },
+        }),
+      }),
+      query: {
+        stripeSubscriptions: {
+          findFirst: async () => null,
+        },
+      },
+    } as const;
+
+    const priceIds = {
+      monthly: 'price_monthly',
+      annual: 'price_annual',
+    } as const;
+
+    type RepoDb = ConstructorParameters<
+      typeof DrizzleSubscriptionRepository
+    >[0];
+    const repo = new DrizzleSubscriptionRepository(
+      db as unknown as RepoDb,
+      priceIds,
+    );
+
+    await expect(
+      repo.upsert({
+        userId: 'user_1',
+        stripeSubscriptionId: 'sub_123',
+        plan: 'monthly',
+        status: 'active',
+        currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
+        cancelAtPeriodEnd: false,
+      }),
+    ).rejects.toMatchObject({ code: 'INTERNAL_ERROR' });
+  });
+
+  it('findByStripeSubscriptionId returns null when missing', async () => {
+    const db = {
+      query: {
+        stripeSubscriptions: {
+          findFirst: async () => null,
+        },
+      },
+      insert: () => {
+        throw new Error('unexpected insert');
+      },
+    } as const;
+
+    const priceIds = {
+      monthly: 'price_monthly',
+      annual: 'price_annual',
+    } as const;
+
+    type RepoDb = ConstructorParameters<
+      typeof DrizzleSubscriptionRepository
+    >[0];
+    const repo = new DrizzleSubscriptionRepository(
+      db as unknown as RepoDb,
+      priceIds,
+    );
+
+    await expect(
+      repo.findByStripeSubscriptionId('sub_123'),
+    ).resolves.toBeNull();
+  });
+
+  it('findByStripeSubscriptionId maps priceId → plan when found', async () => {
+    const db = {
+      query: {
+        stripeSubscriptions: {
+          findFirst: async () => ({
+            id: 'sub_row_1',
+            userId: 'user_1',
+            stripeSubscriptionId: 'sub_123',
+            status: 'active',
+            priceId: 'price_annual',
+            currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
+            cancelAtPeriodEnd: false,
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+          }),
+        },
+      },
+      insert: () => {
+        throw new Error('unexpected insert');
+      },
+    } as const;
+
+    const priceIds = {
+      monthly: 'price_monthly',
+      annual: 'price_annual',
+    } as const;
+
+    type RepoDb = ConstructorParameters<
+      typeof DrizzleSubscriptionRepository
+    >[0];
+    const repo = new DrizzleSubscriptionRepository(
+      db as unknown as RepoDb,
+      priceIds,
+    );
+
+    await expect(
+      repo.findByStripeSubscriptionId('sub_123'),
+    ).resolves.toMatchObject({
+      userId: 'user_1',
+      plan: 'annual',
+    });
+  });
+
+  it('findByStripeSubscriptionId throws INTERNAL_ERROR when the stored priceId is unknown', async () => {
+    const db = {
+      query: {
+        stripeSubscriptions: {
+          findFirst: async () => ({
+            id: 'sub_row_1',
+            userId: 'user_1',
+            priceId: 'price_unknown',
+            status: 'active',
+            currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
+            cancelAtPeriodEnd: false,
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+            stripeSubscriptionId: 'sub_123',
+          }),
+        },
+      },
+      insert: () => {
+        throw new Error('unexpected insert');
+      },
+    } as const;
+
+    const priceIds = {
+      monthly: 'price_monthly',
+      annual: 'price_annual',
+    } as const;
+
+    type RepoDb = ConstructorParameters<
+      typeof DrizzleSubscriptionRepository
+    >[0];
+    const repo = new DrizzleSubscriptionRepository(
+      db as unknown as RepoDb,
+      priceIds,
+    );
+
+    await expect(
+      repo.findByStripeSubscriptionId('sub_123'),
+    ).rejects.toBeInstanceOf(ApplicationError);
+    await expect(
+      repo.findByStripeSubscriptionId('sub_123'),
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+    });
+  });
+});

--- a/src/adapters/repositories/drizzle-subscription-repository.ts
+++ b/src/adapters/repositories/drizzle-subscription-repository.ts
@@ -3,13 +3,28 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type * as schema from '@/db/schema';
 import { stripeSubscriptions } from '@/db/schema';
 import { ApplicationError } from '@/src/application/errors';
-import type { SubscriptionRepository } from '@/src/application/ports/repositories';
+import type {
+  SubscriptionRepository,
+  SubscriptionUpsertInput,
+} from '@/src/application/ports/repositories';
 import {
+  getStripePriceId,
   getSubscriptionPlanFromPriceId,
   type StripePriceIds,
 } from '../config/stripe-prices';
 
 type Db = PostgresJsDatabase<typeof schema>;
+
+function isPostgresUniqueViolation(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  const maybeCode = (error as { code?: unknown }).code;
+  if (maybeCode === '23505') return true;
+
+  const maybeCause = (error as { cause?: unknown }).cause;
+  if (!maybeCause || typeof maybeCause !== 'object') return false;
+  return (maybeCause as { code?: unknown }).code === '23505';
+}
 
 export class DrizzleSubscriptionRepository implements SubscriptionRepository {
   constructor(
@@ -42,5 +57,73 @@ export class DrizzleSubscriptionRepository implements SubscriptionRepository {
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
     };
+  }
+
+  async findByStripeSubscriptionId(stripeSubscriptionId: string) {
+    const row = await this.db.query.stripeSubscriptions.findFirst({
+      where: eq(stripeSubscriptions.stripeSubscriptionId, stripeSubscriptionId),
+    });
+
+    if (!row) return null;
+
+    const plan = getSubscriptionPlanFromPriceId(row.priceId, this.priceIds);
+    if (!plan) {
+      throw new ApplicationError(
+        'INTERNAL_ERROR',
+        `Unknown Stripe price id "${row.priceId}" for subscription ${row.id}`,
+      );
+    }
+
+    return {
+      id: row.id,
+      userId: row.userId,
+      plan,
+      status: row.status,
+      currentPeriodEnd: row.currentPeriodEnd,
+      cancelAtPeriodEnd: row.cancelAtPeriodEnd,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+
+  async upsert(input: SubscriptionUpsertInput): Promise<void> {
+    const priceId = getStripePriceId(input.plan, this.priceIds);
+
+    try {
+      await this.db
+        .insert(stripeSubscriptions)
+        .values({
+          userId: input.userId,
+          stripeSubscriptionId: input.stripeSubscriptionId,
+          status: input.status,
+          priceId,
+          currentPeriodEnd: input.currentPeriodEnd,
+          cancelAtPeriodEnd: input.cancelAtPeriodEnd,
+          updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: stripeSubscriptions.userId,
+          set: {
+            stripeSubscriptionId: input.stripeSubscriptionId,
+            status: input.status,
+            priceId,
+            currentPeriodEnd: input.currentPeriodEnd,
+            cancelAtPeriodEnd: input.cancelAtPeriodEnd,
+            updatedAt: new Date(),
+          },
+        });
+    } catch (error) {
+      if (isPostgresUniqueViolation(error)) {
+        throw new ApplicationError(
+          'CONFLICT',
+          'Stripe subscription id is already mapped to a different user',
+        );
+      }
+
+      throw new ApplicationError(
+        'INTERNAL_ERROR',
+        'Failed to upsert subscription',
+      );
+    }
   }
 }

--- a/src/application/ports/gateways.ts
+++ b/src/application/ports/gateways.ts
@@ -45,10 +45,11 @@ export type WebhookEventResult = {
   processed: boolean;
   subscriptionUpdate?: {
     userId: string; // internal UUID
+    stripeSubscriptionId: string; // opaque external id
+    plan: SubscriptionPlan; // domain plan (monthly/annual)
     status: SubscriptionStatus;
     currentPeriodEnd: Date;
     cancelAtPeriodEnd: boolean;
-    priceId: string; // persisted for audit/debug (not a domain concept)
   };
 };
 

--- a/src/application/ports/repositories.ts
+++ b/src/application/ports/repositories.ts
@@ -6,7 +6,11 @@ import type {
   Subscription,
   Tag,
 } from '@/src/domain/entities';
-import type { QuestionDifficulty } from '@/src/domain/value-objects';
+import type {
+  QuestionDifficulty,
+  SubscriptionPlan,
+  SubscriptionStatus,
+} from '@/src/domain/value-objects';
 
 export type QuestionFilters = {
   tagSlugs: readonly string[];
@@ -88,8 +92,23 @@ export interface TagRepository {
   listAll(): Promise<readonly Tag[]>;
 }
 
+export type SubscriptionUpsertInput = {
+  userId: string;
+  stripeSubscriptionId: string; // opaque external id
+  plan: SubscriptionPlan; // domain plan (monthly/annual)
+  status: SubscriptionStatus;
+  currentPeriodEnd: Date;
+  cancelAtPeriodEnd: boolean;
+};
+
 export interface SubscriptionRepository {
   findByUserId(userId: string): Promise<Subscription | null>;
+
+  findByStripeSubscriptionId(
+    stripeSubscriptionId: string,
+  ): Promise<Subscription | null>;
+
+  upsert(input: SubscriptionUpsertInput): Promise<void>;
 }
 
 export interface StripeCustomerRepository {


### PR DESCRIPTION
Summary
- Extend SubscriptionRepository with upsert() + findByStripeSubscriptionId()
- Add SubscriptionUpsertInput and keep application layer vendor-agnostic (plan + stripeSubscriptionId, no priceId)
- Implement DrizzleSubscriptionRepository.upsert() with userId-keyed upsert + CONFLICT mapping
- Add unit tests (coverage) + integration test cases for upsert behavior
- Update specs (SPEC-004, SPEC-009) and mark DEBT-003 resolved

Notes
- Local integration tests are blocked by non-local DATABASE_URL safety check; CI runs them against local Postgres service.

@coderabbitai review