### PR TITLE
Sync dev → main: docs/spec alignment + BUG-009

### DIFF
--- a/docs/_archive/debt/debt-036-specs-register-and-ports-doc-drift.md
+++ b/docs/_archive/debt/debt-036-specs-register-and-ports-doc-drift.md
@@ -1,0 +1,52 @@
+# DEBT-036: Specs Register and Ports Docs Drift (Status + Interface Mismatch)
+
+**Status:** Resolved
+**Priority:** P2
+**Date:** 2026-02-01
+**Resolved:** 2026-02-01
+
+---
+
+## Description
+
+The specs system drifted in two ways:
+
+1. `docs/specs/index.md` reported many specs as **Implemented** even though the
+   corresponding spec documents still showed `**Status:** Ready` and/or the
+   referenced files did not exist yet (especially feature-slice controller specs).
+2. Some foundational spec documents (especially ports + repository specs) no longer
+   matched the current implementation and SSOT (`docs/specs/master_spec.md`), e.g.:
+   - `StripeEventRepository` interface described `ensure/isProcessed`, but the SSOT
+     idempotency flow requires `claim/lock` semantics.
+   - `WebhookEventResult.subscriptionUpdate` was missing required fields used by
+     controllers (e.g., `stripeCustomerId`).
+
+This created documentation-based “false confidence” and made it harder to audit
+Clean Architecture compliance from first principles.
+
+## Impact
+
+- **SSOT ambiguity:** contributors cannot trust spec status or port definitions.
+- **Review friction:** PR reviews spend time reconciling docs vs code.
+- **Architecture drift risk:** wrong port contracts encourage wrong implementations.
+
+## Resolution
+
+Aligned specs documentation with the current code and the master spec:
+
+- Updated foundational specs to reflect the implemented port interfaces (e.g.
+  Stripe webhook idempotency via `claim/lock`).
+- Corrected spec status reporting in `docs/specs/index.md` to avoid marking
+  incomplete slices as “Implemented”.
+
+## Acceptance Criteria
+
+- [x] Spec index no longer mislabels incomplete slices as “Implemented”
+- [x] Port specs match current `src/application/ports/**` definitions
+- [x] Repository spec idempotency description matches `docs/specs/master_spec.md`
+
+## Related
+
+- `docs/specs/master_spec.md` (Stripe webhook idempotency)
+- ADR-001 (Clean Architecture Layers)
+- ADR-012 (Directory Structure)

--- a/docs/bugs/bug-009-vercel-preview-deployment-rate-limit.md
+++ b/docs/bugs/bug-009-vercel-preview-deployment-rate-limit.md
@@ -1,0 +1,42 @@
+# BUG-009: Vercel Preview Deployment Status Fails Due to Rate Limit
+
+**Status:** Open
+**Priority:** P3
+**Date:** 2026-02-01
+
+---
+
+## Description
+
+Pull requests can show a failing `Vercel` status check even when the code is correct.
+The failure message indicates Vercel preview deployments are being rate limited.
+
+This creates noisy red CI and can mislead reviewers into thinking the PR is broken.
+
+## Steps to Reproduce
+
+1. Open or update a PR.
+2. Observe the `Vercel` status/check on the PR.
+3. See a failure similar to:
+   - `Resource is limited - try again in X hours (api-deployments-free-per-day)`
+
+## Root Cause
+
+The Vercel integration is hitting a free-tier/plan deployment limit for preview deployments.
+
+## Fix
+
+Pending decision (options):
+
+- Upgrade the Vercel plan to raise/remove preview deployment limits.
+- Reduce preview deployments (e.g., only deploy on certain branches).
+- Adjust/disable the PR status integration if it is not required for merge.
+
+## Verification
+
+- [ ] Open a PR and confirm `Vercel` status becomes non-blocking (pass or skipped) under normal usage.
+- [ ] Confirm merges are not blocked by Vercel failures (if Vercel is kept as advisory only).
+
+## Related
+
+- PR #18: Vercel status failure due to rate limiting

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -17,9 +17,9 @@ Bug reports document issues discovered in the codebase along with their root cau
 
 | ID | Title | Status | Priority | Date |
 |----|-------|--------|----------|------|
-| — | *No active bugs* | — | — | — |
+| [BUG-009](./bug-009-vercel-preview-deployment-rate-limit.md) | Vercel Preview Deployment Status Fails Due to Rate Limit | Open | P3 | 2026-02-01 |
 
-**Next Bug ID:** BUG-009
+**Next Bug ID:** BUG-010
 
 ## Archived Bugs
 

--- a/docs/debt/index.md
+++ b/docs/debt/index.md
@@ -19,7 +19,7 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 |----|-------|--------|----------|------|
 | _None_ | — | — | — | — |
 
-**Next Debt ID:** DEBT-036
+**Next Debt ID:** DEBT-037
 
 ## Archived Debt
 
@@ -60,6 +60,7 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 | [DEBT-033](../_archive/debt/debt-033-flat-repository-structure.md) | Flat Repository Structure | P3 | 2026-02-01 |
 | [DEBT-034](../_archive/debt/debt-034-test-coverage-gap-critical.md) | Test Coverage Gap — Must Stabilize Before New Features | P1 | 2026-02-01 |
 | [DEBT-035](../_archive/debt/debt-035-inconsistent-repo-test-mocking.md) | Inconsistent Repo Test Mocking (False Positive) | P2 | 2026-02-01 |
+| [DEBT-036](../_archive/debt/debt-036-specs-register-and-ports-doc-drift.md) | Specs Register and Ports Docs Drift | P2 | 2026-02-01 |
 
 ## Debt Statuses
 

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -27,12 +27,12 @@ Implementation specifications provide detailed technical guidance for building e
 | [SPEC-007](./spec-007-repository-implementations.md) | Repository Implementations (Drizzle) | Implemented | Adapters |
 | [SPEC-008](./spec-008-auth-gateway.md) | Auth Gateway (Clerk) | Implemented | Adapters |
 | [SPEC-009](./spec-009-payment-gateway.md) | Payment Gateway (Stripe) | Implemented | Adapters |
-| [SPEC-010](./spec-010-server-actions.md) | Server Actions (Controllers) | Implemented | Adapters |
-| [SPEC-011](./spec-011-paywall.md) | Paywall (Stripe Subscriptions) | Implemented | Feature |
-| [SPEC-012](./spec-012-core-question-loop.md) | Core Question Loop | Implemented | Feature |
-| [SPEC-013](./spec-013-practice-sessions.md) | Practice Sessions | Implemented | Feature |
-| [SPEC-014](./spec-014-review-bookmarks.md) | Review + Bookmarks | Implemented | Feature |
-| [SPEC-015](./spec-015-dashboard.md) | Dashboard | Implemented | Feature |
+| [SPEC-010](./spec-010-server-actions.md) | Server Actions (Controllers) | Ready | Adapters |
+| [SPEC-011](./spec-011-paywall.md) | Paywall (Stripe Subscriptions) | Ready | Feature |
+| [SPEC-012](./spec-012-core-question-loop.md) | Core Question Loop | Ready | Feature |
+| [SPEC-013](./spec-013-practice-sessions.md) | Practice Sessions | Ready | Feature |
+| [SPEC-014](./spec-014-review-bookmarks.md) | Review + Bookmarks | Ready | Feature |
+| [SPEC-015](./spec-015-dashboard.md) | Dashboard | Ready | Feature |
 | [SPEC-016](./spec-016-observability.md) | Observability (Logging, Error Tracking) | Partial | Infrastructure |
 | [SPEC-017](./spec-017-rate-limiting.md) | Rate Limiting | Proposed | Infrastructure |
 
@@ -41,7 +41,7 @@ Implementation specifications provide detailed technical guidance for building e
 ## Spec Statuses
 
 - **Proposed** — Under review, not yet approved
-- **Approved** — Ready for implementation
+- **Ready** — Ready for implementation
 - **In Progress** — Being implemented
 - **Partial** — Partially implemented
 - **Implemented** — Complete and verified
@@ -75,7 +75,7 @@ Specs are organized by Clean Architecture layer:
 > Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
 > Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
 
-**Status:** Proposed | Approved | In Progress | Implemented | Deprecated
+**Status:** Proposed | Ready | In Progress | Partial | Implemented | Deprecated
 **Layer:** Domain | Application | Adapters | Feature | Infrastructure
 **Date:** YYYY-MM-DD
 

--- a/docs/specs/spec-001-domain-entities.md
+++ b/docs/specs/spec-001-domain-entities.md
@@ -4,7 +4,7 @@
 > Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
 > Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
 
-**Status:** Ready
+**Status:** Implemented
 **Layer:** Domain (Innermost)
 **Dependencies:** SPEC-002 (Value Objects)
 **Implements:** ADR-001, ADR-002

--- a/docs/specs/spec-002-value-objects.md
+++ b/docs/specs/spec-002-value-objects.md
@@ -4,7 +4,7 @@
 > Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
 > Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
 
-**Status:** Ready
+**Status:** Implemented
 **Layer:** Domain (Innermost)
 **Dependencies:** None
 **Implements:** ADR-001, ADR-002

--- a/docs/specs/spec-003-domain-services.md
+++ b/docs/specs/spec-003-domain-services.md
@@ -4,7 +4,7 @@
 > Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
 > Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
 
-**Status:** Ready
+**Status:** Implemented
 **Layer:** Domain (Innermost)
 **Dependencies:** SPEC-001 (Entities), SPEC-002 (Value Objects)
 **Implements:** ADR-001, ADR-002, ADR-003

--- a/docs/specs/spec-005-core-use-cases.md
+++ b/docs/specs/spec-005-core-use-cases.md
@@ -4,7 +4,7 @@
 > Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
 > Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
 
-**Status:** Ready
+**Status:** Implemented
 **Layer:** Application
 **Dependencies:** SPEC-003 (Domain Services), SPEC-004 (Ports)
 **Implements:** ADR-001 (Clean Architecture), ADR-003 (Testing), ADR-006 (Errors)
@@ -73,14 +73,17 @@ export type CheckEntitlementOutput = {
 
 ```ts
 export class CheckEntitlementUseCase {
-  constructor(private readonly subscriptions: SubscriptionRepository) {}
+  constructor(
+    private readonly subscriptions: SubscriptionRepository,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
 }
 ```
 
 **Algorithm:**
 
 1. Load subscription by `userId` (may be null)
-2. Compute `isEntitled(subscription, now)`
+2. Compute `isEntitled(subscription, now())`
 3. Return `{ isEntitled }`
 
 ---

--- a/docs/specs/spec-006-drizzle-schema.md
+++ b/docs/specs/spec-006-drizzle-schema.md
@@ -4,7 +4,7 @@
 > Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
 > Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
 
-**Status:** Ready
+**Status:** Implemented
 **Layer:** Infrastructure (Outermost)
 **Dependencies:** None
 **Implements:** ADR-001, ADR-002

--- a/docs/specs/spec-007-repository-implementations.md
+++ b/docs/specs/spec-007-repository-implementations.md
@@ -4,7 +4,7 @@
 > Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
 > Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
 
-**Status:** Ready
+**Status:** Implemented
 **Layer:** Adapters
 **Dependencies:** SPEC-004 (Ports), SPEC-006 (Drizzle Schema)
 **Implements:** ADR-001 (Clean Architecture), ADR-003 (Testing)
@@ -32,6 +32,7 @@ src/adapters/repositories/
 ├── drizzle-practice-session-repository.ts
 ├── drizzle-bookmark-repository.ts
 ├── drizzle-tag-repository.ts
+├── drizzle-user-repository.ts
 ├── drizzle-subscription-repository.ts
 ├── drizzle-stripe-customer-repository.ts
 ├── drizzle-stripe-event-repository.ts
@@ -79,7 +80,7 @@ Tests should validate:
 Stripe webhook idempotency uses `stripe_events`:
 
 - `stripe_events.id` = Stripe event id (primary key)
-- Repositories must support: `ensure`, `isProcessed`, `markProcessed`, `markFailed`
+- Repositories must support: `claim`, `lock`, `markProcessed`, `markFailed`
 
 See `docs/specs/master_spec.md` Section 4.4.2 for exact behavior.
 
@@ -97,7 +98,7 @@ These integration tests are required before any slice that depends on these repo
 - `QuestionRepository.findPublishedById` returns `null` for non-published questions.
 - `AttemptRepository.insert` creates an attempt row with correct FK wiring.
 - `BookmarkRepository.add/remove/exists/listByUserId` round-trips correctly.
-- `StripeEventRepository.ensure/isProcessed/markProcessed/markFailed` is idempotent and concurrency-safe (unique PK on `stripe_events.id`).
+- `StripeEventRepository.claim/lock/markProcessed/markFailed` is idempotent and concurrency-safe (unique PK on `stripe_events.id`).
 
 ---
 

--- a/docs/specs/spec-008-auth-gateway.md
+++ b/docs/specs/spec-008-auth-gateway.md
@@ -4,7 +4,7 @@
 > Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
 > Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
 
-**Status:** Ready
+**Status:** Implemented
 **Layer:** Adapters
 **Dependencies:** SPEC-004 (Ports), SPEC-006 (Drizzle Schema)
 **Implements:** ADR-004 (Authentication Boundary)
@@ -29,6 +29,9 @@ src/adapters/gateways/
 ├── clerk-auth-gateway.ts
 └── index.ts
 ```
+
+Auth persistence is owned by the `UserRepository` port (persistence adapter),
+so `ClerkAuthGateway` depends on `UserRepository` via constructor injection.
 
 ---
 

--- a/docs/specs/spec-009-payment-gateway.md
+++ b/docs/specs/spec-009-payment-gateway.md
@@ -4,7 +4,7 @@
 > Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
 > Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
 
-**Status:** Ready
+**Status:** Implemented
 **Layer:** Adapters
 **Dependencies:** SPEC-004 (Ports), SPEC-006 (Drizzle Schema)
 **Implements:** ADR-005 (Payment Boundary)


### PR DESCRIPTION
Syncs main with the latest dev commit (50ae217):\n- Document BUG-009 (Vercel preview deployment rate limit).\n- Resolve/Archive DEBT-036 (specs register + ports doc drift) and align spec docs with current code + master spec.\n\nNo production code changes; docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Resolved technical debt by aligning specifications and ports documentation with current codebase
  * Documented Vercel preview deployment rate limiting issue with troubleshooting and resolution steps
  * Updated specification lifecycle: introduced "Ready" status state and marked foundational specifications as "Implemented"
  * Enhanced authentication and payment gateway specifications with clarified dependency relationships

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->