### PR TITLE
Resolve DEBT-230: Decompose seed.ts into focused modules

### DIFF
--- a/docs/_archive/debt/debt-230-decompose-seed-script-into-modules.md
+++ b/docs/_archive/debt/debt-230-decompose-seed-script-into-modules.md
@@ -1,23 +1,24 @@
 # DEBT-230: Decompose seed.ts Into Focused Modules
 
-**Status:** Open
+**Status:** Resolved
 **Priority:** P4
 **Date:** 2026-02-18
-**Last Verified:** 2026-02-18
-**Parent:** [DEBT-224](debt-224-file-size-audit-production-and-test.md)
+**Resolved:** 2026-02-19
+**Last Verified:** 2026-02-19
+**Parent:** [DEBT-224](../../debt/debt-224-file-size-audit-production-and-test.md)
 **Component:** `scripts/seed.ts`
 
 ---
 
 ## Description
 
-`scripts/seed.ts` has grown to **484 lines** (up from 412 at audit time, +72 lines). It mixes five distinct concerns:
+`scripts/seed.ts` was reduced from **486 lines** to **58 lines** by extracting focused modules for each stage in the seed pipeline.
 
 1. **File I/O** — glob pattern matching, reading MDX files from disk
 2. **Markdown parsing** — frontmatter extraction, content validation
 3. **Tag management** — canonical tag upsertion and validation
 4. **Question sync** — diff computation, upsert/delete orchestration
-5. **Placeholder archival** — moving placeholder files
+5. **Placeholder archival** — archiving placeholder rows in the database
 
 **Disposition:** B - Multiple responsibilities should be split.
 
@@ -35,17 +36,17 @@
 
 ## Resolution
 
-Extract stages into focused modules:
+Resolved by extracting stages into focused modules:
 
 ```
 scripts/
-  seed.ts                     (~80 lines — orchestrator, CLI entry point)
+  seed.ts                     (58 lines — orchestrator, CLI entry point)
   seed/
-    file-reader.ts            (~60 lines — glob + MDX file reading)
-    question-parser.ts        (~80 lines — frontmatter + content parsing)
-    tag-manager.ts            (~50 lines — tag upsertion logic)
-    question-syncer.ts        (~120 lines — diff + upsert orchestration)
-    placeholder-archiver.ts   (~30 lines — placeholder file management)
+    file-reader.ts            (45 lines — glob + MDX file reading)
+    question-parser.ts        (115 lines — frontmatter + content parsing)
+    tag-manager.ts            (114 lines — tag upsertion + tag validation)
+    question-syncer.ts        (212 lines — diff + upsert orchestration)
+    placeholder-archiver.ts   (18 lines — placeholder archival)
 ```
 
 Keep `seed.ts` as the thin orchestrator calling each stage in sequence.
@@ -54,12 +55,12 @@ Guardrail: reuse existing `scripts/seed-helpers.ts` where appropriate instead of
 
 ## Verification
 
-- [ ] Each stage extracted to its own module
-- [ ] `seed.ts` orchestrates stages in sequence
+- [x] Each stage extracted to its own module
+- [x] `seed.ts` orchestrates stages in sequence
 - [ ] `pnpm seed` still works end-to-end against local DB
-- [ ] Existing `scripts/seed.test.ts` passes (or is updated to test individual modules)
-- [ ] `pnpm typecheck` passes
+- [x] Existing `scripts/seed.test.ts` passes (updated to import from `seed/tag-manager`)
+- [x] `pnpm typecheck` passes
 
 ## Related
 
-- [DEBT-224](debt-224-file-size-audit-production-and-test.md) - Parent file-size audit
+- [DEBT-224](../../debt/debt-224-file-size-audit-production-and-test.md) - Parent file-size audit

--- a/docs/debt/debt-224-file-size-audit-production-and-test.md
+++ b/docs/debt/debt-224-file-size-audit-production-and-test.md
@@ -4,7 +4,7 @@
 **Priority:** P3
 **Date:** 2026-02-16
 **Decomposed:** 2026-02-18
-**Last Verified:** 2026-02-18
+**Last Verified:** 2026-02-19
 **Component:** Codebase-wide
 
 ---
@@ -18,7 +18,7 @@ This audit has been decomposed into 8 child debt tickets. The table below is tit
 | [DEBT-227](debt-227-split-fake-repositories-into-individual-files.md) | Split fake-repositories.ts Into Individual Files | P3 | B - Split |
 | [DEBT-228](../_archive/debt/debt-228-dry-fake-use-cases-with-generic-base.md) | DRY fake-use-cases.ts With Generic Base Class | P4 | C - DRY (Resolved) |
 | [DEBT-229](../_archive/debt/debt-229-extract-bookmarks-server-action-and-errors.md) | Extract Server Action and Error Handling From bookmarks/page.tsx | P3 | B - Split (Resolved) |
-| [DEBT-230](debt-230-decompose-seed-script-into-modules.md) | Decompose seed.ts Into Focused Modules | P4 | B - Split |
+| [DEBT-230](../_archive/debt/debt-230-decompose-seed-script-into-modules.md) | Decompose seed.ts Into Focused Modules | P4 | B - Split (Resolved) |
 | [DEBT-231](../_archive/debt/debt-231-reduce-browser-spec-probe-duplication.md) | Reduce Browser Spec Probe Component Duplication | P3 | Test bloat (Resolved) |
 | [DEBT-232](../_archive/debt/debt-232-reduce-get-next-question-test-inflation.md) | Reduce get-next-question.test.ts Test Inflation | P3 | Test bloat (Resolved) |
 | [DEBT-233](../_archive/debt/debt-233-add-why-comments-to-justified-large-files.md) | Add WHY Comments to Justified Large Files | P4 | A - Document (Resolved) |
@@ -71,7 +71,7 @@ These tests are large but currently justified by scenario/domain breadth. Monito
 | 1 | `src/application/test-helpers/fakes/fake-repositories.ts` | 1,127 | [DEBT-227](debt-227-split-fake-repositories-into-individual-files.md) | Split into per-fake files |
 | 2 | `scripts/migrate-tag-taxonomy.ts` | 591 | Residual (new debt ticket needed) | Large migration script, currently un-decomposed |
 | 3 | `db/schema.ts` | 548 | [DEBT-233](../_archive/debt/debt-233-add-why-comments-to-justified-large-files.md) | Deep module; document WHY |
-| 4 | `scripts/seed.ts` | 484 | [DEBT-230](debt-230-decompose-seed-script-into-modules.md) | Script decomposition candidate |
+| 4 | `scripts/seed.ts` | 484 | [DEBT-230](../_archive/debt/debt-230-decompose-seed-script-into-modules.md) | Script decomposition candidate (Resolved) |
 | 5 | `src/adapters/repositories/drizzle-attempt-repository.ts` | 438 | [DEBT-233](../_archive/debt/debt-233-add-why-comments-to-justified-large-files.md) | Deep module; document WHY |
 | 6 | `app/(app)/app/history/components/history-questions-tab.tsx` | 393 | [DEBT-233](../_archive/debt/debt-233-add-why-comments-to-justified-large-files.md) | Deep module; document WHY |
 | 7 | `app/(app)/app/questions/[slug]/question-page-client.tsx` | 331 | [DEBT-233](../_archive/debt/debt-233-add-why-comments-to-justified-large-files.md) | Deep module; document WHY |

--- a/docs/debt/index.md
+++ b/docs/debt/index.md
@@ -18,7 +18,6 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 | ID | Title | Priority | Status |
 |----|-------|----------|--------|
 | [DEBT-224](debt-224-file-size-audit-production-and-test.md) | File Size Audit - Production and Test Files Exceeding Guidelines | P3 | Decomposed |
-| [DEBT-230](debt-230-decompose-seed-script-into-modules.md) | Decompose seed.ts Into Focused Modules | P4 | Open |
 
 **Next Debt ID:** DEBT-235
 
@@ -33,6 +32,7 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 | [DEBT-232](../_archive/debt/debt-232-reduce-get-next-question-test-inflation.md) | Reduce get-next-question.test.ts Test Inflation | P3 | 2026-02-18 | — |
 | [DEBT-229](../_archive/debt/debt-229-extract-bookmarks-server-action-and-errors.md) | Extract Server Action and Error Handling From bookmarks/page.tsx | P3 | 2026-02-19 | — |
 | [DEBT-231](../_archive/debt/debt-231-reduce-browser-spec-probe-duplication.md) | Reduce Browser Spec Probe Component Duplication | P3 | 2026-02-19 | — |
+| [DEBT-230](../_archive/debt/debt-230-decompose-seed-script-into-modules.md) | Decompose seed.ts Into Focused Modules | P4 | 2026-02-19 | — |
 | [DEBT-228](../_archive/debt/debt-228-dry-fake-use-cases-with-generic-base.md) | DRY fake-use-cases.ts With Generic Base Class | P4 | 2026-02-18 | — |
 | [DEBT-227](../_archive/debt/debt-227-split-fake-repositories-into-individual-files.md) | Split fake-repositories.ts Into Individual Files | P3 | 2026-02-19 | — |
 | [DEBT-226](../_archive/debt/debt-226-playwright-e2e-timeout-and-import-convention.md) | Playwright E2E Timeout Policy and Import Convention Are Undocumented | P3 | 2026-02-18 | — |

--- a/scripts/seed.test.ts
+++ b/scripts/seed.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { validateSeedQuestionTags } from './seed';
+import { validateSeedQuestionTags } from './seed/tag-manager';
 
 describe('validateSeedQuestionTags', () => {
   it('rejects domain tags before minimum tag count checks', () => {

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,233 +1,17 @@
-import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import dotenv from 'dotenv';
-import { and, eq, inArray, like } from 'drizzle-orm';
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { drizzle } from 'drizzle-orm/postgres-js';
-import fg from 'fast-glob';
-import matter from 'gray-matter';
 import postgres from 'postgres';
 import * as schema from '../db/schema';
-import {
-  CANONICAL_SUBSTANCE_SLUGS,
-  CANONICAL_TOPIC_SLUGS,
-  CANONICAL_TREATMENT_SLUGS,
-} from '../lib/content/draftTaxonomy';
-import {
-  canonicalizeMarkdown,
-  canonicalJsonString,
-  parseMdxQuestionBody,
-  sha256Hex,
-} from '../lib/content/parseMdxQuestion';
-import {
-  FullQuestionSchema,
-  QuestionFrontmatterSchema,
-} from '../lib/content/schemas';
-import { computeChoiceSyncPlan, parseChoiceExplanations } from './seed-helpers';
-
-type SeedTag = {
-  slug: string;
-  name: string;
-  kind: schema.TagKind;
-};
+import { readSeedQuestionFiles } from './seed/file-reader';
+import { archivePlaceholderQuestions } from './seed/placeholder-archiver';
+import { syncQuestionsFromFiles } from './seed/question-syncer';
 
 dotenv.config({ path: '.env.local' });
 dotenv.config({ path: '.env' });
 
-type SeedChoice = {
-  label: string;
-  text_md: string;
-  is_correct: boolean;
-  explanation_md: string | null;
-  sort_order: number;
-};
-
-type SeedQuestionRep = {
-  slug: string;
-  stem_md: string;
-  explanation_md: string;
-  difficulty: schema.QuestionDifficulty;
-  status: schema.QuestionStatus;
-  choices: SeedChoice[];
-  tags: SeedTag[];
-};
-
-const CANONICAL_TOPIC_SLUG_SET = new Set<string>(CANONICAL_TOPIC_SLUGS);
-const CANONICAL_SUBSTANCE_SLUG_SET = new Set<string>(CANONICAL_SUBSTANCE_SLUGS);
-const CANONICAL_TREATMENT_SLUG_SET = new Set<string>(CANONICAL_TREATMENT_SLUGS);
-
-function buildSeedRepFromFile(full: unknown): SeedQuestionRep {
-  const parsed = FullQuestionSchema.parse(full);
-  const parsedExplanations = parseChoiceExplanations(parsed.explanationMd);
-  const generalExplanation = parsedExplanations.generalExplanation;
-
-  const sortedTags = [...parsed.frontmatter.tags].sort((a, b) =>
-    a.slug.localeCompare(b.slug),
-  );
-  const sortedChoices = [...parsed.frontmatter.choices].sort((a, b) =>
-    a.label.localeCompare(b.label),
-  );
-  const validLabels = new Set(sortedChoices.map((choice) => choice.label));
-  for (const label of parsedExplanations.perChoice.keys()) {
-    if (!validLabels.has(label)) {
-      throw new Error(
-        `Explanation references choice label "${label}" that is not present in choices for slug "${parsed.frontmatter.slug}"`,
-      );
-    }
-  }
-
-  return {
-    slug: parsed.frontmatter.slug,
-    stem_md: canonicalizeMarkdown(parsed.stemMd),
-    explanation_md: generalExplanation,
-    difficulty: parsed.frontmatter.difficulty,
-    status: parsed.frontmatter.status,
-    tags: sortedTags.map((t) => ({
-      slug: t.slug,
-      name: t.name,
-      kind: t.kind,
-    })),
-    choices: sortedChoices.map((c, index) => ({
-      label: c.label,
-      text_md: canonicalizeMarkdown(c.text),
-      is_correct: c.correct,
-      explanation_md: parsedExplanations.perChoice.get(c.label) ?? null,
-      sort_order: index + 1,
-    })),
-  };
-}
-
-function buildSeedRepFromDb(
-  question: schema.Question,
-  choices: schema.Choice[],
-  tags: SeedTag[],
-): SeedQuestionRep {
-  return {
-    slug: question.slug,
-    stem_md: canonicalizeMarkdown(question.stemMd),
-    explanation_md: canonicalizeMarkdown(question.explanationMd),
-    difficulty: question.difficulty,
-    status: question.status,
-    choices: [...choices]
-      .sort((a, b) => a.sortOrder - b.sortOrder)
-      .map((c) => ({
-        label: c.label,
-        text_md: canonicalizeMarkdown(c.textMd),
-        is_correct: c.isCorrect,
-        explanation_md: c.explanationMd
-          ? canonicalizeMarkdown(c.explanationMd)
-          : null,
-        sort_order: c.sortOrder,
-      })),
-    tags: [...tags].sort((a, b) => a.slug.localeCompare(b.slug)),
-  };
-}
-
-async function upsertTags(
-  tx: PostgresJsDatabase<typeof schema>,
-  incomingTags: SeedTag[],
-): Promise<Map<string, { id: string } & SeedTag>> {
-  const tagSlugs = incomingTags.map((t) => t.slug);
-
-  const existing = tagSlugs.length
-    ? await tx
-        .select()
-        .from(schema.tags)
-        .where(inArray(schema.tags.slug, tagSlugs))
-    : [];
-
-  const bySlug = new Map(existing.map((t) => [t.slug, t]));
-
-  for (const tag of incomingTags) {
-    const found = bySlug.get(tag.slug);
-    if (found) {
-      if (found.name !== tag.name || found.kind !== tag.kind) {
-        throw new Error(
-          `Tag slug "${tag.slug}" already exists but differs (expected name="${tag.name}", kind="${tag.kind}"; got name="${found.name}", kind="${found.kind}")`,
-        );
-      }
-      continue;
-    }
-
-    const [inserted] = await tx
-      .insert(schema.tags)
-      .values({
-        slug: tag.slug,
-        name: tag.name,
-        kind: tag.kind,
-      })
-      .returning();
-
-    if (!inserted) {
-      throw new Error(`Failed to insert tag slug "${tag.slug}"`);
-    }
-
-    bySlug.set(inserted.slug, inserted);
-  }
-
-  return bySlug;
-}
-
-function parseFrontmatterOrThrow(data: unknown) {
-  return QuestionFrontmatterSchema.parse(data);
-}
-
-export function validateSeedQuestionTags(input: {
-  slug: string;
-  tags: Array<Omit<SeedTag, 'kind'> & { kind: SeedTag['kind'] | 'domain' }>;
-}): void {
-  for (const tag of input.tags) {
-    if (tag.kind === 'domain') {
-      throw new Error(
-        `Question "${input.slug}" has domain tag "${tag.slug}" which is not allowed`,
-      );
-    }
-  }
-
-  const topicCount = input.tags.filter((tag) => tag.kind === 'topic').length;
-  const substanceCount = input.tags.filter(
-    (tag) => tag.kind === 'substance',
-  ).length;
-
-  if (topicCount < 1) {
-    throw new Error(
-      `Question "${input.slug}" must have at least one topic tag`,
-    );
-  }
-  if (substanceCount < 1) {
-    throw new Error(
-      `Question "${input.slug}" must have at least one substance tag`,
-    );
-  }
-
-  for (const tag of input.tags) {
-    if (tag.kind === 'topic' && !CANONICAL_TOPIC_SLUG_SET.has(tag.slug)) {
-      throw new Error(
-        `Question "${input.slug}" has non-canonical topic slug "${tag.slug}"`,
-      );
-    }
-
-    if (
-      tag.kind === 'substance' &&
-      !CANONICAL_SUBSTANCE_SLUG_SET.has(tag.slug)
-    ) {
-      throw new Error(
-        `Question "${input.slug}" has non-canonical substance slug "${tag.slug}"`,
-      );
-    }
-
-    if (
-      tag.kind === 'treatment' &&
-      !CANONICAL_TREATMENT_SLUG_SET.has(tag.slug)
-    ) {
-      throw new Error(
-        `Question "${input.slug}" has non-canonical treatment slug "${tag.slug}"`,
-      );
-    }
-  }
-}
-
-async function main(): Promise<void> {
+export async function runSeed(): Promise<void> {
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
     throw new Error(
@@ -235,244 +19,23 @@ async function main(): Promise<void> {
     );
   }
 
+  const includePlaceholders = process.env.SEED_INCLUDE_PLACEHOLDERS === 'true';
   const sql = postgres(databaseUrl, { max: 1 });
   const db = drizzle(sql, { schema });
+
   try {
-    const includePlaceholders =
-      process.env.SEED_INCLUDE_PLACEHOLDERS === 'true';
-    const patterns = includePlaceholders
-      ? ['content/questions/**/*.mdx']
-      : [
-          'content/questions/**/*.mdx',
-          '!content/questions/placeholder/**/*.mdx',
-        ];
-
-    const files = await fg(patterns, {
-      onlyFiles: true,
-      unique: true,
-      absolute: true,
-      dot: false,
-    });
-
-    if (files.length === 0) {
-      throw new Error(
-        includePlaceholders
-          ? 'No question files found at content/questions/**/*.mdx. Seed requires at least one MDX file.'
-          : 'No question files found after excluding placeholders. Re-run with SEED_INCLUDE_PLACEHOLDERS=true or generate imported content under content/questions/imported/.',
-      );
-    }
-
-    let inserted = 0;
-    let updated = 0;
-    let skipped = 0;
-
-    for (const file of files) {
-      const raw = await readFile(file, 'utf8');
-      const { data, content } = matter(raw);
-
-      const frontmatter = parseFrontmatterOrThrow(data);
-      const { stemMd, explanationMd } = parseMdxQuestionBody(content);
-
-      const seedFromFile = buildSeedRepFromFile({
-        frontmatter,
-        stemMd,
-        explanationMd,
-      });
-      validateSeedQuestionTags({
-        slug: seedFromFile.slug,
-        tags: seedFromFile.tags,
-      });
-
-      const fileHash = sha256Hex(canonicalJsonString(seedFromFile));
-
-      const existing = await db
-        .select()
-        .from(schema.questions)
-        .where(eq(schema.questions.slug, seedFromFile.slug))
-        .limit(1);
-      const existingQuestion = existing.at(0);
-
-      if (!existingQuestion) {
-        await db.transaction(async (tx) => {
-          const [createdQuestion] = await tx
-            .insert(schema.questions)
-            .values({
-              slug: seedFromFile.slug,
-              stemMd: seedFromFile.stem_md,
-              explanationMd: seedFromFile.explanation_md,
-              difficulty: seedFromFile.difficulty,
-              status: seedFromFile.status,
-            })
-            .returning({ id: schema.questions.id });
-
-          if (!createdQuestion) {
-            throw new Error(
-              `Failed to insert question for slug "${seedFromFile.slug}"`,
-            );
-          }
-
-          await tx.insert(schema.choices).values(
-            seedFromFile.choices.map((c) => ({
-              questionId: createdQuestion.id,
-              label: c.label,
-              textMd: c.text_md,
-              isCorrect: c.is_correct,
-              explanationMd: c.explanation_md,
-              sortOrder: c.sort_order,
-            })),
-          );
-
-          const tagMap = await upsertTags(tx, seedFromFile.tags);
-          await tx.insert(schema.questionTags).values(
-            seedFromFile.tags.map((t) => ({
-              questionId: createdQuestion.id,
-              tagId:
-                tagMap.get(t.slug)?.id ??
-                (() => {
-                  throw new Error(`Missing tag id for slug "${t.slug}"`);
-                })(),
-            })),
-          );
-        });
-
-        inserted += 1;
-        continue;
-      }
-
-      const existingChoices = await db
-        .select()
-        .from(schema.choices)
-        .where(eq(schema.choices.questionId, existingQuestion.id));
-
-      const existingTags = await db
-        .select({
-          slug: schema.tags.slug,
-          name: schema.tags.name,
-          kind: schema.tags.kind,
-        })
-        .from(schema.questionTags)
-        .innerJoin(schema.tags, eq(schema.questionTags.tagId, schema.tags.id))
-        .where(eq(schema.questionTags.questionId, existingQuestion.id));
-
-      const seedFromDb = buildSeedRepFromDb(
-        existingQuestion,
-        existingChoices,
-        existingTags,
-      );
-
-      const dbHash = sha256Hex(canonicalJsonString(seedFromDb));
-      if (dbHash === fileHash) {
-        skipped += 1;
-        continue;
-      }
-
-      const desiredLabels = new Set(seedFromFile.choices.map((c) => c.label));
-      const deleteCandidates = existingChoices.filter(
-        (c) => !desiredLabels.has(c.label),
-      );
-
-      const referencedChoiceIds = new Set<string>();
-      if (deleteCandidates.length > 0) {
-        const deleteCandidateIds = deleteCandidates.map((c) => c.id);
-
-        const referenced = await db
-          .select({ selectedChoiceId: schema.attempts.selectedChoiceId })
-          .from(schema.attempts)
-          .where(
-            and(
-              eq(schema.attempts.questionId, existingQuestion.id),
-              inArray(schema.attempts.selectedChoiceId, deleteCandidateIds),
-            ),
-          );
-
-        for (const row of referenced) {
-          if (row.selectedChoiceId)
-            referencedChoiceIds.add(row.selectedChoiceId);
-        }
-      }
-
-      const { deleteChoiceIds } = computeChoiceSyncPlan({
-        existingChoices: existingChoices.map((c) => ({
-          id: c.id,
-          label: c.label,
-        })),
-        desiredChoices: seedFromFile.choices.map((c) => ({ label: c.label })),
-        referencedChoiceIds,
-      });
-
-      await db.transaction(async (tx) => {
-        await tx
-          .update(schema.questions)
-          .set({
-            stemMd: seedFromFile.stem_md,
-            explanationMd: seedFromFile.explanation_md,
-            difficulty: seedFromFile.difficulty,
-            status: seedFromFile.status,
-            updatedAt: new Date(),
-          })
-          .where(eq(schema.questions.id, existingQuestion.id));
-
-        if (deleteChoiceIds.length > 0) {
-          await tx
-            .delete(schema.choices)
-            .where(inArray(schema.choices.id, deleteChoiceIds));
-        }
-
-        for (const choice of seedFromFile.choices) {
-          await tx
-            .insert(schema.choices)
-            .values({
-              questionId: existingQuestion.id,
-              label: choice.label,
-              textMd: choice.text_md,
-              isCorrect: choice.is_correct,
-              explanationMd: choice.explanation_md,
-              sortOrder: choice.sort_order,
-            })
-            .onConflictDoUpdate({
-              target: [schema.choices.questionId, schema.choices.label],
-              set: {
-                textMd: choice.text_md,
-                isCorrect: choice.is_correct,
-                explanationMd: choice.explanation_md,
-                sortOrder: choice.sort_order,
-              },
-            });
-        }
-
-        await tx
-          .delete(schema.questionTags)
-          .where(eq(schema.questionTags.questionId, existingQuestion.id));
-
-        const tagMap = await upsertTags(tx, seedFromFile.tags);
-        await tx.insert(schema.questionTags).values(
-          seedFromFile.tags.map((t) => ({
-            questionId: existingQuestion.id,
-            tagId:
-              tagMap.get(t.slug)?.id ??
-              (() => {
-                throw new Error(`Missing tag id for slug "${t.slug}"`);
-              })(),
-          })),
-        );
-      });
-
-      updated += 1;
-    }
+    const files = await readSeedQuestionFiles(includePlaceholders);
+    const counts = await syncQuestionsFromFiles(db, files);
 
     console.info(
-      `Seed complete: inserted=${inserted} updated=${updated} skipped=${skipped} (files=${files.length})`,
+      `Seed complete: inserted=${counts.inserted} updated=${counts.updated} skipped=${counts.skipped} (files=${files.length})`,
     );
     console.info(`Content root: ${path.resolve('content/questions')}`);
 
     if (!includePlaceholders) {
-      const archived = await db
-        .update(schema.questions)
-        .set({ status: 'archived', updatedAt: new Date() })
-        .where(like(schema.questions.slug, 'placeholder-%'))
-        .returning({ id: schema.questions.id });
+      const archivedCount = await archivePlaceholderQuestions(db);
       console.info(
-        `Archived placeholders: ${archived.length} (slug LIKE "placeholder-%")`,
+        `Archived placeholders: ${archivedCount} (slug LIKE "placeholder-%")`,
       );
     }
   } finally {
@@ -480,7 +43,16 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+async function main(): Promise<void> {
+  await runSeed();
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seed/file-reader.ts
+++ b/scripts/seed/file-reader.ts
@@ -1,0 +1,45 @@
+import { readFile } from 'node:fs/promises';
+import fg from 'fast-glob';
+
+const ALL_QUESTION_PATTERNS = ['content/questions/**/*.mdx'] as const;
+const NON_PLACEHOLDER_PATTERNS = [
+  'content/questions/**/*.mdx',
+  '!content/questions/placeholder/**/*.mdx',
+] as const;
+
+export type SeedSourceFile = {
+  absolutePath: string;
+  raw: string;
+};
+
+function getSeedPatterns(includePlaceholders: boolean): readonly string[] {
+  return includePlaceholders ? ALL_QUESTION_PATTERNS : NON_PLACEHOLDER_PATTERNS;
+}
+
+function getMissingFilesMessage(includePlaceholders: boolean): string {
+  return includePlaceholders
+    ? 'No question files found at content/questions/**/*.mdx. Seed requires at least one MDX file.'
+    : 'No question files found after excluding placeholders. Re-run with SEED_INCLUDE_PLACEHOLDERS=true or generate imported content under content/questions/imported/.';
+}
+
+export async function readSeedQuestionFiles(
+  includePlaceholders: boolean,
+): Promise<SeedSourceFile[]> {
+  const filePaths = await fg([...getSeedPatterns(includePlaceholders)], {
+    onlyFiles: true,
+    unique: true,
+    absolute: true,
+    dot: false,
+  });
+
+  if (filePaths.length === 0) {
+    throw new Error(getMissingFilesMessage(includePlaceholders));
+  }
+
+  return Promise.all(
+    filePaths.map(async (absolutePath) => ({
+      absolutePath,
+      raw: await readFile(absolutePath, 'utf8'),
+    })),
+  );
+}

--- a/scripts/seed/placeholder-archiver.ts
+++ b/scripts/seed/placeholder-archiver.ts
@@ -1,0 +1,18 @@
+import { like } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../../db/schema';
+
+export async function archivePlaceholderQuestions(
+  db: PostgresJsDatabase<typeof schema>,
+): Promise<number> {
+  const archived = await db
+    .update(schema.questions)
+    .set({
+      status: 'archived',
+      updatedAt: new Date(),
+    })
+    .where(like(schema.questions.slug, 'placeholder-%'))
+    .returning({ id: schema.questions.id });
+
+  return archived.length;
+}

--- a/scripts/seed/question-parser.ts
+++ b/scripts/seed/question-parser.ts
@@ -1,0 +1,121 @@
+import matter from 'gray-matter';
+import type {
+  Choice,
+  Question,
+  QuestionDifficulty,
+  QuestionStatus,
+  TagKind,
+} from '../../db/schema';
+import {
+  canonicalizeMarkdown,
+  parseMdxQuestionBody,
+} from '../../lib/content/parseMdxQuestion';
+import {
+  FullQuestionSchema,
+  QuestionFrontmatterSchema,
+} from '../../lib/content/schemas';
+import { parseChoiceExplanations } from '../seed-helpers';
+
+export type SeedTag = {
+  slug: string;
+  name: string;
+  kind: TagKind;
+};
+
+export type SeedChoice = {
+  label: string;
+  text_md: string;
+  is_correct: boolean;
+  explanation_md: string | null;
+  sort_order: number;
+};
+
+export type SeedQuestionRep = {
+  slug: string;
+  stem_md: string;
+  explanation_md: string;
+  difficulty: QuestionDifficulty;
+  status: QuestionStatus;
+  choices: SeedChoice[];
+  tags: SeedTag[];
+};
+
+function buildSeedRepFromParsed(full: unknown): SeedQuestionRep {
+  const parsed = FullQuestionSchema.parse(full);
+  const parsedExplanations = parseChoiceExplanations(parsed.explanationMd);
+  const generalExplanation = parsedExplanations.generalExplanation;
+
+  const sortedTags = [...parsed.frontmatter.tags].sort((a, b) =>
+    a.slug.localeCompare(b.slug),
+  );
+  const sortedChoices = [...parsed.frontmatter.choices].sort((a, b) =>
+    a.label.localeCompare(b.label),
+  );
+  const validLabels = new Set(sortedChoices.map((choice) => choice.label));
+
+  for (const label of parsedExplanations.perChoice.keys()) {
+    if (!validLabels.has(label)) {
+      throw new Error(
+        `Explanation references choice label "${label}" that is not present in choices for slug "${parsed.frontmatter.slug}"`,
+      );
+    }
+  }
+
+  return {
+    slug: parsed.frontmatter.slug,
+    stem_md: canonicalizeMarkdown(parsed.stemMd),
+    explanation_md: generalExplanation,
+    difficulty: parsed.frontmatter.difficulty,
+    status: parsed.frontmatter.status,
+    tags: sortedTags.map((tag) => ({
+      slug: tag.slug,
+      name: tag.name,
+      kind: tag.kind,
+    })),
+    choices: sortedChoices.map((choice, index) => ({
+      label: choice.label,
+      text_md: canonicalizeMarkdown(choice.text),
+      is_correct: choice.correct,
+      explanation_md: parsedExplanations.perChoice.get(choice.label) ?? null,
+      sort_order: index + 1,
+    })),
+  };
+}
+
+export function parseSeedQuestionFile(raw: string): SeedQuestionRep {
+  const { data, content } = matter(raw);
+  const frontmatter = QuestionFrontmatterSchema.parse(data);
+  const { stemMd, explanationMd } = parseMdxQuestionBody(content);
+
+  return buildSeedRepFromParsed({
+    frontmatter,
+    stemMd,
+    explanationMd,
+  });
+}
+
+export function buildSeedRepFromDb(
+  question: Question,
+  choices: Choice[],
+  tags: SeedTag[],
+): SeedQuestionRep {
+  return {
+    slug: question.slug,
+    stem_md: canonicalizeMarkdown(question.stemMd),
+    explanation_md: canonicalizeMarkdown(question.explanationMd),
+    difficulty: question.difficulty,
+    status: question.status,
+    choices: [...choices]
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map((choice) => ({
+        label: choice.label,
+        text_md: canonicalizeMarkdown(choice.textMd),
+        is_correct: choice.isCorrect,
+        explanation_md: choice.explanationMd
+          ? canonicalizeMarkdown(choice.explanationMd)
+          : null,
+        sort_order: choice.sortOrder,
+      })),
+    tags: [...tags].sort((a, b) => a.slug.localeCompare(b.slug)),
+  };
+}

--- a/scripts/seed/question-syncer.ts
+++ b/scripts/seed/question-syncer.ts
@@ -1,0 +1,217 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../../db/schema';
+import {
+  canonicalJsonString,
+  sha256Hex,
+} from '../../lib/content/parseMdxQuestion';
+import { computeChoiceSyncPlan } from '../seed-helpers';
+import type { SeedSourceFile } from './file-reader';
+import { buildSeedRepFromDb, parseSeedQuestionFile } from './question-parser';
+import { upsertTags, validateSeedQuestionTags } from './tag-manager';
+
+export type SeedSyncCounts = {
+  inserted: number;
+  updated: number;
+  skipped: number;
+};
+
+export async function syncQuestionsFromFiles(
+  db: PostgresJsDatabase<typeof schema>,
+  files: SeedSourceFile[],
+): Promise<SeedSyncCounts> {
+  let inserted = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const file of files) {
+    const seedFromFile = parseSeedQuestionFile(file.raw);
+    validateSeedQuestionTags({
+      slug: seedFromFile.slug,
+      tags: seedFromFile.tags,
+    });
+
+    const fileHash = sha256Hex(canonicalJsonString(seedFromFile));
+
+    const existing = await db
+      .select()
+      .from(schema.questions)
+      .where(eq(schema.questions.slug, seedFromFile.slug))
+      .limit(1);
+    const existingQuestion = existing.at(0);
+
+    if (!existingQuestion) {
+      await db.transaction(async (tx) => {
+        const [createdQuestion] = await tx
+          .insert(schema.questions)
+          .values({
+            slug: seedFromFile.slug,
+            stemMd: seedFromFile.stem_md,
+            explanationMd: seedFromFile.explanation_md,
+            difficulty: seedFromFile.difficulty,
+            status: seedFromFile.status,
+          })
+          .returning({ id: schema.questions.id });
+
+        if (!createdQuestion) {
+          throw new Error(
+            `Failed to insert question for slug "${seedFromFile.slug}"`,
+          );
+        }
+
+        await tx.insert(schema.choices).values(
+          seedFromFile.choices.map((choice) => ({
+            questionId: createdQuestion.id,
+            label: choice.label,
+            textMd: choice.text_md,
+            isCorrect: choice.is_correct,
+            explanationMd: choice.explanation_md,
+            sortOrder: choice.sort_order,
+          })),
+        );
+
+        const tagMap = await upsertTags(tx, seedFromFile.tags);
+        await tx.insert(schema.questionTags).values(
+          seedFromFile.tags.map((tag) => ({
+            questionId: createdQuestion.id,
+            tagId:
+              tagMap.get(tag.slug)?.id ??
+              (() => {
+                throw new Error(`Missing tag id for slug "${tag.slug}"`);
+              })(),
+          })),
+        );
+      });
+
+      inserted += 1;
+      continue;
+    }
+
+    const existingChoices = await db
+      .select()
+      .from(schema.choices)
+      .where(eq(schema.choices.questionId, existingQuestion.id));
+
+    const existingTags = await db
+      .select({
+        slug: schema.tags.slug,
+        name: schema.tags.name,
+        kind: schema.tags.kind,
+      })
+      .from(schema.questionTags)
+      .innerJoin(schema.tags, eq(schema.questionTags.tagId, schema.tags.id))
+      .where(eq(schema.questionTags.questionId, existingQuestion.id));
+
+    const seedFromDb = buildSeedRepFromDb(
+      existingQuestion,
+      existingChoices,
+      existingTags,
+    );
+
+    const dbHash = sha256Hex(canonicalJsonString(seedFromDb));
+    if (dbHash === fileHash) {
+      skipped += 1;
+      continue;
+    }
+
+    const desiredLabels = new Set(
+      seedFromFile.choices.map((choice) => choice.label),
+    );
+    const deleteCandidates = existingChoices.filter(
+      (choice) => !desiredLabels.has(choice.label),
+    );
+
+    const referencedChoiceIds = new Set<string>();
+    if (deleteCandidates.length > 0) {
+      const deleteCandidateIds = deleteCandidates.map((choice) => choice.id);
+
+      const referenced = await db
+        .select({ selectedChoiceId: schema.attempts.selectedChoiceId })
+        .from(schema.attempts)
+        .where(
+          and(
+            eq(schema.attempts.questionId, existingQuestion.id),
+            inArray(schema.attempts.selectedChoiceId, deleteCandidateIds),
+          ),
+        );
+
+      for (const row of referenced) {
+        if (row.selectedChoiceId) {
+          referencedChoiceIds.add(row.selectedChoiceId);
+        }
+      }
+    }
+
+    const { deleteChoiceIds } = computeChoiceSyncPlan({
+      existingChoices: existingChoices.map((choice) => ({
+        id: choice.id,
+        label: choice.label,
+      })),
+      desiredChoices: seedFromFile.choices.map((choice) => ({
+        label: choice.label,
+      })),
+      referencedChoiceIds,
+    });
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(schema.questions)
+        .set({
+          stemMd: seedFromFile.stem_md,
+          explanationMd: seedFromFile.explanation_md,
+          difficulty: seedFromFile.difficulty,
+          status: seedFromFile.status,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.questions.id, existingQuestion.id));
+
+      if (deleteChoiceIds.length > 0) {
+        await tx
+          .delete(schema.choices)
+          .where(inArray(schema.choices.id, deleteChoiceIds));
+      }
+
+      for (const choice of seedFromFile.choices) {
+        await tx
+          .insert(schema.choices)
+          .values({
+            questionId: existingQuestion.id,
+            label: choice.label,
+            textMd: choice.text_md,
+            isCorrect: choice.is_correct,
+            explanationMd: choice.explanation_md,
+            sortOrder: choice.sort_order,
+          })
+          .onConflictDoUpdate({
+            target: [schema.choices.questionId, schema.choices.label],
+            set: {
+              textMd: choice.text_md,
+              isCorrect: choice.is_correct,
+              explanationMd: choice.explanation_md,
+              sortOrder: choice.sort_order,
+            },
+          });
+      }
+
+      await tx
+        .delete(schema.questionTags)
+        .where(eq(schema.questionTags.questionId, existingQuestion.id));
+
+      const tagMap = await upsertTags(tx, seedFromFile.tags);
+      await tx.insert(schema.questionTags).values(
+        seedFromFile.tags.map((tag) => ({
+          questionId: existingQuestion.id,
+          tagId:
+            tagMap.get(tag.slug)?.id ??
+            (() => {
+              throw new Error(`Missing tag id for slug "${tag.slug}"`);
+            })(),
+        })),
+      );
+    });
+
+    updated += 1;
+  }
+
+  return { inserted, updated, skipped };
+}

--- a/scripts/seed/tag-manager.ts
+++ b/scripts/seed/tag-manager.ts
@@ -1,0 +1,114 @@
+import { inArray } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../../db/schema';
+import {
+  CANONICAL_SUBSTANCE_SLUGS,
+  CANONICAL_TOPIC_SLUGS,
+  CANONICAL_TREATMENT_SLUGS,
+} from '../../lib/content/draftTaxonomy';
+import type { SeedTag } from './question-parser';
+
+const CANONICAL_TOPIC_SLUG_SET = new Set<string>(CANONICAL_TOPIC_SLUGS);
+const CANONICAL_SUBSTANCE_SLUG_SET = new Set<string>(CANONICAL_SUBSTANCE_SLUGS);
+const CANONICAL_TREATMENT_SLUG_SET = new Set<string>(CANONICAL_TREATMENT_SLUGS);
+
+export function validateSeedQuestionTags(input: {
+  slug: string;
+  tags: Array<Omit<SeedTag, 'kind'> & { kind: SeedTag['kind'] | 'domain' }>;
+}): void {
+  for (const tag of input.tags) {
+    if (tag.kind === 'domain') {
+      throw new Error(
+        `Question "${input.slug}" has domain tag "${tag.slug}" which is not allowed`,
+      );
+    }
+  }
+
+  const topicCount = input.tags.filter((tag) => tag.kind === 'topic').length;
+  const substanceCount = input.tags.filter(
+    (tag) => tag.kind === 'substance',
+  ).length;
+
+  if (topicCount < 1) {
+    throw new Error(
+      `Question "${input.slug}" must have at least one topic tag`,
+    );
+  }
+
+  if (substanceCount < 1) {
+    throw new Error(
+      `Question "${input.slug}" must have at least one substance tag`,
+    );
+  }
+
+  for (const tag of input.tags) {
+    if (tag.kind === 'topic' && !CANONICAL_TOPIC_SLUG_SET.has(tag.slug)) {
+      throw new Error(
+        `Question "${input.slug}" has non-canonical topic slug "${tag.slug}"`,
+      );
+    }
+
+    if (
+      tag.kind === 'substance' &&
+      !CANONICAL_SUBSTANCE_SLUG_SET.has(tag.slug)
+    ) {
+      throw new Error(
+        `Question "${input.slug}" has non-canonical substance slug "${tag.slug}"`,
+      );
+    }
+
+    if (
+      tag.kind === 'treatment' &&
+      !CANONICAL_TREATMENT_SLUG_SET.has(tag.slug)
+    ) {
+      throw new Error(
+        `Question "${input.slug}" has non-canonical treatment slug "${tag.slug}"`,
+      );
+    }
+  }
+}
+
+export async function upsertTags(
+  tx: PostgresJsDatabase<typeof schema>,
+  incomingTags: SeedTag[],
+): Promise<Map<string, { id: string } & SeedTag>> {
+  const tagSlugs = incomingTags.map((tag) => tag.slug);
+
+  const existing = tagSlugs.length
+    ? await tx
+        .select()
+        .from(schema.tags)
+        .where(inArray(schema.tags.slug, tagSlugs))
+    : [];
+
+  const bySlug = new Map(existing.map((tag) => [tag.slug, tag]));
+
+  for (const tag of incomingTags) {
+    const found = bySlug.get(tag.slug);
+    if (found) {
+      if (found.name !== tag.name || found.kind !== tag.kind) {
+        throw new Error(
+          `Tag slug "${tag.slug}" already exists but differs (expected name="${tag.name}", kind="${tag.kind}"; got name="${found.name}", kind="${found.kind}")`,
+        );
+      }
+      continue;
+    }
+
+    const [inserted] = await tx
+      .insert(schema.tags)
+      .values({
+        slug: tag.slug,
+        name: tag.name,
+        kind: tag.kind,
+      })
+      .returning();
+
+    if (!inserted) {
+      throw new Error(`Failed to insert tag slug "${tag.slug}"`);
+    }
+
+    bySlug.set(inserted.slug, inserted);
+  }
+
+  return bySlug;
+}


### PR DESCRIPTION
## Summary
- decompose scripts/seed.ts into focused stage modules under scripts/seed/
- keep scripts/seed.ts as a thin linear orchestrator (58 lines) for env/db setup, stage calls, and summary logging
- move tag validation logic out of seed.ts into scripts/seed/tag-manager.ts and update scripts/seed.test.ts to import it directly
- archive DEBT-230 and update debt register links/status entries

## Notes
- DEBT-224 was updated to mark DEBT-230 resolved, but DEBT-224 itself remains active on this branch because DEBT-227, DEBT-229, and DEBT-231 are still open in docs/debt/

## Validation
- pnpm test --run scripts/seed.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test --run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Seed import now reports counts (inserted/updated/skipped) and respects an env flag to include or archive placeholder questions.
  * Improved validations for tags and seed file content with clearer errors when no seed files are found.

* **Refactor**
  * Seed workflow reorganized into modular steps for safer, transactional imports and more reliable sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->