### PR TITLE
Apply active-exam visibility to latest-attempt readers (BUG-239)

### DIFF
--- a/docs/bugs/bug-239-active-exam-latest-attempt-readers-drop-visible-fallback.md
+++ b/docs/bugs/bug-239-active-exam-latest-attempt-readers-drop-visible-fallback.md
@@ -3,6 +3,7 @@
 **Status:** Open
 **Priority:** P4
 **Date:** 2026-04-25
+**Resolution State:** Fix on branch `fix-bug-239-active-exam-readers`; pending PR review, merge verification, and archival.
 **Confirmed:** 2026-04-25
 **Component:** Practice / Review Hydration / Question Selection
 
@@ -57,11 +58,11 @@ Apply active-exam visibility before latest-row selection in the remaining implic
 
 - [x] Code-level tracer-bullet verified on 2026-04-25.
 - [x] Confirmed BUG-235 fixed attempted-question History by filtering active-exam rows before latest-attempt ranking.
-- [ ] Integration test: `findLatestByUserAndQuestion(...)` returns an older standalone/tutor/ended-exam attempt when a newer active-exam attempt is hidden.
-- [ ] Integration test: `findLatestByUserAndQuestion(...)` returns `null` when only an active-exam attempt exists, then returns that attempt after the exam ends.
-- [ ] Integration test: `findMostRecentAnsweredAtByQuestionIds(...)` ignores active-exam timestamps while preserving older visible timestamps.
-- [ ] Use-case/controller regression: standalone review hydration shows the older visible attempt instead of `no_prior_attempt` in the fallback case.
-- [ ] Full gate after fix: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`.
+- [x] Integration test: `findLatestByUserAndQuestion(...)` returns an older standalone/tutor/ended-exam attempt when a newer active-exam attempt is hidden.
+- [x] Integration test: `findLatestByUserAndQuestion(...)` returns `null` when only an active-exam attempt exists, then returns that attempt after the exam ends.
+- [x] Integration test: `findMostRecentAnsweredAtByQuestionIds(...)` ignores active-exam timestamps while preserving older visible timestamps.
+- [x] Use-case/controller regression: standalone review hydration shows the older visible attempt instead of `no_prior_attempt` in the fallback case.
+- [x] Full gate after fix: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`.
 
 ## Related
 

--- a/docs/practice-engine/exam-answer-secrecy-policy.md
+++ b/docs/practice-engine/exam-answer-secrecy-policy.md
@@ -3,7 +3,7 @@
 > **Parent:** [Practice Engine Index](./index.md)
 > **Scope:** Canonical policy for when correctness/explanations may be exposed
 > **Last Updated:** 2026-04-26
-> **Status:** Enforced. BUG-180/181/185 and BUG-186/187/191/192/193/195 are archived as fixed; BUG-237 rejects active-exam `SubmitAnswer` at the use-case boundary; BUG-236 aligns dashboard streak timestamps with the repository visibility predicate; BUG-235 aligns History latest-visible-attempt fallback semantics. BUG-239 tracks a lower-severity remaining implicit latest-reader fallback gap that does not expose correctness. This document remains the regression contract.
+> **Status:** Enforced. BUG-180/181/185 and BUG-186/187/191/192/193/195 are archived as fixed; BUG-237 rejects active-exam `SubmitAnswer` at the use-case boundary; BUG-236 aligns dashboard streak timestamps with the repository visibility predicate; BUG-235 aligns History latest-visible-attempt fallback semantics; BUG-239 aligns the remaining implicit latest-attempt readers. This document remains the regression contract.
 
 ---
 
@@ -99,8 +99,8 @@ These code paths are current as of 2026-04-26:
 - Repository attempt visibility is centralized in `getActiveExamVisibilityCondition()` at `src/adapters/repositories/shared/active-exam-visibility.ts`; both `DrizzleAttemptRepository` and `DrizzleQuestionRepository` use that helper so active-exam attempts stay hidden while tutor, ended-exam, and standalone attempts remain visible. See [DEBT-366](../debt/debt-366-active-exam-visibility-predicate-duplication.md).
 - `DrizzleAttemptRepository` applies the shared active-exam visibility predicate to dashboard aggregate counts, recent activity, and `listAnsweredAtByUserIdSince(...)` streak timestamps; active-exam attempts are excluded until the session ends while tutor, ended-exam, and standalone attempts remain visible. See [BUG-236](../_archive/bugs/bug-236-dashboard-current-streak-includes-active-exam-attempts.md).
 - `DrizzleAttemptRepository` also applies the shared active-exam visibility predicate inside the attempted-question latest-attempt subquery before `row_number()` ranking, so History excludes active-exam attempts without dropping older visible attempts for the same question. See [BUG-235](../_archive/bugs/bug-235-attempted-question-history-drops-latest-visible-attempt.md).
+- Implicit latest-attempt readers (`findLatestByUserAndQuestion(...)`, `findMostRecentAnsweredAtByQuestionIds(...)`) apply active-exam visibility before row selection / aggregation, so older visible attempts surface as the fallback when a newer active-exam attempt would be hidden. See [BUG-239](../bugs/bug-239-active-exam-latest-attempt-readers-drop-visible-fallback.md).
 - `DrizzleQuestionRepository` excludes active-exam attempts from status-filter and user-history correctness projections via the shared active-exam visibility predicate.
-- Open follow-up: [BUG-239](../bugs/bug-239-active-exam-latest-attempt-readers-drop-visible-fallback.md) tracks two remaining implicit/latest readers that avoid correctness exposure but can hide an older visible attempt behind a newer active-exam row.
 
 ---
 
@@ -123,7 +123,7 @@ Every change that touches review hydration, retry, stats projections, or exam re
 
 6. History attempted-questions projection excludes active-exam attempts at the subquery level, preserving older visible attempts as the latest visible row when present.
 
-7. Implicit/latest attempt readers either select the latest visible row or return `null` without exposing correctness when only active-exam rows exist. BUG-239 tracks the remaining fallback gap.
+7. Implicit/latest attempt readers either select the latest visible row or return `null` without exposing correctness when only active-exam rows exist.
 
 8. UI-level review paths do not render correctness badges from active-exam attempts.
 

--- a/src/adapters/repositories/drizzle-attempt-repository.test.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.test.ts
@@ -52,18 +52,7 @@ function createDbMock() {
   const findLatestLimit = vi.fn(
     async (): Promise<
       Array<{
-        id: string;
-        userId: string;
-        questionId: string;
-        practiceSessionId: string | null;
-        selectedChoiceId: string | null;
-        isCorrect: boolean;
-        timeSpentSeconds: number;
-        retryOfAttemptId?: string | null;
-        retryOrigin?: null;
-        retrySessionId?: string | null;
-        answeredAt: Date;
-        attempts?: {
+        attempts: {
           id: string;
           userId: string;
           questionId: string;
@@ -652,7 +641,6 @@ describe('DrizzleAttemptRepository', () => {
       };
       db._mocks.findLatestLimit.mockResolvedValue([
         {
-          ...attemptRow,
           attempts: attemptRow,
         },
       ]);

--- a/src/adapters/repositories/drizzle-attempt-repository.test.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.test.ts
@@ -1,5 +1,10 @@
+import { eq } from 'drizzle-orm';
 import { describe, expect, it, vi } from 'vitest';
-import { ATTEMPTS_SESSION_QUESTION_UQ } from '@/db/schema';
+import {
+  ATTEMPTS_SESSION_QUESTION_UQ,
+  attempts,
+  practiceSessions,
+} from '@/db/schema';
 import { ApplicationError } from '@/src/application/errors';
 import { DrizzleAttemptRepository } from './drizzle-attempt-repository';
 
@@ -43,6 +48,36 @@ function createDbMock() {
   );
   const answeredAtQueryExecute = vi.fn(
     async (): Promise<Array<{ answeredAt: Date }>> => [],
+  );
+  const findLatestLimit = vi.fn(
+    async (): Promise<
+      Array<{
+        id: string;
+        userId: string;
+        questionId: string;
+        practiceSessionId: string | null;
+        selectedChoiceId: string | null;
+        isCorrect: boolean;
+        timeSpentSeconds: number;
+        retryOfAttemptId?: string | null;
+        retryOrigin?: null;
+        retrySessionId?: string | null;
+        answeredAt: Date;
+        attempts?: {
+          id: string;
+          userId: string;
+          questionId: string;
+          practiceSessionId: string | null;
+          selectedChoiceId: string | null;
+          isCorrect: boolean;
+          timeSpentSeconds: number;
+          retryOfAttemptId?: string | null;
+          retryOrigin?: null;
+          retrySessionId?: string | null;
+          answeredAt: Date;
+        };
+      }>
+    > => [],
   );
   const finalQueryExecute = vi.fn(
     async (): Promise<
@@ -99,6 +134,14 @@ function createDbMock() {
   const answeredAtOrderBy = vi.fn(() => answeredAtQueryExecute());
   const answeredAtWhere = vi.fn(() => ({ orderBy: answeredAtOrderBy }));
   const leftJoinAnsweredAt = vi.fn(() => ({ where: answeredAtWhere }));
+  const findLatestOrderBy = vi.fn(() => ({ limit: findLatestLimit }));
+  const findLatestWhere = vi.fn(() => ({ orderBy: findLatestOrderBy }));
+  const leftJoinFindLatest = vi.fn(() => ({ where: findLatestWhere }));
+  const findLatestFrom = vi.fn(() => ({
+    leftJoin: leftJoinFindLatest,
+    where: findLatestWhere,
+  }));
+  const leftJoinFindMostRecent = vi.fn(() => ({ where: whereGroupBy }));
   const innerJoin = vi.fn(() => ({ where: whereFinal }));
 
   const from = vi.fn((table: unknown) => {
@@ -128,7 +171,11 @@ function createDbMock() {
     };
   });
 
-  const select = vi.fn((fields: Record<string, unknown>) => {
+  const select = vi.fn((fields?: Record<string, unknown>) => {
+    if (fields === undefined) {
+      return { from: findLatestFrom };
+    }
+
     if ('count' in fields) {
       return {
         from: countFrom,
@@ -144,6 +191,19 @@ function createDbMock() {
     if (Object.keys(fields).length === 1 && 'answeredAt' in fields) {
       return {
         from: vi.fn(() => ({ leftJoin: leftJoinAnsweredAt })),
+      };
+    }
+
+    if (
+      Object.keys(fields).length === 2 &&
+      'questionId' in fields &&
+      'answeredAt' in fields
+    ) {
+      return {
+        from: vi.fn(() => ({
+          leftJoin: leftJoinFindMostRecent,
+          where: whereGroupBy,
+        })),
       };
     }
 
@@ -179,6 +239,12 @@ function createDbMock() {
       leftJoinFinal,
       leftJoinRecent,
       leftJoinAnsweredAt,
+      findLatestFrom,
+      leftJoinFindLatest,
+      findLatestWhere,
+      findLatestOrderBy,
+      findLatestLimit,
+      leftJoinFindMostRecent,
       recentWhere,
       recentOrderBy,
       recentLimit,
@@ -544,6 +610,69 @@ describe('DrizzleAttemptRepository', () => {
       await expect(
         repo.findMostRecentAnsweredAtByQuestionIds('user_1', ['q1', 'q2']),
       ).resolves.toEqual([{ questionId: 'q1', answeredAt }]);
+    });
+
+    it('left-joins practice sessions before aggregating latest answeredAt values', async () => {
+      const db = createDbMock();
+      const answeredAt = new Date('2026-02-01T00:00:00Z');
+      db._mocks.groupByExecute.mockResolvedValue([
+        { questionId: 'q1', answeredAt },
+      ]);
+
+      const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
+
+      await expect(
+        repo.findMostRecentAnsweredAtByQuestionIds('user_1', ['q1']),
+      ).resolves.toEqual([{ questionId: 'q1', answeredAt }]);
+
+      expect(db._mocks.leftJoinFindMostRecent).toHaveBeenCalledTimes(1);
+      expect(db._mocks.leftJoinFindMostRecent).toHaveBeenCalledWith(
+        practiceSessions,
+        eq(attempts.practiceSessionId, practiceSessions.id),
+      );
+    });
+  });
+
+  describe('findLatestByUserAndQuestion', () => {
+    it('left-joins practice sessions before selecting the latest attempt', async () => {
+      const db = createDbMock();
+      const answeredAt = new Date('2026-02-01T00:00:00Z');
+      const attemptRow = {
+        id: 'attempt_1',
+        userId: 'user_1',
+        questionId: 'question_1',
+        practiceSessionId: null,
+        selectedChoiceId: 'choice_1',
+        isCorrect: true,
+        timeSpentSeconds: 42,
+        retryOfAttemptId: null,
+        retryOrigin: null,
+        retrySessionId: null,
+        answeredAt,
+      };
+      db._mocks.findLatestLimit.mockResolvedValue([
+        {
+          ...attemptRow,
+          attempts: attemptRow,
+        },
+      ]);
+
+      const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
+
+      await expect(
+        repo.findLatestByUserAndQuestion('user_1', 'question_1'),
+      ).resolves.toMatchObject({
+        id: 'attempt_1',
+        userId: 'user_1',
+        questionId: 'question_1',
+        answeredAt,
+      });
+
+      expect(db._mocks.leftJoinFindLatest).toHaveBeenCalledTimes(1);
+      expect(db._mocks.leftJoinFindLatest).toHaveBeenCalledWith(
+        practiceSessions,
+        eq(attempts.practiceSessionId, practiceSessions.id),
+      );
     });
   });
 

--- a/src/adapters/repositories/drizzle-attempt-repository.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.ts
@@ -262,15 +262,23 @@ export class DrizzleAttemptRepository implements AttemptRepository {
     const [row] = await this.db
       .select()
       .from(attempts)
+      .leftJoin(
+        practiceSessions,
+        eq(attempts.practiceSessionId, practiceSessions.id),
+      )
       .where(
-        and(eq(attempts.userId, userId), eq(attempts.questionId, questionId)),
+        and(
+          eq(attempts.userId, userId),
+          eq(attempts.questionId, questionId),
+          getActiveExamVisibilityCondition(),
+        ),
       )
       .orderBy(desc(attempts.answeredAt), desc(attempts.id))
       .limit(1);
 
     if (!row) return null;
 
-    return toAttemptDomain(row);
+    return toAttemptDomain(row.attempts);
   }
 
   async findByIdAndUserId(
@@ -508,10 +516,15 @@ export class DrizzleAttemptRepository implements AttemptRepository {
         answeredAt: max(attempts.answeredAt).as('answered_at'),
       })
       .from(attempts)
+      .leftJoin(
+        practiceSessions,
+        eq(attempts.practiceSessionId, practiceSessions.id),
+      )
       .where(
         and(
           eq(attempts.userId, userId),
           inArray(attempts.questionId, [...questionIds]),
+          getActiveExamVisibilityCondition(),
         ),
       )
       .groupBy(attempts.questionId);

--- a/src/application/use-cases/get-previous-attempt.test.ts
+++ b/src/application/use-cases/get-previous-attempt.test.ts
@@ -1155,7 +1155,7 @@ describe('GetPreviousAttemptUseCase', () => {
     expect(result?.choiceExplanations).toEqual(expected);
   });
 
-  it('returns the older visible attempt supplied by the implicit latest reader', async () => {
+  it("wraps the implicit-latest repository result as kind: 'attempt' with ISO answeredAt", async () => {
     const userId = 'user-1';
     const questionId = 'q1';
     const answeredAt = new Date('2026-04-25T12:00:00.000Z');

--- a/src/application/use-cases/get-previous-attempt.test.ts
+++ b/src/application/use-cases/get-previous-attempt.test.ts
@@ -1155,6 +1155,55 @@ describe('GetPreviousAttemptUseCase', () => {
     expect(result?.choiceExplanations).toEqual(expected);
   });
 
+  it('returns the older visible attempt supplied by the implicit latest reader', async () => {
+    const userId = 'user-1';
+    const questionId = 'q1';
+    const answeredAt = new Date('2026-04-25T12:00:00.000Z');
+    const question = createQuestion({
+      id: questionId,
+      status: 'published',
+      explanationMd: 'Visible explanation',
+      choices: [
+        createChoice({
+          id: 'c1',
+          questionId,
+          label: 'A',
+          isCorrect: false,
+        }),
+        createChoice({
+          id: 'c2',
+          questionId,
+          label: 'B',
+          isCorrect: true,
+        }),
+      ],
+    });
+    const useCase = new GetPreviousAttemptUseCase(
+      new FakeAttemptRepository([
+        createAttempt({
+          id: 'attempt-visible',
+          userId,
+          questionId,
+          selectedChoiceId: 'c1',
+          isCorrect: false,
+          answeredAt,
+        }),
+      ]),
+      new FakeQuestionRepository([question]),
+      new FakeLogger(),
+    );
+
+    await expect(
+      useCase.execute({ userId, questionId }),
+    ).resolves.toMatchObject({
+      kind: 'attempt',
+      attemptId: 'attempt-visible',
+      selectedChoiceId: 'c1',
+      isCorrect: false,
+      answeredAt: answeredAt.toISOString(),
+    });
+  });
+
   it('propagates repository failures', async () => {
     class FailingAttemptRepository extends FakeAttemptRepository {
       async findLatestByUserAndQuestion(): Promise<never> {

--- a/tests/integration/bug-regression.integration.test.ts
+++ b/tests/integration/bug-regression.integration.test.ts
@@ -1180,6 +1180,322 @@ describe('BUG-235: Attempted-question history keeps latest visible fallback', ()
   });
 });
 
+// ---------------------------------------------------------------------------
+// BUG-239: Latest-attempt readers apply active-exam visibility
+// ---------------------------------------------------------------------------
+
+describe('BUG-239: Latest-attempt readers apply active-exam visibility', () => {
+  async function createSessionForQuestion(input: {
+    userId: string;
+    questionId: string;
+    mode: 'tutor' | 'exam';
+    ended?: boolean;
+  }) {
+    const sessionRepo = new DrizzlePracticeSessionRepository(db);
+    const session = await sessionRepo.create({
+      userId: input.userId,
+      mode: input.mode,
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [input.questionId],
+      },
+    });
+
+    if (input.ended) {
+      await sessionRepo.end(session.id, input.userId);
+    }
+
+    return session;
+  }
+
+  it('findLatestByUserAndQuestion falls back to an older standalone attempt when a newer active-exam attempt is hidden', async () => {
+    const user = await createUser(db, cleanup);
+    const question = await createQuestion(db, cleanup, {
+      slug: `it-bug239-latest-standalone-fallback-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const attemptRepo = new DrizzleAttemptRepository(db);
+    const olderVisibleAt = new Date('2026-04-10T12:00:00.000Z');
+    const newerActiveExamAt = new Date('2026-04-10T13:00:00.000Z');
+
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: null,
+      selectedChoiceId: question.incorrectChoiceId,
+      isCorrect: false,
+      answeredAt: olderVisibleAt,
+    });
+    const activeExamSession = await createSessionForQuestion({
+      userId: user.id,
+      questionId: question.id,
+      mode: 'exam',
+    });
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: activeExamSession.id,
+      selectedChoiceId: question.correctChoiceId,
+      isCorrect: true,
+      answeredAt: newerActiveExamAt,
+    });
+
+    await expect(
+      attemptRepo.findLatestByUserAndQuestion(user.id, question.id),
+    ).resolves.toMatchObject({
+      questionId: question.id,
+      practiceSessionId: null,
+      selectedChoiceId: question.incorrectChoiceId,
+      isCorrect: false,
+      answeredAt: olderVisibleAt,
+    });
+  });
+
+  it('findLatestByUserAndQuestion falls back to an older tutor attempt when a newer active-exam attempt is hidden', async () => {
+    const user = await createUser(db, cleanup);
+    const question = await createQuestion(db, cleanup, {
+      slug: `it-bug239-latest-tutor-fallback-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const attemptRepo = new DrizzleAttemptRepository(db);
+    const olderVisibleAt = new Date('2026-04-11T12:00:00.000Z');
+    const newerActiveExamAt = new Date('2026-04-11T13:00:00.000Z');
+    const tutorSession = await createSessionForQuestion({
+      userId: user.id,
+      questionId: question.id,
+      mode: 'tutor',
+      ended: true,
+    });
+
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: tutorSession.id,
+      selectedChoiceId: question.incorrectChoiceId,
+      isCorrect: false,
+      answeredAt: olderVisibleAt,
+    });
+    const activeExamSession = await createSessionForQuestion({
+      userId: user.id,
+      questionId: question.id,
+      mode: 'exam',
+    });
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: activeExamSession.id,
+      selectedChoiceId: question.correctChoiceId,
+      isCorrect: true,
+      answeredAt: newerActiveExamAt,
+    });
+
+    await expect(
+      attemptRepo.findLatestByUserAndQuestion(user.id, question.id),
+    ).resolves.toMatchObject({
+      questionId: question.id,
+      practiceSessionId: tutorSession.id,
+      selectedChoiceId: question.incorrectChoiceId,
+      isCorrect: false,
+      answeredAt: olderVisibleAt,
+    });
+  });
+
+  it('findLatestByUserAndQuestion falls back to an older ended-exam attempt when a newer active-exam attempt is hidden', async () => {
+    const user = await createUser(db, cleanup);
+    const question = await createQuestion(db, cleanup, {
+      slug: `it-bug239-latest-ended-exam-fallback-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const attemptRepo = new DrizzleAttemptRepository(db);
+    const olderVisibleAt = new Date('2026-04-12T12:00:00.000Z');
+    const newerActiveExamAt = new Date('2026-04-12T13:00:00.000Z');
+    const endedExamSession = await createSessionForQuestion({
+      userId: user.id,
+      questionId: question.id,
+      mode: 'exam',
+      ended: true,
+    });
+
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: endedExamSession.id,
+      selectedChoiceId: question.incorrectChoiceId,
+      isCorrect: false,
+      answeredAt: olderVisibleAt,
+    });
+    const activeExamSession = await createSessionForQuestion({
+      userId: user.id,
+      questionId: question.id,
+      mode: 'exam',
+    });
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: activeExamSession.id,
+      selectedChoiceId: question.correctChoiceId,
+      isCorrect: true,
+      answeredAt: newerActiveExamAt,
+    });
+
+    await expect(
+      attemptRepo.findLatestByUserAndQuestion(user.id, question.id),
+    ).resolves.toMatchObject({
+      questionId: question.id,
+      practiceSessionId: endedExamSession.id,
+      selectedChoiceId: question.incorrectChoiceId,
+      isCorrect: false,
+      answeredAt: olderVisibleAt,
+    });
+  });
+
+  it('findLatestByUserAndQuestion hides an active-exam-only attempt until the exam ends', async () => {
+    const user = await createUser(db, cleanup);
+    const question = await createQuestion(db, cleanup, {
+      slug: `it-bug239-latest-no-fallback-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const attemptRepo = new DrizzleAttemptRepository(db);
+    const sessionRepo = new DrizzlePracticeSessionRepository(db);
+    const activeExamAt = new Date('2026-04-13T12:00:00.000Z');
+    const activeExamSession = await sessionRepo.create({
+      userId: user.id,
+      mode: 'exam',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [question.id],
+      },
+    });
+
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: activeExamSession.id,
+      selectedChoiceId: question.correctChoiceId,
+      isCorrect: true,
+      answeredAt: activeExamAt,
+    });
+
+    await expect(
+      attemptRepo.findLatestByUserAndQuestion(user.id, question.id),
+    ).resolves.toBeNull();
+
+    await sessionRepo.end(activeExamSession.id, user.id);
+
+    await expect(
+      attemptRepo.findLatestByUserAndQuestion(user.id, question.id),
+    ).resolves.toMatchObject({
+      questionId: question.id,
+      practiceSessionId: activeExamSession.id,
+      selectedChoiceId: question.correctChoiceId,
+      isCorrect: true,
+      answeredAt: activeExamAt,
+    });
+  });
+
+  it('findMostRecentAnsweredAtByQuestionIds ignores active-exam timestamps while preserving older visible timestamps', async () => {
+    const user = await createUser(db, cleanup);
+    const question = await createQuestion(db, cleanup, {
+      slug: `it-bug239-most-recent-visible-fallback-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const attemptRepo = new DrizzleAttemptRepository(db);
+    const olderVisibleAt = new Date('2026-04-14T12:00:00.000Z');
+    const newerActiveExamAt = new Date('2026-04-14T13:00:00.000Z');
+
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: null,
+      selectedChoiceId: question.incorrectChoiceId,
+      isCorrect: false,
+      answeredAt: olderVisibleAt,
+    });
+    const activeExamSession = await createSessionForQuestion({
+      userId: user.id,
+      questionId: question.id,
+      mode: 'exam',
+    });
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: question.id,
+      practiceSessionId: activeExamSession.id,
+      selectedChoiceId: question.correctChoiceId,
+      isCorrect: true,
+      answeredAt: newerActiveExamAt,
+    });
+
+    await expect(
+      attemptRepo.findMostRecentAnsweredAtByQuestionIds(user.id, [question.id]),
+    ).resolves.toEqual([
+      {
+        questionId: question.id,
+        answeredAt: olderVisibleAt,
+      },
+    ]);
+  });
+
+  it('findMostRecentAnsweredAtByQuestionIds omits questions whose only attempt is active-exam', async () => {
+    const user = await createUser(db, cleanup);
+    const hiddenQuestion = await createQuestion(db, cleanup, {
+      slug: `it-bug239-most-recent-active-only-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const visibleQuestion = await createQuestion(db, cleanup, {
+      slug: `it-bug239-most-recent-visible-only-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const attemptRepo = new DrizzleAttemptRepository(db);
+    const activeExamAt = new Date('2026-04-15T13:00:00.000Z');
+    const visibleAt = new Date('2026-04-15T12:00:00.000Z');
+    const activeExamSession = await createSessionForQuestion({
+      userId: user.id,
+      questionId: hiddenQuestion.id,
+      mode: 'exam',
+    });
+
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: hiddenQuestion.id,
+      practiceSessionId: activeExamSession.id,
+      selectedChoiceId: hiddenQuestion.correctChoiceId,
+      isCorrect: true,
+      answeredAt: activeExamAt,
+    });
+    await insertAttemptAt({
+      userId: user.id,
+      questionId: visibleQuestion.id,
+      practiceSessionId: null,
+      selectedChoiceId: visibleQuestion.correctChoiceId,
+      isCorrect: true,
+      answeredAt: visibleAt,
+    });
+
+    await expect(
+      attemptRepo.findMostRecentAnsweredAtByQuestionIds(user.id, [
+        hiddenQuestion.id,
+        visibleQuestion.id,
+      ]),
+    ).resolves.toEqual([
+      {
+        questionId: visibleQuestion.id,
+        answeredAt: visibleAt,
+      },
+    ]);
+  });
+});
+
 // BUG-195: Question candidate status filters exclude active-exam attempts
 
 describe('BUG-195: Question candidate status filters exclude active-exam attempts', () => {


### PR DESCRIPTION
## Summary

Closes BUG-239 — the last active bug in the register. After merge, `docs/bugs/` Active section can be emptied during the post-merge archival pass.

`findLatestByUserAndQuestion` and `findMostRecentAnsweredAtByQuestionIds` now apply active-exam visibility before row selection / aggregation, mirroring the BUG-235 filter-before-rank pattern. Older visible attempts now surface as the fallback when a newer active-exam attempt would be hidden, instead of returning `null` or producing a hidden-row timestamp.

Both methods consume the shared `getActiveExamVisibilityCondition()` helper that landed in DEBT-366 (PR #289). Exact-identifier methods (`findByIdAndUserId`, `findBySessionIdAndQuestionId`) are unchanged. The post-fetch active-exam guard in `GetPreviousAttemptUseCase` remains in place for explicit-identifier paths.

## Test plan

- [x] Red first: repository unit tests failed on missing `leftJoin(...)` for both affected readers
- [x] Red first: integration BUG-239 block failed on active-exam rows being selected/aggregated before visibility filtering
- [x] Integration: `findLatestByUserAndQuestion` falls back to older standalone / tutor / ended-exam attempts when a newer active-exam attempt is hidden
- [x] Integration: `findLatestByUserAndQuestion` returns null when only an active-exam attempt exists; returns it after the exam ends
- [x] Integration: `findMostRecentAnsweredAtByQuestionIds` ignores active-exam timestamps and omits questions with only active-exam attempts
- [x] Use-case regression: `getPreviousAttempt` standalone path returns the older visible attempt supplied by the implicit latest reader
- [x] Unit-test mock shapes updated for both affected methods only
- [x] Full gate: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- [x] E2E: `pnpm test:e2e` (34 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed active-exam visibility so readers fall back to older visible attempts (and return null when only an active-exam attempt exists until the exam ends).

* **Documentation**
  * Updated exam answer secrecy policy and bug doc to reflect the finalized visibility/fallback behavior and verification status.

* **Tests**
  * Added unit and integration tests covering latest-attempt and most-recent-answeredAt visibility and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->