### PR TITLE
Sync dev → main: export DrizzleUserRepository

### DIFF
--- a/lib/container.ts
+++ b/lib/container.ts
@@ -14,8 +14,8 @@ import {
   DrizzleStripeEventRepository,
   DrizzleSubscriptionRepository,
   DrizzleTagRepository,
+  DrizzleUserRepository,
 } from '@/src/adapters/repositories';
-import { DrizzleUserRepository } from '@/src/adapters/repositories/drizzle-user-repository';
 import type { DrizzleDb } from '@/src/adapters/shared/database-types';
 import type {
   AuthGateway,

--- a/src/adapters/repositories/index.test.ts
+++ b/src/adapters/repositories/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { DrizzleUserRepository } from '@/src/adapters/repositories';
+
+describe('repositories exports', () => {
+  it('exports DrizzleUserRepository from the barrel', () => {
+    expect(DrizzleUserRepository).toBeTypeOf('function');
+  });
+});

--- a/src/adapters/repositories/index.ts
+++ b/src/adapters/repositories/index.ts
@@ -6,3 +6,4 @@ export { DrizzleStripeCustomerRepository } from './drizzle-stripe-customer-repos
 export { DrizzleStripeEventRepository } from './drizzle-stripe-event-repository';
 export { DrizzleSubscriptionRepository } from './drizzle-subscription-repository';
 export { DrizzleTagRepository } from './drizzle-tag-repository';
+export { DrizzleUserRepository } from './drizzle-user-repository';


### PR DESCRIPTION
Includes 8e1489c:\n- Export DrizzleUserRepository from src/adapters/repositories barrel.\n- Adds a small unit test to lock the export contract.\n- Cleans up lib/container.ts to import from the barrel.