### PR TITLE
Add App Router loading skeletons

### DIFF
--- a/app/(app)/app/billing/loading.tsx
+++ b/app/(app)/app/billing/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoading } from '@/components/loading/page-loading';
+
+export default function Loading() {
+  return <PageLoading label="Loading billing" cardCount={2} />;
+}

--- a/app/(app)/app/bookmarks/loading.tsx
+++ b/app/(app)/app/bookmarks/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoading } from '@/components/loading/page-loading';
+
+export default function Loading() {
+  return <PageLoading label="Loading bookmarks" cardCount={6} />;
+}

--- a/app/(app)/app/dashboard/loading.tsx
+++ b/app/(app)/app/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoading } from '@/components/loading/page-loading';
+
+export default function Loading() {
+  return <PageLoading label="Loading dashboard" cardCount={6} />;
+}

--- a/app/(app)/app/loading-pages.test.tsx
+++ b/app/(app)/app/loading-pages.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+describe('App route loading UIs', () => {
+  it('renders dashboard loading UI', async () => {
+    const Loading = (await import('./dashboard/loading')).default;
+    const html = renderToStaticMarkup(<Loading />);
+    expect(html).toContain('Loading dashboard');
+  });
+
+  it('renders practice loading UI', async () => {
+    const Loading = (await import('./practice/loading')).default;
+    const html = renderToStaticMarkup(<Loading />);
+    expect(html).toContain('Loading practice');
+  });
+
+  it('renders practice session loading UI', async () => {
+    const Loading = (await import('./practice/[sessionId]/loading')).default;
+    const html = renderToStaticMarkup(<Loading />);
+    expect(html).toContain('Loading practice session');
+  });
+
+  it('renders review loading UI', async () => {
+    const Loading = (await import('./review/loading')).default;
+    const html = renderToStaticMarkup(<Loading />);
+    expect(html).toContain('Loading review');
+  });
+
+  it('renders bookmarks loading UI', async () => {
+    const Loading = (await import('./bookmarks/loading')).default;
+    const html = renderToStaticMarkup(<Loading />);
+    expect(html).toContain('Loading bookmarks');
+  });
+
+  it('renders billing loading UI', async () => {
+    const Loading = (await import('./billing/loading')).default;
+    const html = renderToStaticMarkup(<Loading />);
+    expect(html).toContain('Loading billing');
+  });
+
+  it('renders question loading UI', async () => {
+    const Loading = (await import('./questions/[slug]/loading')).default;
+    const html = renderToStaticMarkup(<Loading />);
+    expect(html).toContain('Loading question');
+  });
+});

--- a/app/(app)/app/practice/[sessionId]/loading.tsx
+++ b/app/(app)/app/practice/[sessionId]/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoading } from '@/components/loading/page-loading';
+
+export default function Loading() {
+  return <PageLoading label="Loading practice session" cardCount={1} />;
+}

--- a/app/(app)/app/practice/loading.tsx
+++ b/app/(app)/app/practice/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoading } from '@/components/loading/page-loading';
+
+export default function Loading() {
+  return <PageLoading label="Loading practice" cardCount={3} />;
+}

--- a/app/(app)/app/questions/[slug]/loading.tsx
+++ b/app/(app)/app/questions/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoading } from '@/components/loading/page-loading';
+
+export default function Loading() {
+  return <PageLoading label="Loading question" cardCount={1} />;
+}

--- a/app/(app)/app/review/loading.tsx
+++ b/app/(app)/app/review/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoading } from '@/components/loading/page-loading';
+
+export default function Loading() {
+  return <PageLoading label="Loading review" cardCount={6} />;
+}

--- a/components/loading/page-loading.tsx
+++ b/components/loading/page-loading.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/lib/utils';
+
+type PageLoadingProps = {
+  label: string;
+  cardCount?: number;
+  className?: string;
+};
+
+export function PageLoading({
+  label,
+  cardCount = 3,
+  className,
+}: PageLoadingProps) {
+  const cardKeys = Array.from(
+    { length: cardCount },
+    (_, index) => `skeleton-card-${index}`,
+  );
+
+  return (
+    <div
+      aria-busy="true"
+      aria-live="polite"
+      className={cn('animate-pulse space-y-6', className)}
+    >
+      <p className="sr-only">{label}</p>
+
+      <div className="h-8 w-48 rounded-md bg-background" />
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {cardKeys.map((key) => (
+          <div
+            key={key}
+            className="space-y-4 rounded-xl border border-border bg-background p-6"
+          >
+            <div className="space-y-3">
+              <div className="h-4 w-1/2 rounded bg-muted" />
+              <div className="h-4 w-5/6 rounded bg-muted" />
+              <div className="h-4 w-2/3 rounded bg-muted" />
+            </div>
+            <div className="h-10 w-32 rounded-md bg-muted" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds minimal `loading.tsx` skeletons to prevent blank screens during App Router data fetch/suspense.

- Adds shared `PageLoading` skeleton component
- Adds `loading.tsx` for dashboard, practice, practice session, review, bookmarks, billing, and question detail routes
- Adds render-output tests for all loading UIs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated loading screens with skeleton UI across multiple pages (dashboard, practice, bookmarks, billing, review, and questions)
  * Improved visual feedback during content loading with consistent, accessible loading indicators

* **Tests**
  * Added automated tests for loading screens across all routes to ensure consistent user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->