### PR TITLE
Extract shared getActiveExamVisibilityCondition (DEBT-366)

### DIFF
--- a/docs/debt/debt-366-active-exam-visibility-predicate-duplication.md
+++ b/docs/debt/debt-366-active-exam-visibility-predicate-duplication.md
@@ -4,6 +4,7 @@
 **Created:** 2026-04-25
 **Source:** Post-merge audit after the BUG-235/236/237 trilogy (2026-04-25)
 **Related:** [BUG-235](../_archive/bugs/bug-235-attempted-question-history-drops-latest-visible-attempt.md), [BUG-236](../_archive/bugs/bug-236-dashboard-current-streak-includes-active-exam-attempts.md), [BUG-237](../_archive/bugs/bug-237-submit-answer-allows-active-exam-session-writes.md), [exam-answer-secrecy-policy.md](../practice-engine/exam-answer-secrecy-policy.md)
+**Resolution State:** Fix on branch `debt-366-shared-active-exam-visibility`; pending PR review, merge verification, and archival.
 
 ---
 

--- a/docs/practice-engine/exam-answer-secrecy-policy.md
+++ b/docs/practice-engine/exam-answer-secrecy-policy.md
@@ -2,7 +2,7 @@
 
 > **Parent:** [Practice Engine Index](./index.md)
 > **Scope:** Canonical policy for when correctness/explanations may be exposed
-> **Last Updated:** 2026-04-25
+> **Last Updated:** 2026-04-26
 > **Status:** Enforced. BUG-180/181/185 and BUG-186/187/191/192/193/195 are archived as fixed; BUG-237 rejects active-exam `SubmitAnswer` at the use-case boundary; BUG-236 aligns dashboard streak timestamps with the repository visibility predicate; BUG-235 aligns History latest-visible-attempt fallback semantics. BUG-239 tracks a lower-severity remaining implicit latest-reader fallback gap that does not expose correctness. This document remains the regression contract.
 
 ---
@@ -89,16 +89,17 @@ Use this guard consistently at all answer-key disclosure points. Do not duplicat
 
 ## 6. Current Enforcement Status
 
-These code paths are current as of 2026-04-25:
+These code paths are current as of 2026-04-26:
 
 - `GetPreviousAttempt` returns `null` for active-exam attempts and only reveals `session_unanswered` answers after the exam session has ended.
 - `GetPracticeSessionReview` redacts per-question `isCorrect` while an exam session is still active.
 - `GetNextQuestion` redacts `session.latestIsCorrect` for active exams and only hydrates `previousSubmission` for answered tutor-session questions.
 - `SubmitAnswer` rejects active exam sessions with `VALIDATION_ERROR` before inserting an `attempts` row or calling `recordQuestionAnswer(...)`; active exam answers must use `SaveExamDraftAnswer` before `FinalizeExamAnswers` creates final attempts. See [BUG-237](../_archive/bugs/bug-237-submit-answer-allows-active-exam-session-writes.md).
 - Active-exam draft `cumulativeMs` is bounded at `SAVE_EXAM_DRAFT_MAX_CUMULATIVE_MS` (24 hours) at ingress, clamped in `SaveExamDraftAnswerUseCase`, and capped again in `FinalizeExamAnswersUseCase` before writing `attempts.time_spent_seconds`. See [BUG-238](../bugs/bug-238-active-exam-draft-cumulative-ms-unbounded.md).
-- `DrizzleAttemptRepository` applies `activeExamVisibilityCondition()` to dashboard aggregate counts, recent activity, and `listAnsweredAtByUserIdSince(...)` streak timestamps; active-exam attempts are excluded until the session ends while tutor, ended-exam, and standalone attempts remain visible. See [BUG-236](../_archive/bugs/bug-236-dashboard-current-streak-includes-active-exam-attempts.md).
-- `DrizzleAttemptRepository` also applies `activeExamVisibilityCondition()` inside the attempted-question latest-attempt subquery before `row_number()` ranking, so History excludes active-exam attempts without dropping older visible attempts for the same question. See [BUG-235](../_archive/bugs/bug-235-attempted-question-history-drops-latest-visible-attempt.md).
-- `DrizzleQuestionRepository` excludes active-exam attempts from status-filter and user-history correctness projections via `activeExamVisibilityCondition()`.
+- Repository attempt visibility is centralized in `getActiveExamVisibilityCondition()` at `src/adapters/repositories/shared/active-exam-visibility.ts`; both `DrizzleAttemptRepository` and `DrizzleQuestionRepository` use that helper so active-exam attempts stay hidden while tutor, ended-exam, and standalone attempts remain visible. See [DEBT-366](../debt/debt-366-active-exam-visibility-predicate-duplication.md).
+- `DrizzleAttemptRepository` applies the shared active-exam visibility predicate to dashboard aggregate counts, recent activity, and `listAnsweredAtByUserIdSince(...)` streak timestamps; active-exam attempts are excluded until the session ends while tutor, ended-exam, and standalone attempts remain visible. See [BUG-236](../_archive/bugs/bug-236-dashboard-current-streak-includes-active-exam-attempts.md).
+- `DrizzleAttemptRepository` also applies the shared active-exam visibility predicate inside the attempted-question latest-attempt subquery before `row_number()` ranking, so History excludes active-exam attempts without dropping older visible attempts for the same question. See [BUG-235](../_archive/bugs/bug-235-attempted-question-history-drops-latest-visible-attempt.md).
+- `DrizzleQuestionRepository` excludes active-exam attempts from status-filter and user-history correctness projections via the shared active-exam visibility predicate.
 - Open follow-up: [BUG-239](../bugs/bug-239-active-exam-latest-attempt-readers-drop-visible-fallback.md) tracks two remaining implicit/latest readers that avoid correctness exposure but can hide an older visible attempt behind a newer active-exam row.
 
 ---

--- a/src/adapters/repositories/drizzle-attempt-repository.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.ts
@@ -5,11 +5,8 @@ import {
   eq,
   gte,
   inArray,
-  isNotNull,
   isNull,
   max,
-  ne,
-  or,
   type SQL,
   sql,
 } from 'drizzle-orm';
@@ -38,6 +35,7 @@ import {
   getPostgresConstraintName,
   isPostgresUniqueViolation,
 } from './postgres-errors';
+import { getActiveExamVisibilityCondition } from './shared/active-exam-visibility';
 import { latestAttemptRankSql } from './shared/latest-attempt-rank-sql';
 
 const SESSION_ATTEMPT_READ_LIMIT = 500;
@@ -49,21 +47,6 @@ const SESSION_ATTEMPT_READ_LIMIT = 500;
 // Reviewed in DEBT-224 audit (2026-02-18).
 export class DrizzleAttemptRepository implements AttemptRepository {
   constructor(private readonly db: DrizzleDb) {}
-
-  private activeExamVisibilityCondition(): SQL {
-    const condition = or(
-      isNull(practiceSessions.id),
-      ne(practiceSessions.mode, 'exam'),
-      isNotNull(practiceSessions.endedAt),
-    );
-    if (!condition) {
-      throw new ApplicationError(
-        'INTERNAL_ERROR',
-        'Active exam visibility condition unexpectedly missing',
-      );
-    }
-    return condition;
-  }
 
   private latestAttemptRowsSubquery(userId: string) {
     return this.db
@@ -84,7 +67,7 @@ export class DrizzleAttemptRepository implements AttemptRepository {
         eq(attempts.practiceSessionId, practiceSessions.id),
       )
       .where(
-        and(eq(attempts.userId, userId), this.activeExamVisibilityCondition()),
+        and(eq(attempts.userId, userId), getActiveExamVisibilityCondition()),
       )
       .as('latest_attempt_rows');
   }
@@ -329,7 +312,7 @@ export class DrizzleAttemptRepository implements AttemptRepository {
   ): Promise<number> {
     const where = and(
       eq(attempts.userId, userId),
-      this.activeExamVisibilityCondition(),
+      getActiveExamVisibilityCondition(),
       ...conditions,
     );
 
@@ -393,7 +376,7 @@ export class DrizzleAttemptRepository implements AttemptRepository {
         eq(attempts.practiceSessionId, practiceSessions.id),
       )
       .where(
-        and(eq(attempts.userId, userId), this.activeExamVisibilityCondition()),
+        and(eq(attempts.userId, userId), getActiveExamVisibilityCondition()),
       )
       .orderBy(desc(attempts.answeredAt), desc(attempts.id))
       .limit(limit);
@@ -416,7 +399,7 @@ export class DrizzleAttemptRepository implements AttemptRepository {
         and(
           eq(attempts.userId, userId),
           gte(attempts.answeredAt, since),
-          this.activeExamVisibilityCondition(),
+          getActiveExamVisibilityCondition(),
         ),
       )
       .orderBy(desc(attempts.answeredAt));

--- a/src/adapters/repositories/drizzle-question-repository.ts
+++ b/src/adapters/repositories/drizzle-question-repository.ts
@@ -4,9 +4,6 @@ import {
   desc,
   eq,
   inArray,
-  isNotNull,
-  isNull,
-  ne,
   notInArray,
   or,
   type SQL,
@@ -31,25 +28,11 @@ import {
   type QuestionProgressStatus,
 } from '@/src/domain/value-objects';
 import type { DrizzleDb } from '../shared/database-types';
+import { getActiveExamVisibilityCondition } from './shared/active-exam-visibility';
 import { latestAttemptRankSql } from './shared/latest-attempt-rank-sql';
 
 export class DrizzleQuestionRepository implements QuestionRepository {
   constructor(private readonly db: DrizzleDb) {}
-
-  private activeExamVisibilityCondition(): SQL {
-    const condition = or(
-      isNull(practiceSessions.id),
-      ne(practiceSessions.mode, 'exam'),
-      isNotNull(practiceSessions.endedAt),
-    );
-    if (!condition) {
-      throw new ApplicationError(
-        'INTERNAL_ERROR',
-        'Active exam visibility condition unexpectedly missing',
-      );
-    }
-    return condition;
-  }
 
   private buildPublishedCandidateWhere(filters: QuestionFilters): {
     hasTagFilter: boolean;
@@ -209,7 +192,7 @@ export class DrizzleQuestionRepository implements QuestionRepository {
         eq(attempts.practiceSessionId, practiceSessions.id),
       )
       .where(
-        and(eq(attempts.userId, userId), this.activeExamVisibilityCondition()),
+        and(eq(attempts.userId, userId), getActiveExamVisibilityCondition()),
       )
       .as('latest_attempt_rows');
   }
@@ -236,7 +219,7 @@ export class DrizzleQuestionRepository implements QuestionRepository {
             .where(
               and(
                 eq(attempts.userId, userId),
-                this.activeExamVisibilityCondition(),
+                getActiveExamVisibilityCondition(),
               ),
             ),
         );

--- a/src/adapters/repositories/shared/active-exam-visibility.ts
+++ b/src/adapters/repositories/shared/active-exam-visibility.ts
@@ -1,0 +1,29 @@
+import { isNotNull, isNull, ne, or, type SQL } from 'drizzle-orm';
+import { practiceSessions } from '@/db/schema';
+import { ApplicationError } from '@/src/application/errors';
+
+/**
+ * Returns the SQL predicate that hides attempt rows belonging to active
+ * (non-ended) exam sessions. Standalone attempts (no session) and tutor /
+ * ended-exam attempts pass through.
+ *
+ * Callers MUST include
+ * `leftJoin(practiceSessions, eq(attempts.practiceSessionId, practiceSessions.id))`
+ * (or its equivalent for whichever attempts/sessions tables are in scope) so
+ * `practiceSessions.id`, `practiceSessions.mode`, and `practiceSessions.endedAt`
+ * resolve.
+ */
+export function getActiveExamVisibilityCondition(): SQL {
+  const condition = or(
+    isNull(practiceSessions.id),
+    ne(practiceSessions.mode, 'exam'),
+    isNotNull(practiceSessions.endedAt),
+  );
+  if (!condition) {
+    throw new ApplicationError(
+      'INTERNAL_ERROR',
+      'Active exam visibility condition unexpectedly missing',
+    );
+  }
+  return condition;
+}

--- a/src/adapters/repositories/shared/active-exam-visibility.ts
+++ b/src/adapters/repositories/shared/active-exam-visibility.ts
@@ -19,11 +19,13 @@ export function getActiveExamVisibilityCondition(): SQL {
     ne(practiceSessions.mode, 'exam'),
     isNotNull(practiceSessions.endedAt),
   );
+  /* v8 ignore start -- Drizzle returns SQL for concrete predicates; guard preserves the prior defensive shape. */
   if (!condition) {
     throw new ApplicationError(
       'INTERNAL_ERROR',
       'Active exam visibility condition unexpectedly missing',
     );
   }
+  /* v8 ignore stop */
   return condition;
 }


### PR DESCRIPTION
## Summary

Resolves DEBT-366. Pure deduplication of the identical 14-line `activeExamVisibilityCondition()` private methods on `DrizzleAttemptRepository` and `DrizzleQuestionRepository`. Consolidated into a single `getActiveExamVisibilityCondition()` exported from `src/adapters/repositories/shared/active-exam-visibility.ts`. Both repos import the shared helper.

This unblocks future work — BUG-239 will apply this same predicate to two more reader methods in a follow-up PR, and any future visibility-policy change now has one source of truth instead of two.

## Test plan

- [x] Baseline focused repo tests before refactor: `pnpm test --run src/adapters/repositories/drizzle-attempt-repository.test.ts src/adapters/repositories/drizzle-question-repository.test.ts`
- [x] Zero test files modified — existing suite is the safety net for no behavior change
- [x] `rg -n "private activeExamVisibilityCondition" src/` returns zero hits
- [x] `rg -n "this\\.activeExamVisibilityCondition" src/` returns zero hits
- [x] Full pre-push gate: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- [x] E2E configured locally: `pnpm test:e2e` (34 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated exam visibility policy and debt tracking docs, advanced last-updated date, and added DEBT-366/resolution state.

* **Refactor**
  * Consolidated active-exam visibility logic into a single shared utility and updated repositories to use it for consistent attempt visibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->