### PR TITLE
Use stat-number pattern for post-exam review score banner

### DIFF
--- a/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx
@@ -67,6 +67,18 @@ function getReviewActionLabels(doc: Document) {
   );
 }
 
+function getScoreBanner(doc: Document) {
+  const scoreBanner = Array.from(
+    doc.querySelectorAll('[data-slot="card"]'),
+  ).find((card) => card.textContent?.includes('Exam complete'));
+
+  if (!(scoreBanner instanceof HTMLElement)) {
+    throw new Error('Expected score banner card');
+  }
+
+  return scoreBanner;
+}
+
 describe('PostExamReviewView', () => {
   it('gives the review panel an accessible name for screen readers', () => {
     const doc = renderView();
@@ -279,11 +291,60 @@ describe('PostExamReviewView', () => {
     );
   });
 
+  it('renders the exam score as a stat number while preserving the surface heading', () => {
+    const doc = renderView({
+      rows: [
+        createReviewRow({
+          questionId: 'question-1',
+          slug: 'question-1',
+          order: 1,
+          isAnswered: true,
+          isCorrect: true,
+        }),
+        createReviewRow({
+          questionId: 'question-2',
+          slug: 'question-2',
+          order: 2,
+          isAnswered: true,
+          isCorrect: false,
+        }),
+        createReviewRow({
+          questionId: 'question-3',
+          slug: 'question-3',
+          order: 3,
+          isAnswered: false,
+          isCorrect: null,
+        }),
+      ],
+    });
+    const scoreBanner = getScoreBanner(doc);
+    const heading = scoreBanner.querySelector('h1');
+    const statNumber = Array.from(scoreBanner.querySelectorAll('div')).find(
+      (element) => element.textContent?.trim() === '33%',
+    );
+    const description = Array.from(scoreBanner.querySelectorAll('p')).find(
+      (element) => element.textContent?.includes('1 of 3 correct'),
+    );
+
+    expect(heading?.textContent?.trim()).toBe('Exam complete');
+    expect(scoreBanner.querySelectorAll('h1')).toHaveLength(1);
+    expect(statNumber?.tagName).toBe('DIV');
+    expect(statNumber?.getAttribute('class')).toContain('text-3xl');
+    expect(statNumber?.getAttribute('class')).toContain('font-bold');
+    expect(statNumber?.getAttribute('class')).toContain('font-display');
+    expect(statNumber?.getAttribute('class')).toContain('text-foreground');
+    expect(statNumber?.matches('h1,h2,h3,h4,h5,h6')).toBe(false);
+    expect(description?.tagName).toBe('P');
+    expect(description?.textContent).toContain(
+      '1 of 3 correct · Review each question with detailed feedback.',
+    );
+    expect(scoreBanner.textContent).not.toContain('Score:');
+    expect(scoreBanner.textContent).not.toContain('(1/3)');
+  });
+
   it('renders View Summary as an outline button in the review header', () => {
     const doc = renderView();
-    const scoreBanner = Array.from(
-      doc.querySelectorAll('[data-slot="card"]'),
-    ).find((card) => card.textContent?.includes('Exam complete'));
+    const scoreBanner = getScoreBanner(doc);
     const viewSummaryButton = Array.from(
       scoreBanner?.querySelectorAll('button') ?? [],
     ).find((button) => button.textContent?.trim() === 'View Summary');

--- a/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx
@@ -51,7 +51,6 @@ export function PostExamReviewView({
       ? (review.rows[currentIndex + 1] ?? null)
       : null;
   const focusedQuestionId = currentRow?.questionId ?? null;
-  const scoreLabel = `Score: ${Math.round(summary.totals.accuracy * 100)}% (${summary.totals.correct}/${summary.questionCount})`;
   const navigateToQuestion = (questionId: string) => {
     shouldRestorePanelRef.current = true;
     onNavigateQuestion(questionId);
@@ -74,12 +73,14 @@ export function PostExamReviewView({
       <Card className="rounded-2xl p-4 shadow-sm">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <div className="text-sm text-muted-foreground">Exam complete</div>
-            <h1 className="mt-1 text-2xl font-bold font-heading tracking-tight text-foreground">
-              {scoreLabel}
+            <h1 className="text-sm font-medium text-muted-foreground">
+              Exam complete
             </h1>
+            <div className="mt-1 text-3xl font-bold font-display text-foreground">
+              {`${Math.round(summary.totals.accuracy * 100)}%`}
+            </div>
             <p className="mt-1 text-sm text-muted-foreground">
-              Review each question with detailed feedback.
+              {`${summary.totals.correct} of ${summary.questionCount} correct · Review each question with detailed feedback.`}
             </p>
           </div>
           <Button

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-exam-results-renderer.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-exam-results-renderer.test.tsx
@@ -96,6 +96,18 @@ function renderBranch(input?: {
   );
 }
 
+function getScoreBanner(doc: Document | null) {
+  const scoreBanner = Array.from(
+    doc?.querySelectorAll('[data-slot="card"]') ?? [],
+  ).find((card) => card.textContent?.includes('Exam complete'));
+
+  if (!(scoreBanner instanceof HTMLElement)) {
+    throw new Error('Expected score banner card');
+  }
+
+  return scoreBanner;
+}
+
 describe('renderPracticeSessionExamResults', () => {
   it('renders the exam summary surface when an exam summary is active', () => {
     const doc = renderBranch({
@@ -172,7 +184,25 @@ describe('renderPracticeSessionExamResults', () => {
       postExamReviewLoadState: { status: 'ready' },
     });
 
-    expect(doc?.body.textContent).toContain('Score: 0% (0/1)');
+    const scoreBanner = getScoreBanner(doc);
+    const statNumber = Array.from(scoreBanner.querySelectorAll('div')).find(
+      (element) => element.textContent?.trim() === '0%',
+    );
+    const description = Array.from(scoreBanner.querySelectorAll('p')).find(
+      (element) => element.textContent?.includes('0 of 1 correct'),
+    );
+
+    expect(scoreBanner.querySelector('h1')?.textContent?.trim()).toBe(
+      'Exam complete',
+    );
+    expect(scoreBanner.querySelectorAll('h1')).toHaveLength(1);
+    expect(statNumber?.matches('h1,h2,h3,h4,h5,h6')).toBe(false);
+    expect(statNumber?.getAttribute('class')).toContain('text-3xl');
+    expect(statNumber?.getAttribute('class')).toContain('font-display');
+    expect(description?.tagName).toBe('P');
+    expect(description?.textContent).toContain(
+      '0 of 1 correct · Review each question with detailed feedback.',
+    );
     expect(doc?.body.textContent).toContain('Explanation for review.');
     const viewSummaryButtons = Array.from(
       doc?.querySelectorAll('button') ?? [],

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-results.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-results.browser.spec.tsx
@@ -149,6 +149,34 @@ function renderExamResultsContinuityHarness() {
   return render(<Harness />);
 }
 
+async function expectPostExamReviewScoreBanner(
+  screen: Awaited<ReturnType<typeof renderExamResultsContinuityHarness>>,
+) {
+  await expect
+    .element(screen.getByRole('heading', { level: 1, name: 'Exam complete' }))
+    .toBeVisible();
+  const scoreBanner = screen
+    .getByText('Exam complete')
+    .element()
+    .closest('[data-slot="card"]');
+  const scoreStat = Array.from(scoreBanner?.querySelectorAll('div') ?? []).find(
+    (element) => element.textContent?.trim() === '50%',
+  );
+  const scoreDescription = Array.from(
+    scoreBanner?.querySelectorAll('p') ?? [],
+  ).find((element) => element.textContent?.includes('1 of 2 correct'));
+
+  if (!(scoreStat instanceof HTMLElement)) {
+    throw new Error('Expected score-banner stat number');
+  }
+
+  expect(scoreStat.matches('h1,h2,h3,h4,h5,h6')).toBe(false);
+  expect(scoreDescription?.tagName).toBe('P');
+  expect(scoreDescription?.textContent).toContain(
+    '1 of 2 correct · Review each question with detailed feedback.',
+  );
+}
+
 test('renders session summary branch when summary is present', async () => {
   const screen = await render(
     <PracticeSessionPageView
@@ -281,7 +309,7 @@ test('clicking Review Answers re-enters post-exam review without route ejection'
 
   await screen.getByRole('button', { name: 'Review Answers' }).click();
 
-  await expect.element(screen.getByText('Score: 50% (1/2)')).toBeVisible();
+  await expectPostExamReviewScoreBanner(screen);
   await expect.element(screen.getByText('Explanation 1')).toBeVisible();
   await expect
     .element(screen.getByRole('heading', { name: 'Session Summary' }))
@@ -293,7 +321,7 @@ test('clicking a summary breakdown row opens the exact reviewed question in post
 
   await screen.getByRole('button', { name: /Stem 2/i }).click();
 
-  await expect.element(screen.getByText('Score: 50% (1/2)')).toBeVisible();
+  await expectPostExamReviewScoreBanner(screen);
   await expect.element(screen.getByText('Explanation 2')).toBeVisible();
   await expect
     .element(screen.getByRole('region', { name: 'Question 2 of 2' }))

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-review-stage.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-review-stage.browser.spec.tsx
@@ -177,7 +177,31 @@ test('renders post-exam review with score banner, feedback, and a summary exit',
     />,
   );
 
-  await expect.element(screen.getByText('Score: 50% (1/2)')).toBeVisible();
+  await expect
+    .element(screen.getByRole('heading', { level: 1, name: 'Exam complete' }))
+    .toBeVisible();
+  const scoreBanner = screen
+    .getByText('Exam complete')
+    .element()
+    .closest('[data-slot="card"]');
+  const scoreStat = Array.from(scoreBanner?.querySelectorAll('div') ?? []).find(
+    (element) => element.textContent?.trim() === '50%',
+  );
+  const scoreDescription = Array.from(
+    scoreBanner?.querySelectorAll('p') ?? [],
+  ).find((element) => element.textContent?.includes('1 of 2 correct'));
+
+  if (!(scoreStat instanceof HTMLElement)) {
+    throw new Error('Expected score-banner stat number');
+  }
+
+  expect(scoreStat.matches('h1,h2,h3,h4,h5,h6')).toBe(false);
+  expect(scoreStat.getAttribute('class')).toContain('text-3xl');
+  expect(scoreStat.getAttribute('class')).toContain('font-display');
+  expect(scoreDescription?.tagName).toBe('P');
+  expect(scoreDescription?.textContent).toContain(
+    '1 of 2 correct · Review each question with detailed feedback.',
+  );
   await expect.element(screen.getByText('Because B is correct.')).toBeVisible();
   await expect
     .element(screen.getByRole('button', { name: 'Question 2: Correct' }))
@@ -192,12 +216,12 @@ test('renders post-exam review with score banner, feedback, and a summary exit',
   await screen.getByRole('button', { name: 'Next' }).click();
   expect(onNavigatePostExamReviewQuestion).toHaveBeenCalledWith('q2');
 
-  const scoreBanner = screen
+  const summaryActionBanner = screen
     .getByText('Exam complete')
     .element()
     .closest('[data-slot="card"]');
   const viewSummaryButton = Array.from(
-    scoreBanner?.querySelectorAll('button') ?? [],
+    summaryActionBanner?.querySelectorAll('button') ?? [],
   ).find((button) => button.textContent?.trim() === 'View Summary');
 
   if (!(viewSummaryButton instanceof HTMLButtonElement)) {

--- a/docs/debt/debt-374-session-summary-view-in-history-button-is-redundant-cruft.md
+++ b/docs/debt/debt-374-session-summary-view-in-history-button-is-redundant-cruft.md
@@ -16,6 +16,7 @@ The Session Summary surface (`app/(app)/app/practice/[sessionId]/components/sess
 1. **Review Answers** — filled primary `Button` (lines 130-149).
 2. **New Session** — outline or default-variant `Button` (lines 151-157).
 3. **View in History** — ghost-variant `Button` at lines 158-160:
+
    ```tsx
    <Button asChild variant="ghost" className="rounded-full">
      <Link href={ROUTES.APP_HISTORY}>View in History</Link>
@@ -24,7 +25,7 @@ The Session Summary surface (`app/(app)/app/practice/[sessionId]/components/sess
 
 `ghost` is the `Button` component's most-recessed variant (text-only, no border, no fill). The visual hierarchy already encodes "this is the lowest-priority action on the surface."
 
-The persistent app top-nav (`app/(app)/app/_components/...` nav surface) already exposes `History` as a first-class navigation item one click away from every authenticated screen. Removing the bottom-of-Session-Summary `View in History` button does not hide the History page; it removes a redundant access path.
+The persistent app nav already exposes `History` as a first-class navigation item one click away from every authenticated screen via `components/app-nav-items.ts:12`, consumed by the desktop and mobile nav surfaces. Removing the bottom-of-Session-Summary `View in History` button does not hide the History page; it removes a redundant access path.
 
 ## Why This Is Debt
 
@@ -70,10 +71,10 @@ Ship **Option A**. The two buttons that survive (`Review Answers`, `New Session`
 - **Do NOT modify the top nav** (the persistent `History` link in the app shell stays exactly as-is; it is the surviving path).
 - **Do NOT modify the History page itself.** Any History-page-value-proposition rework is out of scope (see Options B / C).
 - **Do NOT modify `ROUTES.APP_HISTORY`.** The route constant continues to exist; only the Session Summary call site is removed.
-- **Do NOT bundle this with DEBT-373.** DEBT-373 is the post-exam review entry banner typography pass on `post-exam-review-view.tsx`. DEBT-374 is the Session Summary action bar on `session-summary-view.tsx`. Different files, different concerns. Each ships in its own focused PR with its own CR thread.
+- **Do NOT bundle the DEBT-374 implementation with DEBT-373.** DEBT-373 is the post-exam review entry banner typography pass on `post-exam-review-view.tsx`. DEBT-374 is the Session Summary action bar on `session-summary-view.tsx`. Different files, different concerns. The DEBT-374 code change should ship in its own focused PR with its own CR thread.
 - **Do NOT remove the `Button asChild variant="ghost"` styling pattern from anywhere else in the codebase.** Other call sites of the ghost variant are governed by their own design context and remain valid.
 - **Test cleanup is in scope.** Existing assertions on `View in History` in:
-  - `app/(app)/app/practice/[sessionId]/components/session-summary-view.test.tsx` (4 occurrences across 2 tests)
+  - `app/(app)/app/practice/[sessionId]/components/session-summary-view.test.tsx` (5 occurrences across 2 tests)
   - `app/(app)/app/practice/[sessionId]/components/session-summary-view.browser.spec.tsx` (2 occurrences)
   - `app/(app)/app/practice/[sessionId]/page.test.tsx` (3 occurrences)
   - `tests/e2e/practice.spec.ts` (1 occurrence at line 142)

--- a/docs/debt/debt-374-session-summary-view-in-history-button-is-redundant-cruft.md
+++ b/docs/debt/debt-374-session-summary-view-in-history-button-is-redundant-cruft.md
@@ -1,0 +1,98 @@
+# DEBT-374: Session Summary "View in History" Button Is Redundant With Top-Nav History And Should Be Removed
+
+**Priority:** P3
+**Created:** 2026-05-01
+**Source:** Manual UX walkthrough of post-exam Session Summary surface, 2026-05-01 (paired observation alongside [DEBT-372](../_archive/debt/debt-372-post-exam-review-summary-button-label-divergence.md) and [DEBT-373](./debt-373-post-exam-review-score-banner-uses-app-h1-pattern-instead-of-stat-number-pattern.md), filed during the same review pass)
+**Related:** [DEBT-359 Session Summary CTA labels (archived)](../_archive/debt/debt-359-session-summary-cta-labels.md), [DEBT-372 Post-exam review summary button label divergence (archived)](../_archive/debt/debt-372-post-exam-review-summary-button-label-divergence.md), [Frontend Standards](../frontend/standards.md), [Pattern Registry](../frontend/pattern-registry.md)
+
+**Audit verified:** 2026-05-01 against `fa8c130e`.
+
+---
+
+## Context
+
+The Session Summary surface (`app/(app)/app/practice/[sessionId]/components/session-summary-view.tsx`) renders the post-session terminal recap — the screen a student lands on after finishing a practice session. The bottom action bar exposes three CTAs in decreasing visual emphasis:
+
+1. **Review Answers** — filled primary `Button` (lines 130-149).
+2. **New Session** — outline or default-variant `Button` (lines 151-157).
+3. **View in History** — ghost-variant `Button` at lines 158-160:
+   ```tsx
+   <Button asChild variant="ghost" className="rounded-full">
+     <Link href={ROUTES.APP_HISTORY}>View in History</Link>
+   </Button>
+   ```
+
+`ghost` is the `Button` component's most-recessed variant (text-only, no border, no fill). The visual hierarchy already encodes "this is the lowest-priority action on the surface."
+
+The persistent app top-nav (`app/(app)/app/_components/...` nav surface) already exposes `History` as a first-class navigation item one click away from every authenticated screen. Removing the bottom-of-Session-Summary `View in History` button does not hide the History page; it removes a redundant access path.
+
+## Why This Is Debt
+
+- **Redundant access path on a terminal recap screen.** History is in the persistent top nav; it is not a destination the user can lose. The third CTA is a second route to the same place. Redundancy on a terminal screen is cognitive overhead, not affordance.
+- **Hick's Law / decision cost.** Three CTAs > two CTAs in cognitive cost with diminishing return. The two CTAs that survive after removal — `Review Answers` and `New Session` — have crisp, orthogonal intent: "look back at what just happened" vs. "start fresh." The third option splits attention without clarifying intent.
+- **Visual weight already deprioritizes it.** The ghost-variant styling is the most recessed Button variant in the design system. The designer's own emphasis grading already says "this is the least important action on this surface." When the lowest-priority action on a terminal screen is also a redundant path, the action is signal of cruft accumulation, not a feature.
+- **Information value at this moment is low.** The Session Summary surface itself shows the recap a user wants right after a session: stat cards (Answered / Correct / Accuracy / Duration) plus the per-question breakdown panel. Routing the user from this rich recap to History — which is currently a list view with limited longitudinal affordances — adds little marginal information. The user is already where the data is.
+- **Trust erosion when the destination underdelivers.** A CTA placed on a high-attention moment that routes to a low-value destination sets up an expectation the destination cannot fulfill. That is worse for product trust than no CTA. (User feedback during the 2026-05-01 walkthrough framed History as "generally worthless" today — that framing was the surface signal that triggered this ticket. A separate audit of the History page's value proposition is its own concern, out of scope here.)
+- **No prior ticket covers this specific affordance.** DEBT-359 (resolved 2026-04-11) renamed Session Summary CTAs ("Back to Practice" → "New Session", "Review your answers" → "Review Answers") on this same surface but did not adjudicate the third (`View in History`) button. DEBT-372 unified the post-exam *review* surface's summary-navigation labels but did not touch the Session Summary action bar.
+
+## Options
+
+### Option A (recommended): Remove the button outright
+
+Delete the `<Button asChild variant="ghost" className="rounded-full">...</Button>` block at `session-summary-view.tsx:158-160`. The bottom action bar collapses from three CTAs to two (Review Answers, New Session). History remains accessible via the top-nav `History` link.
+
+- **Pro:** Smallest defensible change. Reduces cognitive cost on a terminal recap screen. Aligns visual emphasis with semantic priority — the ghost-variant button was already signaling "lowest priority"; removing it admits the priority is "not on this surface."
+- **Pro:** Top-nav `History` link is preserved unchanged; users who want History from the Session Summary still have a one-click path via the persistent nav.
+- **Con:** If the History page subsequently earns its keep (longitudinal trends, comparison views, streak tracking, filterable past sessions, exportable reports) the bottom-CTA path becomes useful again, and re-adding it later requires re-litigating UI placement. Not a blocker — re-adding a button is cheaper than carrying cruft today.
+
+### Option B: Keep the button, redesign the History page
+
+Leave the button in place; treat the underlying complaint ("History is generally worthless") as the real problem and audit the History page's value proposition.
+
+- **Pro:** Solves the deeper UX problem — a low-value destination — rather than just hiding the path to it.
+- **Con:** Massive scope creep relative to a single-button removal. History page audit is its own multi-week concern (data model, trend computation, comparison surfaces, export). Conflating it with Session Summary cruft removal blocks both. **This option should be filed as a future ticket independently if pursued, but it is NOT the right resolution for DEBT-374.**
+
+### Option C: Replace the button with a smarter affordance
+
+Swap `View in History` for something contextual to this specific session — e.g., "Compare to previous session," "Add to streak," "Export this session." The button slot stays; the label and destination get more useful.
+
+- **Pro:** Preserves the slot for a higher-value action.
+- **Con:** Requires net-new product work (define the comparison view, build the export flow, design the streak surface) before any UI change can land. Cannot ship without those foundations.
+- **Con:** Same scope-creep concern as Option B.
+
+## Recommendation
+
+Ship **Option A**. The two buttons that survive (`Review Answers`, `New Session`) cover the user's actual post-session intents on this terminal recap screen. History remains accessible via the top nav for the rare user who wants it. If/when the History page earns a contextual back-link from Session Summary (Option C territory), file a follow-up ticket then.
+
+## Constraints
+
+- **Single button removal.** Delete only the `<Button asChild variant="ghost" className="rounded-full"><Link href={ROUTES.APP_HISTORY}>View in History</Link></Button>` block at `session-summary-view.tsx:158-160`. Do NOT touch `Review Answers` or `New Session`.
+- **Do NOT modify the top nav** (the persistent `History` link in the app shell stays exactly as-is; it is the surviving path).
+- **Do NOT modify the History page itself.** Any History-page-value-proposition rework is out of scope (see Options B / C).
+- **Do NOT modify `ROUTES.APP_HISTORY`.** The route constant continues to exist; only the Session Summary call site is removed.
+- **Do NOT bundle this with DEBT-373.** DEBT-373 is the post-exam review entry banner typography pass on `post-exam-review-view.tsx`. DEBT-374 is the Session Summary action bar on `session-summary-view.tsx`. Different files, different concerns. Each ships in its own focused PR with its own CR thread.
+- **Do NOT remove the `Button asChild variant="ghost"` styling pattern from anywhere else in the codebase.** Other call sites of the ghost variant are governed by their own design context and remain valid.
+- **Test cleanup is in scope.** Existing assertions on `View in History` in:
+  - `app/(app)/app/practice/[sessionId]/components/session-summary-view.test.tsx` (4 occurrences across 2 tests)
+  - `app/(app)/app/practice/[sessionId]/components/session-summary-view.browser.spec.tsx` (2 occurrences)
+  - `app/(app)/app/practice/[sessionId]/page.test.tsx` (3 occurrences)
+  - `tests/e2e/practice.spec.ts` (1 occurrence at line 142)
+
+  …must be deleted (not weakened, not commented out). If a test's only purpose was asserting the `View in History` link rendered, delete the test entirely; if a test asserted on a list of action-bar labels including `View in History`, edit the list to drop it.
+
+## Why P3
+
+The surface ships, the button works, the route is correct. The cost is one moment of "do I need to click this, or is it the same as the nav link?" cognitive friction per Session Summary view, plus the trust-erosion risk of a CTA pointing at a currently low-value destination. Same severity class as DEBT-359 / DEBT-361 / DEBT-362 / DEBT-372 — all P3 surface-polish tickets. Not blocking; pay it down opportunistically as part of the post-exam UX cleanup pass that is already producing DEBT-372 / DEBT-373.
+
+## Verification
+
+- After the change: `rg -nE "View in History" app/ components/ src/ tests/` returns zero hits.
+- `pnpm test --run` and `pnpm test:browser` pass with hand-edited assertion lists (no snapshot rewrites).
+- `pnpm test:e2e` passes with the `tests/e2e/practice.spec.ts:142` assertion deleted (or its surrounding test rewritten if `View in History` was the only thing it asserted).
+- Manual visual check on a 3-question session: Session Summary action bar shows exactly two buttons (`Review Answers`, `New Session`); top-nav `History` link still works; `/app/history` route is reachable directly.
+- No regression in mobile responsive layout — the action-bar wrapper at `session-summary-view.tsx:128` should still render two buttons cleanly without spacing artifacts from the deleted slot.
+- `ROUTES.APP_HISTORY` is still imported and referenced by the top nav; do NOT remove the constant.
+
+## Future Concern (Out Of Scope)
+
+The user feedback that triggered this ticket — "history is generally worthless" — is a signal the History page may need its own value-proposition audit (longitudinal stats, comparison views, filterable session list, streak tracking, export). That is a feature-level UX/PM ticket, not debt. If pursued, file as a separate non-DEBT ticket (BUG-/audit/spec-class). Removing the Session Summary `View in History` button now does not preclude a future contextual back-link from Session Summary if the History page later earns one — but that would be Option C territory and a separate follow-up.

--- a/docs/debt/index.md
+++ b/docs/debt/index.md
@@ -1,7 +1,7 @@
 # Technical Debt Register
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-05-01 (DEBT-372 resolved)
+**Last Updated:** 2026-05-01 (DEBT-374 opened)
 
 ---
 
@@ -21,8 +21,9 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 | [DEBT-337](./debt-337-future-feedback-enhancements.md) | Future feedback & practice enhancements (F2/F3/F5/F6/F7) — clinical pearl field, reference styling, running score, card collapse, difficulty tags; parked | P4 | — |
 | [DEBT-349](./debt-349-cross-request-published-content-caching.md) | Optional Tier 2 cross-request caching for immutable published questions and tag lists after DEBT-344 shipped request-scoped dedup | P3 | — |
 | [DEBT-373](./debt-373-post-exam-review-score-banner-uses-app-h1-pattern-instead-of-stat-number-pattern.md) | Post-exam review entry banner crams `Score: 33% (1/3)` into one `<h1>` using the app-page-heading pattern (`text-2xl font-bold font-heading tracking-tight`) when typography-policy.md prescribes the stat-number pattern (`text-3xl font-bold font-display`) for percentages and counts — Session Summary and Dashboard already use the stat pattern; this banner is the only stat-bearing surface in the practice/exam flow that diverges. Recommend dropping the `Score:` label, splitting the count to the description line as `"X of Y correct"`, and using the canonical stat-number type | P3 | — |
+| [DEBT-374](./debt-374-session-summary-view-in-history-button-is-redundant-cruft.md) | Session Summary action bar exposes a tertiary ghost-variant `View in History` button (`session-summary-view.tsx:158-160`) that duplicates the persistent top-nav `History` link, imposing Hick's-Law cost on a terminal recap screen and routing users from a high-attention moment to a currently low-value destination. Recommend Option A: remove the button outright; History remains accessible via the always-visible top nav | P3 | — |
 
-**Next Debt ID:** DEBT-374
+**Next Debt ID:** DEBT-375
 
 ---
 

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -230,19 +230,25 @@ test.describe('practice', () => {
     await submitExamButton.click();
     await page.getByRole('button', { name: 'Confirm submit' }).click();
 
+    const scoreBanner = page
+      .locator('[data-slot="card"]')
+      .filter({ hasText: 'Exam complete' });
     await expect(
-      page.getByRole('heading', { name: /^Score: \d+% \(\d\/1\)$/ }),
-    ).toBeVisible({ timeout: 30_000 });
+      scoreBanner.getByRole('heading', {
+        level: 1,
+        name: 'Exam complete',
+      }),
+    ).toHaveCount(1, { timeout: 30_000 });
+    await expect(scoreBanner.getByText(/^\d+%$/)).toBeVisible();
     await expect(
-      page.getByText('Review each question with detailed feedback.'),
+      scoreBanner.locator('p').filter({
+        hasText:
+          /^\d of 1 correct · Review each question with detailed feedback\.$/,
+      }),
     ).toBeVisible();
     await expect(page.getByText(/^(Correct|Incorrect)$/).first()).toBeVisible();
 
-    await page
-      .locator('[data-slot="card"]')
-      .filter({ hasText: 'Exam complete' })
-      .getByRole('button', { name: 'View Summary' })
-      .click();
+    await scoreBanner.getByRole('button', { name: 'View Summary' }).click();
 
     // Wait for the terminal session summary to appear
     await expect(


### PR DESCRIPTION
## Summary

Implements [DEBT-373](docs/debt/debt-373-post-exam-review-score-banner-uses-app-h1-pattern-instead-of-stat-number-pattern.md) Option alpha for the post-exam review score banner.

Production change is limited to `app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx`: remove the concatenated `scoreLabel`, keep the score-banner Card/layout intact, make `Exam complete` the semantic `<h1>`, render the percentage as the canonical stat number, and move the raw count into the description line as natural language.

DEBT-372 button work is NOT touched in this PR.

## Before / After JSX

Before:

```tsx
<div className="text-sm text-muted-foreground">Exam complete</div>
<h1 className="mt-1 text-2xl font-bold font-heading tracking-tight text-foreground">
  {scoreLabel}
</h1>
<p className="mt-1 text-sm text-muted-foreground">
  Review each question with detailed feedback.
</p>
```

After:

```tsx
<h1 className="text-sm font-medium text-muted-foreground">
  Exam complete
</h1>
<div className="mt-1 text-3xl font-bold font-display text-foreground">
  {`${Math.round(summary.totals.accuracy * 100)}%`}
</div>
<p className="mt-1 text-sm text-muted-foreground">
  {`${summary.totals.correct} of ${summary.questionCount} correct · Review each question with detailed feedback.`}
</p>
```

## Tests Updated

- `post-exam-review-view.test.tsx`: added focused component coverage for the split stat shape, scoped to the score-banner card; asserts the semantic `h1`, non-heading stat `div`, stat typography classes, literal middle dot description text, and removal of the old `Score:`/parenthetical shape.
- `practice-session-page-view-review-stage.browser.spec.tsx`: replaced the old concatenated score assertion with score-banner-card scoped heading/stat/description assertions; kept the DEBT-372 summary button selector scoped to the same card.
- `practice-session-exam-results-renderer.test.tsx`: replaced body-level `Score: 0% (0/1)` assertion with score-banner-card scoped heading/stat/description assertions and preserved the two `View Summary` button expectation.
- `practice-session-page-view-results.browser.spec.tsx`: replaced both old score assertions with a local score-banner assertion helper scoped through the `Exam complete` card.
- `tests/e2e/practice.spec.ts`: replaced the old score-heading locator with Playwright card-scoped assertions for the level-1 `Exam complete` heading, percentage stat, and `X of Y correct · ...` paragraph.

No snapshot rewrites. No `.first()` / `.nth()` selector shortcuts were introduced for the score banner.

## A11y

Semantic `<h1>` preserved on the surface; screen readers see `Exam complete` as the page heading. Verified via `getByRole('heading', { level: 1, name: 'Exam complete' })` in component/browser/E2E coverage. The percentage is asserted as a non-heading `div`, and the description line is asserted as a `<p>`.

## Validation

Full gate on the committed tree before push:

- `pnpm db:test:up` passed
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:migrate` passed
- `SEED_INCLUDE_PLACEHOLDERS=true DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:seed` passed (`inserted=0 updated=0 skipped=958`)
- `pnpm typecheck` passed
- `pnpm lint` passed with the expected 19 warn-only `nursery/noExcessiveLinesPerFile` warnings
- `pnpm test --run` passed (`302` files, `2397` tests)
- `pnpm test:browser` passed (`47` files, `241` tests)
- `pnpm test:integration` passed (`16` files, `97` tests)
- `pnpm build` passed
- `pnpm test:e2e` passed (`34/34`)

Pre-push hook also passed `pnpm typecheck && pnpm test --run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  - Post‑exam review now shows a prominent percentage stat and a separate heading "Exam complete", with inline "X of Y correct · Review each question with detailed feedback."

* **Tests**
  - Updated tests to assert the semantic score banner structure (heading, non-heading percentage stat, and descriptive paragraph) instead of matching a single combined score string.

* **Documentation**
  - Added a technical debt entry proposing removal of a redundant "View in History" button from Session Summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->