### PR TITLE
Extract executeIdempotent helper across controllers (DEBT-371)

### DIFF
--- a/docs/debt/debt-371-idempotency-wrapper-boilerplate-across-controllers.md
+++ b/docs/debt/debt-371-idempotency-wrapper-boilerplate-across-controllers.md
@@ -2,6 +2,7 @@
 
 **Priority:** P3
 **Created:** 2026-04-25
+**Resolution State:** Fix on branch `debt-371-execute-idempotent-helper`; PR pending.
 **Source:** Production complexity audit, 2026-04-25
 **Related:** [withIdempotency helper](../../src/adapters/shared/with-idempotency.ts), [Master Spec — Idempotency](../specs/master_spec.md)
 
@@ -130,6 +131,8 @@ The current code is correct and tested. The win is pure readability + DRY. Take 
 
 ## Verification
 
-- All existing controller tests pass unchanged. The helper is a transparent wrapper — there is no new behavior to test beyond what `withIdempotency()` already covers.
-- The 8 call sites listed above each shrink by ~10 lines.
-- `pnpm typecheck && pnpm lint && pnpm test --run`.
+- [x] New helper contract tests cover null/undefined no-key fast paths, keyed delegation, duplicate-key cached return, and cached-result schema parsing: `src/adapters/controllers/shared/execute-idempotent.test.ts`.
+- [x] Existing controller tests pass unchanged: `practice-controller.test.ts`, `bookmark-controller.test.ts`, `question-controller.test.ts`, and `billing-controller.test.ts`.
+- [x] The 8 controller call sites listed above now use `executeIdempotent(...)`; the only remaining `withIdempotency(...)` under `src/adapters/controllers/` is inside the helper.
+- [x] Full pre-push gate passed: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`.
+- [x] Local authenticated E2E passed because the environment was present: `pnpm test:e2e` (34/34).

--- a/docs/debt/debt-371-idempotency-wrapper-boilerplate-across-controllers.md
+++ b/docs/debt/debt-371-idempotency-wrapper-boilerplate-across-controllers.md
@@ -2,7 +2,7 @@
 
 **Priority:** P3
 **Created:** 2026-04-25
-**Resolution State:** Fix on branch `debt-371-execute-idempotent-helper`; PR pending.
+**Resolution State:** Fix on branch `debt-371-execute-idempotent-helper`; PR #293.
 **Source:** Production complexity audit, 2026-04-25
 **Related:** [withIdempotency helper](../../src/adapters/shared/with-idempotency.ts), [Master Spec — Idempotency](../specs/master_spec.md)
 

--- a/src/adapters/controllers/billing-controller.ts
+++ b/src/adapters/controllers/billing-controller.ts
@@ -7,7 +7,6 @@ import {
   CHECKOUT_SESSION_RATE_LIMIT,
   PORTAL_SESSION_RATE_LIMIT,
 } from '@/src/adapters/shared/rate-limits';
-import { withIdempotency } from '@/src/adapters/shared/with-idempotency';
 import { ApplicationError } from '@/src/application/errors';
 import type {
   AuthGateway,
@@ -22,6 +21,7 @@ import type {
   CreatePortalSessionOutput,
 } from '@/src/application/use-cases';
 import { createAction } from './create-action';
+import { executeIdempotent } from './shared/execute-idempotent';
 
 const zSubscriptionPlan = z.enum(['monthly', 'annual']);
 const zIdempotencyKey = z.string().uuid();
@@ -135,18 +135,12 @@ export const createCheckoutSession = createAction({
       );
     }
 
-    if (!idempotencyKey) {
-      return createNewSession();
-    }
-
-    return withIdempotency({
-      repo: d.idempotencyKeyRepository,
-      logger: d.logger,
+    return executeIdempotent({
+      d,
       userId: user.id,
       action: 'billing:createCheckoutSession',
-      key: idempotencyKey,
-      now: d.now,
-      parseResult: (value) => CreateCheckoutSessionOutputSchema.parse(value),
+      idempotencyKey,
+      outputSchema: CreateCheckoutSessionOutputSchema,
       execute: createNewSession,
     });
   },
@@ -185,18 +179,12 @@ export const createPortalSession = createAction({
       return CreatePortalSessionOutputSchema.parse(result);
     }
 
-    if (!idempotencyKey) {
-      return createNewSession();
-    }
-
-    return withIdempotency({
-      repo: d.idempotencyKeyRepository,
-      logger: d.logger,
+    return executeIdempotent({
+      d,
       userId: user.id,
       action: 'billing:createPortalSession',
-      key: idempotencyKey,
-      now: d.now,
-      parseResult: (value) => CreatePortalSessionOutputSchema.parse(value),
+      idempotencyKey,
+      outputSchema: CreatePortalSessionOutputSchema,
       execute: createNewSession,
     });
   },

--- a/src/adapters/controllers/bookmark-controller.ts
+++ b/src/adapters/controllers/bookmark-controller.ts
@@ -3,7 +3,6 @@
 import { z } from 'zod';
 import { createDepsResolver, loadAppContainer } from '@/lib/controller-helpers';
 import { BOOKMARK_MUTATION_RATE_LIMIT } from '@/src/adapters/shared/rate-limits';
-import { withIdempotency } from '@/src/adapters/shared/with-idempotency';
 import { zUuid } from '@/src/adapters/shared/zod-schemas';
 import { ApplicationError } from '@/src/application/errors';
 import type {
@@ -23,6 +22,7 @@ import type {
 import { createAction } from './create-action';
 import type { CheckEntitlementUseCase } from './require-entitled-user-id';
 import { requireEntitledUserId } from './require-entitled-user-id';
+import { executeIdempotent } from './shared/execute-idempotent';
 
 const ToggleBookmarkInputSchema = z
   .object({
@@ -96,18 +96,12 @@ export const toggleBookmark = createAction({
       });
     }
 
-    if (!idempotencyKey) {
-      return toggle();
-    }
-
-    return withIdempotency({
-      repo: d.idempotencyKeyRepository,
-      logger: d.logger,
+    return executeIdempotent({
+      d,
       userId,
       action: 'bookmark:toggleBookmark',
-      key: idempotencyKey,
-      now: d.now,
-      parseResult: (value) => ToggleBookmarkOutputSchema.parse(value),
+      idempotencyKey,
+      outputSchema: ToggleBookmarkOutputSchema,
       execute: toggle,
     });
   },

--- a/src/adapters/controllers/practice-controller.ts
+++ b/src/adapters/controllers/practice-controller.ts
@@ -2,7 +2,6 @@
 
 import { createDepsResolver, loadAppContainer } from '@/lib/controller-helpers';
 import { START_PRACTICE_SESSION_RATE_LIMIT } from '@/src/adapters/shared/rate-limits';
-import { withIdempotency } from '@/src/adapters/shared/with-idempotency';
 import { ApplicationError } from '@/src/application/errors';
 import type {
   AuthGateway,
@@ -58,6 +57,7 @@ import {
 } from './practice-schemas';
 import type { CheckEntitlementUseCase } from './require-entitled-user-id';
 import { requireEntitledUserId } from './require-entitled-user-id';
+import { executeIdempotent } from './shared/execute-idempotent';
 
 export type {
   CountAvailableQuestionsOutput,
@@ -177,18 +177,12 @@ export const startPracticeSession = createAction({
       });
     }
 
-    if (!idempotencyKey) {
-      return createNewSession();
-    }
-
-    return withIdempotency({
-      repo: d.idempotencyKeyRepository,
-      logger: d.logger,
+    return executeIdempotent({
+      d,
       userId,
       action: 'practice:startPracticeSession',
-      key: idempotencyKey,
-      now: d.now,
-      parseResult: (value) => StartPracticeSessionOutputSchema.parse(value),
+      idempotencyKey,
+      outputSchema: StartPracticeSessionOutputSchema,
       execute: createNewSession,
     });
   },
@@ -243,26 +237,17 @@ export const endPracticeSession = createAction({
 
     const { sessionId, idempotencyKey } = input;
 
-    async function endSession(): Promise<EndPracticeSessionOutput> {
-      return d.endPracticeSessionUseCase.execute({
-        userId,
-        sessionId,
-      });
-    }
-
-    if (!idempotencyKey) {
-      return endSession();
-    }
-
-    return withIdempotency({
-      repo: d.idempotencyKeyRepository,
-      logger: d.logger,
+    return executeIdempotent({
+      d,
       userId,
       action: 'practice:endPracticeSession',
-      key: idempotencyKey,
-      now: d.now,
-      parseResult: (value) => EndPracticeSessionOutputSchema.parse(value),
-      execute: endSession,
+      idempotencyKey,
+      outputSchema: EndPracticeSessionOutputSchema,
+      execute: () =>
+        d.endPracticeSessionUseCase.execute({
+          userId,
+          sessionId,
+        }),
     });
   },
 });
@@ -284,18 +269,12 @@ export const finalizeExamAnswers = createAction({
       );
     }
 
-    if (!idempotencyKey) {
-      return finalizeExam();
-    }
-
-    return withIdempotency({
-      repo: d.idempotencyKeyRepository,
-      logger: d.logger,
+    return executeIdempotent({
+      d,
       userId,
       action: 'practice:finalizeExamAnswers',
-      key: idempotencyKey,
-      now: d.now,
-      parseResult: (value) => FinalizeExamAnswersOutputSchema.parse(value),
+      idempotencyKey,
+      outputSchema: FinalizeExamAnswersOutputSchema,
       execute: finalizeExam,
     });
   },
@@ -367,29 +346,19 @@ export const setPracticeSessionQuestionMark = createAction({
 
     const { sessionId, questionId, markedForReview, idempotencyKey } = input;
 
-    async function setMark(): Promise<SetPracticeSessionQuestionMarkOutput> {
-      return d.setPracticeSessionQuestionMarkUseCase.execute({
-        userId,
-        sessionId,
-        questionId,
-        markedForReview,
-      });
-    }
-
-    if (!idempotencyKey) {
-      return setMark();
-    }
-
-    return withIdempotency({
-      repo: d.idempotencyKeyRepository,
-      logger: d.logger,
+    return executeIdempotent({
+      d,
       userId,
       action: 'practice:setPracticeSessionQuestionMark',
-      key: idempotencyKey,
-      now: d.now,
-      parseResult: (value) =>
-        SetPracticeSessionQuestionMarkOutputSchema.parse(value),
-      execute: setMark,
+      idempotencyKey,
+      outputSchema: SetPracticeSessionQuestionMarkOutputSchema,
+      execute: () =>
+        d.setPracticeSessionQuestionMarkUseCase.execute({
+          userId,
+          sessionId,
+          questionId,
+          markedForReview,
+        }),
     });
   },
 });

--- a/src/adapters/controllers/question-controller.ts
+++ b/src/adapters/controllers/question-controller.ts
@@ -8,7 +8,6 @@ import {
   MAX_PRACTICE_SESSION_TAG_FILTERS,
   MAX_TIME_SPENT_SECONDS,
 } from '@/src/adapters/shared/validation-limits';
-import { withIdempotency } from '@/src/adapters/shared/with-idempotency';
 import {
   zDifficulty,
   zQuestionProgressStatus,
@@ -37,6 +36,7 @@ import {
 import { createAction } from './create-action';
 import type { CheckEntitlementUseCase } from './require-entitled-user-id';
 import { requireEntitledUserId } from './require-entitled-user-id';
+import { executeIdempotent } from './shared/execute-idempotent';
 
 const QuestionFiltersSchema = z
   .object({
@@ -252,18 +252,12 @@ export const submitAnswer = createAction({
       });
     }
 
-    if (!idempotencyKey) {
-      return submitOnce();
-    }
-
-    return withIdempotency({
-      repo: d.idempotencyKeyRepository,
-      logger: d.logger,
+    return executeIdempotent({
+      d,
       userId,
       action: 'question:submitAnswer',
-      key: idempotencyKey,
-      now: d.now,
-      parseResult: (value) => SubmitAnswerOutputSchema.parse(value),
+      idempotencyKey,
+      outputSchema: SubmitAnswerOutputSchema,
       execute: submitOnce,
     });
   },

--- a/src/adapters/controllers/shared/execute-idempotent.test.ts
+++ b/src/adapters/controllers/shared/execute-idempotent.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import {
+  FakeIdempotencyKeyRepository,
+  FakeLogger,
+} from '@/src/application/test-helpers/fakes';
+import { executeIdempotent } from './execute-idempotent';
+
+class RecordingIdempotencyKeyRepository extends FakeIdempotencyKeyRepository {
+  calls: string[] = [];
+
+  override async claim(
+    input: Parameters<FakeIdempotencyKeyRepository['claim']>[0],
+  ): ReturnType<FakeIdempotencyKeyRepository['claim']> {
+    this.calls.push('claim');
+    return super.claim(input);
+  }
+
+  override async find(
+    ...args: Parameters<FakeIdempotencyKeyRepository['find']>
+  ): ReturnType<FakeIdempotencyKeyRepository['find']> {
+    this.calls.push('find');
+    return super.find(...args);
+  }
+
+  override async storeResult(
+    input: Parameters<FakeIdempotencyKeyRepository['storeResult']>[0],
+  ): ReturnType<FakeIdempotencyKeyRepository['storeResult']> {
+    this.calls.push('storeResult');
+    return super.storeResult(input);
+  }
+
+  override async storeError(
+    input: Parameters<FakeIdempotencyKeyRepository['storeError']>[0],
+  ): ReturnType<FakeIdempotencyKeyRepository['storeError']> {
+    this.calls.push('storeError');
+    return super.storeError(input);
+  }
+
+  override async pruneExpiredBefore(
+    ...args: Parameters<FakeIdempotencyKeyRepository['pruneExpiredBefore']>
+  ): ReturnType<FakeIdempotencyKeyRepository['pruneExpiredBefore']> {
+    this.calls.push('pruneExpiredBefore');
+    return super.pruneExpiredBefore(...args);
+  }
+}
+
+function createDeps() {
+  const now = () => new Date('2026-04-27T12:00:00.000Z');
+  return {
+    idempotencyKeyRepository: new RecordingIdempotencyKeyRepository(now),
+    logger: new FakeLogger(),
+    now,
+  };
+}
+
+describe('executeIdempotent', () => {
+  it('calls execute directly and never touches the repo when idempotencyKey is null', async () => {
+    const deps = createDeps();
+    const execute = vi.fn().mockResolvedValue({ value: 1 });
+    const schema = z.object({ value: z.number() });
+
+    const result = await executeIdempotent({
+      d: deps,
+      userId: 'user-1',
+      idempotencyKey: null,
+      action: 'practice:test',
+      outputSchema: schema,
+      execute,
+    });
+
+    expect(result).toEqual({ value: 1 });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(deps.idempotencyKeyRepository.calls).toEqual([]);
+  });
+
+  it('calls execute directly when idempotencyKey is undefined', async () => {
+    const deps = createDeps();
+    const execute = vi.fn().mockResolvedValue({ value: 2 });
+    const schema = z.object({ value: z.number() });
+
+    const result = await executeIdempotent({
+      d: deps,
+      userId: 'user-1',
+      idempotencyKey: undefined,
+      action: 'practice:test',
+      outputSchema: schema,
+      execute,
+    });
+
+    expect(result).toEqual({ value: 2 });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(deps.idempotencyKeyRepository.calls).toEqual([]);
+  });
+
+  it('preserves the no-key direct execution path without parsing output', async () => {
+    const deps = createDeps();
+    const execute = vi.fn().mockResolvedValue({ value: 'not-a-number' });
+    const schema = z.object({ value: z.number() });
+
+    await expect(
+      executeIdempotent({
+        d: deps,
+        userId: 'user-1',
+        idempotencyKey: null,
+        action: 'practice:test',
+        outputSchema: schema,
+        execute,
+      }),
+    ).resolves.toEqual({ value: 'not-a-number' });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(deps.idempotencyKeyRepository.calls).toEqual([]);
+  });
+
+  it('delegates to withIdempotency when idempotencyKey is provided', async () => {
+    const deps = createDeps();
+    const execute = vi.fn().mockResolvedValue({ value: 42 });
+    const schema = z.object({ value: z.number() });
+
+    const result = await executeIdempotent({
+      d: deps,
+      userId: 'user-1',
+      idempotencyKey: '11111111-1111-1111-1111-111111111111',
+      action: 'practice:test',
+      outputSchema: schema,
+      execute,
+    });
+
+    expect(result).toEqual({ value: 42 });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(deps.idempotencyKeyRepository.calls).toEqual([
+      'pruneExpiredBefore',
+      'claim',
+      'storeResult',
+    ]);
+  });
+
+  it('returns the cached result on a duplicate idempotencyKey without re-running execute', async () => {
+    const deps = createDeps();
+    const execute = vi.fn().mockResolvedValue({ value: 100 });
+    const schema = z.object({ value: z.number() });
+    const args = {
+      d: deps,
+      userId: 'user-1',
+      idempotencyKey: '22222222-2222-2222-2222-222222222222',
+      action: 'practice:test',
+      outputSchema: schema,
+      execute,
+    };
+
+    const first = await executeIdempotent(args);
+    const second = await executeIdempotent(args);
+
+    expect(first).toEqual({ value: 100 });
+    expect(second).toEqual({ value: 100 });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('parses cached results through the schema', async () => {
+    const deps = createDeps();
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({ value: 100 })
+      .mockResolvedValueOnce({ value: 200 });
+    const schema = z.object({ value: z.number() });
+    const args = {
+      d: deps,
+      userId: 'user-1',
+      idempotencyKey: '33333333-3333-3333-3333-333333333333',
+      action: 'practice:test',
+      outputSchema: schema,
+      execute,
+    };
+
+    await executeIdempotent(args);
+    await deps.idempotencyKeyRepository.storeResult({
+      userId: args.userId,
+      action: args.action,
+      key: args.idempotencyKey,
+      resultJson: { value: 'not-a-number' },
+    });
+
+    await expect(executeIdempotent(args)).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message: 'Cached idempotency result is invalid',
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/adapters/controllers/shared/execute-idempotent.ts
+++ b/src/adapters/controllers/shared/execute-idempotent.ts
@@ -1,0 +1,47 @@
+import type { ZodType, ZodTypeDef } from 'zod';
+import { withIdempotency } from '@/src/adapters/shared/with-idempotency';
+import type { Logger } from '@/src/application/ports/logger';
+import type { IdempotencyKeyRepository } from '@/src/application/ports/repositories';
+
+/**
+ * Structural deps subset shared by every controller that wraps an action with
+ * idempotency. Intentionally narrower than any concrete controller deps type.
+ */
+type IdempotentControllerDeps = {
+  idempotencyKeyRepository: IdempotencyKeyRepository;
+  logger: Logger;
+  now: () => Date;
+};
+
+/**
+ * Bridges the no-key fast path and keyed idempotency path so controller
+ * actions can express their intent without repeating the plumbing block.
+ */
+export async function executeIdempotent<TOutput>({
+  d,
+  userId,
+  idempotencyKey,
+  action,
+  outputSchema,
+  execute,
+}: {
+  d: IdempotentControllerDeps;
+  userId: string;
+  idempotencyKey: string | null | undefined;
+  action: string;
+  outputSchema: ZodType<TOutput, ZodTypeDef, unknown>;
+  execute: () => Promise<TOutput>;
+}): Promise<TOutput> {
+  if (!idempotencyKey) return execute();
+
+  return withIdempotency({
+    repo: d.idempotencyKeyRepository,
+    logger: d.logger,
+    userId,
+    action,
+    key: idempotencyKey,
+    now: d.now,
+    parseResult: (value) => outputSchema.parse(value),
+    execute,
+  });
+}


### PR DESCRIPTION
## Summary

Resolves DEBT-371 (P3). Pure refactor — zero behavior change. The repeated `withIdempotency` boilerplate at 8 sites across 4 controllers is consolidated into a single `executeIdempotent` helper.

The helper uses a structural deps subset (`idempotencyKeyRepository`, `logger`, `now`) and preserves the existing no-key fast path exactly while delegating keyed requests to `withIdempotency` with the same output-schema parse for cached results.

## Test plan

- [x] New `execute-idempotent.test.ts` locks the helper contract: null/undefined no-key fast path, keyed delegation, duplicate-key cached return, cached-result schema parsing
- [x] Existing controller test suites pass with zero modifications
- [x] `rg -n "withIdempotency\\(" src/adapters/controllers/` returns only the helper callsite
- [x] `rg -n "executeIdempotent\\(" src/adapters/controllers/` returns 8 controller callsites
- [x] Full pre-push gate: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- [x] E2E because local authenticated billing env is present: `pnpm test:e2e` (34/34)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized idempotency handling so controllers delegate to a shared idempotency helper for consistent behavior.

* **Tests**
  * Added end-to-end and unit tests covering no-key behavior, keyed execution, duplicate-key cached returns, schema validation of cached results, and CI verification.

* **Documentation**
  * Updated progress and verification details, including explicit test/CI steps and confirmation of successful authenticated E2E runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->