### PR TITLE
Apply active-exam visibility before history ranking

### DIFF
--- a/docs/bugs/bug-235-attempted-question-history-drops-latest-visible-attempt.md
+++ b/docs/bugs/bug-235-attempted-question-history-drops-latest-visible-attempt.md
@@ -3,6 +3,7 @@
 **Status:** Open
 **Priority:** P3
 **Date:** 2026-04-24
+**Resolution State:** Fixed on branch `fix-bug-235-history-latest-visible-fallback`; pending PR review, merge verification, and archival.
 
 ---
 
@@ -87,15 +88,15 @@ The unit-test mock infrastructure for `latestAttemptRowsSubquery` in `src/adapte
 
 ## Verification
 
-- [ ] **Regression — older standalone + newer active-exam:** Add an integration test that creates a standalone visible attempt for question Q, then a newer active-exam attempt for the same Q, and asserts `listAttemptedQuestionsByUserId` returns the question with the **older** standalone attempt's `answeredAt` and `isCorrect`. The active-exam timestamp must NOT appear.
-- [ ] **Regression — older tutor + newer active-exam:** Same scenario with a tutor-mode session for the older attempt. Same assertion shape.
-- [ ] **Regression — older ended-exam + newer active-exam:** Same scenario with an ended-exam-mode session for the older attempt. Same assertion shape.
-- [ ] **Count parity:** In each of the three regression scenarios above, assert `countAttemptedQuestionsByUserId` returns the same count as the list length. List/count must never disagree.
-- [ ] **BUG-192 sibling case preserved (no fallback exists):** Add an integration test that creates ONLY an active-exam attempt for question Q (no prior visible attempt), and asserts the question is **excluded** from list and count while the exam is active. This proves the original BUG-192 behavior is preserved when there is genuinely nothing to fall back to.
-- [ ] **Post-exam-end recovery:** After ending the active exam in any of the regression scenarios, the active-exam attempt becomes the latest visible attempt — the question's `answeredAt` and `isCorrect` in the list now reflect the post-exam attempt, not the older visible one.
-- [ ] **Filter interactions don't regress:** Spot-check that `result: 'correct' | 'incorrect'`, `source: 'adhoc' | 'tutor' | 'exam'`, `difficulty`, and `tagSlug` filters still produce the same results for non-active-exam fixtures as before the fix. The existing BUG-192 integration test in `tests/integration/bug-regression.integration.test.ts` must continue to pass unchanged.
-- [ ] **Existing unit tests pass with mock-shape update:** `src/adapters/repositories/drizzle-attempt-repository.test.ts` `listAttemptedQuestionsByUserId` and `countAttemptedQuestionsByUserId` describe-blocks must continue to pass. Update the mock chain shape (insert a `leftJoin` step before `where`) without changing test intent.
-- [ ] Run the full pre-push gate: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build` (per `.claude/rules/git-workflow.md` — pre-push hook is insufficient).
+- [x] **Regression — older standalone + newer active-exam:** Added integration coverage proving `listAttemptedQuestionsByUserId(...)` falls back to the older standalone row's `answeredAt` and `isCorrect` while the newer active-exam row is hidden. Evidence: `tests/integration/bug-regression.integration.test.ts` → `BUG-235: Attempted-question history keeps latest visible fallback` → `falls back to an older standalone attempt when a newer active-exam attempt is hidden`. Red failed with `[]`; green passed after `latestAttemptRowsSubquery(...)` filtered before ranking.
+- [x] **Regression — older tutor + newer active-exam:** Added integration coverage proving the latest visible tutor-mode row remains selected while a newer active-exam row is hidden. Evidence: `tests/integration/bug-regression.integration.test.ts` → `falls back to an older tutor attempt when a newer active-exam attempt is hidden`. Red failed with `[]`; green passed after the subquery shape matched `DrizzleQuestionRepository`.
+- [x] **Regression — older ended-exam + newer active-exam:** Added integration coverage proving the latest visible ended-exam row remains selected while a newer active-exam row is hidden. Evidence: `tests/integration/bug-regression.integration.test.ts` → `falls back to an older ended-exam attempt when a newer active-exam attempt is hidden`. Red failed with `[]`; green passed after the subquery applied `activeExamVisibilityCondition()` before `row_number()`.
+- [x] **Count parity:** Each BUG-235 regression scenario asserts `countAttemptedQuestionsByUserId(...)` equals the returned list length, so list/count semantics stay paired across standalone, tutor, and ended-exam fallback cases.
+- [x] **BUG-192 sibling case preserved (no fallback exists):** Added integration coverage for a question with only an active-exam attempt: list returns `[]` and count returns `0` while the exam is active, then the question appears after exam end. Evidence: `tests/integration/bug-regression.integration.test.ts` → `continues to hide an active-exam attempt when no visible fallback exists`.
+- [x] **Post-exam-end recovery:** The standalone fallback scenario ends the active exam and re-queries History, proving the formerly hidden active-exam attempt becomes the latest visible row with its newer `answeredAt` and `isCorrect`. The no-fallback sibling test also verifies post-exam recovery from zero visible rows to one visible row.
+- [x] **Filter interactions don't regress:** Existing attempted-question filter integration coverage remains unchanged and is included in the full integration gate: `tests/integration/session-attempt-repository.integration.test.ts` covers result, source, difficulty, tagSlug, combined filters, and deterministic latest-attempt tie-breaks; `tests/integration/bug-regression.integration.test.ts` keeps the BUG-192 active-exam exclusion case green.
+- [x] **Existing unit tests pass with mock-shape update:** `src/adapters/repositories/drizzle-attempt-repository.test.ts` now models the `latestAttemptRowsSubquery(...)` chain as `.from().leftJoin().where().as()` and asserts the new latest-row left join is used for both list and count paths. Evidence: `pnpm test --run src/adapters/repositories/drizzle-attempt-repository.test.ts` passed with 29 tests.
+- [x] Run the full pre-push gate: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build` (per `.claude/rules/git-workflow.md` — pre-push hook is insufficient). Evidence: full pre-push gate passed locally on 2026-04-25 after the code and documentation updates.
 
 ## Related
 

--- a/docs/bugs/bug-235-attempted-question-history-drops-latest-visible-attempt.md
+++ b/docs/bugs/bug-235-attempted-question-history-drops-latest-visible-attempt.md
@@ -45,17 +45,57 @@ This does not reveal active-exam correctness, so it is lower severity than BUG-1
 
 ## Expected Fix
 
-Apply the active-exam visibility predicate before latest-attempt ranking for attempted-question History queries. The implementation should either:
-- Move the `practice_sessions` join and `activeExamVisibilityCondition()` into `DrizzleAttemptRepository.latestAttemptRowsSubquery(...)`, matching `DrizzleQuestionRepository`, or
-- Extract a shared latest-visible-attempt subquery helper used by both repositories.
+Move the `practice_sessions` join and `activeExamVisibilityCondition()` **inside** `DrizzleAttemptRepository.latestAttemptRowsSubquery(...)` at `src/adapters/repositories/drizzle-attempt-repository.ts:68-83`, mirroring the established pattern in `DrizzleQuestionRepository.latestAttemptRowsSubquery(...)` at `src/adapters/repositories/drizzle-question-repository.ts:195-214`.
 
-The list and count queries must keep identical filtering semantics.
+**Implementation choice — pinned.** Do NOT extract a shared latest-visible-attempt helper across repositories. Two private subqueries with overlapping shape but different SELECT lists is honest duplication, not a candidate for premature abstraction (per `CLAUDE.md`). The Question repository already has the correct shape; copy it into the Attempt repository and stop.
+
+**Concrete shape (adapt to existing imports):**
+
+```typescript
+private latestAttemptRowsSubquery(userId: string) {
+  return this.db
+    .select({
+      questionId: attempts.questionId,
+      answeredAt: attempts.answeredAt,
+      practiceSessionId: attempts.practiceSessionId,
+      isCorrect: attempts.isCorrect,
+      attemptRank: latestAttemptRankSql({
+        questionId: attempts.questionId,
+        answeredAt: attempts.answeredAt,
+        id: attempts.id,
+      }).as('attempt_rank'),
+    })
+    .from(attempts)
+    .leftJoin(
+      practiceSessions,
+      eq(attempts.practiceSessionId, practiceSessions.id),
+    )
+    .where(
+      and(eq(attempts.userId, userId), this.activeExamVisibilityCondition()),
+    )
+    .as('latest_attempt_rows');
+}
+```
+
+**Then remove the now-redundant outer predicate** at `drizzle-attempt-repository.ts:94`: delete `this.activeExamVisibilityCondition()` from `buildAttemptedQuestionsConditions(...)`. After the subquery filters active-exam rows BEFORE ranking, the outer condition is dead duplication. Keep `eq(latestAttemptRows.attemptRank, 1)` and the rest of the conditions exactly as they are. The outer `leftJoin(practiceSessions, ...)` in `listAttemptedQuestionsByUserId` (lines 447-450) and `countAttemptedQuestionsByUserId` (lines 496-499) **must stay** — those joins are still needed to surface `practiceSessions.mode` for the `sessionMode` SELECT column (line 444) and the `source: 'tutor' | 'exam'` filter at `buildAttemptedQuestionsConditions(...)` line 111.
+
+This is a **defense-in-depth alignment** with the secrecy/visibility policy. After BUG-237's fix, the upstream `submitAnswer` write boundary no longer creates active-exam `attempts` rows in the normal flow. This bug fix nonetheless stands because (a) the projection layer must independently enforce the policy as the regression contract demands, (b) any historical active-exam attempt rows created before BUG-237's fix must yield correct latest-visible fallback semantics, and (c) the inconsistency between the Attempt repository's subquery shape and the Question repository's subquery shape is itself a maintenance hazard.
+
+Do NOT modify `DrizzleQuestionRepository` — its `latestAttemptRowsSubquery` is already correct and is the reference exemplar. Do NOT modify the `AttemptRepository` port. Do NOT modify any consumer use case (`GetAttemptedQuestionsUseCase`, etc.). The list and count queries must keep identical filtering semantics — they already share the subquery and the conditions builder, so symmetry is preserved by construction.
+
+The unit-test mock infrastructure for `latestAttemptRowsSubquery` in `src/adapters/repositories/drizzle-attempt-repository.test.ts` will need to be updated to reflect the new chain shape (`.from().leftJoin().where().as()` instead of `.from().where().as()`). Mirror the BUG-236 PR #285 approach for adding `leftJoin` mock steps without touching unrelated test scaffolding.
 
 ## Verification
 
-- [ ] Add an integration regression test that creates an older visible attempt and a newer active-exam attempt for the same question, then verifies History still returns the older visible attempt.
-- [ ] Verify the attempted-question count remains stable in that same scenario.
-- [ ] Verify the active-exam attempt becomes the latest visible attempt only after the exam session ends.
+- [ ] **Regression — older standalone + newer active-exam:** Add an integration test that creates a standalone visible attempt for question Q, then a newer active-exam attempt for the same Q, and asserts `listAttemptedQuestionsByUserId` returns the question with the **older** standalone attempt's `answeredAt` and `isCorrect`. The active-exam timestamp must NOT appear.
+- [ ] **Regression — older tutor + newer active-exam:** Same scenario with a tutor-mode session for the older attempt. Same assertion shape.
+- [ ] **Regression — older ended-exam + newer active-exam:** Same scenario with an ended-exam-mode session for the older attempt. Same assertion shape.
+- [ ] **Count parity:** In each of the three regression scenarios above, assert `countAttemptedQuestionsByUserId` returns the same count as the list length. List/count must never disagree.
+- [ ] **BUG-192 sibling case preserved (no fallback exists):** Add an integration test that creates ONLY an active-exam attempt for question Q (no prior visible attempt), and asserts the question is **excluded** from list and count while the exam is active. This proves the original BUG-192 behavior is preserved when there is genuinely nothing to fall back to.
+- [ ] **Post-exam-end recovery:** After ending the active exam in any of the regression scenarios, the active-exam attempt becomes the latest visible attempt — the question's `answeredAt` and `isCorrect` in the list now reflect the post-exam attempt, not the older visible one.
+- [ ] **Filter interactions don't regress:** Spot-check that `result: 'correct' | 'incorrect'`, `source: 'adhoc' | 'tutor' | 'exam'`, `difficulty`, and `tagSlug` filters still produce the same results for non-active-exam fixtures as before the fix. The existing BUG-192 integration test in `tests/integration/bug-regression.integration.test.ts` must continue to pass unchanged.
+- [ ] **Existing unit tests pass with mock-shape update:** `src/adapters/repositories/drizzle-attempt-repository.test.ts` `listAttemptedQuestionsByUserId` and `countAttemptedQuestionsByUserId` describe-blocks must continue to pass. Update the mock chain shape (insert a `leftJoin` step before `where`) without changing test intent.
+- [ ] Run the full pre-push gate: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build` (per `.claude/rules/git-workflow.md` — pre-push hook is insufficient).
 
 ## Related
 

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -123,7 +123,7 @@ Confirmed bugs that are not yet archived are listed below. Items may still be un
 | Bug | Priority | Summary |
 |-----|----------|---------|
 | [BUG-237](./bug-237-submit-answer-allows-active-exam-session-writes.md) | P2 | Fix in PR #284: active-exam `submitAnswer` is rejected before attempt/session-answer writes; archive after merge verification |
-| [BUG-235](./bug-235-attempted-question-history-drops-latest-visible-attempt.md) | P3 | Attempted-question History can hide a prior visible attempt when the same question has a newer active-exam attempt |
+| [BUG-235](./bug-235-attempted-question-history-drops-latest-visible-attempt.md) | P3 | Fix on branch: History latest-attempt ranking now filters active-exam attempts before rank selection; archive after merge verification |
 | [BUG-236](./bug-236-dashboard-current-streak-includes-active-exam-attempts.md) | P3 | Fix on branch: dashboard streak timestamp reader now applies active-exam visibility; archive after merge verification |
 
 ## Audit #19 — Active-Exam Visibility Regression Sweep (2026-04-24)

--- a/docs/practice-engine/exam-answer-secrecy-policy.md
+++ b/docs/practice-engine/exam-answer-secrecy-policy.md
@@ -3,7 +3,7 @@
 > **Parent:** [Practice Engine Index](./index.md)
 > **Scope:** Canonical policy for when correctness/explanations may be exposed
 > **Last Updated:** 2026-04-25
-> **Status:** Enforced. BUG-180/181/185 and BUG-186/187/191/192/193/195 are archived as fixed; BUG-237 now rejects active-exam `SubmitAnswer` at the use-case boundary; BUG-236 aligns dashboard streak timestamps with the repository visibility predicate. This document remains the regression contract.
+> **Status:** Enforced. BUG-180/181/185 and BUG-186/187/191/192/193/195 are archived as fixed; BUG-237 now rejects active-exam `SubmitAnswer` at the use-case boundary; BUG-236 aligns dashboard streak timestamps with the repository visibility predicate; BUG-235 aligns History latest-visible-attempt fallback semantics. This document remains the regression contract.
 
 ---
 
@@ -96,6 +96,7 @@ These code paths are current as of 2026-04-25:
 - `GetNextQuestion` redacts `session.latestIsCorrect` for active exams and only hydrates `previousSubmission` for answered tutor-session questions.
 - `SubmitAnswer` rejects active exam sessions with `VALIDATION_ERROR` before inserting an `attempts` row or calling `recordQuestionAnswer(...)`; active exam answers must use `SaveExamDraftAnswer` before `FinalizeExamAnswers` creates final attempts. See [BUG-237](../bugs/bug-237-submit-answer-allows-active-exam-session-writes.md).
 - `DrizzleAttemptRepository` applies `activeExamVisibilityCondition()` to dashboard aggregate counts, recent activity, and `listAnsweredAtByUserIdSince(...)` streak timestamps; active-exam attempts are excluded until the session ends while tutor, ended-exam, and standalone attempts remain visible. See [BUG-236](../bugs/bug-236-dashboard-current-streak-includes-active-exam-attempts.md).
+- `DrizzleAttemptRepository` also applies `activeExamVisibilityCondition()` inside the attempted-question latest-attempt subquery before `row_number()` ranking, so History excludes active-exam attempts without dropping older visible attempts for the same question. See [BUG-235](../bugs/bug-235-attempted-question-history-drops-latest-visible-attempt.md).
 - `DrizzleQuestionRepository` excludes active-exam attempts from status-filter and user-history correctness projections via `activeExamVisibilityCondition()`.
 
 ---
@@ -117,7 +118,7 @@ Every change that touches review hydration, retry, stats projections, or exam re
 
 5. Dashboard/stats projections exclude active-exam attempts from counts, recent activity, and streak timestamp inputs.
 
-6. History attempted-questions projection does not expose correctness for active-exam attempts.
+6. History attempted-questions projection excludes active-exam attempts at the subquery level, preserving older visible attempts as the latest visible row when present.
 
 7. UI-level review paths do not render correctness badges from active-exam attempts.
 

--- a/src/adapters/repositories/drizzle-attempt-repository.test.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.test.ts
@@ -81,6 +81,7 @@ function createDbMock() {
   });
 
   const whereGroupBy = vi.fn(() => ({ groupBy, as: latestRowsAs }));
+  const leftJoinLatestAttemptRows = vi.fn(() => ({ where: whereGroupBy }));
 
   const offset = vi.fn(() => finalQueryExecute());
   const limit = vi.fn(() => ({ offset }));
@@ -134,6 +135,12 @@ function createDbMock() {
       };
     }
 
+    if ('attemptRank' in fields) {
+      return {
+        from: vi.fn(() => ({ leftJoin: leftJoinLatestAttemptRows })),
+      };
+    }
+
     if (Object.keys(fields).length === 1 && 'answeredAt' in fields) {
       return {
         from: vi.fn(() => ({ leftJoin: leftJoinAnsweredAt })),
@@ -166,6 +173,7 @@ function createDbMock() {
       groupByAs,
       groupByExecute,
       recentQueryExecute,
+      leftJoinLatestAttemptRows,
       answeredAtQueryExecute,
       innerJoin,
       leftJoinFinal,
@@ -806,6 +814,8 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
       await repo.listAttemptedQuestionsByUserId('user_1', 20, 0);
 
+      expect(db._mocks.leftJoinLatestAttemptRows).toHaveBeenCalledTimes(1);
+      expect(db._mocks.whereGroupBy).toHaveBeenCalledTimes(1);
       expect(db._mocks.whereFinal).toHaveBeenCalledTimes(1);
     });
   });
@@ -856,6 +866,8 @@ describe('DrizzleAttemptRepository', () => {
         repo.countAttemptedQuestionsByUserId('user_1'),
       ).resolves.toBe(3);
 
+      expect(db._mocks.leftJoinLatestAttemptRows).toHaveBeenCalledTimes(1);
+      expect(db._mocks.whereGroupBy).toHaveBeenCalledTimes(1);
       expect(db._mocks.countWhere).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/adapters/repositories/drizzle-attempt-repository.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.ts
@@ -79,7 +79,13 @@ export class DrizzleAttemptRepository implements AttemptRepository {
         }).as('attempt_rank'),
       })
       .from(attempts)
-      .where(eq(attempts.userId, userId))
+      .leftJoin(
+        practiceSessions,
+        eq(attempts.practiceSessionId, practiceSessions.id),
+      )
+      .where(
+        and(eq(attempts.userId, userId), this.activeExamVisibilityCondition()),
+      )
       .as('latest_attempt_rows');
   }
 
@@ -89,10 +95,7 @@ export class DrizzleAttemptRepository implements AttemptRepository {
     >,
     filters?: AttemptedQuestionsFilters,
   ): SQL[] {
-    const conditions: SQL[] = [
-      eq(latestAttemptRows.attemptRank, 1),
-      this.activeExamVisibilityCondition(),
-    ];
+    const conditions: SQL[] = [eq(latestAttemptRows.attemptRank, 1)];
 
     const resultFilter = filters?.result ?? null;
     if (resultFilter === 'correct') {

--- a/tests/integration/bug-regression.integration.test.ts
+++ b/tests/integration/bug-regression.integration.test.ts
@@ -26,6 +26,7 @@ async function insertAttemptAt(input: {
   questionId: string;
   practiceSessionId: string | null;
   selectedChoiceId: string;
+  isCorrect?: boolean;
   answeredAt: Date;
 }) {
   await db.insert(schema.attempts).values({
@@ -33,7 +34,7 @@ async function insertAttemptAt(input: {
     questionId: input.questionId,
     practiceSessionId: input.practiceSessionId,
     selectedChoiceId: input.selectedChoiceId,
-    isCorrect: true,
+    isCorrect: input.isCorrect ?? true,
     timeSpentSeconds: 5,
     answeredAt: input.answeredAt,
   });
@@ -624,6 +625,289 @@ describe('BUG-192: Attempted-question history excludes active-exam attempts', ()
     await expect(
       attemptRepo.countAttemptedQuestionsByUserId(user.id),
     ).resolves.toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BUG-235: History attempted-questions keeps latest visible fallback
+// ---------------------------------------------------------------------------
+
+describe('BUG-235: Attempted-question history keeps latest visible fallback', () => {
+  it('falls back to an older standalone attempt when a newer active-exam attempt is hidden', async () => {
+    const user = await createUser(db, cleanup);
+    const question = await createQuestion(db, cleanup, {
+      slug: `it-bug235-standalone-fallback-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const attemptRepo = new DrizzleAttemptRepository(db);
+    const sessionRepo = new DrizzlePracticeSessionRepository(db);
+    const olderVisibleAt = new Date('2026-04-01T12:00:00.000Z');
+    const newerActiveExamAt = new Date('2026-04-02T12:00:00.000Z');
+
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: null,
+      selectedChoiceId: question.incorrectChoiceId,
+      isCorrect: false,
+      answeredAt: olderVisibleAt,
+    });
+
+    const activeExamSession = await sessionRepo.create({
+      userId: user.id,
+      mode: 'exam',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [question.id],
+      },
+    });
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: activeExamSession.id,
+      selectedChoiceId: question.correctChoiceId,
+      isCorrect: true,
+      answeredAt: newerActiveExamAt,
+    });
+
+    const activeRows = await attemptRepo.listAttemptedQuestionsByUserId(
+      user.id,
+      10,
+      0,
+    );
+    expect(activeRows).toEqual([
+      {
+        questionId: question.id,
+        answeredAt: olderVisibleAt,
+        isCorrect: false,
+        sessionId: null,
+        sessionMode: null,
+      },
+    ]);
+    await expect(
+      attemptRepo.countAttemptedQuestionsByUserId(user.id),
+    ).resolves.toBe(activeRows.length);
+
+    await sessionRepo.end(activeExamSession.id, user.id);
+
+    const endedRows = await attemptRepo.listAttemptedQuestionsByUserId(
+      user.id,
+      10,
+      0,
+    );
+    expect(endedRows).toEqual([
+      {
+        questionId: question.id,
+        answeredAt: newerActiveExamAt,
+        isCorrect: true,
+        sessionId: activeExamSession.id,
+        sessionMode: 'exam',
+      },
+    ]);
+    await expect(
+      attemptRepo.countAttemptedQuestionsByUserId(user.id),
+    ).resolves.toBe(endedRows.length);
+  });
+
+  it('falls back to an older tutor attempt when a newer active-exam attempt is hidden', async () => {
+    const user = await createUser(db, cleanup);
+    const question = await createQuestion(db, cleanup, {
+      slug: `it-bug235-tutor-fallback-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const attemptRepo = new DrizzleAttemptRepository(db);
+    const sessionRepo = new DrizzlePracticeSessionRepository(db);
+    const olderVisibleAt = new Date('2026-04-03T12:00:00.000Z');
+    const newerActiveExamAt = new Date('2026-04-04T12:00:00.000Z');
+
+    const tutorSession = await sessionRepo.create({
+      userId: user.id,
+      mode: 'tutor',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [question.id],
+      },
+    });
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: tutorSession.id,
+      selectedChoiceId: question.incorrectChoiceId,
+      isCorrect: false,
+      answeredAt: olderVisibleAt,
+    });
+    await sessionRepo.end(tutorSession.id, user.id);
+
+    const activeExamSession = await sessionRepo.create({
+      userId: user.id,
+      mode: 'exam',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [question.id],
+      },
+    });
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: activeExamSession.id,
+      selectedChoiceId: question.correctChoiceId,
+      isCorrect: true,
+      answeredAt: newerActiveExamAt,
+    });
+
+    const rows = await attemptRepo.listAttemptedQuestionsByUserId(
+      user.id,
+      10,
+      0,
+    );
+    expect(rows).toEqual([
+      {
+        questionId: question.id,
+        answeredAt: olderVisibleAt,
+        isCorrect: false,
+        sessionId: tutorSession.id,
+        sessionMode: 'tutor',
+      },
+    ]);
+    await expect(
+      attemptRepo.countAttemptedQuestionsByUserId(user.id),
+    ).resolves.toBe(rows.length);
+  });
+
+  it('falls back to an older ended-exam attempt when a newer active-exam attempt is hidden', async () => {
+    const user = await createUser(db, cleanup);
+    const question = await createQuestion(db, cleanup, {
+      slug: `it-bug235-ended-exam-fallback-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const attemptRepo = new DrizzleAttemptRepository(db);
+    const sessionRepo = new DrizzlePracticeSessionRepository(db);
+    const olderVisibleAt = new Date('2026-04-05T12:00:00.000Z');
+    const newerActiveExamAt = new Date('2026-04-06T12:00:00.000Z');
+
+    const endedExamSession = await sessionRepo.create({
+      userId: user.id,
+      mode: 'exam',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [question.id],
+      },
+    });
+    await sessionRepo.end(endedExamSession.id, user.id);
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: endedExamSession.id,
+      selectedChoiceId: question.incorrectChoiceId,
+      isCorrect: false,
+      answeredAt: olderVisibleAt,
+    });
+
+    const activeExamSession = await sessionRepo.create({
+      userId: user.id,
+      mode: 'exam',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [question.id],
+      },
+    });
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: activeExamSession.id,
+      selectedChoiceId: question.correctChoiceId,
+      isCorrect: true,
+      answeredAt: newerActiveExamAt,
+    });
+
+    const rows = await attemptRepo.listAttemptedQuestionsByUserId(
+      user.id,
+      10,
+      0,
+    );
+    expect(rows).toEqual([
+      {
+        questionId: question.id,
+        answeredAt: olderVisibleAt,
+        isCorrect: false,
+        sessionId: endedExamSession.id,
+        sessionMode: 'exam',
+      },
+    ]);
+    await expect(
+      attemptRepo.countAttemptedQuestionsByUserId(user.id),
+    ).resolves.toBe(rows.length);
+  });
+
+  it('continues to hide an active-exam attempt when no visible fallback exists', async () => {
+    const user = await createUser(db, cleanup);
+    const question = await createQuestion(db, cleanup, {
+      slug: `it-bug235-no-fallback-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const attemptRepo = new DrizzleAttemptRepository(db);
+    const sessionRepo = new DrizzlePracticeSessionRepository(db);
+    const activeExamAt = new Date('2026-04-07T12:00:00.000Z');
+
+    const activeExamSession = await sessionRepo.create({
+      userId: user.id,
+      mode: 'exam',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [question.id],
+      },
+    });
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: activeExamSession.id,
+      selectedChoiceId: question.correctChoiceId,
+      isCorrect: true,
+      answeredAt: activeExamAt,
+    });
+
+    await expect(
+      attemptRepo.listAttemptedQuestionsByUserId(user.id, 10, 0),
+    ).resolves.toEqual([]);
+    await expect(
+      attemptRepo.countAttemptedQuestionsByUserId(user.id),
+    ).resolves.toBe(0);
+
+    await sessionRepo.end(activeExamSession.id, user.id);
+
+    const endedRows = await attemptRepo.listAttemptedQuestionsByUserId(
+      user.id,
+      10,
+      0,
+    );
+    expect(endedRows).toEqual([
+      {
+        questionId: question.id,
+        answeredAt: activeExamAt,
+        isCorrect: true,
+        sessionId: activeExamSession.id,
+        sessionMode: 'exam',
+      },
+    ]);
+    await expect(
+      attemptRepo.countAttemptedQuestionsByUserId(user.id),
+    ).resolves.toBe(endedRows.length);
   });
 });
 


### PR DESCRIPTION
## Summary
- Fixes BUG-235 by applying `activeExamVisibilityCondition()` inside `DrizzleAttemptRepository.latestAttemptRowsSubquery(...)` before `row_number()` ranking.
- Preserves older visible History attempts as the latest visible row when a newer active-exam attempt exists for the same question.
- Updates BUG-235 docs, the bug index, and the exam-answer secrecy policy to record the in-flight fix state.

## Test plan
- Integration DB setup: `pnpm db:test:up && DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:migrate && SEED_INCLUDE_PLACEHOLDERS=true DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:seed`
- Red: `pnpm test:integration -t "BUG-235"` failed the three fallback scenarios with `[]` because the active-exam row ranked first and was filtered afterward.
- Green targeted: `pnpm test:integration -t "BUG-235"` passed.
- Unit mock-shape check: `pnpm test --run src/adapters/repositories/drizzle-attempt-repository.test.ts` passed (29 tests).
- Full gate: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build` passed locally on 2026-04-25.
- Authenticated E2E: required env keys were present; `lsof -ti:3000 | xargs kill -9 2>/dev/null; pnpm test:e2e` passed (34 tests).
- Pre-push hook: passed `pnpm typecheck && pnpm test --run` during push.

Closes BUG-235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed attempted question history to correctly display the most recent visible attempt when newer attempts are hidden during active exams. Previously, visible older attempts were incorrectly dropped from the history.

* **Documentation**
  * Updated documentation reflecting the corrected history ranking and exam visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->