### PR TITLE
Fix DEBT-364 post-exam review re-entry cursor reset

### DIFF
--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.browser.spec.tsx
@@ -1,0 +1,205 @@
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from 'vitest-browser-react';
+import type { ActionResult } from '@/src/adapters/controllers/action-result';
+import type {
+  EndPracticeSessionOutput,
+  GetCompletedSessionQuestionsWithFeedbackOutput,
+} from '@/src/adapters/controllers/practice-controller';
+import { createDeferred } from '@/tests/test-helpers/create-deferred';
+import { ok } from '@/tests/test-helpers/ok';
+import { usePracticeSessionExamResultsContinuity } from './use-practice-session-exam-results-continuity';
+import {
+  createPostExamReview,
+  createPostExamReviewRow,
+  createSummary,
+} from './use-practice-session-exam-results-continuity.fixtures';
+
+type GetCompletedSessionQuestionsWithFeedbackFn = Parameters<
+  typeof usePracticeSessionExamResultsContinuity
+>[0]['getCompletedSessionQuestionsWithFeedbackFn'];
+
+async function renderContinuityHook(input?: {
+  initialSummary?: EndPracticeSessionOutput | null;
+  getCompletedSessionQuestionsWithFeedbackFn?: GetCompletedSessionQuestionsWithFeedbackFn;
+}) {
+  const initialSummary = input?.initialSummary ?? null;
+  const getCompletedSessionQuestionsWithFeedbackFn =
+    input?.getCompletedSessionQuestionsWithFeedbackFn ?? vi.fn();
+  const isMounted = () => true;
+
+  return renderHook(() => {
+    const [summary, setSummaryState] =
+      useState<EndPracticeSessionOutput | null>(initialSummary);
+
+    return usePracticeSessionExamResultsContinuity({
+      summary,
+      setSummaryState,
+      isMounted,
+      sessionId: 'session-1',
+      getCompletedSessionQuestionsWithFeedbackFn,
+    });
+  });
+}
+
+describe('usePracticeSessionExamResultsContinuity (browser)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resets untargeted cached summary re-entry to the first available row instead of the persisted cursor', async () => {
+    const review = createPostExamReview(
+      createPostExamReviewRow({
+        questionId: 'q1',
+        order: 1,
+        isAvailable: false,
+      }),
+      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
+    );
+    const getCompletedSessionQuestionsWithFeedbackFn = vi
+      .fn<GetCompletedSessionQuestionsWithFeedbackFn>()
+      .mockResolvedValue(ok(review));
+    const harness = await renderContinuityHook({
+      getCompletedSessionQuestionsWithFeedbackFn,
+    });
+
+    await harness.result.current.enterPostExamReview(createSummary());
+    await expect
+      .poll(() => harness.result.current.postExamReviewLoadState.status)
+      .toBe('ready');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+
+    harness.result.current.onNavigatePostExamReviewQuestion('q3');
+    await expect
+      .poll(() => harness.result.current.postExamReviewCurrentQuestionId)
+      .toBe('q3');
+
+    harness.result.current.onViewSummary();
+    await expect
+      .poll(() => harness.result.current.examResultsSubstage)
+      .toBe('session_summary');
+
+    harness.result.current.onReenterPostExamReview();
+
+    await expect
+      .poll(() => harness.result.current.examResultsSubstage)
+      .toBe('post_exam_review');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(getCompletedSessionQuestionsWithFeedbackFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the requested cached summary re-entry row when a specific question id is provided', async () => {
+    const review = createPostExamReview(
+      createPostExamReviewRow({ questionId: 'q1', order: 1 }),
+      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
+    );
+    const harness = await renderContinuityHook({
+      getCompletedSessionQuestionsWithFeedbackFn: vi
+        .fn<GetCompletedSessionQuestionsWithFeedbackFn>()
+        .mockResolvedValue(ok(review)),
+    });
+
+    await harness.result.current.enterPostExamReview(createSummary());
+    await expect
+      .poll(() => harness.result.current.postExamReviewLoadState.status)
+      .toBe('ready');
+
+    harness.result.current.onNavigatePostExamReviewQuestion('q3');
+    harness.result.current.onViewSummary();
+    await expect
+      .poll(() => harness.result.current.examResultsSubstage)
+      .toBe('session_summary');
+
+    harness.result.current.onReenterPostExamReview('q2');
+
+    await expect
+      .poll(() => harness.result.current.examResultsSubstage)
+      .toBe('post_exam_review');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+  });
+
+  it('resets untargeted lazy-hydrated summary re-entry to the first available row even when the persisted cursor points later in the review', async () => {
+    const review = createPostExamReview(
+      createPostExamReviewRow({
+        questionId: 'q1',
+        order: 1,
+        isAvailable: false,
+      }),
+      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
+    );
+    const reviewLoad =
+      createDeferred<
+        ActionResult<GetCompletedSessionQuestionsWithFeedbackOutput>
+      >();
+    const getCompletedSessionQuestionsWithFeedbackFn = vi.fn(
+      async () => reviewLoad.promise,
+    );
+    const harness = await renderContinuityHook({
+      getCompletedSessionQuestionsWithFeedbackFn,
+    });
+
+    harness.result.current.setSummary(createSummary());
+    await expect
+      .poll(() => harness.result.current.examResultsSubstage)
+      .toBe('session_summary');
+
+    harness.result.current.onNavigatePostExamReviewQuestion('q3');
+    await expect
+      .poll(() => harness.result.current.postExamReviewCurrentQuestionId)
+      .toBe('q3');
+
+    harness.result.current.onReenterPostExamReview();
+    await expect
+      .poll(() => harness.result.current.postExamReviewLoadState.status)
+      .toBe('loading');
+
+    reviewLoad.resolve(ok(review));
+    await reviewLoad.promise;
+
+    await expect
+      .poll(() => harness.result.current.postExamReviewLoadState.status)
+      .toBe('ready');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.result.current.examResultsSubstage).toBe('post_exam_review');
+  });
+
+  it('preserves the requested lazy-hydrated summary re-entry row when a specific question id is provided', async () => {
+    const review = createPostExamReview(
+      createPostExamReviewRow({ questionId: 'q1', order: 1 }),
+      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
+    );
+    const reviewLoad =
+      createDeferred<
+        ActionResult<GetCompletedSessionQuestionsWithFeedbackOutput>
+      >();
+    const harness = await renderContinuityHook({
+      getCompletedSessionQuestionsWithFeedbackFn: vi.fn(
+        async () => reviewLoad.promise,
+      ),
+    });
+
+    harness.result.current.setSummary(createSummary());
+    harness.result.current.onNavigatePostExamReviewQuestion('q3');
+    await expect
+      .poll(() => harness.result.current.examResultsSubstage)
+      .toBe('session_summary');
+
+    harness.result.current.onReenterPostExamReview('q2');
+    await expect
+      .poll(() => harness.result.current.postExamReviewLoadState.status)
+      .toBe('loading');
+
+    reviewLoad.resolve(ok(review));
+    await reviewLoad.promise;
+
+    await expect
+      .poll(() => harness.result.current.postExamReviewLoadState.status)
+      .toBe('ready');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.result.current.examResultsSubstage).toBe('post_exam_review');
+  });
+});

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.fixtures.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.fixtures.ts
@@ -1,0 +1,72 @@
+import type {
+  EndPracticeSessionOutput,
+  GetCompletedSessionQuestionsWithFeedbackOutput,
+} from '@/src/adapters/controllers/practice-controller';
+
+export function createSummary(
+  input?: Partial<EndPracticeSessionOutput>,
+): EndPracticeSessionOutput {
+  return {
+    sessionId: 'session-1',
+    endedAt: '2026-02-07T00:20:00.000Z',
+    mode: 'exam',
+    questionCount: 3,
+    totals: {
+      answered: 3,
+      correct: 2,
+      accuracy: 2 / 3,
+      durationSeconds: 180,
+    },
+    ...input,
+  };
+}
+
+export function createPostExamReviewRow(input: {
+  questionId: string;
+  order: number;
+  isAvailable?: boolean;
+}): GetCompletedSessionQuestionsWithFeedbackOutput['rows'][number] {
+  if (input.isAvailable === false) {
+    return {
+      isAvailable: false,
+      questionId: input.questionId,
+      order: input.order,
+      isAnswered: true,
+      isCorrect: false,
+      markedForReview: false,
+    };
+  }
+
+  return {
+    isAvailable: true,
+    questionId: input.questionId,
+    slug: `${input.questionId}-slug`,
+    stemMd: `Stem for ${input.questionId}`,
+    difficulty: 'easy',
+    order: input.order,
+    isAnswered: true,
+    isCorrect: true,
+    markedForReview: false,
+    choices: [
+      { id: `${input.questionId}-choice-1`, label: 'A', textMd: 'Choice A' },
+    ],
+    selectedChoiceId: `${input.questionId}-choice-1`,
+    correctChoiceId: `${input.questionId}-choice-1`,
+    explanationMd: `Explanation for ${input.questionId}`,
+    referenceMd: null,
+    choiceExplanations: [],
+  };
+}
+
+export function createPostExamReview(
+  ...rows: GetCompletedSessionQuestionsWithFeedbackOutput['rows']
+): GetCompletedSessionQuestionsWithFeedbackOutput {
+  return {
+    sessionId: 'session-1',
+    mode: 'exam',
+    totalCount: rows.length,
+    answeredCount: rows.filter((row) => row.isAnswered).length,
+    markedCount: rows.filter((row) => row.markedForReview).length,
+    rows,
+  };
+}

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.test.tsx
@@ -1,11 +1,165 @@
 // @vitest-environment jsdom
 
+import { act, useState } from 'react';
+import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ActionResult } from '@/src/adapters/controllers/action-result';
+import type {
+  EndPracticeSessionOutput,
+  GetCompletedSessionQuestionsWithFeedbackOutput,
+} from '@/src/adapters/controllers/practice-controller';
 import { renderHook } from '@/src/application/test-helpers/render-hook';
+import { createDeferred } from '@/tests/test-helpers/create-deferred';
+import { ok } from '@/tests/test-helpers/ok';
 import { usePracticeSessionExamResultsContinuity } from './use-practice-session-exam-results-continuity';
 
+type ContinuityOutput = ReturnType<
+  typeof usePracticeSessionExamResultsContinuity
+>;
+type GetCompletedSessionQuestionsWithFeedbackFn = Parameters<
+  typeof usePracticeSessionExamResultsContinuity
+>[0]['getCompletedSessionQuestionsWithFeedbackFn'];
+
+function createSummary(
+  input?: Partial<EndPracticeSessionOutput>,
+): EndPracticeSessionOutput {
+  return {
+    sessionId: 'session-1',
+    endedAt: '2026-02-07T00:20:00.000Z',
+    mode: 'exam',
+    questionCount: 3,
+    totals: {
+      answered: 3,
+      correct: 2,
+      accuracy: 2 / 3,
+      durationSeconds: 180,
+    },
+    ...input,
+  };
+}
+
+function createPostExamReviewRow(input: {
+  questionId: string;
+  order: number;
+  isAvailable?: boolean;
+}): GetCompletedSessionQuestionsWithFeedbackOutput['rows'][number] {
+  if (input.isAvailable === false) {
+    return {
+      isAvailable: false,
+      questionId: input.questionId,
+      order: input.order,
+      isAnswered: true,
+      isCorrect: false,
+      markedForReview: false,
+    };
+  }
+
+  return {
+    isAvailable: true,
+    questionId: input.questionId,
+    slug: `${input.questionId}-slug`,
+    stemMd: `Stem for ${input.questionId}`,
+    difficulty: 'easy',
+    order: input.order,
+    isAnswered: true,
+    isCorrect: true,
+    markedForReview: false,
+    choices: [
+      { id: `${input.questionId}-choice-1`, label: 'A', textMd: 'Choice A' },
+    ],
+    selectedChoiceId: `${input.questionId}-choice-1`,
+    correctChoiceId: `${input.questionId}-choice-1`,
+    explanationMd: `Explanation for ${input.questionId}`,
+    referenceMd: null,
+    choiceExplanations: [],
+  };
+}
+
+function createPostExamReview(
+  ...rows: GetCompletedSessionQuestionsWithFeedbackOutput['rows']
+): GetCompletedSessionQuestionsWithFeedbackOutput {
+  return {
+    sessionId: 'session-1',
+    mode: 'exam',
+    totalCount: rows.length,
+    answeredCount: rows.filter((row) => row.isAnswered).length,
+    markedCount: rows.filter((row) => row.markedForReview).length,
+    rows,
+  };
+}
+
+const liveHookCleanups: Array<() => Promise<void>> = [];
+
+async function renderLiveContinuityHook(input?: {
+  initialSummary?: EndPracticeSessionOutput | null;
+  getCompletedSessionQuestionsWithFeedbackFn?: GetCompletedSessionQuestionsWithFeedbackFn;
+}) {
+  let current: ContinuityOutput | null = null;
+
+  function Harness() {
+    const [summary, setSummaryState] =
+      useState<EndPracticeSessionOutput | null>(input?.initialSummary ?? null);
+
+    current = usePracticeSessionExamResultsContinuity({
+      summary,
+      setSummaryState,
+      isMounted: () => true,
+      sessionId: 'session-1',
+      getCompletedSessionQuestionsWithFeedbackFn:
+        input?.getCompletedSessionQuestionsWithFeedbackFn ?? vi.fn(),
+    });
+
+    return null;
+  }
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  const cleanup = async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  };
+  liveHookCleanups.push(cleanup);
+
+  await act(async () => {
+    root.render(<Harness />);
+  });
+
+  const getCurrent = () => {
+    if (!current) {
+      throw new Error('Expected hook output to be available');
+    }
+    return current;
+  };
+
+  return {
+    get current() {
+      return getCurrent();
+    },
+    async run<T>(callback: () => T | Promise<T>): Promise<T> {
+      let value: T | undefined;
+      await act(async () => {
+        value = await callback();
+      });
+      if (value === undefined) {
+        return undefined as T;
+      }
+      return value;
+    },
+  };
+}
+
 describe('usePracticeSessionExamResultsContinuity', () => {
-  afterEach(() => {
+  afterEach(async () => {
+    while (liveHookCleanups.length > 0) {
+      const cleanup = liveHookCleanups.pop();
+      if (cleanup) {
+        await cleanup();
+      }
+    }
     vi.restoreAllMocks();
   });
 
@@ -31,5 +185,163 @@ describe('usePracticeSessionExamResultsContinuity', () => {
     expect(typeof output.onRetryPostExamReview).toBe('function');
     expect(typeof output.onViewSummary).toBe('function');
     expect(typeof output.enterPostExamReview).toBe('function');
+  });
+
+  it('resets untargeted cached summary re-entry to the first available row instead of the persisted cursor', async () => {
+    const review = createPostExamReview(
+      createPostExamReviewRow({
+        questionId: 'q1',
+        order: 1,
+        isAvailable: false,
+      }),
+      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
+    );
+    const getCompletedSessionQuestionsWithFeedbackFn = vi
+      .fn<GetCompletedSessionQuestionsWithFeedbackFn>()
+      .mockResolvedValue(ok(review));
+    const harness = await renderLiveContinuityHook({
+      getCompletedSessionQuestionsWithFeedbackFn,
+    });
+
+    await harness.run(async () => {
+      await harness.current.enterPostExamReview(createSummary());
+    });
+    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q2');
+
+    await harness.run(async () => {
+      harness.current.onNavigatePostExamReviewQuestion('q3');
+    });
+    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q3');
+
+    await harness.run(async () => {
+      harness.current.onViewSummary();
+    });
+    expect(harness.current.examResultsSubstage).toBe('session_summary');
+
+    await harness.run(async () => {
+      harness.current.onReenterPostExamReview();
+    });
+
+    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.current.examResultsSubstage).toBe('post_exam_review');
+    expect(getCompletedSessionQuestionsWithFeedbackFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the requested cached summary re-entry row when a specific question id is provided', async () => {
+    const review = createPostExamReview(
+      createPostExamReviewRow({ questionId: 'q1', order: 1 }),
+      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
+    );
+    const harness = await renderLiveContinuityHook({
+      getCompletedSessionQuestionsWithFeedbackFn: vi
+        .fn<GetCompletedSessionQuestionsWithFeedbackFn>()
+        .mockResolvedValue(ok(review)),
+    });
+
+    await harness.run(async () => {
+      await harness.current.enterPostExamReview(createSummary());
+    });
+    await harness.run(async () => {
+      harness.current.onNavigatePostExamReviewQuestion('q3');
+      harness.current.onViewSummary();
+    });
+    expect(harness.current.examResultsSubstage).toBe('session_summary');
+
+    await harness.run(async () => {
+      harness.current.onReenterPostExamReview('q2');
+    });
+
+    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.current.examResultsSubstage).toBe('post_exam_review');
+  });
+
+  it('resets untargeted lazy-hydrated summary re-entry to the first available row even when the persisted cursor points later in the review', async () => {
+    const review = createPostExamReview(
+      createPostExamReviewRow({
+        questionId: 'q1',
+        order: 1,
+        isAvailable: false,
+      }),
+      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
+    );
+    const reviewLoad =
+      createDeferred<
+        ActionResult<GetCompletedSessionQuestionsWithFeedbackOutput>
+      >();
+    const getCompletedSessionQuestionsWithFeedbackFn = vi.fn(
+      async () => reviewLoad.promise,
+    );
+    const harness = await renderLiveContinuityHook({
+      getCompletedSessionQuestionsWithFeedbackFn,
+    });
+
+    await harness.run(async () => {
+      harness.current.setSummary(createSummary());
+    });
+    await harness.run(async () => {
+      harness.current.onNavigatePostExamReviewQuestion('q3');
+    });
+    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q3');
+
+    await harness.run(async () => {
+      harness.current.onReenterPostExamReview();
+    });
+    expect(harness.current.postExamReviewLoadState).toEqual({
+      status: 'loading',
+    });
+
+    await harness.run(async () => {
+      reviewLoad.resolve(ok(review));
+      await reviewLoad.promise;
+    });
+
+    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.current.postExamReviewLoadState).toEqual({
+      status: 'ready',
+    });
+    expect(harness.current.examResultsSubstage).toBe('post_exam_review');
+  });
+
+  it('preserves the requested lazy-hydrated summary re-entry row when a specific question id is provided', async () => {
+    const review = createPostExamReview(
+      createPostExamReviewRow({ questionId: 'q1', order: 1 }),
+      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
+    );
+    const reviewLoad =
+      createDeferred<
+        ActionResult<GetCompletedSessionQuestionsWithFeedbackOutput>
+      >();
+    const harness = await renderLiveContinuityHook({
+      getCompletedSessionQuestionsWithFeedbackFn: vi.fn(
+        async () => reviewLoad.promise,
+      ),
+    });
+
+    await harness.run(async () => {
+      harness.current.setSummary(createSummary());
+      harness.current.onNavigatePostExamReviewQuestion('q3');
+    });
+
+    await harness.run(async () => {
+      harness.current.onReenterPostExamReview('q2');
+    });
+    expect(harness.current.postExamReviewLoadState).toEqual({
+      status: 'loading',
+    });
+
+    await harness.run(async () => {
+      reviewLoad.resolve(ok(review));
+      await reviewLoad.promise;
+    });
+
+    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.current.postExamReviewLoadState).toEqual({
+      status: 'ready',
+    });
+    expect(harness.current.examResultsSubstage).toBe('post_exam_review');
   });
 });

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.test.tsx
@@ -140,13 +140,10 @@ async function renderLiveContinuityHook(input?: {
       return getCurrent();
     },
     async run<T>(callback: () => T | Promise<T>): Promise<T> {
-      let value: T | undefined;
+      let value!: T;
       await act(async () => {
         value = await callback();
       });
-      if (value === undefined) {
-        return undefined as T;
-      }
       return value;
     },
   };

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.test.tsx
@@ -1,162 +1,18 @@
 // @vitest-environment jsdom
 
-import { act, useState } from 'react';
-import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { ActionResult } from '@/src/adapters/controllers/action-result';
-import type {
-  EndPracticeSessionOutput,
-  GetCompletedSessionQuestionsWithFeedbackOutput,
-} from '@/src/adapters/controllers/practice-controller';
 import { renderHook } from '@/src/application/test-helpers/render-hook';
-import { createDeferred } from '@/tests/test-helpers/create-deferred';
-import { ok } from '@/tests/test-helpers/ok';
-import { usePracticeSessionExamResultsContinuity } from './use-practice-session-exam-results-continuity';
-
-type ContinuityOutput = ReturnType<
-  typeof usePracticeSessionExamResultsContinuity
->;
-type GetCompletedSessionQuestionsWithFeedbackFn = Parameters<
-  typeof usePracticeSessionExamResultsContinuity
->[0]['getCompletedSessionQuestionsWithFeedbackFn'];
-
-function createSummary(
-  input?: Partial<EndPracticeSessionOutput>,
-): EndPracticeSessionOutput {
-  return {
-    sessionId: 'session-1',
-    endedAt: '2026-02-07T00:20:00.000Z',
-    mode: 'exam',
-    questionCount: 3,
-    totals: {
-      answered: 3,
-      correct: 2,
-      accuracy: 2 / 3,
-      durationSeconds: 180,
-    },
-    ...input,
-  };
-}
-
-function createPostExamReviewRow(input: {
-  questionId: string;
-  order: number;
-  isAvailable?: boolean;
-}): GetCompletedSessionQuestionsWithFeedbackOutput['rows'][number] {
-  if (input.isAvailable === false) {
-    return {
-      isAvailable: false,
-      questionId: input.questionId,
-      order: input.order,
-      isAnswered: true,
-      isCorrect: false,
-      markedForReview: false,
-    };
-  }
-
-  return {
-    isAvailable: true,
-    questionId: input.questionId,
-    slug: `${input.questionId}-slug`,
-    stemMd: `Stem for ${input.questionId}`,
-    difficulty: 'easy',
-    order: input.order,
-    isAnswered: true,
-    isCorrect: true,
-    markedForReview: false,
-    choices: [
-      { id: `${input.questionId}-choice-1`, label: 'A', textMd: 'Choice A' },
-    ],
-    selectedChoiceId: `${input.questionId}-choice-1`,
-    correctChoiceId: `${input.questionId}-choice-1`,
-    explanationMd: `Explanation for ${input.questionId}`,
-    referenceMd: null,
-    choiceExplanations: [],
-  };
-}
-
-function createPostExamReview(
-  ...rows: GetCompletedSessionQuestionsWithFeedbackOutput['rows']
-): GetCompletedSessionQuestionsWithFeedbackOutput {
-  return {
-    sessionId: 'session-1',
-    mode: 'exam',
-    totalCount: rows.length,
-    answeredCount: rows.filter((row) => row.isAnswered).length,
-    markedCount: rows.filter((row) => row.markedForReview).length,
-    rows,
-  };
-}
-
-const liveHookCleanups: Array<() => Promise<void>> = [];
-
-async function renderLiveContinuityHook(input?: {
-  initialSummary?: EndPracticeSessionOutput | null;
-  getCompletedSessionQuestionsWithFeedbackFn?: GetCompletedSessionQuestionsWithFeedbackFn;
-}) {
-  let current: ContinuityOutput | null = null;
-
-  function Harness() {
-    const [summary, setSummaryState] =
-      useState<EndPracticeSessionOutput | null>(input?.initialSummary ?? null);
-
-    current = usePracticeSessionExamResultsContinuity({
-      summary,
-      setSummaryState,
-      isMounted: () => true,
-      sessionId: 'session-1',
-      getCompletedSessionQuestionsWithFeedbackFn:
-        input?.getCompletedSessionQuestionsWithFeedbackFn ?? vi.fn(),
-    });
-
-    return null;
-  }
-
-  const container = document.createElement('div');
-  document.body.appendChild(container);
-  const root = createRoot(container);
-
-  const cleanup = async () => {
-    await act(async () => {
-      root.unmount();
-    });
-    container.remove();
-  };
-  liveHookCleanups.push(cleanup);
-
-  await act(async () => {
-    root.render(<Harness />);
-  });
-
-  const getCurrent = () => {
-    if (!current) {
-      throw new Error('Expected hook output to be available');
-    }
-    return current;
-  };
-
-  return {
-    get current() {
-      return getCurrent();
-    },
-    async run<T>(callback: () => T | Promise<T>): Promise<T> {
-      let value!: T;
-      await act(async () => {
-        value = await callback();
-      });
-      return value;
-    },
-  };
-}
+import {
+  resolvePostExamReviewCurrentQuestionId,
+  usePracticeSessionExamResultsContinuity,
+} from './use-practice-session-exam-results-continuity';
+import {
+  createPostExamReview,
+  createPostExamReviewRow,
+} from './use-practice-session-exam-results-continuity.fixtures';
 
 describe('usePracticeSessionExamResultsContinuity', () => {
-  afterEach(async () => {
-    while (liveHookCleanups.length > 0) {
-      const cleanup = liveHookCleanups.pop();
-      if (cleanup) {
-        await cleanup();
-      }
-    }
+  afterEach(() => {
     vi.restoreAllMocks();
   });
 
@@ -184,7 +40,20 @@ describe('usePracticeSessionExamResultsContinuity', () => {
     expect(typeof output.enterPostExamReview).toBe('function');
   });
 
-  it('resets untargeted cached summary re-entry to the first available row instead of the persisted cursor', async () => {
+  it('prefers the specifically requested available question over the persisted cursor', () => {
+    const review = createPostExamReview(
+      createPostExamReviewRow({ questionId: 'q1', order: 1 }),
+      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+    );
+    expect(
+      resolvePostExamReviewCurrentQuestionId(review, {
+        requestedQuestionId: 'q2',
+        persistedQuestionId: 'q1',
+      }),
+    ).toBe('q2');
+  });
+
+  it('falls back to the persisted available question when the requested row is unavailable', () => {
     const review = createPostExamReview(
       createPostExamReviewRow({
         questionId: 'q1',
@@ -192,153 +61,58 @@ describe('usePracticeSessionExamResultsContinuity', () => {
         isAvailable: false,
       }),
       createPostExamReviewRow({ questionId: 'q2', order: 2 }),
-      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
     );
-    const getCompletedSessionQuestionsWithFeedbackFn = vi
-      .fn<GetCompletedSessionQuestionsWithFeedbackFn>()
-      .mockResolvedValue(ok(review));
-    const harness = await renderLiveContinuityHook({
-      getCompletedSessionQuestionsWithFeedbackFn,
-    });
 
-    await harness.run(async () => {
-      await harness.current.enterPostExamReview(createSummary());
-    });
-    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q2');
-
-    await harness.run(async () => {
-      harness.current.onNavigatePostExamReviewQuestion('q3');
-    });
-    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q3');
-
-    await harness.run(async () => {
-      harness.current.onViewSummary();
-    });
-    expect(harness.current.examResultsSubstage).toBe('session_summary');
-
-    await harness.run(async () => {
-      harness.current.onReenterPostExamReview();
-    });
-
-    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q2');
-    expect(harness.current.examResultsSubstage).toBe('post_exam_review');
-    expect(getCompletedSessionQuestionsWithFeedbackFn).toHaveBeenCalledTimes(1);
+    expect(
+      resolvePostExamReviewCurrentQuestionId(review, {
+        requestedQuestionId: 'q1',
+        persistedQuestionId: 'q2',
+      }),
+    ).toBe('q2');
   });
 
-  it('preserves the requested cached summary re-entry row when a specific question id is provided', async () => {
-    const review = createPostExamReview(
-      createPostExamReviewRow({ questionId: 'q1', order: 1 }),
-      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
-      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
-    );
-    const harness = await renderLiveContinuityHook({
-      getCompletedSessionQuestionsWithFeedbackFn: vi
-        .fn<GetCompletedSessionQuestionsWithFeedbackFn>()
-        .mockResolvedValue(ok(review)),
-    });
-
-    await harness.run(async () => {
-      await harness.current.enterPostExamReview(createSummary());
-    });
-    await harness.run(async () => {
-      harness.current.onNavigatePostExamReviewQuestion('q3');
-      harness.current.onViewSummary();
-    });
-    expect(harness.current.examResultsSubstage).toBe('session_summary');
-
-    await harness.run(async () => {
-      harness.current.onReenterPostExamReview('q2');
-    });
-
-    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q2');
-    expect(harness.current.examResultsSubstage).toBe('post_exam_review');
-  });
-
-  it('resets untargeted lazy-hydrated summary re-entry to the first available row even when the persisted cursor points later in the review', async () => {
+  it('falls back to the first available row when the requested and persisted cursors are unavailable', () => {
     const review = createPostExamReview(
       createPostExamReviewRow({
         questionId: 'q1',
         order: 1,
         isAvailable: false,
       }),
-      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+      createPostExamReviewRow({
+        questionId: 'q2',
+        order: 2,
+        isAvailable: false,
+      }),
       createPostExamReviewRow({ questionId: 'q3', order: 3 }),
     );
-    const reviewLoad =
-      createDeferred<
-        ActionResult<GetCompletedSessionQuestionsWithFeedbackOutput>
-      >();
-    const getCompletedSessionQuestionsWithFeedbackFn = vi.fn(
-      async () => reviewLoad.promise,
-    );
-    const harness = await renderLiveContinuityHook({
-      getCompletedSessionQuestionsWithFeedbackFn,
-    });
 
-    await harness.run(async () => {
-      harness.current.setSummary(createSummary());
-    });
-    await harness.run(async () => {
-      harness.current.onNavigatePostExamReviewQuestion('q3');
-    });
-    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q3');
-
-    await harness.run(async () => {
-      harness.current.onReenterPostExamReview();
-    });
-    expect(harness.current.postExamReviewLoadState).toEqual({
-      status: 'loading',
-    });
-
-    await harness.run(async () => {
-      reviewLoad.resolve(ok(review));
-      await reviewLoad.promise;
-    });
-
-    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q2');
-    expect(harness.current.postExamReviewLoadState).toEqual({
-      status: 'ready',
-    });
-    expect(harness.current.examResultsSubstage).toBe('post_exam_review');
+    expect(
+      resolvePostExamReviewCurrentQuestionId(review, {
+        requestedQuestionId: 'q1',
+        persistedQuestionId: 'q2',
+      }),
+    ).toBe('q3');
   });
 
-  it('preserves the requested lazy-hydrated summary re-entry row when a specific question id is provided', async () => {
+  it('falls back to the first row when no review rows are available', () => {
     const review = createPostExamReview(
-      createPostExamReviewRow({ questionId: 'q1', order: 1 }),
-      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
-      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
+      createPostExamReviewRow({
+        questionId: 'q1',
+        order: 1,
+        isAvailable: false,
+      }),
+      createPostExamReviewRow({
+        questionId: 'q2',
+        order: 2,
+        isAvailable: false,
+      }),
     );
-    const reviewLoad =
-      createDeferred<
-        ActionResult<GetCompletedSessionQuestionsWithFeedbackOutput>
-      >();
-    const harness = await renderLiveContinuityHook({
-      getCompletedSessionQuestionsWithFeedbackFn: vi.fn(
-        async () => reviewLoad.promise,
-      ),
-    });
 
-    await harness.run(async () => {
-      harness.current.setSummary(createSummary());
-      harness.current.onNavigatePostExamReviewQuestion('q3');
-    });
-
-    await harness.run(async () => {
-      harness.current.onReenterPostExamReview('q2');
-    });
-    expect(harness.current.postExamReviewLoadState).toEqual({
-      status: 'loading',
-    });
-
-    await harness.run(async () => {
-      reviewLoad.resolve(ok(review));
-      await reviewLoad.promise;
-    });
-
-    expect(harness.current.postExamReviewCurrentQuestionId).toBe('q2');
-    expect(harness.current.postExamReviewLoadState).toEqual({
-      status: 'ready',
-    });
-    expect(harness.current.examResultsSubstage).toBe('post_exam_review');
+    expect(
+      resolvePostExamReviewCurrentQuestionId(review, {
+        requestedQuestionId: 'missing',
+        persistedQuestionId: 'also-missing',
+      }),
+    ).toBe('q1');
   });
 });

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.ts
@@ -199,7 +199,9 @@ export function usePracticeSessionExamResultsContinuity(input: {
         setPostExamReviewCurrentQuestionId(
           resolvePostExamReviewCurrentQuestionId(postExamReview, {
             requestedQuestionId: questionId ?? null,
-            persistedQuestionId: postExamReviewCurrentQuestionId,
+            persistedQuestionId: questionId
+              ? postExamReviewCurrentQuestionId
+              : null,
           }),
         );
         setExamResultsSubstage('post_exam_review');
@@ -208,7 +210,9 @@ export function usePracticeSessionExamResultsContinuity(input: {
       if (postExamReviewLoadState.status === 'loading') return;
       void loadPostExamReview(nextSummary, {
         requestedQuestionId: questionId ?? null,
-        persistedQuestionId: postExamReviewCurrentQuestionId,
+        persistedQuestionId: questionId
+          ? postExamReviewCurrentQuestionId
+          : null,
         nextSubstageOnSuccess: 'post_exam_review',
       });
     },

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
@@ -473,7 +473,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
   });
 
-  it('re-enters post-exam review without a question id by preserving the current reviewed question', async () => {
+  it('re-enters post-exam review without a question id at the first available row instead of the current reviewed question', async () => {
     finalizeExamAnswersMock.mockResolvedValue(
       ok({
         sessionId: 'session-1',
@@ -528,7 +528,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     await expect
       .poll(() => harness.result.current.examResultsSubstage)
       .toBe('post_exam_review');
-    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q1');
     expect(getCompletedSessionQuestionsWithFeedbackMock).toHaveBeenCalledTimes(
       1,
     );
@@ -591,7 +591,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
   });
 
-  it('falls back to the first available reviewed question when the persisted question is unavailable', async () => {
+  it('falls back to the first available reviewed question on untargeted re-entry when the current cursor points at an unavailable row', async () => {
     finalizeExamAnswersMock.mockResolvedValue(
       ok({
         sessionId: 'session-1',
@@ -652,7 +652,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
       .toBe('q2');
   });
 
-  it('lazy-hydrates completed feedback when summary re-entry has no preserved post-exam review payload', async () => {
+  it('lazy-hydrates completed feedback to the first available row when summary re-entry has no preserved post-exam review payload', async () => {
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
         sessionId: 'session-1',

--- a/docs/practice-engine/interaction-contracts.md
+++ b/docs/practice-engine/interaction-contracts.md
@@ -278,10 +278,12 @@ Both substages render within the same `/app/practice/[sessionId]` orchestrator. 
 
 | Entry type | Cursor behavior | Rationale |
 |------------|----------------|-----------|
-| Initial (after exam submit) | First available question (Q1) | Fresh review pass — user has never seen feedback |
-| Re-entry via `Review Answers` button | First available question | Untargeted `onReenterPostExamReview()` now clears the persisted cursor so the CTA reopens the review as a fresh pass |
-| Re-entry via breakdown row click | Lands on the clicked question when available; otherwise falls back to the last viewed available question, then the first available question | `resolvePostExamReviewCurrentQuestionId()` prefers `requestedQuestionId`, then `persistedQuestionId` |
-| Re-entry after page refresh / cold start | First available question after the payload is fetched | The in-memory cursor is gone, so no persisted question ID exists |
+| Initial (after exam submit) | First available question (Q1); if none are available, the first review row | Fresh review pass — user has never seen feedback |
+| Re-entry via `Review Answers` button | First available question; if none are available, the first review row | Untargeted `onReenterPostExamReview()` now clears the persisted cursor so the CTA reopens the review as a fresh pass while the shared resolver keeps the final first-row fallback |
+| Re-entry via breakdown row click | Lands on the clicked question when available; otherwise falls back to the last viewed available question, then the first available question, then the first review row | `resolvePostExamReviewCurrentQuestionId()` prefers `requestedQuestionId`, then `persistedQuestionId` |
+| Re-entry after page refresh / cold start | First available question after the payload is fetched; if none are available, the first review row | The in-memory cursor is gone, so no persisted question ID exists |
+
+The shared cursor resolver order remains: requested available question -> persisted available question -> first available row -> first review row. Untargeted `Review Answers` re-entry changes only by clearing the persisted cursor before resolution.
 
 **Load behavior:**
 

--- a/docs/practice-engine/interaction-contracts.md
+++ b/docs/practice-engine/interaction-contracts.md
@@ -4,7 +4,7 @@
 > **Scope:** Click-by-click UI contracts for tutor and exam modes — buttons, persistence, locking, navigation, and post-session flows
 > **Related:** [Practice Modes](./practice-modes.md) (lifecycle/data), [BS-055](../brainstorming/bs-055-exam-session-interaction-model-rethink.md) (decisions)
 > **Status:** Current implementation. Historical BS-055 rationale remains, but the contracts below now describe shipped behavior; follow-up deltas are tracked separately in debt docs where noted.
-> **Last Updated:** 2026-04-16
+> **Last Updated:** 2026-04-20
 
 ---
 
@@ -279,7 +279,7 @@ Both substages render within the same `/app/practice/[sessionId]` orchestrator. 
 | Entry type | Cursor behavior | Rationale |
 |------------|----------------|-----------|
 | Initial (after exam submit) | First available question (Q1) | Fresh review pass — user has never seen feedback |
-| Re-entry via `Review Answers` button | Reuses the last viewed available question when `postExamReviewCurrentQuestionId` is still valid; otherwise falls back to the first available question | `onReenterPostExamReview()` always passes `persistedQuestionId: postExamReviewCurrentQuestionId` on untargeted re-entry |
+| Re-entry via `Review Answers` button | First available question | Untargeted `onReenterPostExamReview()` now clears the persisted cursor so the CTA reopens the review as a fresh pass |
 | Re-entry via breakdown row click | Lands on the clicked question when available; otherwise falls back to the last viewed available question, then the first available question | `resolvePostExamReviewCurrentQuestionId()` prefers `requestedQuestionId`, then `persistedQuestionId` |
 | Re-entry after page refresh / cold start | First available question after the payload is fetched | The in-memory cursor is gone, so no persisted question ID exists |
 

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -246,6 +246,77 @@ test.describe('practice', () => {
     ).toBeVisible({ timeout: 30_000 });
   });
 
+  test('reopens post-exam review at the first question when Review Answers is clicked from the session summary', async ({
+    page,
+  }) => {
+    await signInWithClerkPassword(page);
+    await ensureSubscribed(page);
+    await startSession(page, 'exam', 3);
+
+    await selectChoiceByLabel(page, 'A');
+    await page.getByRole('button', { name: 'Next' }).click();
+    await selectChoiceByLabel(page, 'A');
+    await page.getByRole('button', { name: 'Next' }).click();
+    await selectChoiceByLabel(page, 'A');
+    await expect(
+      page.getByRole('button', { name: 'Review & Submit' }),
+    ).toBeVisible();
+
+    await page
+      .getByTestId('bottom-action-bar')
+      .getByRole('button', { name: 'Review & Submit' })
+      .click();
+
+    const submitExamButton = page.getByRole('button', { name: 'Submit exam' });
+    await expect(submitExamButton).toBeVisible({ timeout: 15_000 });
+    await submitExamButton.click();
+    await page.getByRole('button', { name: 'Confirm submit' }).click();
+
+    const getQuestionNavigatorButton = (order: number) =>
+      page
+        .getByRole('navigation', { name: 'Question navigator' })
+        .getByRole('button', {
+          name: new RegExp(`^Question ${order}:`),
+        });
+
+    await expect(page.getByText('Question 1 of 3')).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByRole('button', { name: 'Next' })).toBeVisible();
+    await expect(getQuestionNavigatorButton(1)).toHaveAttribute(
+      'aria-current',
+      'step',
+    );
+
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page.getByText('Question 2 of 3')).toBeVisible();
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page.getByText('Question 3 of 3')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Finish review' }),
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Next' })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Finish review' }).click();
+    await expect(
+      page.getByRole('heading', { name: 'Session Summary' }),
+    ).toBeVisible({ timeout: 30_000 });
+
+    await page.getByRole('button', { name: 'Review Answers' }).click();
+
+    await expect(page.getByText('Question 1 of 3')).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByRole('button', { name: 'Next' })).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Finish review' }),
+    ).toHaveCount(0);
+    await expect(getQuestionNavigatorButton(1)).toHaveAttribute(
+      'aria-current',
+      'step',
+    );
+  });
+
   test('resets the active question viewport after next and previous navigation', async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

Problem: `Review Answers` on the Session Summary reopened post-exam review at the last viewed question, which commonly meant the final row and made the missing `Next` button look like a broken footer.

Solution: untargeted `onReenterPostExamReview()` now clears the persisted cursor in both branches so `Review Answers` reopens on the first available row. Targeted summary breakdown re-entry still honors the clicked `questionId`.

Debt doc: `docs/debt/debt-364-post-exam-review-reentry-cursor-persistence.md`

## Mental Map / Touch Points Checked

- `app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.ts`
  - both `onReenterPostExamReview` branches
  - `resolvePostExamReviewCurrentQuestionId`
  - `onViewSummary`
- `app/(app)/app/practice/[sessionId]/components/practice-session-exam-results-renderer.tsx`
  - untargeted `Review Answers` callback path
  - targeted breakdown-row callback path
- `app/(app)/app/practice/[sessionId]/components/session-summary-view.tsx`
  - summary button wiring
- `app/(app)/app/shared/components/session-breakdown-list.tsx`
  - interactive targeted row wiring
- `app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx`
  - footer remains purely cursor-derived; no view-layer change
- `app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx`
  - existing sticky-cursor contract flipped for untargeted re-entry
  - targeted row contract preserved
- `tests/e2e/practice.spec.ts`
  - Summary -> Review Answers -> Q1 regression path added
- `docs/practice-engine/interaction-contracts.md`
  - live contract updated to match shipped semantics
- Browser back/forward restoration path reviewed: unchanged because it does not go through `onReenterPostExamReview`

## Behavior After This Change

- `Review Answers` from Session Summary reopens post-exam review on Q1 / the first available row.
- Clicking a Session Summary breakdown row still reopens the specific clicked question.
- `View Summary` still preserves cursor while leaving review; only untargeted re-entry resets it.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test --run`
- `pnpm test:browser`
- `pnpm test:integration`
- `pnpm build`
- `pnpm test:e2e`

## Notes

- Independent of DEBT-363 Concern 2A (already shipped)
- Independent of DEBT-365 Concerns 3A / 5A (separate follow-up PRs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Untargeted "Review Answers" re-entry now clears any persisted cursor so review opens at the first available question instead of the previously viewed one.

* **Tests**
  * Added unit, browser, and E2E tests covering targeted vs untargeted re-entry, cached vs lazy-hydrated scenarios, selection fallbacks, and reopening review landing on Question 1.

* **Documentation**
  * Updated interaction contract to reflect untargeted re-entry behavior and fallback order; updated "Last Updated" date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->