### PR TITLE
Drop exam-mode Finish exam header CTA

### DIFF
--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.browser.spec.tsx
@@ -1096,7 +1096,7 @@ test('restores the question panel when retrying from an in-panel load error', as
   }
 });
 
-test('renders Finish exam in the active exam-question header', async () => {
+test('does not render Finish exam in the active exam-question header', async () => {
   const screen = await render(
     <PracticeSessionPageView
       summary={null}
@@ -1137,6 +1137,50 @@ test('renders Finish exam in the active exam-question header', async () => {
 
   await expect
     .element(screen.getByRole('button', { name: 'Finish exam' }))
+    .not.toBeInTheDocument();
+});
+
+test('keeps End session in the active tutor-question header', async () => {
+  const screen = await render(
+    <PracticeSessionPageView
+      summary={null}
+      review={null}
+      navigator={null}
+      sessionInfo={{
+        sessionId: 'session-1',
+        mode: 'tutor',
+        index: 0,
+        total: 2,
+        isMarkedForReview: false,
+      }}
+      loadState={{ status: 'ready' }}
+      question={{
+        questionId: 'q1',
+        slug: 'q-1',
+        stemMd: 'Stem 1',
+        difficulty: 'easy',
+        choices: [{ id: 'c1', label: 'A', textMd: 'Choice A', sortOrder: 1 }],
+        session: null,
+      }}
+      selectedChoiceId={null}
+      isAnswered={false}
+      submitResult={null}
+      isPending={false}
+      bookmarkStatus="idle"
+      isBookmarked={false}
+      canSubmit={false}
+      onEndSession={() => undefined}
+      onTryAgain={() => undefined}
+      onToggleBookmark={() => undefined}
+      onToggleMarkForReview={() => undefined}
+      onSelectChoice={() => undefined}
+      onSubmit={() => undefined}
+      onNextQuestion={() => undefined}
+    />,
+  );
+
+  await expect
+    .element(screen.getByRole('button', { name: 'End session' }))
     .toBeVisible();
 });
 

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.browser.spec.tsx
@@ -1138,6 +1138,9 @@ test('does not render Finish exam in the active exam-question header', async () 
   await expect
     .element(screen.getByRole('button', { name: 'Finish exam' }))
     .not.toBeInTheDocument();
+  await expect
+    .element(screen.getByRole('button', { name: 'End session' }))
+    .not.toBeInTheDocument();
 });
 
 test('keeps End session in the active tutor-question header', async () => {

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller.browser.spec.tsx
@@ -193,7 +193,7 @@ async function openExamReviewQuestion(
   await expect
     .element(screen.getByTestId('question-id'))
     .toHaveTextContent('question-3');
-  await screen.getByRole('button', { name: 'Finish exam' }).click();
+  await screen.getByRole('button', { name: 'Review & Submit' }).click();
   await expect
     .element(screen.getByRole('heading', { name: 'Review & Submit' }))
     .toBeVisible();
@@ -649,7 +649,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .element(screen.getByTestId('question-id'))
       .toHaveTextContent('question-3');
 
-    await screen.getByRole('button', { name: 'Finish exam' }).click();
+    await screen.getByRole('button', { name: 'Review & Submit' }).click();
     await expect
       .element(screen.getByTestId('active-view'))
       .toHaveTextContent('review');

--- a/app/(app)/app/practice/components/practice-view.tsx
+++ b/app/(app)/app/practice/components/practice-view.tsx
@@ -377,7 +377,7 @@ export function PracticeView(props: PracticeViewProps) {
             </p>
           </div>
           <div className="flex items-center gap-3">
-            {props.onEndSession ? (
+            {props.onEndSession && !isExamMode ? (
               <Button
                 type="button"
                 variant="outline"
@@ -389,7 +389,7 @@ export function PracticeView(props: PracticeViewProps) {
               >
                 {endSessionLabel}
               </Button>
-            ) : (
+            ) : !props.onEndSession ? (
               <Button
                 asChild
                 variant="link"
@@ -397,7 +397,7 @@ export function PracticeView(props: PracticeViewProps) {
               >
                 <Link href={backLink.href}>{backLink.label}</Link>
               </Button>
-            )}
+            ) : null}
           </div>
         </div>
         {props.belowHeadingContent}

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -207,6 +207,14 @@ test.describe('practice', () => {
     await expect(
       page.getByRole('button', { name: 'Review & Submit' }),
     ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Finish exam' })).toHaveCount(
+      0,
+    );
+    await expect(
+      page
+        .getByTestId('bottom-action-bar')
+        .getByRole('button', { name: 'Review & Submit' }),
+    ).toHaveCount(1);
 
     // Click "Review & Submit" on the last question to enter exam review view
     await page

--- a/tests/integration/user-repository.integration.test.ts
+++ b/tests/integration/user-repository.integration.test.ts
@@ -12,14 +12,22 @@ const { db, sql } = createIntegrationDb();
 const cleanup = createCleanupState();
 
 function createScriptedNow(...timestamps: Date[]) {
+  if (timestamps.length === 0) {
+    return () => {
+      throw new Error('Expected at least one scripted timestamp');
+    };
+  }
+
   let index = 0;
 
   return () => {
-    const value = timestamps[Math.min(index, timestamps.length - 1)];
-    if (!value) {
-      throw new Error('Expected at least one scripted timestamp');
+    if (index >= timestamps.length) {
+      throw new Error(
+        `Scripted now() exhausted after ${timestamps.length} call(s)`,
+      );
     }
 
+    const value = timestamps[index];
     index += 1;
     return value;
   };
@@ -34,6 +42,16 @@ afterAll(async () => {
 });
 
 describe('DrizzleUserRepository', () => {
+  it('throws when scripted time is drawn more times than configured', () => {
+    const observedAt = new Date('2026-02-01T00:00:00.000Z');
+    const now = createScriptedNow(observedAt);
+
+    expect(now()).toBe(observedAt);
+    expect(() => now()).toThrowError(
+      'Scripted now() exhausted after 1 call(s)',
+    );
+  });
+
   it('upserts users by clerk id and can find them', async () => {
     const repo = new DrizzleUserRepository(db);
     const clerkUserId = `user_${randomUUID().replaceAll('-', '')}`;

--- a/tests/integration/user-repository.integration.test.ts
+++ b/tests/integration/user-repository.integration.test.ts
@@ -11,6 +11,20 @@ import {
 const { db, sql } = createIntegrationDb();
 const cleanup = createCleanupState();
 
+function createScriptedNow(...timestamps: Date[]) {
+  let index = 0;
+
+  return () => {
+    const value = timestamps[Math.min(index, timestamps.length - 1)];
+    if (!value) {
+      throw new Error('Expected at least one scripted timestamp');
+    }
+
+    index += 1;
+    return value;
+  };
+}
+
 afterEach(async () => {
   await cleanupAfterEach(db, cleanup);
 });
@@ -99,7 +113,12 @@ describe('DrizzleUserRepository', () => {
   });
 
   it('updates email when upserting an existing user', async () => {
-    const repo = new DrizzleUserRepository(db);
+    const firstObservedAt = new Date('2026-02-01T00:00:00.000Z');
+    const secondObservedAt = new Date('2026-02-01T00:00:01.000Z');
+    const repo = new DrizzleUserRepository(
+      db,
+      createScriptedNow(firstObservedAt, secondObservedAt),
+    );
     const clerkUserId = `user_${randomUUID().replaceAll('-', '')}`;
 
     const first = await repo.upsertByClerkId(
@@ -114,11 +133,18 @@ describe('DrizzleUserRepository', () => {
     expect(second).toMatchObject({
       id: first.id,
       email: secondEmail,
+      createdAt: firstObservedAt,
+      updatedAt: secondObservedAt,
     });
   });
 
   it('updates clerkUserId when a different clerkId arrives for the same email', async () => {
-    const repo = new DrizzleUserRepository(db);
+    const firstObservedAt = new Date('2026-02-01T00:00:00.000Z');
+    const secondObservedAt = new Date('2026-02-01T00:00:01.000Z');
+    const repo = new DrizzleUserRepository(
+      db,
+      createScriptedNow(firstObservedAt, secondObservedAt),
+    );
     const email = `it-${randomUUID()}@example.com`;
     const clerkId1 = `user_${randomUUID().replaceAll('-', '')}`;
     const clerkId2 = `user_${randomUUID().replaceAll('-', '')}`;
@@ -131,6 +157,8 @@ describe('DrizzleUserRepository', () => {
     expect(second).toMatchObject({
       id: first.id,
       email,
+      createdAt: firstObservedAt,
+      updatedAt: secondObservedAt,
     });
 
     await expect(repo.findByClerkId(clerkId2)).resolves.toMatchObject({


### PR DESCRIPTION
## Summary
- remove the exam-mode header `Finish exam` button from `PracticeView`
- preserve tutor-mode header `End session` button and footer `Review & Submit` routing
- update browser/controller/E2E coverage to the new contract

## Problem
DEBT-363 Concern 2 found two differently labeled CTAs on the last exam question: header `Finish exam` and footer `Review & Submit`. Both routed to the same `onEndSession` path and landed on the same `ExamReviewView`.

## Solution
- gate the header action so it renders only outside exam mode
- keep `onEndSession` wired to the last-question footer `Review & Submit`
- leave tutor-mode header behavior unchanged
- update controller/browser review-entry flows to use the footer CTA

## Mental Map Checklist
- `app/(app)/app/practice/components/practice-view.tsx`: header button render path is now gated off in exam mode
- `app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx`: `endSessionLabel` derivation stays in place; no footer routing changed
- `onEndSession` still originates from the session page controller and is still consumed by the tutor header path and the last-question exam footer path
- contracts flipped in:
  - `app/(app)/app/practice/[sessionId]/components/practice-session-page-view.browser.spec.tsx`
  - `app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller.browser.spec.tsx`
  - `tests/e2e/practice.spec.ts`

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test --run`
- `pnpm test:browser`
- `pnpm db:test:up`
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:migrate`
- `SEED_INCLUDE_PLACEHOLDERS=true DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:seed`
- `pnpm test:integration`
- `pnpm build`
- `pnpm test:e2e`

## Debt
- Implements `docs/debt/debt-363-exam-shell-scroll-model-and-dual-cta.md` Concern 2A
- DEBT-365 Concern 1 should now auto-resolve in the next docs-only revision


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined session header actions: "Finish exam" removed in exam mode, "End session" suppressed in exam-question headers, and "End session" shown in tutor mode where appropriate.
  * Ensured "Review & Submit" appears in the expected pre-review UI and navigation flows.

* **Tests**
  * Updated browser, integration, and e2e tests to assert revised button visibility and counts.
  * Added a deterministic test time helper and assertions to validate scripted creation/update timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->