### PR TITLE
Resolve DEBT-013: Time spent tracking is out of scope for MVP

### DIFF
--- a/docs/debt/debt-013-time-spent-tracking-post-mvp.md
+++ b/docs/debt/debt-013-time-spent-tracking-post-mvp.md
@@ -1,12 +1,15 @@
 # DEBT-013: Time Spent Tracking Deferred (MVP Uses `time_spent_seconds = 0`)
 
-**Status:** Open
+**Status:** Resolved
 **Priority:** P3
 **Date:** 2026-02-01
+**Resolved:** 2026-02-01
 
 ## Summary
 
 Per SSOT (`docs/specs/master_spec.md`, SubmitAnswer behavior), attempts currently persist `time_spent_seconds = 0` for MVP. This keeps the system simple but prevents pacing analytics.
+
+This is not an architectural defect; it is an explicit MVP scope decision (see `docs/specs/master_spec.md` “Out of Scope for MVP”).
 
 ## Impact
 

--- a/docs/specs/master_spec.md
+++ b/docs/specs/master_spec.md
@@ -2441,6 +2441,7 @@ Enable Stripe Customer Portal and configure:
 
 * **Admin UI for question authoring** — content is authored in MDX and seeded via script; admin UI adds large surface area and auth roles.
 * **Spaced repetition algorithm** — requires scheduling, per-tag modeling, and more complex data structures; MVP focuses on straightforward practice/review.
+* **Time spent tracking / pacing analytics** — MVP persists `attempts.time_spent_seconds = 0` and does not attempt to measure per-question timing.
 * **AI-generated questions** — quality/safety and editorial control are MVP priorities; AI generation introduces validation risk.
 * **Native mobile app** — web app is sufficient for initial market; mobile adds parallel build/test/deploy complexity.
 * **Offline mode** — requires caching and conflict resolution; not needed for initial board prep workflow.


### PR DESCRIPTION
Closes DEBT-013 by making the MVP scope decision explicit in SSOT.

- Add an explicit Out-of-Scope bullet in `docs/specs/master_spec.md` for time spent tracking / pacing analytics
- Mark `docs/debt/debt-013-time-spent-tracking-post-mvp.md` as resolved (this is a scope decision, not a code defect)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified MVP feature scope: time spent tracking records total duration but does not measure per-question timing.
  * Identified features outside MVP scope: team accounts, leaderboards, social features, advanced analytics, and multiple exam types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->