### PR TITLE
Apply active-exam visibility to dashboard streak timestamps

### DIFF
--- a/docs/bugs/bug-236-dashboard-current-streak-includes-active-exam-attempts.md
+++ b/docs/bugs/bug-236-dashboard-current-streak-includes-active-exam-attempts.md
@@ -44,18 +44,24 @@ This does not expose correctness, but it violates the dashboard's active-exam vi
 
 ## Expected Fix
 
-Update `DrizzleAttemptRepository.listAnsweredAtByUserIdSince(...)` to use the same active-exam visibility predicate as the other `AttemptStatsReader` methods:
-- Join `practice_sessions` on `attempts.practiceSessionId`.
-- Apply `activeExamVisibilityCondition()` with the existing user/date predicates.
-- Keep ordering deterministic with the current descending timestamp order.
+Update `DrizzleAttemptRepository.listAnsweredAtByUserIdSince(...)` at `src/adapters/repositories/drizzle-attempt-repository.ts:401-412` to mirror the established sister-method pattern in this same file:
 
-Add regression coverage that proves current streak ignores active-exam attempts until the exam session ends.
+- **Switch from the relational query API to the explicit query builder.** The sister methods `countWhere(...)` (lines 323-343) and `listRecentByUserId(...)` (lines 368-399) both use `this.db.select(...).from(attempts).leftJoin(practiceSessions, ...).where(and(eq(attempts.userId, userId), this.activeExamVisibilityCondition(), <other-conditions>))`. Use the same shape — do NOT use `db.query.attempts.findMany(...)` with a nested `with:` clause; the relational API does not cleanly support filtering on joined-table columns and would diverge from sibling code.
+- **Use `leftJoin(practiceSessions, eq(attempts.practiceSessionId, practiceSessions.id))`.** A left join is required so standalone-quick-practice attempts (where `attempts.practiceSessionId IS NULL`) survive — `activeExamVisibilityCondition()` (`drizzle-attempt-repository.ts:53-66`) already returns true for the `practiceSessions.id IS NULL` branch produced by the unmatched leftJoin.
+- **Apply `this.activeExamVisibilityCondition()`** alongside the existing `eq(attempts.userId, userId)` and `gte(attempts.answeredAt, since)` predicates inside a single `and(...)` block.
+- **Preserve the public contract:** select only `attempts.answeredAt` (no extra columns from `practiceSessions`), keep `orderBy(desc(attempts.answeredAt))`, return `readonly Date[]` exactly as the port `AttemptStatsReader.listAnsweredAtByUserIdSince` declares.
+
+This is a **defense-in-depth alignment** with the secrecy/visibility policy. After BUG-237's fix, the upstream `submitAnswer` write boundary no longer creates active-exam `attempts` rows in the normal flow. This bug fix nonetheless stands because (a) the projection layer must independently enforce the policy as the regression contract demands, (b) any historical active-exam attempt rows created before BUG-237's fix must be filtered, and (c) the inconsistency between sibling methods is itself a maintenance hazard.
+
+Do NOT modify any other repository methods. Do NOT modify the `AttemptStatsReader` port. Do NOT modify `GetUserStatsUseCase` — its `computeStreak(attemptsLast60Days, now)` call is correct as written and consumes whatever `Date[]` the repository returns. Do NOT modify the `FakeAttemptRepository` for this bug; the fake's broader fidelity gap (it does not currently model `activeExamVisibilityCondition()` for any method) is out of scope and would expand the diff unnecessarily — the integration test against real Postgres is the authoritative coverage for this fix.
 
 ## Verification
 
-- [ ] Add repository integration coverage for `listAnsweredAtByUserIdSince(...)` excluding active-exam attempts.
-- [ ] Add a use-case regression test for `GetUserStatsUseCase` proving `currentStreakDays` ignores active-exam timestamps until exam end.
-- [ ] Verify the existing dashboard count, accuracy, and recent-activity tests still pass.
+- [ ] Add a `DrizzleAttemptRepository` integration test (`tests/integration/`, real Postgres test DB) for `listAnsweredAtByUserIdSince(...)` covering all four visibility cases: (1) active-exam-mode session attempt is **excluded**, (2) ended-exam-mode session attempt is **included**, (3) tutor-mode session attempt (any state) is **included**, (4) standalone attempt (`practiceSessionId IS NULL`) is **included**.
+- [ ] Add an integration test proving the returned ordering remains `answeredAt DESC` with at least three timestamps, including ones across the visibility boundary.
+- [ ] Verify the existing `GetUserStatsUseCase` unit tests still pass unchanged (the fake is not being modified, so existing fake-driven streak tests must continue to pass).
+- [ ] Verify the existing dashboard accuracy / count / recent-activity integration tests still pass — none of them touch this method, but the regression suite must stay green.
+- [ ] Run the full pre-push gate: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build` (per `.claude/rules/git-workflow.md` — pre-push hook is insufficient).
 
 ## Related
 

--- a/docs/bugs/bug-236-dashboard-current-streak-includes-active-exam-attempts.md
+++ b/docs/bugs/bug-236-dashboard-current-streak-includes-active-exam-attempts.md
@@ -3,6 +3,7 @@
 **Status:** Open
 **Priority:** P3
 **Date:** 2026-04-24
+**Resolution State:** Fixed on branch `fix-bug-236-dashboard-streak-active-exam`; pending PR review, merge verification, and archival.
 
 ---
 
@@ -57,11 +58,11 @@ Do NOT modify any other repository methods. Do NOT modify the `AttemptStatsReade
 
 ## Verification
 
-- [ ] Add a `DrizzleAttemptRepository` integration test (`tests/integration/`, real Postgres test DB) for `listAnsweredAtByUserIdSince(...)` covering all four visibility cases: (1) active-exam-mode session attempt is **excluded**, (2) ended-exam-mode session attempt is **included**, (3) tutor-mode session attempt (any state) is **included**, (4) standalone attempt (`practiceSessionId IS NULL`) is **included**.
-- [ ] Add an integration test proving the returned ordering remains `answeredAt DESC` with at least three timestamps, including ones across the visibility boundary.
-- [ ] Verify the existing `GetUserStatsUseCase` unit tests still pass unchanged (the fake is not being modified, so existing fake-driven streak tests must continue to pass).
-- [ ] Verify the existing dashboard accuracy / count / recent-activity integration tests still pass — none of them touch this method, but the regression suite must stay green.
-- [ ] Run the full pre-push gate: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build` (per `.claude/rules/git-workflow.md` — pre-push hook is insufficient).
+- [x] Add a `DrizzleAttemptRepository` integration test (`tests/integration/`, real Postgres test DB) for `listAnsweredAtByUserIdSince(...)` covering all four visibility cases: (1) active-exam-mode session attempt is **excluded**, (2) ended-exam-mode session attempt is **included**, (3) tutor-mode session attempt (any state) is **included**, (4) standalone attempt (`practiceSessionId IS NULL`) is **included**. Evidence: `tests/integration/bug-regression.integration.test.ts` → `BUG-236: Dashboard streak timestamps exclude active-exam attempts` → `filters active exam attempts while preserving ended exam, tutor, and standalone timestamps`. Red failed because the active-exam timestamp was returned; green passed after `listAnsweredAtByUserIdSince(...)` applied `activeExamVisibilityCondition()`.
+- [x] Add an integration test proving the returned ordering remains `answeredAt DESC` with at least three timestamps, including ones across the visibility boundary. Evidence: `tests/integration/bug-regression.integration.test.ts` → `BUG-236: Dashboard streak timestamps exclude active-exam attempts` → `keeps answeredAt descending order after filtering hidden active-exam rows`. Red failed because the hidden active-exam row appeared first; green passed with only visible timestamps ordered newest to oldest.
+- [x] Verify the existing `GetUserStatsUseCase` unit tests still pass unchanged (the fake is not being modified, so existing fake-driven streak tests must continue to pass). Evidence: `pnpm test --run` in the full gate includes the unchanged `src/application/use-cases/get-user-stats.test.ts` suite.
+- [x] Verify the existing dashboard accuracy / count / recent-activity integration tests still pass — none of them touch this method, but the regression suite must stay green. Evidence: `pnpm test:integration` in the full gate includes the existing BUG-187 dashboard count and recent-activity integration coverage plus the new BUG-236 regression tests.
+- [x] Run the full pre-push gate: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build` (per `.claude/rules/git-workflow.md` — pre-push hook is insufficient). Evidence: full pre-push gate passed locally on 2026-04-25 after the code and documentation updates.
 
 ## Related
 

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -1,7 +1,7 @@
 # Bug Reports
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-04-24
+**Last Updated:** 2026-04-25
 
 ---
 
@@ -124,7 +124,7 @@ Confirmed bugs that are not yet archived are listed below. Items may still be un
 |-----|----------|---------|
 | [BUG-237](./bug-237-submit-answer-allows-active-exam-session-writes.md) | P2 | Fix in PR #284: active-exam `submitAnswer` is rejected before attempt/session-answer writes; archive after merge verification |
 | [BUG-235](./bug-235-attempted-question-history-drops-latest-visible-attempt.md) | P3 | Attempted-question History can hide a prior visible attempt when the same question has a newer active-exam attempt |
-| [BUG-236](./bug-236-dashboard-current-streak-includes-active-exam-attempts.md) | P3 | Dashboard current streak can include active-exam attempt timestamps before the exam is ended |
+| [BUG-236](./bug-236-dashboard-current-streak-includes-active-exam-attempts.md) | P3 | Fix on branch: dashboard streak timestamp reader now applies active-exam visibility; archive after merge verification |
 
 ## Audit #19 — Active-Exam Visibility Regression Sweep (2026-04-24)
 

--- a/docs/practice-engine/exam-answer-secrecy-policy.md
+++ b/docs/practice-engine/exam-answer-secrecy-policy.md
@@ -2,8 +2,8 @@
 
 > **Parent:** [Practice Engine Index](./index.md)
 > **Scope:** Canonical policy for when correctness/explanations may be exposed
-> **Last Updated:** 2026-04-24
-> **Status:** Enforced. BUG-180/181/185 and BUG-186/187/191/192/193/195 are archived as fixed; BUG-237 now rejects active-exam `SubmitAnswer` at the use-case boundary. This document remains the regression contract.
+> **Last Updated:** 2026-04-25
+> **Status:** Enforced. BUG-180/181/185 and BUG-186/187/191/192/193/195 are archived as fixed; BUG-237 now rejects active-exam `SubmitAnswer` at the use-case boundary; BUG-236 aligns dashboard streak timestamps with the repository visibility predicate. This document remains the regression contract.
 
 ---
 
@@ -89,12 +89,13 @@ Use this guard consistently at all answer-key disclosure points. Do not duplicat
 
 ## 6. Current Enforcement Status
 
-These code paths are current as of 2026-04-24:
+These code paths are current as of 2026-04-25:
 
 - `GetPreviousAttempt` returns `null` for active-exam attempts and only reveals `session_unanswered` answers after the exam session has ended.
 - `GetPracticeSessionReview` redacts per-question `isCorrect` while an exam session is still active.
 - `GetNextQuestion` redacts `session.latestIsCorrect` for active exams and only hydrates `previousSubmission` for answered tutor-session questions.
 - `SubmitAnswer` rejects active exam sessions with `VALIDATION_ERROR` before inserting an `attempts` row or calling `recordQuestionAnswer(...)`; active exam answers must use `SaveExamDraftAnswer` before `FinalizeExamAnswers` creates final attempts. See [BUG-237](../bugs/bug-237-submit-answer-allows-active-exam-session-writes.md).
+- `DrizzleAttemptRepository` applies `activeExamVisibilityCondition()` to dashboard aggregate counts, recent activity, and `listAnsweredAtByUserIdSince(...)` streak timestamps; active-exam attempts are excluded until the session ends while tutor, ended-exam, and standalone attempts remain visible. See [BUG-236](../bugs/bug-236-dashboard-current-streak-includes-active-exam-attempts.md).
 - `DrizzleQuestionRepository` excludes active-exam attempts from status-filter and user-history correctness projections via `activeExamVisibilityCondition()`.
 
 ---
@@ -114,7 +115,7 @@ Every change that touches review hydration, retry, stats projections, or exam re
 
 4. `GetNextQuestion` must not return `latestIsCorrect` for active exam sessions.
 
-5. Dashboard/stats projection does not expose correctness for active-exam attempts.
+5. Dashboard/stats projections exclude active-exam attempts from counts, recent activity, and streak timestamp inputs.
 
 6. History attempted-questions projection does not expose correctness for active-exam attempts.
 

--- a/src/adapters/repositories/drizzle-attempt-repository.test.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.test.ts
@@ -41,6 +41,9 @@ function createDbMock() {
       }>
     > => [],
   );
+  const answeredAtQueryExecute = vi.fn(
+    async (): Promise<Array<{ answeredAt: Date }>> => [],
+  );
   const finalQueryExecute = vi.fn(
     async (): Promise<
       Array<{
@@ -92,6 +95,9 @@ function createDbMock() {
   const recentOrderBy = vi.fn(() => ({ limit: recentLimit }));
   const recentWhere = vi.fn(() => ({ orderBy: recentOrderBy }));
   const leftJoinRecent = vi.fn(() => ({ where: recentWhere }));
+  const answeredAtOrderBy = vi.fn(() => answeredAtQueryExecute());
+  const answeredAtWhere = vi.fn(() => ({ orderBy: answeredAtOrderBy }));
+  const leftJoinAnsweredAt = vi.fn(() => ({ where: answeredAtWhere }));
   const innerJoin = vi.fn(() => ({ where: whereFinal }));
 
   const from = vi.fn((table: unknown) => {
@@ -128,6 +134,12 @@ function createDbMock() {
       };
     }
 
+    if (Object.keys(fields).length === 1 && 'answeredAt' in fields) {
+      return {
+        from: vi.fn(() => ({ leftJoin: leftJoinAnsweredAt })),
+      };
+    }
+
     return { from };
   });
 
@@ -154,12 +166,16 @@ function createDbMock() {
       groupByAs,
       groupByExecute,
       recentQueryExecute,
+      answeredAtQueryExecute,
       innerJoin,
       leftJoinFinal,
       leftJoinRecent,
+      leftJoinAnsweredAt,
       recentWhere,
       recentOrderBy,
       recentLimit,
+      answeredAtWhere,
+      answeredAtOrderBy,
       whereFinal,
       orderBy,
       limit,
@@ -612,7 +628,7 @@ describe('DrizzleAttemptRepository', () => {
     it('returns answeredAt values from the database', async () => {
       const db = createDbMock();
       const answeredAt = new Date('2026-02-02T00:00:00Z');
-      db._mocks.queryFindMany.mockResolvedValue([{ answeredAt }]);
+      db._mocks.answeredAtQueryExecute.mockResolvedValue([{ answeredAt }]);
 
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
@@ -622,6 +638,8 @@ describe('DrizzleAttemptRepository', () => {
           new Date('2026-02-01T00:00:00Z'),
         ),
       ).resolves.toEqual([answeredAt]);
+      expect(db._mocks.leftJoinAnsweredAt).toHaveBeenCalledTimes(1);
+      expect(db._mocks.answeredAtWhere).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/adapters/repositories/drizzle-attempt-repository.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.ts
@@ -402,11 +402,21 @@ export class DrizzleAttemptRepository implements AttemptRepository {
     userId: string,
     since: Date,
   ): Promise<readonly Date[]> {
-    const rows = await this.db.query.attempts.findMany({
-      columns: { answeredAt: true },
-      where: and(eq(attempts.userId, userId), gte(attempts.answeredAt, since)),
-      orderBy: desc(attempts.answeredAt),
-    });
+    const rows = await this.db
+      .select({ answeredAt: attempts.answeredAt })
+      .from(attempts)
+      .leftJoin(
+        practiceSessions,
+        eq(attempts.practiceSessionId, practiceSessions.id),
+      )
+      .where(
+        and(
+          eq(attempts.userId, userId),
+          gte(attempts.answeredAt, since),
+          this.activeExamVisibilityCondition(),
+        ),
+      )
+      .orderBy(desc(attempts.answeredAt));
 
     return rows.map((row) => row.answeredAt);
   }

--- a/tests/integration/bug-regression.integration.test.ts
+++ b/tests/integration/bug-regression.integration.test.ts
@@ -21,6 +21,24 @@ import {
 const { db, sql } = createIntegrationDb();
 const cleanup = createCleanupState();
 
+async function insertAttemptAt(input: {
+  userId: string;
+  questionId: string;
+  practiceSessionId: string | null;
+  selectedChoiceId: string;
+  answeredAt: Date;
+}) {
+  await db.insert(schema.attempts).values({
+    userId: input.userId,
+    questionId: input.questionId,
+    practiceSessionId: input.practiceSessionId,
+    selectedChoiceId: input.selectedChoiceId,
+    isCorrect: true,
+    timeSpentSeconds: 5,
+    answeredAt: input.answeredAt,
+  });
+}
+
 afterEach(async () => {
   await cleanupAfterEach(db, cleanup);
 });
@@ -308,6 +326,226 @@ describe('BUG-187: Dashboard counts exclude active-exam attempts', () => {
     // Tutor attempts always counted, even while session is active
     await expect(attemptRepo.countByUserId(user.id)).resolves.toBe(1);
     await expect(attemptRepo.countCorrectByUserId(user.id)).resolves.toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BUG-236: Dashboard current streak excludes active-exam attempts
+// ---------------------------------------------------------------------------
+
+describe('BUG-236: Dashboard streak timestamps exclude active-exam attempts', () => {
+  it('filters active exam attempts while preserving ended exam, tutor, and standalone timestamps', async () => {
+    const since = new Date('2026-02-01T00:00:00.000Z');
+    const sessionRepo = new DrizzlePracticeSessionRepository(db);
+    const attemptRepo = new DrizzleAttemptRepository(db);
+
+    const endedExamUser = await createUser(db, cleanup);
+    const endedExamQuestion = await createQuestion(db, cleanup, {
+      slug: `it-bug236-ended-exam-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const endedExamTimestamp = new Date('2026-04-01T12:00:00.000Z');
+    const endedExamSession = await sessionRepo.create({
+      userId: endedExamUser.id,
+      mode: 'exam',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [endedExamQuestion.id],
+      },
+    });
+    await sessionRepo.end(endedExamSession.id, endedExamUser.id);
+    await insertAttemptAt({
+      userId: endedExamUser.id,
+      questionId: endedExamQuestion.id,
+      practiceSessionId: endedExamSession.id,
+      selectedChoiceId: endedExamQuestion.correctChoiceId,
+      answeredAt: endedExamTimestamp,
+    });
+
+    const tutorUser = await createUser(db, cleanup);
+    const tutorQuestion = await createQuestion(db, cleanup, {
+      slug: `it-bug236-tutor-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const tutorTimestamp = new Date('2026-04-02T12:00:00.000Z');
+    const tutorSession = await sessionRepo.create({
+      userId: tutorUser.id,
+      mode: 'tutor',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [tutorQuestion.id],
+      },
+    });
+    await insertAttemptAt({
+      userId: tutorUser.id,
+      questionId: tutorQuestion.id,
+      practiceSessionId: tutorSession.id,
+      selectedChoiceId: tutorQuestion.correctChoiceId,
+      answeredAt: tutorTimestamp,
+    });
+
+    const standaloneUser = await createUser(db, cleanup);
+    const standaloneQuestion = await createQuestion(db, cleanup, {
+      slug: `it-bug236-standalone-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const standaloneTimestamp = new Date('2026-04-03T12:00:00.000Z');
+    await insertAttemptAt({
+      userId: standaloneUser.id,
+      questionId: standaloneQuestion.id,
+      practiceSessionId: null,
+      selectedChoiceId: standaloneQuestion.correctChoiceId,
+      answeredAt: standaloneTimestamp,
+    });
+
+    const activeExamUser = await createUser(db, cleanup);
+    const activeExamQuestion = await createQuestion(db, cleanup, {
+      slug: `it-bug236-active-exam-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const activeExamTimestamp = new Date('2026-04-04T12:00:00.000Z');
+    const activeExamSession = await sessionRepo.create({
+      userId: activeExamUser.id,
+      mode: 'exam',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [activeExamQuestion.id],
+      },
+    });
+    await insertAttemptAt({
+      userId: activeExamUser.id,
+      questionId: activeExamQuestion.id,
+      practiceSessionId: activeExamSession.id,
+      selectedChoiceId: activeExamQuestion.correctChoiceId,
+      answeredAt: activeExamTimestamp,
+    });
+
+    await expect(
+      attemptRepo.listAnsweredAtByUserIdSince(endedExamUser.id, since),
+    ).resolves.toEqual([endedExamTimestamp]);
+    await expect(
+      attemptRepo.listAnsweredAtByUserIdSince(tutorUser.id, since),
+    ).resolves.toEqual([tutorTimestamp]);
+    await expect(
+      attemptRepo.listAnsweredAtByUserIdSince(standaloneUser.id, since),
+    ).resolves.toEqual([standaloneTimestamp]);
+    await expect(
+      attemptRepo.listAnsweredAtByUserIdSince(activeExamUser.id, since),
+    ).resolves.toEqual([]);
+  });
+
+  it('keeps answeredAt descending order after filtering hidden active-exam rows', async () => {
+    const user = await createUser(db, cleanup);
+    const since = new Date('2026-02-01T00:00:00.000Z');
+    const sessionRepo = new DrizzlePracticeSessionRepository(db);
+    const attemptRepo = new DrizzleAttemptRepository(db);
+
+    const qStandalone = await createQuestion(db, cleanup, {
+      slug: `it-bug236-order-standalone-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const qTutor = await createQuestion(db, cleanup, {
+      slug: `it-bug236-order-tutor-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const qEndedExam = await createQuestion(db, cleanup, {
+      slug: `it-bug236-order-ended-exam-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const qActiveExam = await createQuestion(db, cleanup, {
+      slug: `it-bug236-order-active-exam-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+
+    const tutorSession = await sessionRepo.create({
+      userId: user.id,
+      mode: 'tutor',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [qTutor.id],
+      },
+    });
+    await sessionRepo.end(tutorSession.id, user.id);
+
+    const endedExamSession = await sessionRepo.create({
+      userId: user.id,
+      mode: 'exam',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [qEndedExam.id],
+      },
+    });
+    await sessionRepo.end(endedExamSession.id, user.id);
+
+    const activeExamSession = await sessionRepo.create({
+      userId: user.id,
+      mode: 'exam',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [qActiveExam.id],
+      },
+    });
+
+    const hiddenNewest = new Date('2026-04-04T12:00:00.000Z');
+    const visibleNewest = new Date('2026-04-03T12:00:00.000Z');
+    const visibleMiddle = new Date('2026-04-02T12:00:00.000Z');
+    const visibleOldest = new Date('2026-04-01T12:00:00.000Z');
+
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: qStandalone.id,
+      practiceSessionId: null,
+      selectedChoiceId: qStandalone.correctChoiceId,
+      answeredAt: visibleOldest,
+    });
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: qTutor.id,
+      practiceSessionId: tutorSession.id,
+      selectedChoiceId: qTutor.correctChoiceId,
+      answeredAt: visibleMiddle,
+    });
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: qEndedExam.id,
+      practiceSessionId: endedExamSession.id,
+      selectedChoiceId: qEndedExam.correctChoiceId,
+      answeredAt: visibleNewest,
+    });
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: qActiveExam.id,
+      practiceSessionId: activeExamSession.id,
+      selectedChoiceId: qActiveExam.correctChoiceId,
+      answeredAt: hiddenNewest,
+    });
+
+    const answeredAt = await attemptRepo.listAnsweredAtByUserIdSince(
+      user.id,
+      since,
+    );
+
+    expect(answeredAt).toEqual([visibleNewest, visibleMiddle, visibleOldest]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Applies `activeExamVisibilityCondition()` to `DrizzleAttemptRepository.listAnsweredAtByUserIdSince(...)`, aligning dashboard current-streak inputs with dashboard counts and recent activity.
- Adds real Postgres BUG-236 regression coverage for active-exam exclusion, ended-exam inclusion, tutor inclusion, standalone inclusion, and `answeredAt DESC` ordering.
- Updates the BUG-236 record, bug index, and exam-answer secrecy policy to document the enforced projection behavior.

## Test plan
- Red first: `pnpm test:integration -t "BUG-236"` failed with active-exam timestamps returned by the old query.
- Green targeted: `pnpm test:integration -t "BUG-236"` passed after the repository predicate landed.
- Repository unit harness: `pnpm test --run src/adapters/repositories/drizzle-attempt-repository.test.ts` passed.
- Integration DB setup used: `pnpm db:test:up && DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:migrate && SEED_INCLUDE_PLACEHOLDERS=true DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:seed`.
- Full gate after final commit: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build` passed (`pnpm test --run`: 282 files / 2330 tests; `pnpm test:browser`: 36 files / 241 tests; `pnpm test:integration`: 13 files / 85 tests; `pnpm build`: successful).
- Authenticated E2E after final commit: `lsof -ti:3000 | xargs kill -9 2>/dev/null; pnpm test:e2e` passed (34 tests).
- Pre-push hook passed: `pnpm typecheck && pnpm test --run` passed during `git push`.

Closes BUG-236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed dashboard streak timestamp calculation to properly exclude active exam attempts, ensuring accurate streak tracking.

* **Documentation**
  * Updated bug tracking documentation to reflect completion and verification status.
  * Clarified active exam visibility policy for dashboard metrics (streak, activity, counts).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->