### PR TITLE
Mirror active-exam visibility in FakeAttemptRepository (DEBT-367)

### DIFF
--- a/docs/debt/debt-367-fake-attempt-repository-missing-active-exam-visibility.md
+++ b/docs/debt/debt-367-fake-attempt-repository-missing-active-exam-visibility.md
@@ -4,7 +4,7 @@
 **Created:** 2026-04-25
 **Source:** Identified as out-of-scope in the BUG-236 doc; resurfaced in the 2026-04-25 post-merge audit
 **Related:** [BUG-235](../_archive/bugs/bug-235-attempted-question-history-drops-latest-visible-attempt.md), [BUG-236](../_archive/bugs/bug-236-dashboard-current-streak-includes-active-exam-attempts.md), [BUG-237](../_archive/bugs/bug-237-submit-answer-allows-active-exam-session-writes.md), [BUG-239](../_archive/bugs/bug-239-active-exam-latest-attempt-readers-drop-visible-fallback.md), [exam-answer-secrecy-policy.md](../practice-engine/exam-answer-secrecy-policy.md)
-**Resolution State:** Fix on branch `debt-367-fake-visibility-fidelity`; PR pending.
+**Resolution State:** Fix on branch `debt-367-fake-visibility-fidelity`; PR #292 pending review and merge.
 
 **Audit verified:** 2026-04-27 against `87284372`.
 

--- a/docs/debt/debt-367-fake-attempt-repository-missing-active-exam-visibility.md
+++ b/docs/debt/debt-367-fake-attempt-repository-missing-active-exam-visibility.md
@@ -4,6 +4,7 @@
 **Created:** 2026-04-25
 **Source:** Identified as out-of-scope in the BUG-236 doc; resurfaced in the 2026-04-25 post-merge audit
 **Related:** [BUG-235](../_archive/bugs/bug-235-attempted-question-history-drops-latest-visible-attempt.md), [BUG-236](../_archive/bugs/bug-236-dashboard-current-streak-includes-active-exam-attempts.md), [BUG-237](../_archive/bugs/bug-237-submit-answer-allows-active-exam-session-writes.md), [BUG-239](../_archive/bugs/bug-239-active-exam-latest-attempt-readers-drop-visible-fallback.md), [exam-answer-secrecy-policy.md](../practice-engine/exam-answer-secrecy-policy.md)
+**Resolution State:** Fix on branch `debt-367-fake-visibility-fidelity`; PR pending.
 
 **Audit verified:** 2026-04-27 against `87284372`.
 
@@ -13,7 +14,7 @@
 
 `DrizzleAttemptRepository` (the production adapter) applies the shared `getActiveExamVisibilityCondition()` helper in ten read paths. Every projection that surfaces attempt data to a user must hide rows whose practice session is in active (non-ended) exam mode. This is enforced by the BUG-235/236/237/239 visibility sweep and codified in `docs/practice-engine/exam-answer-secrecy-policy.md`.
 
-`FakeAttemptRepository` (the in-memory fake at `src/application/test-helpers/fakes/fake-attempt-repository.ts`, 389 LOC) does NOT apply this filter. The fake's `InMemoryAttempt` type carries `sessionMode` (line 18) but has no field for session `endedAt` and no helper that mirrors the visibility predicate. As a result, the ten sister methods silently return rows that the real repository would hide:
+Before the `debt-367-fake-visibility-fidelity` branch, `FakeAttemptRepository` (the in-memory fake at `src/application/test-helpers/fakes/fake-attempt-repository.ts`) did NOT apply this filter. The fake's `InMemoryAttempt` type carried `sessionMode` but had no field for session `endedAt` and no helper that mirrored the visibility predicate. As a result, the ten sister methods silently returned rows that the real repository would hide:
 
 - `findLatestByUserAndQuestion` (line 124)
 - `countByUserId` (line 167)
@@ -43,16 +44,16 @@ Today this is partially papered over by integration tests (`tests/integration/bu
 
 ## Remediation
 
-1. Extend `InMemoryAttempt` (line 16-19) to track session lifecycle: add `sessionEndedAt: Date | null` alongside the existing `sessionMode: 'tutor' | 'exam' | null`.
+1. Extend `InMemoryAttempt` (line 16-19) to track session lifecycle: add optional `sessionEndedAt: Date | null` alongside the existing `sessionMode: 'tutor' | 'exam' | null`.
 2. Add a private helper `private isHiddenByActiveExam(attempt: InMemoryAttempt): boolean` that returns `true` only when `attempt.practiceSessionId !== null && attempt.sessionMode === 'exam' && attempt.sessionEndedAt === null`. That keeps ad-hoc standalone attempts visible even if a test seeds inconsistent `sessionMode` metadata, mirroring the production predicate exactly.
 3. Apply the helper in the ten methods listed above. For `listAttemptedQuestionsByUserId` / `countAttemptedQuestionsByUserId`, apply the filter at the *first* step of `getFilteredAttemptedCandidates` (before the `mostRecentByQuestionId` ranking pass) so the fake mirrors BUG-235's filter-before-rank ordering. For `findMostRecentAnsweredAtByQuestionIds`, apply it before the per-question max aggregation so the fake mirrors BUG-239.
-4. Update fake-construction call sites that need the new field (test helpers and factories under `src/application/test-helpers/`). Default `sessionEndedAt: null` for back-compat where existing tests don't care.
+4. Update fake-construction call sites that need the new field (test helpers and factories under `src/application/test-helpers/`). Existing fake seeds without `sessionEndedAt` remain visible for back-compat; tests must set `sessionEndedAt: null` explicitly when they intend to model an active exam row.
 5. Add a focused unit test (`fake-attempt-repository.test.ts`, create if missing) covering each of the ten methods with a mixed-visibility seed: one active-exam attempt, one ended-exam attempt, one tutor attempt, one standalone attempt. Assert the active-exam row is hidden in every case.
 
 ## Constraints
 
 - Do NOT change the `AttemptRepository` port interface. The fake's seed shape is internal.
-- Do NOT break existing fake-using tests. `sessionEndedAt` defaults to `null` so the new rule applies only when tests explicitly seed an active-exam row (the common existing seed has `sessionMode: null` or `'tutor'`, which the rule leaves alone).
+- Do NOT break existing fake-using tests. Missing `sessionEndedAt` means legacy seed data is not asserting active-exam lifecycle state; the new rule applies only when tests explicitly seed `practiceSessionId !== null`, `sessionMode: 'exam'`, and `sessionEndedAt: null`.
 - Do NOT also extend the fake to model BUG-237's submit-time guard. The fake mirrors the *read* contract here; BUG-237's invariant lives in `SubmitAnswerUseCase` and is already covered by use-case tests.
 
 ## Why P2 (not P3)
@@ -61,7 +62,8 @@ This is not a user-visible defect *today* — production code is correct and int
 
 ## Verification
 
-- All ten target methods filter active-exam rows when seeded with `sessionMode: 'exam', sessionEndedAt: null`.
-- All ten target methods include the row when `sessionEndedAt` is set (ended exam) or `sessionMode: 'tutor' | null` or `practiceSessionId: null`.
-- Existing tests using the fake continue to pass — no behavior change for any test that doesn't seed an active-exam row.
-- `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:integration` stays green.
+- [x] All ten target methods filter active-exam rows when seeded with `sessionMode: 'exam', sessionEndedAt: null` (`fake-attempt-repository.test.ts`).
+- [x] All ten target methods include the row when `sessionEndedAt` is set (ended exam) or `sessionMode: 'tutor' | null` or `practiceSessionId: null` (`fake-attempt-repository.test.ts`).
+- [x] Existing tests using the fake continue to pass — no behavior change for legacy fake seeds that do not explicitly model an active exam row (`pnpm test --run`).
+- [x] Full pre-push gate (`pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`) stays green.
+- [x] Authenticated billing E2E suite stays green when local `.env.local` prerequisites are present (`pnpm test:e2e`, 34/34).

--- a/docs/practice-engine/exam-answer-secrecy-policy.md
+++ b/docs/practice-engine/exam-answer-secrecy-policy.md
@@ -2,8 +2,8 @@
 
 > **Parent:** [Practice Engine Index](./index.md)
 > **Scope:** Canonical policy for when correctness/explanations may be exposed
-> **Last Updated:** 2026-04-26
-> **Status:** Enforced. BUG-180/181/185 and BUG-186/187/191/192/193/195 are archived as fixed; BUG-237 rejects active-exam `SubmitAnswer` at the use-case boundary; BUG-236 aligns dashboard streak timestamps with the repository visibility predicate; BUG-235 aligns History latest-visible-attempt fallback semantics; BUG-239 aligns the remaining implicit latest-attempt readers. This document remains the regression contract.
+> **Last Updated:** 2026-04-27
+> **Status:** Enforced. BUG-180/181/185 and BUG-186/187/191/192/193/195 are archived as fixed; BUG-237 rejects active-exam `SubmitAnswer` at the use-case boundary; BUG-236 aligns dashboard streak timestamps with the repository visibility predicate; BUG-235 aligns History latest-visible-attempt fallback semantics; BUG-239 aligns the remaining implicit latest-attempt readers; DEBT-367 aligns `FakeAttemptRepository` read fidelity with the production visibility predicate. This document remains the regression contract.
 
 ---
 
@@ -89,18 +89,19 @@ Use this guard consistently at all answer-key disclosure points. Do not duplicat
 
 ## 6. Current Enforcement Status
 
-These code paths are current as of 2026-04-26:
+These code paths are current as of 2026-04-27:
 
 - `GetPreviousAttempt` returns `null` for active-exam attempts and only reveals `session_unanswered` answers after the exam session has ended.
 - `GetPracticeSessionReview` redacts per-question `isCorrect` while an exam session is still active.
 - `GetNextQuestion` redacts `session.latestIsCorrect` for active exams and only hydrates `previousSubmission` for answered tutor-session questions.
 - `SubmitAnswer` rejects active exam sessions with `VALIDATION_ERROR` before inserting an `attempts` row or calling `recordQuestionAnswer(...)`; active exam answers must use `SaveExamDraftAnswer` before `FinalizeExamAnswers` creates final attempts. See [BUG-237](../_archive/bugs/bug-237-submit-answer-allows-active-exam-session-writes.md).
-- Active-exam draft `cumulativeMs` is bounded at `SAVE_EXAM_DRAFT_MAX_CUMULATIVE_MS` (24 hours) at ingress, clamped in `SaveExamDraftAnswerUseCase`, and capped again in `FinalizeExamAnswersUseCase` before writing `attempts.time_spent_seconds`. See [BUG-238](../bugs/bug-238-active-exam-draft-cumulative-ms-unbounded.md).
-- Repository attempt visibility is centralized in `getActiveExamVisibilityCondition()` at `src/adapters/repositories/shared/active-exam-visibility.ts`; both `DrizzleAttemptRepository` and `DrizzleQuestionRepository` use that helper so active-exam attempts stay hidden while tutor, ended-exam, and standalone attempts remain visible. See [DEBT-366](../debt/debt-366-active-exam-visibility-predicate-duplication.md).
+- Active-exam draft `cumulativeMs` is bounded at `SAVE_EXAM_DRAFT_MAX_CUMULATIVE_MS` (24 hours) at ingress, clamped in `SaveExamDraftAnswerUseCase`, and capped again in `FinalizeExamAnswersUseCase` before writing `attempts.time_spent_seconds`. See [BUG-238](../_archive/bugs/bug-238-active-exam-draft-cumulative-ms-unbounded.md).
+- Repository attempt visibility is centralized in `getActiveExamVisibilityCondition()` at `src/adapters/repositories/shared/active-exam-visibility.ts`; both `DrizzleAttemptRepository` and `DrizzleQuestionRepository` use that helper so active-exam attempts stay hidden while tutor, ended-exam, and standalone attempts remain visible. See [DEBT-366](../_archive/debt/debt-366-active-exam-visibility-predicate-duplication.md).
 - `DrizzleAttemptRepository` applies the shared active-exam visibility predicate to dashboard aggregate counts, recent activity, and `listAnsweredAtByUserIdSince(...)` streak timestamps; active-exam attempts are excluded until the session ends while tutor, ended-exam, and standalone attempts remain visible. See [BUG-236](../_archive/bugs/bug-236-dashboard-current-streak-includes-active-exam-attempts.md).
 - `DrizzleAttemptRepository` also applies the shared active-exam visibility predicate inside the attempted-question latest-attempt subquery before `row_number()` ranking, so History excludes active-exam attempts without dropping older visible attempts for the same question. See [BUG-235](../_archive/bugs/bug-235-attempted-question-history-drops-latest-visible-attempt.md).
-- Implicit latest-attempt readers (`findLatestByUserAndQuestion(...)`, `findMostRecentAnsweredAtByQuestionIds(...)`) apply active-exam visibility before row selection / aggregation, so older visible attempts surface as the fallback when a newer active-exam attempt would be hidden. See [BUG-239](../bugs/bug-239-active-exam-latest-attempt-readers-drop-visible-fallback.md).
+- Implicit latest-attempt readers (`findLatestByUserAndQuestion(...)`, `findMostRecentAnsweredAtByQuestionIds(...)`) apply active-exam visibility before row selection / aggregation, so older visible attempts surface as the fallback when a newer active-exam attempt would be hidden. See [BUG-239](../_archive/bugs/bug-239-active-exam-latest-attempt-readers-drop-visible-fallback.md).
 - `DrizzleQuestionRepository` excludes active-exam attempts from status-filter and user-history correctness projections via the shared active-exam visibility predicate.
+- `FakeAttemptRepository` mirrors production active-exam visibility for the ten read paths in the BUG-235/236/237/239 family, including filter-before-rank for attempted-question history and filter-before-aggregate for implicit latest-attempt timestamps. See [DEBT-367](../debt/debt-367-fake-attempt-repository-missing-active-exam-visibility.md).
 
 ---
 

--- a/src/application/test-helpers/fakes/fake-attempt-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-attempt-repository.test.ts
@@ -434,19 +434,23 @@ describe('FakeAttemptRepository', () => {
           }),
         ]);
 
-        await expect(
-          repo.findMostRecentAnsweredAtByQuestionIds(userId, [
-            'q-shared',
-            'q-other',
-          ]),
-        ).resolves.toEqual([
-          {
-            questionId: 'q-shared',
-            answeredAt: new Date('2026-04-25T10:00:00Z'),
-          },
+        const result = await repo.findMostRecentAnsweredAtByQuestionIds(
+          userId,
+          ['q-shared', 'q-other'],
+        );
+        const byQuestionId = (
+          left: (typeof result)[number],
+          right: (typeof result)[number],
+        ) => left.questionId.localeCompare(right.questionId);
+
+        expect([...result].sort(byQuestionId)).toEqual([
           {
             questionId: 'q-other',
             answeredAt: new Date('2026-04-25T09:00:00Z'),
+          },
+          {
+            questionId: 'q-shared',
+            answeredAt: new Date('2026-04-25T10:00:00Z'),
           },
         ]);
       });

--- a/src/application/test-helpers/fakes/fake-attempt-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-attempt-repository.test.ts
@@ -5,11 +5,22 @@ import { FakeAttemptRepository } from './fake-attempt-repository';
 type SeedAttempt = NonNullable<
   ConstructorParameters<typeof FakeAttemptRepository>[0]
 >[number];
+type VisibilitySeedAttempt = SeedAttempt & {
+  sessionEndedAt?: Date | null;
+};
 
-function makeAttempt(overrides: Partial<SeedAttempt> = {}): SeedAttempt {
+const userId = 'user-1';
+const hiddenActiveExamAt = new Date('2026-04-25T12:00:00Z');
+const visibleEndedExamAt = new Date('2026-04-25T11:00:00Z');
+const visibleTutorAt = new Date('2026-04-25T10:00:00Z');
+const visibleStandaloneAt = new Date('2026-04-25T09:00:00Z');
+
+function makeAttempt(
+  overrides: Partial<VisibilitySeedAttempt> = {},
+): VisibilitySeedAttempt {
   return {
     id: 'attempt-1',
-    userId: 'user-1',
+    userId,
     questionId: 'q-1',
     practiceSessionId: null,
     selectedChoiceId: 'c-1',
@@ -23,7 +34,405 @@ function makeAttempt(overrides: Partial<SeedAttempt> = {}): SeedAttempt {
   };
 }
 
+function activeExamSeed(
+  overrides: Partial<VisibilitySeedAttempt> = {},
+): VisibilitySeedAttempt {
+  return makeAttempt({
+    id: 'attempt-active-exam',
+    questionId: 'q-active-exam',
+    practiceSessionId: 'session-active-exam',
+    sessionMode: 'exam',
+    sessionEndedAt: null,
+    selectedChoiceId: 'choice-active-exam',
+    isCorrect: true,
+    answeredAt: hiddenActiveExamAt,
+    ...overrides,
+  });
+}
+
+function endedExamSeed(
+  overrides: Partial<VisibilitySeedAttempt> = {},
+): VisibilitySeedAttempt {
+  return activeExamSeed({
+    id: 'attempt-ended-exam',
+    questionId: 'q-ended-exam',
+    practiceSessionId: 'session-ended-exam',
+    sessionEndedAt: new Date('2026-04-01T00:00:00Z'),
+    selectedChoiceId: 'choice-ended-exam',
+    isCorrect: true,
+    answeredAt: visibleEndedExamAt,
+    ...overrides,
+  });
+}
+
+function tutorSeed(
+  overrides: Partial<VisibilitySeedAttempt> = {},
+): VisibilitySeedAttempt {
+  return activeExamSeed({
+    id: 'attempt-tutor',
+    questionId: 'q-tutor',
+    practiceSessionId: 'session-tutor',
+    sessionMode: 'tutor',
+    sessionEndedAt: null,
+    selectedChoiceId: 'choice-tutor',
+    isCorrect: true,
+    answeredAt: visibleTutorAt,
+    ...overrides,
+  });
+}
+
+function standaloneSeed(
+  overrides: Partial<VisibilitySeedAttempt> = {},
+): VisibilitySeedAttempt {
+  return activeExamSeed({
+    id: 'attempt-standalone',
+    questionId: 'q-standalone',
+    practiceSessionId: null,
+    sessionMode: null,
+    sessionEndedAt: null,
+    selectedChoiceId: 'choice-standalone',
+    isCorrect: true,
+    answeredAt: visibleStandaloneAt,
+    ...overrides,
+  });
+}
+
 describe('FakeAttemptRepository', () => {
+  describe('active-exam visibility fidelity', () => {
+    describe.each([
+      {
+        name: 'countByUserId',
+        read: (repo: FakeAttemptRepository) => repo.countByUserId(userId),
+        empty: 0,
+        visible: 1,
+        mixed: 3,
+      },
+      {
+        name: 'countCorrectByUserId',
+        read: (repo: FakeAttemptRepository) =>
+          repo.countCorrectByUserId(userId),
+        empty: 0,
+        visible: 1,
+        mixed: 3,
+      },
+      {
+        name: 'countByUserIdSince',
+        read: (repo: FakeAttemptRepository) =>
+          repo.countByUserIdSince(userId, new Date('2026-04-25T00:00:00Z')),
+        empty: 0,
+        visible: 1,
+        mixed: 3,
+      },
+      {
+        name: 'countCorrectByUserIdSince',
+        read: (repo: FakeAttemptRepository) =>
+          repo.countCorrectByUserIdSince(
+            userId,
+            new Date('2026-04-25T00:00:00Z'),
+          ),
+        empty: 0,
+        visible: 1,
+        mixed: 3,
+      },
+      {
+        name: 'countAttemptedQuestionsByUserId',
+        read: (repo: FakeAttemptRepository) =>
+          repo.countAttemptedQuestionsByUserId(userId),
+        empty: 0,
+        visible: 1,
+        mixed: 3,
+      },
+    ])('$name', ({ read, empty, visible, mixed }) => {
+      it('hides active-exam attempts', async () => {
+        const repo = new FakeAttemptRepository([activeExamSeed()]);
+
+        await expect(read(repo)).resolves.toBe(empty);
+      });
+
+      it.each([
+        ['ended exam', endedExamSeed],
+        ['tutor', tutorSeed],
+        ['standalone', standaloneSeed],
+      ])('keeps %s attempts visible', async (_name, seed) => {
+        const repo = new FakeAttemptRepository([seed()]);
+
+        await expect(read(repo)).resolves.toBe(visible);
+      });
+
+      it('hides only active-exam attempts from a mixed seed', async () => {
+        const repo = new FakeAttemptRepository([
+          activeExamSeed(),
+          endedExamSeed(),
+          tutorSeed(),
+          standaloneSeed(),
+        ]);
+
+        await expect(read(repo)).resolves.toBe(mixed);
+      });
+    });
+
+    describe('listRecentByUserId', () => {
+      it('hides active-exam attempts', async () => {
+        const repo = new FakeAttemptRepository([activeExamSeed()]);
+
+        await expect(repo.listRecentByUserId(userId, 10)).resolves.toEqual([]);
+      });
+
+      it.each([
+        ['ended exam', endedExamSeed],
+        ['tutor', tutorSeed],
+        ['standalone', standaloneSeed],
+      ])('keeps %s attempts visible', async (_name, seed) => {
+        const attempt = seed();
+        const repo = new FakeAttemptRepository([attempt]);
+
+        await expect(
+          repo.listRecentByUserId(userId, 10),
+        ).resolves.toMatchObject([{ id: attempt.id }]);
+      });
+
+      it('hides only active-exam attempts from a mixed seed', async () => {
+        const repo = new FakeAttemptRepository([
+          activeExamSeed(),
+          endedExamSeed(),
+          tutorSeed(),
+          standaloneSeed(),
+        ]);
+
+        const result = await repo.listRecentByUserId(userId, 10);
+
+        expect(result.map((attempt) => attempt.id)).toEqual([
+          'attempt-ended-exam',
+          'attempt-tutor',
+          'attempt-standalone',
+        ]);
+      });
+    });
+
+    describe('listAnsweredAtByUserIdSince', () => {
+      it('hides active-exam attempts', async () => {
+        const repo = new FakeAttemptRepository([activeExamSeed()]);
+
+        await expect(
+          repo.listAnsweredAtByUserIdSince(
+            userId,
+            new Date('2026-04-25T00:00:00Z'),
+          ),
+        ).resolves.toEqual([]);
+      });
+
+      it.each([
+        ['ended exam', endedExamSeed],
+        ['tutor', tutorSeed],
+        ['standalone', standaloneSeed],
+      ])('keeps %s attempts visible', async (_name, seed) => {
+        const attempt = seed();
+        const repo = new FakeAttemptRepository([attempt]);
+
+        await expect(
+          repo.listAnsweredAtByUserIdSince(
+            userId,
+            new Date('2026-04-25T00:00:00Z'),
+          ),
+        ).resolves.toEqual([attempt.answeredAt]);
+      });
+
+      it('hides only active-exam attempts from a mixed seed', async () => {
+        const repo = new FakeAttemptRepository([
+          activeExamSeed(),
+          endedExamSeed(),
+          tutorSeed(),
+          standaloneSeed(),
+        ]);
+
+        await expect(
+          repo.listAnsweredAtByUserIdSince(
+            userId,
+            new Date('2026-04-25T00:00:00Z'),
+          ),
+        ).resolves.toEqual([
+          visibleEndedExamAt,
+          visibleTutorAt,
+          visibleStandaloneAt,
+        ]);
+      });
+    });
+
+    describe('findLatestByUserAndQuestion', () => {
+      it('hides active-exam attempts', async () => {
+        const repo = new FakeAttemptRepository([
+          activeExamSeed({ questionId: 'q-shared' }),
+        ]);
+
+        await expect(
+          repo.findLatestByUserAndQuestion(userId, 'q-shared'),
+        ).resolves.toBeNull();
+      });
+
+      it.each([
+        ['ended exam', endedExamSeed],
+        ['tutor', tutorSeed],
+        ['standalone', standaloneSeed],
+      ])('keeps %s attempts visible', async (_name, seed) => {
+        const attempt = seed({ questionId: 'q-shared' });
+        const repo = new FakeAttemptRepository([attempt]);
+
+        await expect(
+          repo.findLatestByUserAndQuestion(userId, 'q-shared'),
+        ).resolves.toMatchObject({ id: attempt.id });
+      });
+
+      it('falls back to the older visible attempt when a newer active-exam attempt is hidden', async () => {
+        const repo = new FakeAttemptRepository([
+          standaloneSeed({
+            id: 'attempt-visible-older',
+            questionId: 'q-shared',
+            answeredAt: new Date('2026-04-25T10:00:00Z'),
+          }),
+          activeExamSeed({
+            id: 'attempt-hidden-newer',
+            questionId: 'q-shared',
+            answeredAt: new Date('2026-04-25T11:00:00Z'),
+          }),
+        ]);
+
+        await expect(
+          repo.findLatestByUserAndQuestion(userId, 'q-shared'),
+        ).resolves.toMatchObject({ id: 'attempt-visible-older' });
+      });
+    });
+
+    describe('listAttemptedQuestionsByUserId / countAttemptedQuestionsByUserId', () => {
+      it('hides active-exam attempts', async () => {
+        const repo = new FakeAttemptRepository([
+          activeExamSeed({ questionId: 'q-active-only' }),
+        ]);
+
+        await expect(
+          repo.listAttemptedQuestionsByUserId(userId, 10, 0),
+        ).resolves.toEqual([]);
+        await expect(
+          repo.countAttemptedQuestionsByUserId(userId),
+        ).resolves.toBe(0);
+      });
+
+      it.each([
+        ['ended exam', endedExamSeed],
+        ['tutor', tutorSeed],
+        ['standalone', standaloneSeed],
+      ])('keeps %s attempts visible', async (_name, seed) => {
+        const attempt = seed({ questionId: 'q-visible' });
+        const repo = new FakeAttemptRepository([attempt]);
+
+        await expect(
+          repo.listAttemptedQuestionsByUserId(userId, 10, 0),
+        ).resolves.toMatchObject([
+          {
+            questionId: 'q-visible',
+            answeredAt: attempt.answeredAt,
+            isCorrect: attempt.isCorrect,
+          },
+        ]);
+        await expect(
+          repo.countAttemptedQuestionsByUserId(userId),
+        ).resolves.toBe(1);
+      });
+
+      it('filters before latest-attempt ranking so older visible attempts remain surfaced', async () => {
+        const repo = new FakeAttemptRepository([
+          tutorSeed({
+            id: 'attempt-visible-older',
+            questionId: 'q-shared',
+            isCorrect: true,
+            answeredAt: new Date('2026-04-25T10:00:00Z'),
+          }),
+          activeExamSeed({
+            id: 'attempt-hidden-newer',
+            questionId: 'q-shared',
+            isCorrect: false,
+            answeredAt: new Date('2026-04-25T11:00:00Z'),
+          }),
+          endedExamSeed({ questionId: 'q-ended' }),
+          standaloneSeed({ questionId: 'q-standalone' }),
+        ]);
+
+        const result = await repo.listAttemptedQuestionsByUserId(userId, 10, 0);
+
+        expect(result).toMatchObject([
+          { questionId: 'q-ended' },
+          { questionId: 'q-shared', isCorrect: true },
+          { questionId: 'q-standalone' },
+        ]);
+        await expect(
+          repo.countAttemptedQuestionsByUserId(userId),
+        ).resolves.toBe(3);
+      });
+    });
+
+    describe('findMostRecentAnsweredAtByQuestionIds', () => {
+      it('hides active-exam attempts', async () => {
+        const repo = new FakeAttemptRepository([
+          activeExamSeed({ questionId: 'q-active-only' }),
+        ]);
+
+        await expect(
+          repo.findMostRecentAnsweredAtByQuestionIds(userId, ['q-active-only']),
+        ).resolves.toEqual([]);
+      });
+
+      it.each([
+        ['ended exam', endedExamSeed],
+        ['tutor', tutorSeed],
+        ['standalone', standaloneSeed],
+      ])('keeps %s attempts visible', async (_name, seed) => {
+        const attempt = seed({ questionId: 'q-visible' });
+        const repo = new FakeAttemptRepository([attempt]);
+
+        await expect(
+          repo.findMostRecentAnsweredAtByQuestionIds(userId, ['q-visible']),
+        ).resolves.toEqual([
+          { questionId: 'q-visible', answeredAt: attempt.answeredAt },
+        ]);
+      });
+
+      it('aggregates after filtering so an older visible timestamp wins over a hidden newer one', async () => {
+        const repo = new FakeAttemptRepository([
+          endedExamSeed({
+            id: 'attempt-visible-older',
+            questionId: 'q-shared',
+            answeredAt: new Date('2026-04-25T10:00:00Z'),
+          }),
+          activeExamSeed({
+            id: 'attempt-hidden-newer',
+            questionId: 'q-shared',
+            answeredAt: new Date('2026-04-25T11:00:00Z'),
+          }),
+          standaloneSeed({
+            id: 'attempt-visible-other',
+            questionId: 'q-other',
+            answeredAt: new Date('2026-04-25T09:00:00Z'),
+          }),
+        ]);
+
+        await expect(
+          repo.findMostRecentAnsweredAtByQuestionIds(userId, [
+            'q-shared',
+            'q-other',
+          ]),
+        ).resolves.toEqual([
+          {
+            questionId: 'q-shared',
+            answeredAt: new Date('2026-04-25T10:00:00Z'),
+          },
+          {
+            questionId: 'q-other',
+            answeredAt: new Date('2026-04-25T09:00:00Z'),
+          },
+        ]);
+      });
+    });
+  });
+
   describe('count*', () => {
     it('counts attempts with correctness and since filters', async () => {
       const repo = new FakeAttemptRepository([

--- a/src/application/test-helpers/fakes/fake-attempt-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-attempt-repository.test.ts
@@ -97,8 +97,30 @@ function standaloneSeed(
   });
 }
 
+function legacyExamSeed(
+  overrides: Partial<VisibilitySeedAttempt> = {},
+): VisibilitySeedAttempt {
+  const attempt = activeExamSeed({
+    id: 'attempt-legacy-exam',
+    questionId: 'q-legacy-exam',
+    ...overrides,
+  });
+  delete attempt.sessionEndedAt;
+  return attempt;
+}
+
 describe('FakeAttemptRepository', () => {
   describe('active-exam visibility fidelity', () => {
+    it('keeps legacy exam-shaped seeds visible when sessionEndedAt is omitted', async () => {
+      const attempt = legacyExamSeed();
+      const repo = new FakeAttemptRepository([attempt]);
+
+      await expect(repo.countByUserId(userId)).resolves.toBe(1);
+      await expect(
+        repo.findLatestByUserAndQuestion(userId, attempt.questionId),
+      ).resolves.toMatchObject({ id: attempt.id });
+    });
+
     describe.each([
       {
         name: 'countByUserId',

--- a/src/application/test-helpers/fakes/fake-attempt-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-attempt-repository.test.ts
@@ -5,9 +5,7 @@ import { FakeAttemptRepository } from './fake-attempt-repository';
 type SeedAttempt = NonNullable<
   ConstructorParameters<typeof FakeAttemptRepository>[0]
 >[number];
-type VisibilitySeedAttempt = SeedAttempt & {
-  sessionEndedAt?: Date | null;
-};
+type VisibilitySeedAttempt = SeedAttempt;
 
 const userId = 'user-1';
 const hiddenActiveExamAt = new Date('2026-04-25T12:00:00Z');

--- a/src/application/test-helpers/fakes/fake-attempt-repository.ts
+++ b/src/application/test-helpers/fakes/fake-attempt-repository.ts
@@ -16,6 +16,7 @@ import type {
 type InMemoryAttempt = Attempt & {
   practiceSessionId: string | null;
   sessionMode?: 'tutor' | 'exam' | null;
+  sessionEndedAt?: Date | null;
 };
 
 export class FakeAttemptRepository implements AttemptRepository {
@@ -79,6 +80,7 @@ export class FakeAttemptRepository implements AttemptRepository {
       retryOrigin: input.retryOrigin ?? null,
       retrySessionId: input.retrySessionId ?? null,
       answeredAt: new Date(),
+      sessionEndedAt: null,
     };
     this.attempts = [...this.attempts, attempt];
     return attempt;
@@ -126,7 +128,10 @@ export class FakeAttemptRepository implements AttemptRepository {
     questionId: string,
   ): Promise<Attempt | null> {
     const matching = this.attempts.filter(
-      (a) => a.userId === userId && a.questionId === questionId,
+      (a) =>
+        a.userId === userId &&
+        a.questionId === questionId &&
+        !this.isHiddenByActiveExam(a),
     );
     if (matching.length === 0) return null;
 
@@ -165,17 +170,24 @@ export class FakeAttemptRepository implements AttemptRepository {
   }
 
   async countByUserId(userId: string): Promise<number> {
-    return this.attempts.filter((a) => a.userId === userId).length;
+    return this.attempts.filter(
+      (a) => a.userId === userId && !this.isHiddenByActiveExam(a),
+    ).length;
   }
 
   async countCorrectByUserId(userId: string): Promise<number> {
-    return this.attempts.filter((a) => a.userId === userId && a.isCorrect)
-      .length;
+    return this.attempts.filter(
+      (a) =>
+        a.userId === userId && a.isCorrect && !this.isHiddenByActiveExam(a),
+    ).length;
   }
 
   async countByUserIdSince(userId: string, since: Date): Promise<number> {
     return this.attempts.filter(
-      (a) => a.userId === userId && a.answeredAt >= since,
+      (a) =>
+        a.userId === userId &&
+        a.answeredAt >= since &&
+        !this.isHiddenByActiveExam(a),
     ).length;
   }
 
@@ -184,7 +196,11 @@ export class FakeAttemptRepository implements AttemptRepository {
     since: Date,
   ): Promise<number> {
     return this.attempts.filter(
-      (a) => a.userId === userId && a.answeredAt >= since && a.isCorrect,
+      (a) =>
+        a.userId === userId &&
+        a.answeredAt >= since &&
+        a.isCorrect &&
+        !this.isHiddenByActiveExam(a),
     ).length;
   }
 
@@ -193,7 +209,7 @@ export class FakeAttemptRepository implements AttemptRepository {
     limit: number,
   ): Promise<readonly (Attempt & { sessionMode: 'tutor' | 'exam' | null })[]> {
     return this.attempts
-      .filter((a) => a.userId === userId)
+      .filter((a) => a.userId === userId && !this.isHiddenByActiveExam(a))
       .slice()
       .sort((a, b) => b.answeredAt.getTime() - a.answeredAt.getTime())
       .slice(0, limit)
@@ -208,7 +224,12 @@ export class FakeAttemptRepository implements AttemptRepository {
     since: Date,
   ): Promise<readonly Date[]> {
     return this.attempts
-      .filter((a) => a.userId === userId && a.answeredAt >= since)
+      .filter(
+        (a) =>
+          a.userId === userId &&
+          a.answeredAt >= since &&
+          !this.isHiddenByActiveExam(a),
+      )
       .slice()
       .sort((a, b) => b.answeredAt.getTime() - a.answeredAt.getTime())
       .map((a) => a.answeredAt);
@@ -246,6 +267,7 @@ export class FakeAttemptRepository implements AttemptRepository {
     const mostRecentByQuestionId = new Map<string, InMemoryAttempt>();
     for (const attempt of this.attempts) {
       if (attempt.userId !== userId) continue;
+      if (this.isHiddenByActiveExam(attempt)) continue;
       const existing = mostRecentByQuestionId.get(attempt.questionId);
       if (!existing || this.isLaterAttempt(attempt, existing)) {
         mostRecentByQuestionId.set(attempt.questionId, attempt);
@@ -355,6 +377,7 @@ export class FakeAttemptRepository implements AttemptRepository {
     for (const attempt of this.attempts) {
       if (attempt.userId !== userId) continue;
       if (!questionIdSet.has(attempt.questionId)) continue;
+      if (this.isHiddenByActiveExam(attempt)) continue;
 
       const current = mostRecentByQuestionId.get(attempt.questionId);
       if (!current || attempt.answeredAt > current) {
@@ -372,6 +395,14 @@ export class FakeAttemptRepository implements AttemptRepository {
 
   getAll(): readonly InMemoryAttempt[] {
     return this.attempts;
+  }
+
+  private isHiddenByActiveExam(attempt: InMemoryAttempt): boolean {
+    return (
+      attempt.practiceSessionId !== null &&
+      attempt.sessionMode === 'exam' &&
+      attempt.sessionEndedAt === null
+    );
   }
 
   private isLaterAttempt(


### PR DESCRIPTION
## Summary

Resolves DEBT-367 (P2). Closes the highest-leverage silent-regression vector for the BUG-235/236/237/239 active-exam visibility family.

`DrizzleAttemptRepository` applies the shared `getActiveExamVisibilityCondition()` predicate in 10 read paths after PR #289 (DEBT-366) consolidated it. `FakeAttemptRepository` previously mirrored zero of those, so unit tests against the fake could pass scenarios real Postgres hides.

This PR extends `InMemoryAttempt` with optional `sessionEndedAt`, adds a private `isHiddenByActiveExam` helper, and applies it in all 10 sister methods. The fake hides explicit active-exam seed rows (`practiceSessionId !== null`, `sessionMode === 'exam'`, `sessionEndedAt === null`) while preserving legacy fake seeds that do not model lifecycle state. Filter-before-rank order is preserved for attempted-question history and filter-before-aggregate for per-question latest timestamps.

No port changes. No real-repo changes. No scope expansion.

## Test plan

- [x] Red first: `pnpm test --run src/application/test-helpers/fakes/fake-attempt-repository.test.ts` failed with 20 visibility failures before implementation
- [x] Targeted green: `pnpm test --run src/application/test-helpers/fakes/fake-attempt-repository.test.ts src/application/use-cases/get-attempted-questions.test.ts src/application/use-cases/get-user-stats.test.ts`
- [x] New `fake-attempt-repository.test.ts` coverage for all 10 methods across active-exam hidden, ended-exam visible, tutor visible, and standalone visible cases
- [x] Mixed-seed tests prove BUG-235 filter-before-rank fallback and BUG-239 aggregate-after-filter behavior
- [x] Existing fake-using tests across the unit suite remain green with zero modifications
- [x] Full pre-push gate: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- [x] E2E: `pnpm test:e2e` (34/34) because local auth/billing env is configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage to enforce hiding of active-exam attempts across reads, counts, ranking and aggregation; added deterministic seeding, visibility-specific factories (active-exam, ended, tutor, standalone, legacy), and CI/browser plus authenticated E2E verification.

* **Documentation**
  * Updated exam-answer secrecy policy and debt record (DEBT-367) with current date, clarified visibility rules (legacy seeds optional sessionEndedAt) and concrete verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->