### PR TITLE
Fix Stripe webhook signature handling

### DIFF
--- a/docs/debt/debt-003-missing-subscription-update-method.md
+++ b/docs/debt/debt-003-missing-subscription-update-method.md
@@ -38,7 +38,7 @@ Per SPEC-007 and webhook processing needs:
 interface SubscriptionRepository {
   findByUserId(userId: string): Promise<Subscription | null>;
   findByStripeSubscriptionId(stripeSubId: string): Promise<Subscription | null>;
-  upsert(subscription: Subscription): Promise<void>;
+  upsert(input: SubscriptionUpsertInput): Promise<void>;
 }
 ```
 

--- a/src/adapters/gateways/stripe-payment-gateway.ts
+++ b/src/adapters/gateways/stripe-payment-gateway.ts
@@ -112,11 +112,16 @@ export class StripePaymentGateway implements PaymentGateway {
     rawBody: string,
     signature: string,
   ): Promise<WebhookEventResult> {
-    const event = this.deps.stripe.webhooks.constructEvent(
-      rawBody,
-      signature,
-      this.deps.webhookSecret,
-    );
+    let event: ReturnType<StripeClient['webhooks']['constructEvent']>;
+    try {
+      event = this.deps.stripe.webhooks.constructEvent(
+        rawBody,
+        signature,
+        this.deps.webhookSecret,
+      );
+    } catch {
+      throw new ApplicationError('STRIPE_ERROR', 'Invalid webhook signature');
+    }
 
     const result: WebhookEventResult = {
       eventId: event.id,


### PR DESCRIPTION
## Why
- Follow up on CodeRabbit: map Stripe webhook signature verification failures to an `ApplicationError('STRIPE_ERROR', 'Invalid webhook signature')`.
- Fix doc drift in `docs/debt/debt-003-missing-subscription-update-method.md` (upsert signature).

## What changed
- Add unit test for signature failure behavior.
- Wrap `stripe.webhooks.constructEvent(...)` in try/catch and throw `ApplicationError` on failure.
- Update DEBT-003 snippet to match `SubscriptionUpsertInput`.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test --run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of payment webhook verification failures with proper error reporting.

* **Tests**
  * Added test coverage for webhook signature verification error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->