### PR TITLE
Fix BUG-050: fail on Stripe subscriptions missing metadata.user_id

### DIFF
--- a/docs/_archive/bugs/bug-050-stripe-webhook-missing-user-id-metadata.md
+++ b/docs/_archive/bugs/bug-050-stripe-webhook-missing-user-id-metadata.md
@@ -1,0 +1,47 @@
+# BUG-050: Stripe Webhook Skips Events Missing `metadata.user_id`
+
+**Status:** Resolved
+**Priority:** P1
+**Date:** 2026-02-03
+
+---
+
+## Description
+
+Some Stripe webhook events were treated as “safe to ignore” when the retrieved subscription was missing `metadata.user_id`.
+
+**Expected behavior:** If we cannot map a Stripe subscription to an internal `userId` via `metadata.user_id`, treat this as a processing error so the webhook fails loudly and the `stripe_events.error` field captures the failure for investigation/retry.
+
+**Actual behavior:** For `checkout.session.completed` and `customer.subscription.created`, the gateway logged a warning and returned no `subscriptionUpdate`, causing the webhook controller to mark the event as processed and respond `200` without syncing subscription state.
+
+## Location
+
+- `src/adapters/gateways/stripe-payment-gateway.ts`
+  - `normalizeSubscriptionUpdate()` missing `metadata.user_id` branch
+
+## Root Cause
+
+An earlier mitigation (BUG-041) allowed `customer.subscription.created` events without `metadata.user_id` to be treated as ignorable to avoid noisy Stripe retries. That exception also covered `checkout.session.completed`, which can represent a paid checkout completion where silently skipping is unacceptable.
+
+## Impact
+
+- **Silent subscription desync:** The system can fail to upsert `stripe_subscriptions` for some Stripe events.
+- **Entitlement risk:** If checkout success eager-sync does not run (user closes tab), a paying user can remain unentitled due to missing DB state.
+- **Poor observability:** The `stripe_events` row is marked processed with `error = null`, hiding the failure from DB-based monitoring.
+
+## Fix
+
+- Remove the “skip” behavior when `metadata.user_id` is missing.
+- Log an error with event/subscription/customer identifiers.
+- Throw `ApplicationError('STRIPE_ERROR')` so the webhook controller marks the event as failed and the webhook responds with a non-2xx status.
+
+## Verification
+
+- [x] Unit test: `customer.subscription.created` without `metadata.user_id` throws `STRIPE_ERROR` and logs `logger.error`.
+- [x] Unit test: `checkout.session.completed` subscription without `metadata.user_id` throws `STRIPE_ERROR` and logs `logger.error`.
+- [x] Unit test: `customer.subscription.deleted` normalization covered.
+
+## Related
+
+- `docs/_archive/bugs/bug-041-webhook-subscription-created-missing-metadata.md`
+- `docs/specs/spec-009-payment-gateway.md` — “do not silently ignore” required fields

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -17,7 +17,7 @@ Bug reports document issues discovered in the codebase along with their root cau
 
 ✅ No active bugs.
 
-**Next Bug ID:** BUG-050
+**Next Bug ID:** BUG-051
 
 ## Foundation Audit
 
@@ -28,6 +28,7 @@ See: [Foundation Audit Report](foundation-audit-report.md)
 
 | ID | Title | Priority | Resolved |
 |----|-------|----------|----------|
+| [BUG-050](../_archive/bugs/bug-050-stripe-webhook-missing-user-id-metadata.md) | Stripe Webhook Skips Events Missing `metadata.user_id` | P1 | 2026-02-03 |
 | [BUG-049](../_archive/bugs/bug-049-silent-pruning-failures-stripe-webhook.md) | Silent Pruning Failures in Stripe Webhook Controller | P3 | 2026-02-03 |
 | [BUG-048](../_archive/bugs/bug-048-webhook-rate-limiter-fails-open.md) | Webhook Rate Limiter Failures Fail Open | P2 | 2026-02-03 |
 | [BUG-047](../_archive/bugs/bug-047-multiple-subscriptions-per-user.md) | Multiple Subscriptions Created Per User | P1 | 2026-02-02 |

--- a/src/adapters/gateways/stripe-payment-gateway.ts
+++ b/src/adapters/gateways/stripe-payment-gateway.ts
@@ -271,26 +271,15 @@ export class StripePaymentGateway implements PaymentGateway {
     const { subscription } = input;
     const userId = subscription.metadata?.user_id;
     if (!userId) {
-      if (
-        input.type === 'customer.subscription.created' ||
-        input.type === 'checkout.session.completed'
-      ) {
-        const message =
-          input.type === 'customer.subscription.created'
-            ? 'Skipping subscription.created event without metadata.user_id'
-            : 'Skipping checkout.session.completed event without metadata.user_id';
-
-        this.deps.logger.warn(
-          {
-            eventId: input.eventId,
-            stripeSubscriptionId: subscription.id ?? null,
-            stripeCustomerId: subscription.customer ?? null,
-          },
-          message,
-        );
-        return null;
-      }
-
+      this.deps.logger.error(
+        {
+          eventId: input.eventId,
+          type: input.type,
+          stripeSubscriptionId: subscription.id,
+          stripeCustomerId: subscription.customer,
+        },
+        'Stripe subscription metadata.user_id is required',
+      );
       throw new ApplicationError(
         'STRIPE_ERROR',
         'Stripe subscription metadata.user_id is required',


### PR DESCRIPTION
## Summary
- Prevents silently skipping Stripe webhook events when subscription `metadata.user_id` is missing.
- Adds unit coverage for `customer.subscription.deleted` normalization.
- Archives BUG-050 documentation and updates bug index.

## Verification
- pnpm typecheck
- pnpm test --run
- pnpm lint
- pnpm build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Stripe webhook event processing to properly detect and report missing user metadata errors, preventing silent subscription synchronization failures and improving error observability.

* **Tests**
  * Enhanced test coverage for multiple Stripe webhook event types to verify proper error handling and logging when metadata is missing.

* **Documentation**
  * Added comprehensive documentation for the resolved Stripe webhook issue in the bug registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->