### PR TITLE
Merge dev to main (BUG-053)

### DIFF
--- a/app/(marketing)/checkout/success/page.test.ts
+++ b/app/(marketing)/checkout/success/page.test.ts
@@ -201,6 +201,18 @@ describe('syncCheckoutSuccess', () => {
       subscription: null,
     },
     {
+      reason: 'missing_user_id',
+      input: { sessionId: 'cs_test' },
+      session: { customer: 'cus_123', subscription: 'sub_123' },
+      subscription: { metadata: {} },
+    },
+    {
+      reason: 'missing_user_id',
+      input: { sessionId: 'cs_test' },
+      session: { customer: 'cus_123', subscription: 'sub_123' },
+      subscription: { metadata: { user_id: '' } },
+    },
+    {
       reason: 'user_id_mismatch',
       input: { sessionId: 'cs_test' },
       session: { customer: 'cus_123', subscription: 'sub_123' },

--- a/app/(marketing)/checkout/success/page.tsx
+++ b/app/(marketing)/checkout/success/page.tsx
@@ -285,8 +285,12 @@ export async function syncCheckoutSuccess(
   );
 
   const metadataUserId = subscription.metadata?.user_id;
+  assertNonEmptyString(metadataUserId, 'missing_user_id', {
+    sessionId,
+    metadataUserId: metadataUserId ?? null,
+  });
   // Prevent cross-account leakage if the user switches accounts mid-checkout.
-  if (metadataUserId && metadataUserId !== user.id) {
+  if (metadataUserId !== user.id) {
     fail('user_id_mismatch', {
       sessionId,
       metadataUserId,

--- a/docs/_archive/bugs/bug-053-checkout-success-missing-user-id-metadata.md
+++ b/docs/_archive/bugs/bug-053-checkout-success-missing-user-id-metadata.md
@@ -1,0 +1,38 @@
+# BUG-053: Checkout Success Accepts Missing `metadata.user_id`
+
+**Status:** Resolved
+**Priority:** P1
+**Date:** 2026-02-03
+**Resolved:** 2026-02-03
+
+---
+
+## Summary
+
+The checkout success page could accept Stripe subscriptions with missing/empty `metadata.user_id` and still upsert the subscription row for the currently authenticated user.
+
+This violated the paywall SSOT requirement that **internal user identity mapping comes from Stripe metadata** and weakened defense-in-depth against cross-account attribution.
+
+## Root Cause
+
+`syncCheckoutSuccess()` only rejected mismatched `metadata.user_id` when the value was truthy:
+
+- Missing `metadata.user_id` (or `''`) bypassed the mismatch check
+- The code proceeded to upsert the subscription for the authenticated user
+
+## Fix
+
+1. Require `subscription.metadata.user_id` to be a **non-empty string**
+2. Require it to **match** the authenticated `user.id`
+3. Add a regression test for the new validation reason `missing_user_id`
+
+## Verification
+
+- [x] Unit test added: `app/(marketing)/checkout/success/page.test.ts`
+- [ ] Manual: complete checkout and confirm subscription is persisted and entitlement works
+
+## Related
+
+- SSOT: `docs/specs/spec-011-paywall.md` (“User identity mapping”)
+- `app/(marketing)/checkout/success/page.tsx` — `syncCheckoutSuccess()`
+

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -17,7 +17,7 @@ Bug reports document issues discovered in the codebase along with their root cau
 
 ✅ No active bugs.
 
-**Next Bug ID:** BUG-053
+**Next Bug ID:** BUG-054
 
 ## Foundation Audit
 
@@ -28,6 +28,7 @@ See: [Foundation Audit Report](foundation-audit-report.md)
 
 | ID | Title | Priority | Resolved |
 |----|-------|----------|----------|
+| [BUG-053](../_archive/bugs/bug-053-checkout-success-missing-user-id-metadata.md) | Checkout Success Accepts Missing `metadata.user_id` | P1 | 2026-02-03 |
 | [BUG-052](../_archive/bugs/bug-052-non-entitled-subscriptions-could-start-new-checkout.md) | Non-Entitled Subscriptions Could Start New Checkout Sessions | P1 | 2026-02-03 |
 | [BUG-051](../_archive/bugs/bug-051-checkout-success-redirects-with-non-entitled-status.md) | Checkout Success Redirects with Non-Entitled Status | P1 | 2026-02-03 |
 | [BUG-050](../_archive/bugs/bug-050-stripe-webhook-missing-user-id-metadata.md) | Stripe Webhook Skips Events Missing `metadata.user_id` | P1 | 2026-02-03 |


### PR DESCRIPTION
Promotes BUG-053 fix (checkout success requires Stripe metadata.user_id) from dev to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a validation issue in the checkout success process to properly verify user identity metadata matches the authenticated user, preventing potential cross-account data inconsistencies.

* **Tests**
  * Added test cases to validate proper handling of missing or empty user identity information during checkout success flows.

* **Documentation**
  * Added bug report documentation for the resolved validation issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->