### PR TITLE
Refactor Stripe webhook route tests to DI

### DIFF
--- a/app/api/stripe/webhook/handler.ts
+++ b/app/api/stripe/webhook/handler.ts
@@ -1,0 +1,93 @@
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { NextResponse } from 'next/server';
+import type * as schema from '@/db/schema';
+import type {
+  StripeWebhookDeps,
+  StripeWebhookInput,
+} from '@/src/adapters/controllers/stripe-webhook-controller';
+import {
+  DrizzleStripeCustomerRepository,
+  DrizzleStripeEventRepository,
+  DrizzleSubscriptionRepository,
+} from '@/src/adapters/repositories';
+import { isApplicationError } from '@/src/application/errors';
+import type { PaymentGateway } from '@/src/application/ports/gateways';
+
+type StripeWebhookRouteDb = {
+  transaction: <T>(
+    fn: (tx: PostgresJsDatabase<typeof schema>) => Promise<T>,
+  ) => Promise<T>;
+};
+
+type StripeWebhookRouteEnv = {
+  NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY: string;
+  NEXT_PUBLIC_STRIPE_PRICE_ID_ANNUAL: string;
+};
+
+type StripeWebhookRouteLogger = {
+  error: (context: unknown, message: string) => void;
+};
+
+export type StripeWebhookRouteContainer = {
+  db: StripeWebhookRouteDb;
+  env: StripeWebhookRouteEnv;
+  logger: StripeWebhookRouteLogger;
+  paymentGateway: PaymentGateway;
+};
+
+export function createWebhookHandler(
+  createContainer: () => StripeWebhookRouteContainer,
+  processStripeWebhook: (
+    deps: StripeWebhookDeps,
+    input: StripeWebhookInput,
+  ) => Promise<void>,
+) {
+  return async function POST(req: Request) {
+    const signature = req.headers.get('stripe-signature');
+    if (!signature) {
+      return NextResponse.json(
+        { error: 'Missing stripe-signature header' },
+        { status: 400 },
+      );
+    }
+
+    const rawBody = await req.text();
+    const container = createContainer();
+
+    try {
+      await processStripeWebhook(
+        {
+          paymentGateway: container.paymentGateway,
+          transaction: async (fn) =>
+            container.db.transaction(async (tx) =>
+              fn({
+                stripeEvents: new DrizzleStripeEventRepository(tx),
+                subscriptions: new DrizzleSubscriptionRepository(tx, {
+                  monthly: container.env.NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY,
+                  annual: container.env.NEXT_PUBLIC_STRIPE_PRICE_ID_ANNUAL,
+                }),
+                stripeCustomers: new DrizzleStripeCustomerRepository(tx),
+              }),
+            ),
+        },
+        { rawBody, signature },
+      );
+
+      return NextResponse.json({ received: true }, { status: 200 });
+    } catch (error) {
+      if (
+        isApplicationError(error) &&
+        error.code === 'STRIPE_ERROR' &&
+        error.message === 'Invalid webhook signature'
+      ) {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+
+      container.logger.error({ error }, 'Stripe webhook failed');
+      return NextResponse.json(
+        { error: 'Webhook processing failed' },
+        { status: 500 },
+      );
+    }
+  };
+}

--- a/app/api/stripe/webhook/route.test.ts
+++ b/app/api/stripe/webhook/route.test.ts
@@ -1,32 +1,49 @@
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { describe, expect, it, vi } from 'vitest';
+import type { StripeWebhookRouteContainer } from '@/app/api/stripe/webhook/handler';
+import { createWebhookHandler } from '@/app/api/stripe/webhook/handler';
+import type * as schema from '@/db/schema';
 import { ApplicationError } from '@/src/application/errors';
+import type { PaymentGateway } from '@/src/application/ports/gateways';
 
-vi.mock('server-only', () => ({}));
+type Db = PostgresJsDatabase<typeof schema>;
 
-const processStripeWebhookMock = vi.fn();
-vi.mock('@/src/adapters/controllers/stripe-webhook-controller', () => ({
-  processStripeWebhook: (...args: unknown[]) =>
-    processStripeWebhookMock(...args),
-}));
+function createPaymentGatewayStub(): PaymentGateway {
+  return {
+    createCheckoutSession: async () => ({ url: 'https://stripe/checkout' }),
+    createPortalSession: async () => ({ url: 'https://stripe/portal' }),
+    processWebhookEvent: async () => ({ eventId: 'evt_1', type: 'test' }),
+  };
+}
 
-const loggerErrorMock = vi.fn();
-vi.mock('@/lib/container', () => ({
-  createContainer: () => ({
+function createTestDeps() {
+  const loggerError = vi.fn();
+  const createContainer = vi.fn<() => StripeWebhookRouteContainer>(() => ({
     db: {
-      transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn({}),
+      transaction: async <T>(fn: (tx: Db) => Promise<T>): Promise<T> =>
+        fn({} as Db),
     },
     env: {
       NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY: 'price_m',
       NEXT_PUBLIC_STRIPE_PRICE_ID_ANNUAL: 'price_a',
     },
-    logger: { error: loggerErrorMock },
-    paymentGateway: {},
-  }),
-}));
+    logger: { error: loggerError },
+    paymentGateway: createPaymentGatewayStub(),
+  }));
+
+  const processStripeWebhook = vi.fn();
+
+  return {
+    POST: createWebhookHandler(createContainer, processStripeWebhook),
+    createContainer,
+    processStripeWebhook,
+    loggerError,
+  };
+}
 
 describe('POST /api/stripe/webhook', () => {
   it('returns 400 when stripe-signature header is missing', async () => {
-    const { POST } = await import('./route');
+    const { POST, createContainer, processStripeWebhook } = createTestDeps();
 
     const res = await POST(
       new Request('http://localhost/api/stripe/webhook', {
@@ -36,12 +53,13 @@ describe('POST /api/stripe/webhook', () => {
     );
 
     expect(res.status).toBe(400);
+    expect(createContainer).not.toHaveBeenCalled();
+    expect(processStripeWebhook).not.toHaveBeenCalled();
   });
 
   it('returns 200 and received=true when processing succeeds', async () => {
-    processStripeWebhookMock.mockResolvedValue(undefined);
-
-    const { POST } = await import('./route');
+    const { POST, processStripeWebhook } = createTestDeps();
+    processStripeWebhook.mockResolvedValue(undefined);
 
     const res = await POST(
       new Request('http://localhost/api/stripe/webhook', {
@@ -56,11 +74,11 @@ describe('POST /api/stripe/webhook', () => {
   });
 
   it('returns 400 when signature verification fails', async () => {
-    processStripeWebhookMock.mockRejectedValue(
+    const { POST, processStripeWebhook } = createTestDeps();
+
+    processStripeWebhook.mockRejectedValue(
       new ApplicationError('STRIPE_ERROR', 'Invalid webhook signature'),
     );
-
-    const { POST } = await import('./route');
 
     const res = await POST(
       new Request('http://localhost/api/stripe/webhook', {
@@ -74,10 +92,9 @@ describe('POST /api/stripe/webhook', () => {
   });
 
   it('returns 500 when processing fails unexpectedly', async () => {
-    loggerErrorMock.mockClear();
-    processStripeWebhookMock.mockRejectedValue(new Error('boom'));
-
-    const { POST } = await import('./route');
+    const { POST, loggerError, processStripeWebhook } = createTestDeps();
+    loggerError.mockClear();
+    processStripeWebhook.mockRejectedValue(new Error('boom'));
 
     const res = await POST(
       new Request('http://localhost/api/stripe/webhook', {
@@ -91,6 +108,50 @@ describe('POST /api/stripe/webhook', () => {
     await expect(res.json()).resolves.toEqual({
       error: 'Webhook processing failed',
     });
-    expect(loggerErrorMock).toHaveBeenCalledTimes(1);
+    expect(loggerError).toHaveBeenCalledTimes(1);
+  });
+
+  it('provides a transaction wrapper to processStripeWebhook', async () => {
+    const containerTransaction = vi.fn(
+      async <T>(fn: (tx: Db) => Promise<T>): Promise<T> => fn({} as Db),
+    ) as unknown as StripeWebhookRouteContainer['db']['transaction'];
+    const createContainer = vi.fn<() => StripeWebhookRouteContainer>(() => ({
+      db: { transaction: containerTransaction },
+      env: {
+        NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY: 'price_m',
+        NEXT_PUBLIC_STRIPE_PRICE_ID_ANNUAL: 'price_a',
+      },
+      logger: { error: vi.fn() },
+      paymentGateway: createPaymentGatewayStub(),
+    }));
+
+    const processStripeWebhook = vi.fn(async (deps: unknown) => {
+      const d = deps as {
+        transaction: (fn: (tx: unknown) => Promise<void>) => Promise<void>;
+      };
+      await d.transaction(async (tx) => {
+        const t = tx as {
+          stripeEvents: { claim: unknown };
+          subscriptions: { upsert: unknown };
+          stripeCustomers: { insert: unknown };
+        };
+        expect(typeof t.stripeEvents.claim).toBe('function');
+        expect(typeof t.subscriptions.upsert).toBe('function');
+        expect(typeof t.stripeCustomers.insert).toBe('function');
+      });
+    });
+
+    const POST = createWebhookHandler(createContainer, processStripeWebhook);
+
+    const res = await POST(
+      new Request('http://localhost/api/stripe/webhook', {
+        method: 'POST',
+        headers: { 'stripe-signature': 'sig_1' },
+        body: 'raw',
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(containerTransaction).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,60 +1,7 @@
-import { NextResponse } from 'next/server';
 import { createContainer } from '@/lib/container';
 import { processStripeWebhook } from '@/src/adapters/controllers/stripe-webhook-controller';
-import {
-  DrizzleStripeCustomerRepository,
-  DrizzleStripeEventRepository,
-  DrizzleSubscriptionRepository,
-} from '@/src/adapters/repositories';
-import { isApplicationError } from '@/src/application/errors';
+import { createWebhookHandler } from './handler';
 
 export const runtime = 'nodejs';
 
-export async function POST(req: Request) {
-  const signature = req.headers.get('stripe-signature');
-  if (!signature) {
-    return NextResponse.json(
-      { error: 'Missing stripe-signature header' },
-      { status: 400 },
-    );
-  }
-
-  const rawBody = await req.text();
-  const container = createContainer();
-
-  try {
-    await processStripeWebhook(
-      {
-        paymentGateway: container.paymentGateway,
-        transaction: async (fn) =>
-          container.db.transaction(async (tx) =>
-            fn({
-              stripeEvents: new DrizzleStripeEventRepository(tx),
-              subscriptions: new DrizzleSubscriptionRepository(tx, {
-                monthly: container.env.NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY,
-                annual: container.env.NEXT_PUBLIC_STRIPE_PRICE_ID_ANNUAL,
-              }),
-              stripeCustomers: new DrizzleStripeCustomerRepository(tx),
-            }),
-          ),
-      },
-      { rawBody, signature },
-    );
-
-    return NextResponse.json({ received: true }, { status: 200 });
-  } catch (error) {
-    if (
-      isApplicationError(error) &&
-      error.code === 'STRIPE_ERROR' &&
-      error.message === 'Invalid webhook signature'
-    ) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-
-    container.logger.error({ error }, 'Stripe webhook failed');
-    return NextResponse.json(
-      { error: 'Webhook processing failed' },
-      { status: 500 },
-    );
-  }
-}
+export const POST = createWebhookHandler(createContainer, processStripeWebhook);

--- a/src/adapters/gateways/clerk-auth-gateway.ts
+++ b/src/adapters/gateways/clerk-auth-gateway.ts
@@ -2,10 +2,10 @@ import { eq } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type * as schema from '@/db/schema';
 import { users } from '@/db/schema';
+import { isPostgresUniqueViolation } from '@/src/adapters/repositories/postgres-errors';
 import { ApplicationError } from '@/src/application/errors';
 import type { AuthGateway } from '@/src/application/ports/gateways';
 import type { User } from '@/src/domain/entities';
-import { getPostgresErrorCode } from '../repositories/postgres-errors';
 
 type Db = PostgresJsDatabase<typeof schema>;
 
@@ -48,7 +48,7 @@ export class ClerkAuthGateway implements AuthGateway {
   private mapDbError(error: unknown): ApplicationError {
     if (error instanceof ApplicationError) return error;
 
-    if (getPostgresErrorCode(error) === '23505') {
+    if (isPostgresUniqueViolation(error)) {
       return new ApplicationError(
         'CONFLICT',
         'User could not be upserted due to a uniqueness constraint',

--- a/src/adapters/repositories/postgres-errors.test.ts
+++ b/src/adapters/repositories/postgres-errors.test.ts
@@ -22,7 +22,13 @@ describe('postgres-errors', () => {
 
   it('returns null when error shape is not a postgres error', () => {
     expect(getPostgresErrorCode(null)).toBeNull();
+    expect(getPostgresErrorCode(undefined)).toBeNull();
+    expect(getPostgresErrorCode('string')).toBeNull();
     expect(getPostgresErrorCode({ code: 123 })).toBeNull();
     expect(getPostgresErrorCode({ cause: { code: 123 } })).toBeNull();
+  });
+
+  it('returns false for other Postgres error codes', () => {
+    expect(isPostgresUniqueViolation({ code: '23503' })).toBe(false);
   });
 });


### PR DESCRIPTION
Follow-up to CodeRabbit feedback: remove vi.mock from Stripe webhook route tests by refactoring to an injectable handler factory. Also applies alias import + postgres error helper nitpicks.