### PR TITLE
Resolve DEBT-357: Consolidate drifted test doubles onto repo-standard fakes

### DIFF
--- a/components/auth-nav.test.tsx
+++ b/components/auth-nav.test.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MarketingLayout } from '@/components/marketing/marketing-layout';
 import { FakeAuthGateway } from '@/src/application/test-helpers/fakes/fake-gateways';
+import { FakeCheckEntitlementUseCase } from '@/src/application/test-helpers/fakes/fake-use-cases';
 import { createUser } from '@/src/domain/test-helpers/factories';
 import {
   restoreProcessEnv,
@@ -82,12 +83,10 @@ describe('AuthNav', () => {
     process.env.NEXT_PUBLIC_SKIP_CLERK = 'false';
 
     const authGateway = new FakeAuthGateway(null);
-    // Required by AuthNavDeps type but never reached — unauthenticated path returns early.
-    const checkEntitlementUseCase = {
-      execute: vi.fn(async () => {
-        throw new Error('Should not be called for unauthenticated user');
-      }),
-    };
+    const checkEntitlementUseCase = new FakeCheckEntitlementUseCase(
+      { isEntitled: false },
+      new Error('Should not be called for unauthenticated user'),
+    );
 
     const { AuthNav } = await import('./auth-nav');
 
@@ -119,11 +118,10 @@ describe('AuthNav', () => {
     process.env.NEXT_PUBLIC_SKIP_CLERK = 'false';
 
     const authGateway = new FakeAuthGateway(null);
-    const checkEntitlementUseCase = {
-      execute: vi.fn(async () => {
-        throw new Error('Should not be called for unauthenticated user');
-      }),
-    };
+    const checkEntitlementUseCase = new FakeCheckEntitlementUseCase(
+      { isEntitled: false },
+      new Error('Should not be called for unauthenticated user'),
+    );
 
     const { AuthNav } = await import('./auth-nav');
 
@@ -144,12 +142,10 @@ describe('AuthNav', () => {
     process.env.NEXT_PUBLIC_SKIP_CLERK = 'false';
 
     const authGateway = new FakeAuthGateway(null);
-    // Required by AuthNavDeps type but never reached — unauthenticated path returns early.
-    const checkEntitlementUseCase = {
-      execute: vi.fn(async () => {
-        throw new Error('Should not be called for unauthenticated user');
-      }),
-    };
+    const checkEntitlementUseCase = new FakeCheckEntitlementUseCase(
+      { isEntitled: false },
+      new Error('Should not be called for unauthenticated user'),
+    );
 
     const { AuthNav } = await import('./auth-nav');
     const PricingPage = (await import('@/app/pricing/page')).default;
@@ -192,9 +188,9 @@ describe('AuthNav', () => {
 
     const user = createUser({ id: 'user_1' });
     const authGateway = new FakeAuthGateway(user);
-    const checkEntitlementUseCase = {
-      execute: vi.fn(async () => ({ isEntitled: true })),
-    };
+    const checkEntitlementUseCase = new FakeCheckEntitlementUseCase({
+      isEntitled: true,
+    });
 
     const authNav = await AuthNav({
       deps: { authGateway, checkEntitlementUseCase },
@@ -227,9 +223,9 @@ describe('AuthNav', () => {
 
     const user = createUser({ id: 'user_1' });
     const authGateway = new FakeAuthGateway(user);
-    const checkEntitlementUseCase = {
-      execute: vi.fn(async () => ({ isEntitled: true })),
-    };
+    const checkEntitlementUseCase = new FakeCheckEntitlementUseCase({
+      isEntitled: true,
+    });
 
     const authNav = await AuthNav({
       deps: { authGateway, checkEntitlementUseCase },
@@ -279,9 +275,9 @@ describe('AuthNav', () => {
 
     const user = createUser({ id: 'user_1' });
     const authGateway = new FakeAuthGateway(user);
-    const checkEntitlementUseCase = {
-      execute: vi.fn(async () => ({ isEntitled: false })),
-    };
+    const checkEntitlementUseCase = new FakeCheckEntitlementUseCase({
+      isEntitled: false,
+    });
 
     const authNav = await AuthNav({
       deps: { authGateway, checkEntitlementUseCase },
@@ -308,9 +304,9 @@ describe('AuthNav', () => {
 
     const user = createUser({ id: 'user_1' });
     const authGateway = new FakeAuthGateway(user);
-    const checkEntitlementUseCase = {
-      execute: vi.fn(async () => ({ isEntitled: false })),
-    };
+    const checkEntitlementUseCase = new FakeCheckEntitlementUseCase({
+      isEntitled: false,
+    });
 
     const authNav = await AuthNav({
       deps: { authGateway, checkEntitlementUseCase },
@@ -345,9 +341,9 @@ describe('AuthNav', () => {
 
     const user = createUser({ id: 'user_1' });
     const authGateway = new FakeAuthGateway(user);
-    const checkEntitlementUseCase = {
-      execute: vi.fn(async () => ({ isEntitled: false })),
-    };
+    const checkEntitlementUseCase = new FakeCheckEntitlementUseCase({
+      isEntitled: false,
+    });
 
     const element = await PricingPage({
       searchParams: Promise.resolve({}),

--- a/components/get-started-cta.test.tsx
+++ b/components/get-started-cta.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { AuthGateway } from '@/src/application/ports/gateways';
+import { FakeAuthGateway } from '@/src/application/test-helpers/fakes/fake-gateways';
+import { FakeCheckEntitlementUseCase } from '@/src/application/test-helpers/fakes/fake-use-cases';
+import { createUser } from '@/src/domain/test-helpers/factories';
 import {
   restoreProcessEnv,
   snapshotProcessEnv,
@@ -23,21 +25,10 @@ describe('GetStartedCta', () => {
   it('links to /pricing when user is not entitled', async () => {
     const { GetStartedCta } = await import('@/components/get-started-cta');
 
-    const authGateway: AuthGateway = {
-      getCurrentUser: vi.fn(async () => ({
-        id: 'user_1',
-        email: 'user@example.com',
-        createdAt: new Date('2026-02-01T00:00:00Z'),
-        updatedAt: new Date('2026-02-01T00:00:00Z'),
-      })),
-      requireUser: vi.fn(async () => {
-        throw new Error('not used');
-      }),
-    };
-
-    const checkEntitlementUseCase = {
-      execute: vi.fn(async () => ({ isEntitled: false })),
-    };
+    const authGateway = new FakeAuthGateway(createUser());
+    const checkEntitlementUseCase = new FakeCheckEntitlementUseCase({
+      isEntitled: false,
+    });
 
     const element = await GetStartedCta({
       deps: { authGateway, checkEntitlementUseCase },
@@ -52,16 +43,10 @@ describe('GetStartedCta', () => {
   it('links to /pricing when unauthenticated', async () => {
     const { GetStartedCta } = await import('@/components/get-started-cta');
 
-    const authGateway: AuthGateway = {
-      getCurrentUser: vi.fn(async () => null),
-      requireUser: vi.fn(async () => {
-        throw new Error('not used');
-      }),
-    };
-
-    const checkEntitlementUseCase = {
-      execute: vi.fn(async () => ({ isEntitled: true })),
-    };
+    const authGateway = new FakeAuthGateway(null);
+    const checkEntitlementUseCase = new FakeCheckEntitlementUseCase({
+      isEntitled: true,
+    });
 
     const element = await GetStartedCta({
       deps: { authGateway, checkEntitlementUseCase },
@@ -71,27 +56,16 @@ describe('GetStartedCta', () => {
     expect(html).toContain('data-slot="button"');
     expect(html).toContain('href="/pricing"');
     expect(html).toContain('Get Started');
-    expect(checkEntitlementUseCase.execute).not.toHaveBeenCalled();
+    expect(checkEntitlementUseCase.inputs).toHaveLength(0);
   });
 
   it('links to /app/dashboard when user is entitled', async () => {
     const { GetStartedCta } = await import('@/components/get-started-cta');
 
-    const authGateway: AuthGateway = {
-      getCurrentUser: vi.fn(async () => ({
-        id: 'user_1',
-        email: 'user@example.com',
-        createdAt: new Date('2026-02-01T00:00:00Z'),
-        updatedAt: new Date('2026-02-01T00:00:00Z'),
-      })),
-      requireUser: vi.fn(async () => {
-        throw new Error('not used');
-      }),
-    };
-
-    const checkEntitlementUseCase = {
-      execute: vi.fn(async () => ({ isEntitled: true })),
-    };
+    const authGateway = new FakeAuthGateway(createUser());
+    const checkEntitlementUseCase = new FakeCheckEntitlementUseCase({
+      isEntitled: true,
+    });
 
     const element = await GetStartedCta({
       deps: { authGateway, checkEntitlementUseCase },
@@ -122,20 +96,9 @@ describe('GetStartedCta', () => {
     const element = await GetStartedCta({
       options: {
         loadContainer: async () => ({
-          createAuthGateway: () => ({
-            getCurrentUser: async () => ({
-              id: 'user_1',
-              email: 'user@example.com',
-              createdAt: new Date('2026-02-01T00:00:00Z'),
-              updatedAt: new Date('2026-02-01T00:00:00Z'),
-            }),
-            requireUser: async () => {
-              throw new Error('not used');
-            },
-          }),
-          createCheckEntitlementUseCase: () => ({
-            execute: async () => ({ isEntitled: false }),
-          }),
+          createAuthGateway: () => new FakeAuthGateway(createUser()),
+          createCheckEntitlementUseCase: () =>
+            new FakeCheckEntitlementUseCase({ isEntitled: false }),
         }),
       },
     });

--- a/docs/_archive/debt/debt-357-test-double-discipline-drift.md
+++ b/docs/_archive/debt/debt-357-test-double-discipline-drift.md
@@ -2,8 +2,13 @@
 
 **Priority:** P3
 **Created:** 2026-04-08
+**Status:** Resolved (PR #273, merged 2026-04-10)
 **Source:** Follow-up from [DEBT-354](./debt-354-god-file-and-clean-code-audit.md)
-**Related:** [docs/dev/react-vitest-testing.md](../dev/react-vitest-testing.md), [clerk-auth-gateway.test.ts](../../src/adapters/gateways/clerk-auth-gateway.test.ts), [get-started-cta.test.tsx](../../components/get-started-cta.test.tsx), [auth-nav.test.tsx](../../components/auth-nav.test.tsx)
+**Related:** [docs/dev/react-vitest-testing.md](../../dev/react-vitest-testing.md), [clerk-auth-gateway.test.ts](../../src/adapters/gateways/clerk-auth-gateway.test.ts), [get-started-cta.test.tsx](../../components/get-started-cta.test.tsx), [auth-nav.test.tsx](../../components/auth-nav.test.tsx)
+
+### Resolution
+
+Added `FakeCheckEntitlementUseCase` to `src/application/test-helpers/fakes/fake-use-cases.ts`. Replaced the 42-line inline `createFakeUserRepository()` in `clerk-auth-gateway.test.ts` with `FakeUserRepository` and converted interaction assertions (`_calls`) to behavioral assertions (`findByClerkId`). Replaced all inline `AuthGateway` and entitlement use-case stubs in `get-started-cta.test.tsx` and `auth-nav.test.tsx` with `FakeAuthGateway`, `FakeCheckEntitlementUseCase`, and `createUser()`. Zero production code changed. Net −88 lines.
 
 ---
 

--- a/docs/_archive/debt/debt-357-test-double-discipline-drift.md
+++ b/docs/_archive/debt/debt-357-test-double-discipline-drift.md
@@ -2,8 +2,13 @@
 
 **Priority:** P3
 **Created:** 2026-04-08
+**Status:** Resolved (PR #273)
 **Source:** Follow-up from [DEBT-354](./debt-354-god-file-and-clean-code-audit.md)
-**Related:** [docs/dev/react-vitest-testing.md](../dev/react-vitest-testing.md), [clerk-auth-gateway.test.ts](../../src/adapters/gateways/clerk-auth-gateway.test.ts), [get-started-cta.test.tsx](../../components/get-started-cta.test.tsx), [auth-nav.test.tsx](../../components/auth-nav.test.tsx)
+**Related:** [docs/dev/react-vitest-testing.md](../../dev/react-vitest-testing.md), [clerk-auth-gateway.test.ts](../../src/adapters/gateways/clerk-auth-gateway.test.ts), [get-started-cta.test.tsx](../../components/get-started-cta.test.tsx), [auth-nav.test.tsx](../../components/auth-nav.test.tsx)
+
+## Resolution
+
+Added `FakeCheckEntitlementUseCase` to `src/application/test-helpers/fakes/fake-use-cases.ts`. Replaced the 42-line inline `createFakeUserRepository()` in `clerk-auth-gateway.test.ts` with `FakeUserRepository` and converted interaction assertions (`_calls`) to behavioral assertions (`findByClerkId`). Replaced all inline `AuthGateway` and entitlement use-case stubs in `get-started-cta.test.tsx` and `auth-nav.test.tsx` with `FakeAuthGateway`, `FakeCheckEntitlementUseCase`, and `createUser()`. Zero production code changed. Net −88 lines.
 
 ---
 

--- a/docs/debt/debt-357-test-double-discipline-drift.md
+++ b/docs/debt/debt-357-test-double-discipline-drift.md
@@ -2,13 +2,8 @@
 
 **Priority:** P3
 **Created:** 2026-04-08
-**Status:** Resolved (PR #273, merged 2026-04-10)
 **Source:** Follow-up from [DEBT-354](./debt-354-god-file-and-clean-code-audit.md)
-**Related:** [docs/dev/react-vitest-testing.md](../../dev/react-vitest-testing.md), [clerk-auth-gateway.test.ts](../../src/adapters/gateways/clerk-auth-gateway.test.ts), [get-started-cta.test.tsx](../../components/get-started-cta.test.tsx), [auth-nav.test.tsx](../../components/auth-nav.test.tsx)
-
-### Resolution
-
-Added `FakeCheckEntitlementUseCase` to `src/application/test-helpers/fakes/fake-use-cases.ts`. Replaced the 42-line inline `createFakeUserRepository()` in `clerk-auth-gateway.test.ts` with `FakeUserRepository` and converted interaction assertions (`_calls`) to behavioral assertions (`findByClerkId`). Replaced all inline `AuthGateway` and entitlement use-case stubs in `get-started-cta.test.tsx` and `auth-nav.test.tsx` with `FakeAuthGateway`, `FakeCheckEntitlementUseCase`, and `createUser()`. Zero production code changed. Net −88 lines.
+**Related:** [docs/dev/react-vitest-testing.md](../dev/react-vitest-testing.md), [clerk-auth-gateway.test.ts](../../src/adapters/gateways/clerk-auth-gateway.test.ts), [get-started-cta.test.tsx](../../components/get-started-cta.test.tsx), [auth-nav.test.tsx](../../components/auth-nav.test.tsx)
 
 ---
 

--- a/docs/debt/index.md
+++ b/docs/debt/index.md
@@ -1,7 +1,7 @@
 # Technical Debt Register
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-04-10
+**Last Updated:** 2026-04-10 (DEBT-357 resolved)
 
 ---
 
@@ -22,7 +22,6 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 | [DEBT-349](./debt-349-cross-request-published-content-caching.md) | Optional Tier 2 cross-request caching for immutable published questions and tag lists after DEBT-344 shipped request-scoped dedup | P3 | — |
 | [DEBT-352](./debt-352-post-exam-review-focus-ring-flash.md) | Post-exam review focus-ring flash — remove forced `focusVisible: true` while preserving panel focus transfer and keyboard/screen-reader affordance | P3 | — |
 | [DEBT-356](./debt-356-duplicate-question-surface-renderers.md) | Duplicate question-surface renderers — `QuestionView` and `PracticeView` now duplicate too much question-card/feedback/action-shell composition and should share a thinner common surface layer | P3 | — |
-| [DEBT-357](./debt-357-test-double-discipline-drift.md) | Test double discipline drift — some render/adapter tests have slid back to ad hoc inline doubles despite existing repo-standard fakes and fake use-case helpers | P3 | — |
 **Next Debt ID:** DEBT-359
 
 ---
@@ -31,6 +30,7 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 
 | ID | Title | Priority | Resolved | GitHub Issue |
 |----|-------|----------|----------|--------------|
+| [DEBT-357](../_archive/debt/debt-357-test-double-discipline-drift.md) | Test double discipline drift — consolidated drifted inline doubles onto repo-standard fakes (`FakeUserRepository`, `FakeAuthGateway`, `FakeCheckEntitlementUseCase`) in three test files | P3 | 2026-04-10 | [PR #273](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/273) |
 | [DEBT-355](../_archive/debt/debt-355-cross-feature-question-flow-coupling.md) | Cross-feature question-flow coupling — extracted shared error-message and async-action helpers from `practice/` to neutral `shared/` boundary | P2 | 2026-04-10 | [PR #272](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/272) |
 | [DEBT-354](../_archive/debt/debt-354-god-file-and-clean-code-audit.md) | God-file and clean-code audit — audit complete; child tickets DEBT-355/356/357 opened for coupling, duplication, and test-discipline drift | P2 | 2026-04-09 | [PR #271](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/271) |
 | [DEBT-358](../_archive/debt/debt-358-exam-review-question-navigation-stranded.md) | Exam review question navigation stranded — clicking a question from Review & Submit disables the navigator because `isInReviewStage` stays `true`, stranding the student on one question | P2 | 2026-04-09 | [PR #270](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/270) |

--- a/docs/debt/index.md
+++ b/docs/debt/index.md
@@ -1,7 +1,7 @@
 # Technical Debt Register
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-04-10 (DEBT-357 resolved)
+**Last Updated:** 2026-04-10
 
 ---
 
@@ -22,6 +22,7 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 | [DEBT-349](./debt-349-cross-request-published-content-caching.md) | Optional Tier 2 cross-request caching for immutable published questions and tag lists after DEBT-344 shipped request-scoped dedup | P3 | — |
 | [DEBT-352](./debt-352-post-exam-review-focus-ring-flash.md) | Post-exam review focus-ring flash — remove forced `focusVisible: true` while preserving panel focus transfer and keyboard/screen-reader affordance | P3 | — |
 | [DEBT-356](./debt-356-duplicate-question-surface-renderers.md) | Duplicate question-surface renderers — `QuestionView` and `PracticeView` now duplicate too much question-card/feedback/action-shell composition and should share a thinner common surface layer | P3 | — |
+| [DEBT-357](./debt-357-test-double-discipline-drift.md) | Test double discipline drift — some render/adapter tests have slid back to ad hoc inline doubles despite existing repo-standard fakes and fake use-case helpers | P3 | — |
 **Next Debt ID:** DEBT-359
 
 ---
@@ -30,7 +31,6 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 
 | ID | Title | Priority | Resolved | GitHub Issue |
 |----|-------|----------|----------|--------------|
-| [DEBT-357](../_archive/debt/debt-357-test-double-discipline-drift.md) | Test double discipline drift — consolidated drifted inline doubles onto repo-standard fakes (`FakeUserRepository`, `FakeAuthGateway`, `FakeCheckEntitlementUseCase`) in three test files | P3 | 2026-04-10 | [PR #273](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/273) |
 | [DEBT-355](../_archive/debt/debt-355-cross-feature-question-flow-coupling.md) | Cross-feature question-flow coupling — extracted shared error-message and async-action helpers from `practice/` to neutral `shared/` boundary | P2 | 2026-04-10 | [PR #272](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/272) |
 | [DEBT-354](../_archive/debt/debt-354-god-file-and-clean-code-audit.md) | God-file and clean-code audit — audit complete; child tickets DEBT-355/356/357 opened for coupling, duplication, and test-discipline drift | P2 | 2026-04-09 | [PR #271](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/271) |
 | [DEBT-358](../_archive/debt/debt-358-exam-review-question-navigation-stranded.md) | Exam review question navigation stranded — clicking a question from Review & Submit disables the navigator because `isInReviewStage` stays `true`, stranding the student on one question | P2 | 2026-04-09 | [PR #270](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/270) |

--- a/docs/debt/index.md
+++ b/docs/debt/index.md
@@ -22,7 +22,6 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 | [DEBT-349](./debt-349-cross-request-published-content-caching.md) | Optional Tier 2 cross-request caching for immutable published questions and tag lists after DEBT-344 shipped request-scoped dedup | P3 | — |
 | [DEBT-352](./debt-352-post-exam-review-focus-ring-flash.md) | Post-exam review focus-ring flash — remove forced `focusVisible: true` while preserving panel focus transfer and keyboard/screen-reader affordance | P3 | — |
 | [DEBT-356](./debt-356-duplicate-question-surface-renderers.md) | Duplicate question-surface renderers — `QuestionView` and `PracticeView` now duplicate too much question-card/feedback/action-shell composition and should share a thinner common surface layer | P3 | — |
-| [DEBT-357](./debt-357-test-double-discipline-drift.md) | Test double discipline drift — some render/adapter tests have slid back to ad hoc inline doubles despite existing repo-standard fakes and fake use-case helpers | P3 | — |
 **Next Debt ID:** DEBT-359
 
 ---
@@ -31,6 +30,7 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 
 | ID | Title | Priority | Resolved | GitHub Issue |
 |----|-------|----------|----------|--------------|
+| [DEBT-357](../_archive/debt/debt-357-test-double-discipline-drift.md) | Test double discipline drift — consolidated drifted inline doubles onto repo-standard fakes (`FakeUserRepository`, `FakeAuthGateway`, `FakeCheckEntitlementUseCase`) in three test files | P3 | 2026-04-10 | [PR #273](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/273) |
 | [DEBT-355](../_archive/debt/debt-355-cross-feature-question-flow-coupling.md) | Cross-feature question-flow coupling — extracted shared error-message and async-action helpers from `practice/` to neutral `shared/` boundary | P2 | 2026-04-10 | [PR #272](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/272) |
 | [DEBT-354](../_archive/debt/debt-354-god-file-and-clean-code-audit.md) | God-file and clean-code audit — audit complete; child tickets DEBT-355/356/357 opened for coupling, duplication, and test-discipline drift | P2 | 2026-04-09 | [PR #271](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/271) |
 | [DEBT-358](../_archive/debt/debt-358-exam-review-question-navigation-stranded.md) | Exam review question navigation stranded — clicking a question from Review & Submit disables the navigator because `isInReviewStage` stays `true`, stranding the student on one question | P2 | 2026-04-09 | [PR #270](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/270) |

--- a/src/adapters/gateways/clerk-auth-gateway.test.ts
+++ b/src/adapters/gateways/clerk-auth-gateway.test.ts
@@ -1,56 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import { ApplicationError } from '@/src/application/errors';
-import type { UserRepository } from '@/src/application/ports/repositories';
+import { FakeUserRepository } from '@/src/application/test-helpers/fakes';
 import { ClerkAuthGateway } from './clerk-auth-gateway';
-
-function createFakeUserRepository(): UserRepository & {
-  _calls: {
-    upsertByClerkId: Array<{
-      clerkId: string;
-      email: string;
-      observedAt: Date | null;
-    }>;
-  };
-} {
-  const calls: {
-    upsertByClerkId: Array<{
-      clerkId: string;
-      email: string;
-      observedAt: Date | null;
-    }>;
-  } = { upsertByClerkId: [] };
-  const baseUser = {
-    id: 'user_1',
-    createdAt: new Date('2026-02-01T00:00:00Z'),
-    updatedAt: new Date('2026-02-01T00:00:00Z'),
-  };
-
-  return {
-    _calls: calls,
-    findByClerkId: async () => null,
-    lockByClerkId: async () => null,
-    upsertByClerkId: async (clerkId, email, options) => {
-      calls.upsertByClerkId.push({
-        clerkId,
-        email,
-        observedAt: options?.observedAt ?? null,
-      });
-      return {
-        id: baseUser.id,
-        email,
-        createdAt: baseUser.createdAt,
-        updatedAt: baseUser.updatedAt,
-      };
-    },
-    deleteByClerkId: async () => false,
-  };
-}
 
 describe('ClerkAuthGateway', () => {
   const clerkUpdatedAt = new Date('2026-02-02T00:00:00Z');
 
   it('returns null from getCurrentUser when unauthenticated', async () => {
-    const userRepository = createFakeUserRepository();
+    const userRepository = new FakeUserRepository();
 
     const gateway = new ClerkAuthGateway({
       userRepository,
@@ -58,11 +15,11 @@ describe('ClerkAuthGateway', () => {
     });
 
     await expect(gateway.getCurrentUser()).resolves.toBeNull();
-    expect(userRepository._calls.upsertByClerkId).toHaveLength(0);
+    expect(await userRepository.findByClerkId('clerk_1')).toBeNull();
   });
 
   it('throws UNAUTHENTICATED from requireUser when unauthenticated', async () => {
-    const userRepository = createFakeUserRepository();
+    const userRepository = new FakeUserRepository();
 
     const gateway = new ClerkAuthGateway({
       userRepository,
@@ -78,7 +35,7 @@ describe('ClerkAuthGateway', () => {
   });
 
   it('throws INTERNAL_ERROR when the Clerk user has no email addresses', async () => {
-    const userRepository = createFakeUserRepository();
+    const userRepository = new FakeUserRepository();
 
     const gateway = new ClerkAuthGateway({
       userRepository,
@@ -91,11 +48,11 @@ describe('ClerkAuthGateway', () => {
     await expect(gateway.requireUser()).rejects.toMatchObject({
       code: 'INTERNAL_ERROR',
     });
-    expect(userRepository._calls.upsertByClerkId).toHaveLength(0);
+    expect(await userRepository.findByClerkId('clerk_1')).toBeNull();
   });
 
   it('uses the primary email address when available', async () => {
-    const userRepository = createFakeUserRepository();
+    const userRepository = new FakeUserRepository();
 
     const gateway = new ClerkAuthGateway({
       userRepository,
@@ -111,19 +68,16 @@ describe('ClerkAuthGateway', () => {
     });
 
     const user = await gateway.requireUser();
+    const storedUser = await userRepository.findByClerkId('clerk_1');
 
     expect(user.email).toBe('primary@example.com');
-    expect(userRepository._calls.upsertByClerkId).toEqual([
-      {
-        clerkId: 'clerk_1',
-        email: 'primary@example.com',
-        observedAt: clerkUpdatedAt,
-      },
-    ]);
+    expect(storedUser).not.toBeNull();
+    expect(storedUser?.email).toBe('primary@example.com');
+    expect(storedUser?.updatedAt).toEqual(clerkUpdatedAt);
   });
 
   it('uses first email when no primary is set', async () => {
-    const userRepository = createFakeUserRepository();
+    const userRepository = new FakeUserRepository();
 
     const gateway = new ClerkAuthGateway({
       userRepository,
@@ -139,19 +93,16 @@ describe('ClerkAuthGateway', () => {
     });
 
     const user = await gateway.requireUser();
+    const storedUser = await userRepository.findByClerkId('clerk_1');
 
     expect(user.email).toBe('first@example.com');
-    expect(userRepository._calls.upsertByClerkId).toEqual([
-      {
-        clerkId: 'clerk_1',
-        email: 'first@example.com',
-        observedAt: clerkUpdatedAt,
-      },
-    ]);
+    expect(storedUser).not.toBeNull();
+    expect(storedUser?.email).toBe('first@example.com');
+    expect(storedUser?.updatedAt).toEqual(clerkUpdatedAt);
   });
 
   it('returns the user from the repository', async () => {
-    const userRepository = createFakeUserRepository();
+    const userRepository = new FakeUserRepository();
 
     const gateway = new ClerkAuthGateway({
       userRepository,
@@ -165,15 +116,15 @@ describe('ClerkAuthGateway', () => {
     const user = await gateway.getCurrentUser();
 
     expect(user).toEqual({
-      id: 'user_1',
+      id: 'user-1',
       email: 'user@example.com',
-      createdAt: new Date('2026-02-01T00:00:00Z'),
-      updatedAt: new Date('2026-02-01T00:00:00Z'),
+      createdAt: clerkUpdatedAt,
+      updatedAt: clerkUpdatedAt,
     });
   });
 
   it('accepts Date updatedAt values from Clerk payloads', async () => {
-    const userRepository = createFakeUserRepository();
+    const userRepository = new FakeUserRepository();
     const observedAt = new Date('2026-02-02T01:23:45.000Z');
 
     const gateway = new ClerkAuthGateway({
@@ -188,17 +139,14 @@ describe('ClerkAuthGateway', () => {
     await expect(gateway.requireUser()).resolves.toMatchObject({
       email: 'user@example.com',
     });
-    expect(userRepository._calls.upsertByClerkId).toEqual([
-      {
-        clerkId: 'clerk_1',
-        email: 'user@example.com',
-        observedAt,
-      },
-    ]);
+    const storedUser = await userRepository.findByClerkId('clerk_1');
+    expect(storedUser).not.toBeNull();
+    expect(storedUser?.email).toBe('user@example.com');
+    expect(storedUser?.updatedAt).toEqual(observedAt);
   });
 
   it('throws INTERNAL_ERROR when Clerk updatedAt is missing', async () => {
-    const userRepository = createFakeUserRepository();
+    const userRepository = new FakeUserRepository();
 
     const gateway = new ClerkAuthGateway({
       userRepository,
@@ -212,11 +160,11 @@ describe('ClerkAuthGateway', () => {
       code: 'INTERNAL_ERROR',
       message: 'Clerk user updatedAt is required',
     });
-    expect(userRepository._calls.upsertByClerkId).toHaveLength(0);
+    expect(await userRepository.findByClerkId('clerk_1')).toBeNull();
   });
 
   it('propagates repository errors', async () => {
-    const userRepository = createFakeUserRepository();
+    const userRepository = new FakeUserRepository();
     userRepository.upsertByClerkId = async () => {
       throw new ApplicationError('CONFLICT', 'User conflict');
     };
@@ -236,7 +184,7 @@ describe('ClerkAuthGateway', () => {
   });
 
   it('retries transient errors from getClerkUser', async () => {
-    const userRepository = createFakeUserRepository();
+    const userRepository = new FakeUserRepository();
 
     const getClerkUser = vi
       .fn()

--- a/src/application/test-helpers/fakes/fake-use-cases.ts
+++ b/src/application/test-helpers/fakes/fake-use-cases.ts
@@ -92,3 +92,7 @@ export class FakeSetPracticeSessionQuestionMarkUseCase extends FakeUseCase<
   U.SetPracticeSessionQuestionMarkInput,
   U.SetPracticeSessionQuestionMarkOutput
 > {}
+export class FakeCheckEntitlementUseCase extends FakeUseCase<
+  U.CheckEntitlementInput,
+  U.CheckEntitlementOutput
+> {}

--- a/src/application/test-helpers/fakes/index.ts
+++ b/src/application/test-helpers/fakes/index.ts
@@ -17,6 +17,7 @@ export { FakeStripeEventRepository } from './fake-stripe-event-repository';
 export { FakeSubscriptionRepository } from './fake-subscription-repository';
 export { FakeTagRepository } from './fake-tag-repository';
 export {
+  FakeCheckEntitlementUseCase,
   FakeCountAvailableQuestionsUseCase,
   FakeCreateCheckoutSessionUseCase,
   FakeCreatePortalSessionUseCase,


### PR DESCRIPTION
## Summary

- Added `FakeCheckEntitlementUseCase` to the shared fake use-cases (used by two component test files)
- Replaced 42-line inline `createFakeUserRepository()` in `clerk-auth-gateway.test.ts` with `FakeUserRepository`; converted interaction assertions (`_calls`) to behavioral assertions (`findByClerkId`)
- Replaced all inline `AuthGateway` object literals and entitlement stubs in `get-started-cta.test.tsx` with `FakeAuthGateway` + `FakeCheckEntitlementUseCase` + `createUser()`
- Replaced all inline entitlement stubs in `auth-nav.test.tsx` with `FakeCheckEntitlementUseCase`
- Zero production code changed. Net −88 lines of test boilerplate.

Resolves DEBT-357.

## Test plan

- [x] `pnpm vitest run src/adapters/gateways/clerk-auth-gateway.test.ts` — 9 tests pass
- [x] `pnpm vitest run components/get-started-cta.test.tsx` — 5 tests pass
- [x] `pnpm vitest run components/auth-nav.test.tsx` — 8 tests pass
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test --run` — full suite passes
- [x] `pnpm test:browser`
- [x] `pnpm test:integration`
- [x] `pnpm build`
- [x] `pnpm test:e2e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced inline mocks with centralized fake test doubles for authentication, entitlement checks, and user repository to improve consistency.
  * Updated tests to assert behavior (state/outputs) rather than internal interaction tracking.

* **Chores**
  * Marked related technical-debt entry as resolved and updated documentation links and index to reflect the resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->