### PR TITLE
Remove redundant View in History button from Session Summary

### DIFF
--- a/app/(app)/app/practice/[sessionId]/components/session-summary-view.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/session-summary-view.browser.spec.tsx
@@ -58,9 +58,6 @@ test('renders summary totals and per-question breakdown', async () => {
     .element(screen.getByText('[Question no longer available]'))
     .toBeVisible();
   await expect
-    .element(screen.getByRole('link', { name: 'View in History' }))
-    .toHaveAttribute('href', ROUTES.APP_HISTORY);
-  await expect
     .element(screen.getByRole('link', { name: 'New Session' }))
     .toHaveAttribute('href', ROUTES.APP_PRACTICE);
   await expect
@@ -200,7 +197,7 @@ test('renders loading and error states for summary review', async () => {
   await expect.element(screen.getByText('Review unavailable.')).toBeVisible();
 });
 
-test('renders exactly 2 tutor actions', async () => {
+test('renders only the New Session action for tutor summaries', async () => {
   const screen = await render(
     <SessionSummaryView
       summary={{
@@ -222,9 +219,6 @@ test('renders exactly 2 tutor actions', async () => {
 
   await expect
     .element(screen.getByRole('link', { name: 'New Session' }))
-    .toBeVisible();
-  await expect
-    .element(screen.getByRole('link', { name: 'View in History' }))
     .toBeVisible();
   await expect
     .element(screen.getByRole('link', { name: 'Review Answers' }))

--- a/app/(app)/app/practice/[sessionId]/components/session-summary-view.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/session-summary-view.test.tsx
@@ -150,7 +150,6 @@ describe('SessionSummaryView', () => {
       const text = link.textContent?.trim();
       return (
         text === 'New Session' ||
-        text === 'View in History' ||
         text === 'Back to Dashboard' ||
         text === 'Start another session'
       );
@@ -158,7 +157,6 @@ describe('SessionSummaryView', () => {
 
     expect(actionLinks.map((link) => link.textContent?.trim())).toEqual([
       'New Session',
-      'View in History',
     ]);
   });
 
@@ -206,7 +204,6 @@ describe('SessionSummaryView', () => {
       return (
         text === 'Review Answers' ||
         text === 'New Session' ||
-        text === 'View in History' ||
         text === 'Back to Dashboard' ||
         text === 'Start another session'
       );
@@ -215,7 +212,6 @@ describe('SessionSummaryView', () => {
     expect(actionLinks.map((link) => link.textContent?.trim())).toEqual([
       'Review Answers',
       'New Session',
-      'View in History',
     ]);
 
     const reviewLink = Array.from(doc.querySelectorAll('a')).find(
@@ -233,15 +229,6 @@ describe('SessionSummaryView', () => {
     );
     expect(newSessionTokens.has('border')).toBe(true);
     expect(newSessionTokens.has('bg-background')).toBe(true);
-
-    const historyLink = Array.from(doc.querySelectorAll('a')).find(
-      (link) => link.textContent?.trim() === 'View in History',
-    );
-    const historyLinkTokens = getClassTokens(
-      historyLink?.getAttribute('class') ?? '',
-    );
-    expect(historyLinkTokens.has('hover:bg-accent')).toBe(true);
-    expect(historyLinkTokens.has('border')).toBe(false);
   });
 
   it('omits the removed practice-missed CTA when the exam summary is perfect', () => {

--- a/app/(app)/app/practice/[sessionId]/components/session-summary-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/session-summary-view.tsx
@@ -155,9 +155,6 @@ export function SessionSummaryView({
         >
           <Link href={ROUTES.APP_PRACTICE}>New Session</Link>
         </Button>
-        <Button asChild variant="ghost" className="rounded-full">
-          <Link href={ROUTES.APP_HISTORY}>View in History</Link>
-        </Button>
       </div>
     </div>
   );

--- a/app/(app)/app/practice/[sessionId]/page.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/page.test.tsx
@@ -145,8 +145,6 @@ describe('app/(app)/app/practice/[sessionId]', () => {
     expect(html).toContain('Duration');
     expect(html).toContain('2m 3s');
     expect(html).toContain('Question breakdown');
-    expect(html).toContain('View in History');
-    expect(html).toContain('href="/app/history"');
     expect(html).toContain('New Session');
     expect(html).toContain(`href="${ROUTES.APP_PRACTICE}"`);
     expect(html).not.toContain('Back to Dashboard');
@@ -260,7 +258,6 @@ describe('app/(app)/app/practice/[sessionId]', () => {
       return (
         text === 'Review Answers' ||
         text === 'New Session' ||
-        text === 'View in History' ||
         text === 'Back to Dashboard' ||
         text === 'Start another session'
       );
@@ -269,7 +266,6 @@ describe('app/(app)/app/practice/[sessionId]', () => {
     expect(actionLinks.map((link) => link.textContent?.trim())).toEqual([
       'Review Answers',
       'New Session',
-      'View in History',
     ]);
     expect(html).toContain('Review Answers');
     expect(html).toContain(

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -138,9 +138,6 @@ test.describe('practice', () => {
     await expect(
       page.getByRole('heading', { name: 'Session Summary' }),
     ).toBeVisible();
-    await expect(
-      page.getByRole('link', { name: 'View in History' }),
-    ).toHaveAttribute('href', '/app/history');
   });
 
   test('quick practice submit shows correctness feedback', async ({ page }) => {


### PR DESCRIPTION
## Summary

Implements [DEBT-374](docs/debt/debt-374-session-summary-view-in-history-button-is-redundant-cruft.md) Option A: remove the redundant ghost-variant `View in History` CTA from the Session Summary action bar.

The top-nav `History` link remains the surviving access path via `components/app-nav-items.ts:12`, and `/app/history` is still reachable directly.

## Production Diff

`app/(app)/app/practice/[sessionId]/components/session-summary-view.tsx`

- Deleted the single ghost Button block:

```tsx
<Button asChild variant="ghost" className="rounded-full">
  <Link href={ROUTES.APP_HISTORY}>View in History</Link>
</Button>
```

- No import cleanup was needed: `Link`, `Button`, and `ROUTES` are still used by the surviving `Review Answers` / `New Session` actions.
- `Review Answers`, `New Session`, and the action-bar wrapper `flex flex-col gap-3 sm:flex-row` are otherwise unchanged.

## Test Cleanup

- `app/(app)/app/practice/[sessionId]/components/session-summary-view.test.tsx`
  - Removed `View in History` from paired action-link filters and expected label lists.
  - Removed the ghost-variant token assertions for the deleted link.
- `app/(app)/app/practice/[sessionId]/components/session-summary-view.browser.spec.tsx`
  - Removed `View in History` href/visibility assertions.
  - Updated the stale deletion-driven tutor-action test name to reflect the surviving `New Session` action.
- `app/(app)/app/practice/[sessionId]/page.test.tsx`
  - Removed static-render assertions for `View in History` and `/app/history` from Session Summary.
  - Removed `View in History` from the page-level action-link filter/list pair.
- `tests/e2e/practice.spec.ts`
  - Removed the discrete Session Summary `View in History` visibility/href assertion.

## Verification

- `rg -n 'View in History' app/ components/ src/ lib/ tests/` returns zero hits.
- Top-nav History link is unchanged: `components/app-nav-items.ts:12` still has `{ href: ROUTES.APP_HISTORY, label: 'History' }`.
- Production-server visual check completed on a 3-question exam flow:
  - Session Summary action bar labels: `Review Answers`, `New Session`
  - action-bar class remains `flex flex-col gap-3 sm:flex-row`
  - child count is `2`
  - top-nav `History` href remains `/app/history`

Full local gate:

- `pnpm db:test:up` passed
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:migrate` passed
- `SEED_INCLUDE_PLACEHOLDERS=true DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:seed` passed
- `pnpm typecheck` passed
- `pnpm lint` passed with the expected 19 warn-level `nursery/noExcessiveLinesPerFile` warnings
- `pnpm test --run` passed: 302 files / 2397 tests
- `pnpm test:browser` passed: 47 files / 241 tests
- `pnpm test:integration` passed: 16 files / 97 tests
- `pnpm build` passed
- `pnpm test:e2e` passed: 34 tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the "View in History" link from practice session summary pages.

* **Tests**
  * Updated unit and end-to-end tests to reflect removal of the "View in History" button across all session summary scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->