### PR TITLE
Fix DEBT-352: Remove forced focusVisible from post-exam review panel

### DIFF
--- a/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx
@@ -93,6 +93,13 @@ describe('PostExamReviewView', () => {
     expect(className).toContain('focus-visible:ring-[3px]');
   });
 
+  it('keeps the review panel programmatically focusable with tabIndex -1', () => {
+    const doc = renderView();
+    const panel = doc.querySelector('#practice-question-panel');
+
+    expect(panel?.getAttribute('tabindex')).toBe('-1');
+  });
+
   it('renders a warning banner for unanswered questions', () => {
     const doc = renderView();
     const banner = Array.from(doc.querySelectorAll('[role="status"]')).find(

--- a/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx
@@ -53,7 +53,7 @@ export function PostExamReviewView({
 
   useEffect(() => {
     if (focusedQuestionId === null) return;
-    panelRef.current?.focus({ focusVisible: true });
+    panelRef.current?.focus();
   }, [focusedQuestionId]);
 
   return (

--- a/docs/_archive/debt/debt-352-post-exam-review-focus-ring-flash.md
+++ b/docs/_archive/debt/debt-352-post-exam-review-focus-ring-flash.md
@@ -4,7 +4,7 @@
 **Created:** 2026-04-07
 **Status:** Resolved (PR #274)
 **Source:** [BS-061 Review Surface Divergence Audit](../../brainstorming/bs-061-review-surface-divergence-audit.md)
-**Related:** [DEBT-326](./debt-326-post-exam-review-focus-management.md), [post-exam-review-view.tsx](../../app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx)
+**Related:** [DEBT-326](./debt-326-post-exam-review-focus-management.md), [post-exam-review-view.tsx](../../../app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx)
 
 ## Resolution
 
@@ -32,9 +32,9 @@ The underlying focus handoff is correct. The forced visible-ring behavior is not
 
 ## Current Code References
 
-- [post-exam-review-view.tsx](../../app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx)
-- [post-exam-review-view.test.tsx](../../app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx)
-- [post-exam-review-view.browser.spec.tsx](../../app/(app)/app/practice/[sessionId]/components/post-exam-review-view.browser.spec.tsx)
+- [post-exam-review-view.tsx](../../../app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx)
+- [post-exam-review-view.test.tsx](../../../app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx)
+- [post-exam-review-view.browser.spec.tsx](../../../app/(app)/app/practice/[sessionId]/components/post-exam-review-view.browser.spec.tsx)
 
 ## Exact Decided Behavior
 
@@ -47,7 +47,7 @@ This debt removes the forced visible ring. It does not remove focus transfer.
 
 ## Implementation Notes
 
-- This is a refinement of [DEBT-326](../_archive/debt/debt-326-post-exam-review-focus-management.md), not a reversal of it.
+- This is a refinement of [DEBT-326](./debt-326-post-exam-review-focus-management.md), not a reversal of it.
 - Pointer users should no longer see the forced ring on mount or question changes.
 - Keyboard users must still be able to perceive where focus lands.
 

--- a/docs/_archive/debt/debt-352-post-exam-review-focus-ring-flash.md
+++ b/docs/_archive/debt/debt-352-post-exam-review-focus-ring-flash.md
@@ -2,8 +2,13 @@
 
 **Priority:** P3
 **Created:** 2026-04-07
-**Source:** [BS-061 Review Surface Divergence Audit](../brainstorming/bs-061-review-surface-divergence-audit.md)
-**Related:** [DEBT-326](../_archive/debt/debt-326-post-exam-review-focus-management.md), [post-exam-review-view.tsx](../../app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx)
+**Status:** Resolved (PR #274)
+**Source:** [BS-061 Review Surface Divergence Audit](../../brainstorming/bs-061-review-surface-divergence-audit.md)
+**Related:** [DEBT-326](./debt-326-post-exam-review-focus-management.md), [post-exam-review-view.tsx](../../app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx)
+
+## Resolution
+
+Removed `{ focusVisible: true }` from the programmatic `focus()` call in `PostExamReviewView`, so the browser applies `:focus-visible` only when its own heuristics determine it's appropriate (keyboard/screen-reader input). All focus management infrastructure preserved: `useEffect` + `panelRef`, `tabIndex={-1}`, `focus-visible:ring-*` classes, `aria-label`. Added unit test for `tabIndex={-1}`. Browser spec confirming focus transfer passes unchanged. One line of production code changed.
 
 ---
 

--- a/docs/debt/index.md
+++ b/docs/debt/index.md
@@ -20,7 +20,6 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 | [DEBT-332](./debt-332-security-posture-audit.md) | Security posture audit — Clerk strict CSP report-only is deployed and verified in production/dev, no RLS (accepted architecture decision); remaining work is enforcing mode or explicitly accepting the residual report-only posture | P2 | — |
 | [DEBT-337](./debt-337-future-feedback-enhancements.md) | Future feedback & practice enhancements (F2/F3/F5/F6/F7) — clinical pearl field, reference styling, running score, card collapse, difficulty tags; parked | P4 | — |
 | [DEBT-349](./debt-349-cross-request-published-content-caching.md) | Optional Tier 2 cross-request caching for immutable published questions and tag lists after DEBT-344 shipped request-scoped dedup | P3 | — |
-| [DEBT-352](./debt-352-post-exam-review-focus-ring-flash.md) | Post-exam review focus-ring flash — remove forced `focusVisible: true` while preserving panel focus transfer and keyboard/screen-reader affordance | P3 | — |
 | [DEBT-356](./debt-356-duplicate-question-surface-renderers.md) | Duplicate question-surface renderers — `QuestionView` and `PracticeView` now duplicate too much question-card/feedback/action-shell composition and should share a thinner common surface layer | P3 | — |
 **Next Debt ID:** DEBT-359
 
@@ -30,6 +29,7 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 
 | ID | Title | Priority | Resolved | GitHub Issue |
 |----|-------|----------|----------|--------------|
+| [DEBT-352](../_archive/debt/debt-352-post-exam-review-focus-ring-flash.md) | Post-exam review focus-ring flash — removed forced `focusVisible: true` from programmatic focus while preserving panel focus transfer and keyboard/screen-reader affordance | P3 | 2026-04-10 | [PR #274](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/274) |
 | [DEBT-357](../_archive/debt/debt-357-test-double-discipline-drift.md) | Test double discipline drift — consolidated drifted inline doubles onto repo-standard fakes (`FakeUserRepository`, `FakeAuthGateway`, `FakeCheckEntitlementUseCase`) in three test files | P3 | 2026-04-10 | [PR #273](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/273) |
 | [DEBT-355](../_archive/debt/debt-355-cross-feature-question-flow-coupling.md) | Cross-feature question-flow coupling — extracted shared error-message and async-action helpers from `practice/` to neutral `shared/` boundary | P2 | 2026-04-10 | [PR #272](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/272) |
 | [DEBT-354](../_archive/debt/debt-354-god-file-and-clean-code-audit.md) | God-file and clean-code audit — audit complete; child tickets DEBT-355/356/357 opened for coupling, duplication, and test-discipline drift | P2 | 2026-04-09 | [PR #271](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/271) |


### PR DESCRIPTION
## Summary

- Removed `{ focusVisible: true }` from the programmatic `focus()` call in `PostExamReviewView`, so the browser applies `:focus-visible` only when its own heuristics determine it's appropriate (keyboard/screen-reader input)
- All focus management infrastructure preserved: `useEffect` + `panelRef`, `tabIndex={-1}`, `focus-visible:ring-*` classes, `aria-label`
- Added unit test for `tabIndex={-1}` panel attribute; browser spec confirming focus transfer passes unchanged
- Archived DEBT-352 debt doc and updated debt index

## What changed

**Production:** One line in `post-exam-review-view.tsx` (line 56) — `focus({ focusVisible: true })` → `focus()`

**Tests:** One new unit test verifying `tabIndex={-1}` on the review panel. Existing browser spec (focus transfer on mount and navigation) passes unchanged.

**Docs:** DEBT-352 archived with resolution summary. Debt index updated.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test --run` — 2303 tests passed
- [x] `pnpm test:browser` — 226 tests passed (including `post-exam-review-view.browser.spec.tsx`)
- [x] `pnpm build` — clean production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified post-exam review panel focus behavior to reduce a visible focus-ring flash and improve accessibility during review.

* **Tests**
  * Added a unit test ensuring the review panel remains programmatically focusable with the correct focusability attributes.

* **Documentation**
  * Marked the accessibility item as resolved and updated archival/index documentation and resolution notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->