### PR TITLE
Unify post-exam review summary button label on View Summary

### DIFF
--- a/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx
@@ -56,17 +56,15 @@ function renderView(input?: {
 }
 
 function getReviewActionLabels(doc: Document) {
-  return Array.from(doc.querySelectorAll('button'))
-    .filter((button) => {
-      const label = button.textContent?.trim();
-      return (
-        label === 'Previous' ||
-        label === 'Next' ||
-        label === 'Finish review' ||
-        button.hasAttribute('aria-pressed')
-      );
-    })
-    .map((button) => button.textContent?.trim());
+  const actionBar = doc.querySelector('[data-testid="bottom-action-bar"]');
+
+  if (!actionBar) {
+    throw new Error('Expected bottom action bar');
+  }
+
+  return Array.from(actionBar.querySelectorAll('button')).map((button) =>
+    button.textContent?.trim(),
+  );
 }
 
 describe('PostExamReviewView', () => {
@@ -204,7 +202,7 @@ describe('PostExamReviewView', () => {
     expect(getReviewActionLabels(doc)).toEqual(['Next', 'Bookmark']);
   });
 
-  it('renders the last-question action bar with finish review before bookmark', () => {
+  it('renders the last-question action bar with view summary before bookmark', () => {
     const rows = [
       createReviewRow({
         questionId: 'question-1',
@@ -225,15 +223,15 @@ describe('PostExamReviewView', () => {
 
     expect(getReviewActionLabels(doc)).toEqual([
       'Previous',
-      'Finish review',
+      'View Summary',
       'Bookmark',
     ]);
   });
 
-  it('renders the single-question action bar with finish review before bookmark', () => {
+  it('renders the single-question action bar with view summary before bookmark', () => {
     const doc = renderView();
 
-    expect(getReviewActionLabels(doc)).toEqual(['Finish review', 'Bookmark']);
+    expect(getReviewActionLabels(doc)).toEqual(['View Summary', 'Bookmark']);
   });
 
   it('renders the review action bar in the document-flow content stack without sticky shell markers', () => {
@@ -283,9 +281,18 @@ describe('PostExamReviewView', () => {
 
   it('renders View Summary as an outline button in the review header', () => {
     const doc = renderView();
-    const viewSummaryButton = Array.from(doc.querySelectorAll('button')).find(
-      (button) => button.textContent?.trim() === 'View Summary',
-    );
+    const scoreBanner = Array.from(
+      doc.querySelectorAll('[data-slot="card"]'),
+    ).find((card) => card.textContent?.includes('Exam complete'));
+    const viewSummaryButton = Array.from(
+      scoreBanner?.querySelectorAll('button') ?? [],
+    ).find((button) => button.textContent?.trim() === 'View Summary');
+
+    expect(
+      Array.from(scoreBanner?.querySelectorAll('button') ?? []).filter(
+        (button) => button.textContent?.trim() === 'View Summary',
+      ),
+    ).toHaveLength(1);
 
     expect(viewSummaryButton?.getAttribute('data-variant')).toBe('outline');
   });

--- a/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx
@@ -181,7 +181,7 @@ export function PostExamReviewView({
             className="rounded-full"
             onClick={onViewSummary}
           >
-            Finish review
+            View Summary
           </Button>
         )}
 

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-exam-results-renderer.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-exam-results-renderer.test.tsx
@@ -174,7 +174,10 @@ describe('renderPracticeSessionExamResults', () => {
 
     expect(doc?.body.textContent).toContain('Score: 0% (0/1)');
     expect(doc?.body.textContent).toContain('Explanation for review.');
-    expect(doc?.body.textContent).toContain('View Summary');
+    const viewSummaryButtons = Array.from(
+      doc?.querySelectorAll('button') ?? [],
+    ).filter((button) => button.textContent?.trim() === 'View Summary');
+    expect(viewSummaryButtons).toHaveLength(2);
   });
 
   it('returns null when no exam-results surface is active', () => {

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-review-stage.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-review-stage.browser.spec.tsx
@@ -192,7 +192,19 @@ test('renders post-exam review with score banner, feedback, and a summary exit',
   await screen.getByRole('button', { name: 'Next' }).click();
   expect(onNavigatePostExamReviewQuestion).toHaveBeenCalledWith('q2');
 
-  await screen.getByRole('button', { name: 'View Summary' }).click();
+  const scoreBanner = screen
+    .getByText('Exam complete')
+    .element()
+    .closest('[data-slot="card"]');
+  const viewSummaryButton = Array.from(
+    scoreBanner?.querySelectorAll('button') ?? [],
+  ).find((button) => button.textContent?.trim() === 'View Summary');
+
+  if (!(viewSummaryButton instanceof HTMLButtonElement)) {
+    throw new Error('Expected score-banner View Summary button');
+  }
+
+  viewSummaryButton.click();
   expect(onViewSummary).toHaveBeenCalledTimes(1);
 });
 

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -238,7 +238,11 @@ test.describe('practice', () => {
     ).toBeVisible();
     await expect(page.getByText(/^(Correct|Incorrect)$/).first()).toBeVisible();
 
-    await page.getByRole('button', { name: 'View Summary' }).click();
+    await page
+      .locator('[data-slot="card"]')
+      .filter({ hasText: 'Exam complete' })
+      .getByRole('button', { name: 'View Summary' })
+      .click();
 
     // Wait for the terminal session summary to appear
     await expect(
@@ -292,12 +296,13 @@ test.describe('practice', () => {
     await expect(page.getByText('Question 2 of 3')).toBeVisible();
     await page.getByRole('button', { name: 'Next' }).click();
     await expect(page.getByText('Question 3 of 3')).toBeVisible();
+    const bottomActionBar = page.getByTestId('bottom-action-bar');
     await expect(
-      page.getByRole('button', { name: 'Finish review' }),
+      bottomActionBar.getByRole('button', { name: 'View Summary' }),
     ).toBeVisible();
     await expect(page.getByRole('button', { name: 'Next' })).toHaveCount(0);
 
-    await page.getByRole('button', { name: 'Finish review' }).click();
+    await bottomActionBar.getByRole('button', { name: 'View Summary' }).click();
     await expect(
       page.getByRole('heading', { name: 'Session Summary' }),
     ).toBeVisible({ timeout: 30_000 });
@@ -309,7 +314,9 @@ test.describe('practice', () => {
     });
     await expect(page.getByRole('button', { name: 'Next' })).toBeVisible();
     await expect(
-      page.getByRole('button', { name: 'Finish review' }),
+      page
+        .getByTestId('bottom-action-bar')
+        .getByRole('button', { name: 'View Summary' }),
     ).toHaveCount(0);
     await expect(getQuestionNavigatorButton(1)).toHaveAttribute(
       'aria-current',


### PR DESCRIPTION
## Summary

Implements DEBT-372 Option A.

Spec: `docs/debt/debt-372-post-exam-review-summary-button-label-divergence.md`

Production diff: exactly one label in `app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx:184` changed from `Finish review` to `View Summary`.

DEBT-373 score-banner typography work is NOT in scope and not touched in this PR.

## Test Updates

- `app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx`: updated bottom action assertions to scope through `data-testid="bottom-action-bar"`; scoped the score-banner outline assertion to the card containing `Exam complete`.
- `tests/e2e/practice.spec.ts`: scoped the persistent top summary escape to the score-banner card; scoped terminal summary assertions/clicks to `data-testid="bottom-action-bar"`; kept first-review-page checks scoped to the bottom bar.
- `app/(app)/app/practice/[sessionId]/components/practice-session-page-view-review-stage.browser.spec.tsx`: scoped summary navigation to the score-banner card in the controlled review-stage render; left the hydration-error fallback query unchanged because that render has only one `View Summary` button.
- `app/(app)/app/practice/[sessionId]/components/practice-session-exam-results-renderer.test.tsx`: updated the hydrated review assertion to expect two `View Summary` buttons; kept the hydration-error fallback action list as `Retry review` plus `View Summary`.

Final-question rendering now produces two buttons with the same accessible name 'View Summary'. This is intentional per DEBT-372 Option A; the persistent top button and the bottom terminal button both call onViewSummary with the same destination, so identical labels reflect identical behavior. Test selectors are scoped per region to handle the duplicate.

## Verification

- `pnpm db:test:up`
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:migrate`
- `SEED_INCLUDE_PLACEHOLDERS=true DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:seed`
- `pnpm typecheck`
- `pnpm lint` (passes with the expected 19 warn-only `nursery/noExcessiveLinesPerFile` warnings on legacy oversized tests)
- `pnpm test --run` (302 files, 2396 tests)
- `pnpm test:browser` (47 files, 241 tests)
- `pnpm test:integration` (16 files, 97 tests)
- `pnpm build`
- `pnpm test:e2e` (34 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Improved clarity in the post-exam review interface by renaming the action button from "Finish review" to "View Summary" when completing a practice exam session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->