### PR TITLE
Sync dev → main: docs accuracy cleanup

### DIFF
--- a/docs/_archive/debt/debt-014-lib-throws-plain-error.md
+++ b/docs/_archive/debt/debt-014-lib-throws-plain-error.md
@@ -68,5 +68,5 @@ We treat `lib/` as an outer (framework/infrastructure) layer, but we still requi
 - Kept **startup/build-time** failures as plain `Error`:
   - `lib/env.ts` (invalid configuration is fatal)
   - `lib/content/parseMdxQuestion.ts` (content parsing failures are build/seed-time concerns)
-- Added unit tests:
-  - `lib/auth.test.ts`
+- Note on tests:
+  - A previous `lib/auth.test.ts` was removed later as redundant/anti-pattern (it relied on module-level mocks for our own code). See DEBT-035.

--- a/docs/_archive/debt/debt-033-flat-repository-structure.md
+++ b/docs/_archive/debt/debt-033-flat-repository-structure.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-All 8 Drizzle repositories exist in a flat structure at `src/adapters/repositories/` with no organization by aggregate root or domain concept. As the system grows, this structure won't scale well.
+All 9 Drizzle repositories exist in a flat structure at `src/adapters/repositories/` with no organization by aggregate root or domain concept. As the system grows, this structure won't scale well.
 
 ## Location
 
@@ -27,6 +27,7 @@ src/adapters/repositories/
 ├── drizzle-stripe-event-repository.ts
 ├── drizzle-subscription-repository.ts
 ├── drizzle-tag-repository.ts
+├── drizzle-user-repository.ts
 ├── index.ts
 ├── postgres-errors.ts
 └── practice-session-limits.ts

--- a/docs/_archive/debt/debt-035-inconsistent-repo-test-mocking.md
+++ b/docs/_archive/debt/debt-035-inconsistent-repo-test-mocking.md
@@ -31,11 +31,14 @@ This **is** a fake passed through dependency injection. The `vi.fn()` is just a 
 
 ## What Was Actually Fixed
 
-The real violations were:
-- `lib/auth.test.ts` — Used `vi.mock('./db', './container')` — **DELETED**
-- `lib/container.test.ts` — Used `vi.mock('./db', './env')` — **DELETED**
+The real violations were test files that mocked our own modules at the module level
+(bypassing DI) and created flakiness/redundancy:
 
-These mocked our own code at the module level, bypassing DI. They were also redundant with adapter tests.
+- `lib/auth.test.ts` — **deleted** (module-level mocking anti-pattern + redundant coverage)
+- An earlier version of `lib/container.test.ts` — **deleted**, then later replaced with a DI-friendly `lib/container.test.ts`
+  that only mocks uninjectable external modules (`server-only`, `stripe`).
+
+These were redundant with adapter-level tests and violated the “fakes over mocks” rule for our own code.
 
 ## Resolution
 
@@ -56,7 +59,7 @@ Can you pass it through a constructor?
 
 ## Verification
 
-- [x] Deleted `lib/auth.test.ts` (vi.mock anti-pattern)
-- [x] Deleted `lib/container.test.ts` (vi.mock anti-pattern)
-- [x] Reviewed remaining vi.mock() usage — only external SDKs (Clerk, Next.js)
+- [x] Deleted `lib/auth.test.ts` (module-level mocking anti-pattern)
+- [x] Deleted the original `lib/container.test.ts` (module-level mocking anti-pattern)
+- [x] Reviewed remaining `vi.mock()` usage — only external/uninjectable modules (Clerk hooks, Next.js internals, Stripe SDK, `server-only`)
 - [x] Repository tests use fakes via DI — pattern is correct

--- a/docs/specs/spec-001-domain-entities.md
+++ b/docs/specs/spec-001-domain-entities.md
@@ -217,6 +217,6 @@ pnpm typecheck
 
 ## Definition of Done
 
-- [ ] All entity types defined as readonly
-- [ ] Zero external imports (only value-objects from same layer)
-- [ ] Barrel export in index.ts
+- [x] All entity types defined as readonly
+- [x] Zero external imports (only value-objects from same layer)
+- [x] Barrel export in index.ts

--- a/docs/specs/spec-002-value-objects.md
+++ b/docs/specs/spec-002-value-objects.md
@@ -498,8 +498,8 @@ pnpm test --run src/domain/value-objects/
 
 ## Definition of Done
 
-- [ ] All value objects defined with const arrays
-- [ ] Type guards for runtime validation
-- [ ] Business logic functions (isEntitledStatus, shouldShowExplanationForMode)
-- [ ] Zero external dependencies
-- [ ] All tests pass
+- [x] All value objects defined with const arrays
+- [x] Type guards for runtime validation
+- [x] Business logic functions (isEntitledStatus, shouldShowExplanationForMode)
+- [x] Zero external dependencies
+- [x] All tests pass

--- a/docs/specs/spec-003-domain-services.md
+++ b/docs/specs/spec-003-domain-services.md
@@ -543,8 +543,8 @@ pnpm test src/domain/services/
 
 ## Definition of Done
 
-- [ ] All services are pure functions (no side effects)
-- [ ] Zero external dependencies (only domain layer imports)
-- [ ] 100% test coverage
-- [ ] All tests pass without mocks
-- [ ] Barrel export in index.ts
+- [x] All services are pure functions (no side effects)
+- [x] Zero external dependencies (only domain layer imports)
+- [x] 100% test coverage
+- [x] All tests pass without mocks
+- [x] Barrel export in index.ts

--- a/docs/specs/spec-006-drizzle-schema.md
+++ b/docs/specs/spec-006-drizzle-schema.md
@@ -90,7 +90,7 @@ We verify the migration output (not the TypeScript AST) via integration tests:
 
 ## Definition of Done
 
-- [ ] `db/schema.ts` matches `docs/specs/master_spec.md` Section 3
-- [ ] `pnpm db:generate` produces a migration that includes `pgcrypto`
-- [ ] `pnpm db:migrate` applies cleanly on a fresh database
-- [ ] `pnpm test:integration` passes against a migrated Postgres database
+- [x] `db/schema.ts` matches `docs/specs/master_spec.md` Section 3
+- [x] `pnpm db:generate` produces a migration that includes `pgcrypto`
+- [x] `pnpm db:migrate` applies cleanly on a fresh database
+- [x] `pnpm test:integration` passes against a migrated Postgres database


### PR DESCRIPTION
Includes 44921f3:\n- Fixes minor inaccuracies in archived debt docs (DEBT-014/033/035) without changing intent.\n- Marks Definition of Done checklists as completed for implemented specs (SPEC-001/002/003/006).\n\nNo runtime/code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated multiple specification documents' Definition of Done checklists to mark domain entities, value objects, domain services, and Drizzle schema work as completed.
  * Refined technical debt documentation to clarify test mocking anti-patterns and updated repository structure documentation to reflect current architecture.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->