### PR TITLE
Stabilize error boundary tests

### DIFF
--- a/app/(app)/app/billing/error.test.tsx
+++ b/app/(app)/app/billing/error.test.tsx
@@ -18,5 +18,5 @@ describe('app/(app)/app/billing/error', () => {
     expect(html).toContain('Error ID');
     expect(html).toContain('digest_123');
     expect(html).toContain('focus-visible:ring-[3px]');
-  });
+  }, 10_000);
 });

--- a/app/(app)/app/dashboard/error.test.tsx
+++ b/app/(app)/app/dashboard/error.test.tsx
@@ -18,5 +18,5 @@ describe('app/(app)/app/dashboard/error', () => {
     expect(html).toContain('Error ID');
     expect(html).toContain('digest_123');
     expect(html).toContain('focus-visible:ring-[3px]');
-  });
+  }, 10_000);
 });

--- a/app/(app)/app/practice/error.test.tsx
+++ b/app/(app)/app/practice/error.test.tsx
@@ -18,5 +18,5 @@ describe('app/(app)/app/practice/error', () => {
     expect(html).toContain('Error ID');
     expect(html).toContain('digest_123');
     expect(html).toContain('focus-visible:ring-[3px]');
-  });
+  }, 10_000);
 });

--- a/app/error.test.tsx
+++ b/app/error.test.tsx
@@ -17,5 +17,5 @@ describe('app/error', () => {
     expect(html).toContain('Error ID');
     expect(html).toContain('digest_123');
     expect(html).toContain('focus-visible:ring-[3px]');
-  });
+  }, 10_000);
 });

--- a/app/global-error.test.tsx
+++ b/app/global-error.test.tsx
@@ -18,5 +18,5 @@ describe('app/global-error', () => {
     expect(html).toContain('digest_123');
     expect(html).toContain('focus-visible:ring-[3px]');
     expect(html).toContain('<html');
-  });
+  }, 10_000);
 });


### PR DESCRIPTION
Increase timeout on error-boundary render tests to avoid cold-transform flakiness in CI/pre-push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased timeouts for error boundary test cases to improve test reliability and reduce potential flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->