### PR TITLE
Fix build: force dynamic /app routes

### DIFF
--- a/app/(app)/app/layout.test.ts
+++ b/app/(app)/app/layout.test.ts
@@ -19,6 +19,11 @@ function createUser(): UserLike {
 }
 
 describe('app/(app)/app/layout', () => {
+  it('forces dynamic rendering to avoid build-time prerendering auth-gated routes', async () => {
+    const mod = await import('./layout');
+    expect((mod as Record<string, unknown>).dynamic).toBe('force-dynamic');
+  });
+
   it('redirects to /pricing when user is not entitled', async () => {
     const user = createUser();
 

--- a/app/(app)/app/layout.tsx
+++ b/app/(app)/app/layout.tsx
@@ -5,6 +5,9 @@ import { MobileNav } from '@/components/mobile-nav';
 import type { AuthGateway } from '@/src/application/ports/gateways';
 import type { CheckEntitlementUseCase } from '@/src/application/ports/use-cases';
 
+// Auth-gated routes must be dynamic to avoid build-time prerendering.
+export const dynamic = 'force-dynamic';
+
 export type AppLayoutDeps = {
   authGateway: AuthGateway;
   checkEntitlementUseCase: CheckEntitlementUseCase;


### PR DESCRIPTION
Fixes Next.js build failing when auth is skipped (NEXT_PUBLIC_SKIP_CLERK=true) by forcing the /app route group to be dynamic. Adds a regression unit test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * App layout now configured to use dynamic rendering for authenticated routes, preventing static build-time prerendering issues.

* **Tests**
  * Added test to verify dynamic rendering configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->