### PR TITLE
DEBT-375: Tutor session footer View Summary terminal CTA

### DIFF
--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-question-navigation.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-question-navigation.browser.spec.tsx
@@ -383,7 +383,10 @@ test('hasPreviousQuestion is true when current question is not first', async () 
     .not.toBeDisabled();
 });
 
-test('hasNextQuestion is false when current question is last available', async () => {
+test('routes the last tutor-question footer View Summary button through onEndSession instead of onNextQuestion', async () => {
+  const onEndSession = vi.fn();
+  const onNextQuestion = vi.fn();
+
   const screen = await render(
     <PracticeSessionPageView
       summary={null}
@@ -442,19 +445,24 @@ test('hasNextQuestion is false when current question is last available', async (
       bookmarkStatus="idle"
       isBookmarked={false}
       canSubmit={false}
-      onEndSession={noop}
+      onEndSession={onEndSession}
       onTryAgain={noop}
       onToggleBookmark={noop}
       onSelectChoice={noop}
       onSubmit={noop}
-      onNextQuestion={noop}
+      onNextQuestion={onNextQuestion}
       onNavigateQuestion={noop}
     />,
   );
 
+  const bottomActionBar = screen.getByTestId('bottom-action-bar');
+
   await expect
-    .element(screen.getByRole('button', { name: 'Next' }))
+    .element(bottomActionBar.getByRole('button', { name: 'Next' }))
     .not.toBeInTheDocument();
+  await bottomActionBar.getByRole('button', { name: 'View Summary' }).click();
+  expect(onEndSession).toHaveBeenCalledTimes(1);
+  expect(onNextQuestion).not.toHaveBeenCalled();
 });
 
 test('clicking Next in a completed session navigates to the next available question id', async () => {

--- a/app/(app)/app/practice/components/practice-view-answer-feedback.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-answer-feedback.test.tsx
@@ -174,6 +174,7 @@ describe('PracticeView answer feedback', () => {
     );
 
     expect(html).not.toContain('Review answers');
+    expect(html).toContain('View Summary');
   });
 
   it('passes selected choice context to feedback after submit', () => {

--- a/app/(app)/app/practice/components/practice-view-navigation.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-navigation.test.tsx
@@ -12,6 +12,16 @@ beforeAll(async () => {
   PracticeView = (await import('./practice-view')).PracticeView;
 });
 
+function getButtonLabels(container: Element | null) {
+  if (!container) {
+    throw new Error('Expected action group');
+  }
+
+  return Array.from(container.querySelectorAll('button')).map((button) =>
+    (button.textContent ?? '').trim(),
+  );
+}
+
 describe('PracticeView navigation', () => {
   it('renders a Previous button when onPreviousQuestion is provided', () => {
     const question = createNextQuestion();
@@ -133,7 +143,7 @@ describe('PracticeView navigation', () => {
     expect(html).not.toContain('Next Question');
   });
 
-  it('hides Next when hasNextQuestion is false', () => {
+  it('keeps the last-question slot empty when onEndSession is missing', () => {
     const question = createNextQuestion();
 
     const props: Parameters<typeof PracticeView>[0] = {
@@ -158,11 +168,128 @@ describe('PracticeView navigation', () => {
 
     const html = renderToStaticMarkup(<PracticeView {...props} />);
     const doc = new DOMParser().parseFromString(html, 'text/html');
-    const nextButton = Array.from(doc.querySelectorAll('button')).find(
-      (button) => button.textContent?.includes('Next'),
+    const primaryGroup = doc.querySelector(
+      '[data-testid="tutor-action-primary-group"]',
+    );
+    const secondaryGroup = doc.querySelector(
+      '[data-testid="tutor-action-secondary-group"]',
     );
 
-    expect(nextButton).toBeUndefined();
+    expect(getButtonLabels(primaryGroup)).toEqual(['Previous', 'Submit']);
+    expect(getButtonLabels(secondaryGroup)).toEqual([]);
+    expect(doc.body.textContent).not.toContain('Next');
+    expect(doc.body.textContent).not.toContain('View Summary');
+  });
+
+  it('renders an outline View Summary button in the primary group before final tutor submission', () => {
+    const question = createNextQuestion();
+
+    const props: Parameters<typeof PracticeView>[0] = {
+      sessionInfo: {
+        sessionId: 'session-1',
+        mode: 'tutor',
+        index: 2,
+        total: 3,
+        isMarkedForReview: false,
+      },
+      loadState: { status: 'ready' },
+      question,
+      selectedChoiceId: null,
+      isAnswered: false,
+      submitResult: null,
+      isPending: false,
+      bookmarkStatus: 'idle',
+      isBookmarked: false,
+      canSubmit: false,
+      onEndSession: () => undefined,
+      onTryAgain: () => undefined,
+      onToggleBookmark: () => undefined,
+      onSelectChoice: () => undefined,
+      onSubmit: () => undefined,
+      onNextQuestion: () => undefined,
+      onPreviousQuestion: () => undefined,
+      hasPreviousQuestion: true,
+      hasNextQuestion: false,
+    };
+
+    const html = renderToStaticMarkup(<PracticeView {...props} />);
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const primaryGroup = doc.querySelector(
+      '[data-testid="tutor-action-primary-group"]',
+    );
+    const secondaryGroup = doc.querySelector(
+      '[data-testid="tutor-action-secondary-group"]',
+    );
+    const viewSummaryButton = Array.from(
+      primaryGroup?.querySelectorAll('button') ?? [],
+    ).find((button) => button.textContent?.trim() === 'View Summary');
+
+    expect(getButtonLabels(primaryGroup)).toEqual([
+      'Previous',
+      'Submit',
+      'View Summary',
+    ]);
+    expect(getButtonLabels(secondaryGroup)).toEqual([]);
+    expect(viewSummaryButton?.getAttribute('data-variant')).toBe('outline');
+  });
+
+  it('promotes View Summary after final tutor feedback and keeps Bookmark in the secondary group', () => {
+    const question = createNextQuestion();
+    const selectedChoice = question.choices[0];
+    if (!selectedChoice) {
+      throw new Error('Expected at least one choice');
+    }
+
+    const props: Parameters<typeof PracticeView>[0] = {
+      sessionInfo: {
+        sessionId: 'session-1',
+        mode: 'tutor',
+        index: 2,
+        total: 3,
+        isMarkedForReview: false,
+      },
+      loadState: { status: 'ready' },
+      question,
+      selectedChoiceId: selectedChoice.id,
+      isAnswered: true,
+      submitResult: {
+        attemptId: 'attempt-1',
+        isCorrect: true,
+        correctChoiceId: selectedChoice.id,
+        explanationMd: 'Because.',
+        referenceMd: null,
+        choiceExplanations: [],
+      },
+      isPending: false,
+      bookmarkStatus: 'idle',
+      isBookmarked: false,
+      canSubmit: false,
+      onEndSession: () => undefined,
+      onTryAgain: () => undefined,
+      onToggleBookmark: () => undefined,
+      onSelectChoice: () => undefined,
+      onSubmit: () => undefined,
+      onNextQuestion: () => undefined,
+      onPreviousQuestion: () => undefined,
+      hasPreviousQuestion: true,
+      hasNextQuestion: false,
+    };
+
+    const html = renderToStaticMarkup(<PracticeView {...props} />);
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const primaryGroup = doc.querySelector(
+      '[data-testid="tutor-action-primary-group"]',
+    );
+    const secondaryGroup = doc.querySelector(
+      '[data-testid="tutor-action-secondary-group"]',
+    );
+    const viewSummaryButton = Array.from(
+      primaryGroup?.querySelectorAll('button') ?? [],
+    ).find((button) => button.textContent?.trim() === 'View Summary');
+
+    expect(getButtonLabels(primaryGroup)).toEqual(['Previous', 'View Summary']);
+    expect(getButtonLabels(secondaryGroup)).toEqual(['Bookmark']);
+    expect(viewSummaryButton?.getAttribute('data-variant')).toBe('default');
   });
 
   it('keeps tutor action bar ordering as Previous, Submit, Next before feedback', () => {

--- a/app/(app)/app/practice/components/practice-view.browser.spec.tsx
+++ b/app/(app)/app/practice/components/practice-view.browser.spec.tsx
@@ -645,3 +645,70 @@ test('calls onEndSession from the bottom-bar Review & Submit button on the last 
   await screen.getByRole('button', { name: 'Review & Submit' }).click();
   expect(onEndSession).toHaveBeenCalledTimes(1);
 });
+
+test('calls onEndSession from the bottom-bar View Summary button on the last tutor question', async () => {
+  const onEndSession = vi.fn();
+  const onNextQuestion = vi.fn();
+
+  const screen = await render(
+    <PracticeView
+      sessionInfo={{
+        sessionId: 'session-1',
+        mode: 'tutor',
+        index: 1,
+        total: 2,
+        isMarkedForReview: false,
+      }}
+      loadState={{ status: 'ready' }}
+      question={{
+        questionId: 'question-2',
+        slug: 'question-2',
+        stemMd: 'What is the next best step?',
+        difficulty: 'easy',
+        choices: [
+          { id: 'choice_a', label: 'A', textMd: 'Option A', sortOrder: 1 },
+        ],
+        session: null,
+      }}
+      selectedChoiceId="choice_a"
+      isAnswered={true}
+      submitResult={{
+        attemptId: 'attempt-1',
+        isCorrect: true,
+        correctChoiceId: 'choice_a',
+        explanationMd: 'Because',
+        referenceMd: null,
+        choiceExplanations: [],
+      }}
+      isPending={false}
+      bookmarkStatus="idle"
+      isBookmarked={false}
+      canSubmit={false}
+      onEndSession={onEndSession}
+      onTryAgain={() => undefined}
+      onToggleBookmark={() => undefined}
+      onSelectChoice={() => undefined}
+      onSubmit={() => undefined}
+      onNextQuestion={onNextQuestion}
+      onPreviousQuestion={() => undefined}
+      hasPreviousQuestion
+      hasNextQuestion={false}
+    />,
+  );
+
+  const primaryGroup = screen.getByTestId('tutor-action-primary-group');
+  const secondaryGroup = screen.getByTestId('tutor-action-secondary-group');
+
+  await expect.element(primaryGroup).toBeVisible();
+  await expect.element(secondaryGroup).toBeVisible();
+  await expect
+    .element(primaryGroup.getByRole('button', { name: 'View Summary' }))
+    .toBeVisible();
+  await expect
+    .element(secondaryGroup.getByRole('button', { name: 'Bookmark' }))
+    .toBeVisible();
+
+  await primaryGroup.getByRole('button', { name: 'View Summary' }).click();
+  expect(onEndSession).toHaveBeenCalledTimes(1);
+  expect(onNextQuestion).not.toHaveBeenCalled();
+});

--- a/app/(app)/app/practice/components/practice-view.tsx
+++ b/app/(app)/app/practice/components/practice-view.tsx
@@ -99,6 +99,7 @@ type TutorActionBarProps = Pick<
   | 'isBookmarked'
   | 'isPending'
   | 'loadState'
+  | 'onEndSession'
   | 'onNextQuestion'
   | 'onPreviousQuestion'
   | 'onSubmit'
@@ -113,9 +114,13 @@ function TutorActionBar(props: TutorActionBarProps) {
     props.isPending || props.loadState.status === 'loading';
   const isPreviousDisabled =
     isActionBarDisabled || props.canNavigatePrevious === false;
+  const isLastQuestion = props.hasNextQuestion === false;
 
-  return (
-    <>
+  const navigationGroup = (
+    <div
+      className="flex flex-wrap items-center gap-3"
+      data-testid="tutor-action-primary-group"
+    >
       {props.onPreviousQuestion ? (
         props.hasPreviousQuestion ? (
           <Button
@@ -143,8 +148,20 @@ function TutorActionBar(props: TutorActionBarProps) {
         </Button>
       ) : null}
 
-      {props.hasNextQuestion === false ? (
-        <ActionBarSpacer />
+      {isLastQuestion ? (
+        props.onEndSession ? (
+          <Button
+            type="button"
+            variant={props.submitResult ? 'default' : 'outline'}
+            className="rounded-full"
+            disabled={isActionBarDisabled}
+            onClick={props.onEndSession}
+          >
+            View Summary
+          </Button>
+        ) : (
+          <ActionBarSpacer />
+        )
       ) : (
         <Button
           type="button"
@@ -156,7 +173,14 @@ function TutorActionBar(props: TutorActionBarProps) {
           Next
         </Button>
       )}
+    </div>
+  );
 
+  const secondaryGroup = (
+    <div
+      className="flex flex-wrap items-center gap-3 sm:ml-auto"
+      data-testid="tutor-action-secondary-group"
+    >
       {hasBooleanCorrectness(props.submitResult) ? (
         <Button
           type="button"
@@ -169,6 +193,13 @@ function TutorActionBar(props: TutorActionBarProps) {
           {props.isBookmarked ? 'Remove bookmark' : 'Bookmark'}
         </Button>
       ) : null}
+    </div>
+  );
+
+  return (
+    <>
+      {navigationGroup}
+      {secondaryGroup}
     </>
   );
 }
@@ -360,6 +391,7 @@ export function PracticeView(props: PracticeViewProps) {
           loadState={props.loadState}
           onNextQuestion={props.onNextQuestion}
           onPreviousQuestion={props.onPreviousQuestion}
+          onEndSession={props.onEndSession}
           onSubmit={props.onSubmit}
           onToggleBookmark={props.onToggleBookmark}
           submitResult={props.submitResult}

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -140,6 +140,50 @@ test.describe('practice', () => {
     ).toBeVisible();
   });
 
+  test('subscribed user can finish a tutor session from the last-question footer', async ({
+    page,
+  }) => {
+    await signInWithClerkPassword(page);
+    await ensureSubscribed(page);
+
+    await startSession(page, 'tutor', 3);
+
+    for (const questionNumber of [1, 2] as const) {
+      await expect(
+        page.getByText(`Question ${questionNumber} of 3`),
+      ).toBeVisible();
+      await selectChoiceByLabel(page, 'A');
+      await page.getByRole('button', { name: 'Submit' }).click();
+      await expect(page.getByTestId('verdict-pill')).toBeVisible({
+        timeout: 10_000,
+      });
+      await page
+        .getByTestId('bottom-action-bar')
+        .getByRole('button', { name: 'Next' })
+        .click();
+    }
+
+    await expect(page.getByText('Question 3 of 3')).toBeVisible();
+    await selectChoiceByLabel(page, 'A');
+    await page.getByRole('button', { name: 'Submit' }).click();
+    await expect(page.getByTestId('verdict-pill')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const bottomActionBar = page.getByTestId('bottom-action-bar');
+    await expect(
+      bottomActionBar.getByRole('button', { name: 'View Summary' }),
+    ).toBeVisible();
+    await expect(
+      bottomActionBar.getByRole('button', { name: 'Next' }),
+    ).toHaveCount(0);
+
+    await bottomActionBar.getByRole('button', { name: 'View Summary' }).click();
+    await expect(
+      page.getByRole('heading', { name: 'Session Summary' }),
+    ).toBeVisible({ timeout: 30_000 });
+  });
+
   test('quick practice submit shows correctness feedback', async ({ page }) => {
     await signInWithClerkPassword(page);
     await ensureSubscribed(page);


### PR DESCRIPTION
## Summary

Closes the tutor footer dead-end on the last question. Adds a `View Summary` button calling `onEndSession`, restructures `TutorActionBar` into exam-parallel two-group layout (`tutor-action-primary-group` + `tutor-action-secondary-group` with `sm:ml-auto`), and moves `Bookmark` into the right-aligned secondary slot. Header `End session` is intentionally unchanged.

Spec: [`docs/debt/debt-375-...md`](../blob/dev/docs/debt/debt-375-tutor-session-action-bar-no-terminal-cta-on-last-question.md)

## Test plan

- [x] Red-first targeted unit/browser tests failed against the spacer implementation
- [x] `pnpm db:test:up`
- [x] `DATABASE_URL=postgresql://postgres:postgres@localhost:5434/addiction_boards_test pnpm db:migrate`
- [x] `SEED_INCLUDE_PLACEHOLDERS=true DATABASE_URL=postgresql://postgres:postgres@localhost:5434/addiction_boards_test pnpm db:seed`
- [x] `pnpm typecheck`
- [x] `pnpm lint` (19 expected warn-only noExcessiveLinesPerFile warnings on legacy oversized files)
- [x] `pnpm test --run` (302 files / 2,399 tests)
- [x] `pnpm test:browser` (47 files / 242 tests)
- [x] `pnpm test:integration` (16 files / 97 tests)
- [x] `pnpm build`
- [x] `pnpm test:e2e` (35 passed)
- [x] Manual-equivalent E2E: tutor session, advance to last question, submit, bottom-bar `View Summary` -> Session Summary
- [x] Regression: header `End session` remains available in tutor mode
- [x] Regression: exam `Review & Submit` and mark-for-review action bar tests still pass

## Out of scope

- Pre-submit `Next` clickability in tutor (DEBT-376 candidate)
- Question Navigator card vertical density (DEBT-377 candidate)
- `Finish exam` dead-prop label cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tutor mode now displays a "View Summary" button on the final practice question instead of the typical "Next" button, enabling users to conclude the session and access their performance summary.

* **Tests**
  * Added comprehensive test coverage including unit tests and end-to-end tests to verify the "View Summary" button behavior and overall session completion flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->