### PR TITLE
DEBT-376: Rename active-exam endSessionLabel to 'Review & Submit'

### DIFF
--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-active-question.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-active-question.browser.spec.tsx
@@ -87,7 +87,7 @@ test('renders active question branch with navigator and navigation callback', as
   expect(onNavigateQuestion).toHaveBeenCalledWith('q2');
 });
 
-test('does not render Finish exam in the active exam-question header', async () => {
+test('does not render Review & Submit in the active exam-question header', async () => {
   const screen = await render(
     <PracticeSessionPageView
       summary={null}
@@ -127,7 +127,7 @@ test('does not render Finish exam in the active exam-question header', async () 
   );
 
   await expect
-    .element(screen.getByRole('button', { name: 'Finish exam' }))
+    .element(screen.getByRole('button', { name: 'Review & Submit' }))
     .not.toBeInTheDocument();
   await expect
     .element(screen.getByRole('button', { name: 'End session' }))

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx
@@ -264,7 +264,7 @@ export function PracticeSessionPageView(props: PracticeSessionPageViewProps) {
       bookmarkMessage={props.bookmarkMessage}
       bookmarkMessageVersion={props.bookmarkMessageVersion}
       canSubmit={props.canSubmit}
-      endSessionLabel={mode === 'exam' ? 'Finish exam' : 'End session'}
+      endSessionLabel={mode === 'exam' ? 'Review & Submit' : 'End session'}
       onEndSession={props.onEndSession}
       onTryAgain={onTryAgainResolved}
       onRetryBookmarks={props.onRetryBookmarks}

--- a/app/(app)/app/practice/components/practice-view-layout.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-layout.test.tsx
@@ -195,7 +195,7 @@ describe('PracticeView layout', () => {
   it('renders an explicit session action when no more questions remain', () => {
     const html = renderToStaticMarkup(
       <PracticeView
-        endSessionLabel="Finish exam"
+        endSessionLabel="Review & Submit"
         loadState={{ status: 'ready' }}
         question={null}
         selectedChoiceId={null}
@@ -216,7 +216,7 @@ describe('PracticeView layout', () => {
 
     const doc = new DOMParser().parseFromString(html, 'text/html');
     const endButtons = Array.from(doc.querySelectorAll('button')).filter(
-      (button) => button.textContent?.includes('Finish exam'),
+      (button) => button.textContent?.includes('Review & Submit'),
     );
     expect(endButtons).toHaveLength(2);
   });

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -248,9 +248,6 @@ test.describe('practice', () => {
     await expect(
       page.getByRole('button', { name: 'Review & Submit' }),
     ).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Finish exam' })).toHaveCount(
-      0,
-    );
     await expect(
       page
         .getByTestId('bottom-action-bar')


### PR DESCRIPTION
## Summary

The active-exam empty-state button labeled `'Finish exam'` does not finish the exam — `onEndSession` calls `loadReview()` (navigation to Review & Submit stage), not a finalize. Renames the label to `'Review & Submit'` matching DEBT-361's canonical vocabulary so the button tells the truth about what clicking it does. One-line production diff at `practice-session-page-view.tsx:267`. Mechanical test updates align existing fixtures/assertions with the new label and delete one obsolete count-0 assertion.

Spec: [`docs/debt/debt-376-...md`](../blob/dev/docs/debt/debt-376-active-exam-finish-exam-label-lies-about-its-action.md)

## Test plan

- [x] `pnpm db:test:up`
- [x] `DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:migrate`
- [x] `SEED_INCLUDE_PLACEHOLDERS=true DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:seed`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test --run`
- [x] `pnpm test:browser`
- [x] `pnpm test:integration`
- [x] `pnpm build`
- [x] `pnpm test:e2e`
- [x] Grep verification: `rg "Finish exam" app/ src/ tests/` returns zero hits
- [x] Grep verification: `rg "Review & Submit" app/ src/ tests/` includes the new page-view label

## TDD note

The requested test-first edits were applied before the production rename. The targeted checks did not go red because the specified unit test injects `endSessionLabel` directly, the browser fixture is mid-exam and asserts absence, and the E2E change deletes an obsolete assertion. After the one-line production rename, targeted checks and the full gate passed.

## Out of scope

- Empty-state reachability proof (label correctness is independent of edge-case frequency)
- `endSessionLabel` prop removal (Option γ rejection)
- Tutor-mode `'End session'` label (semantically correct for tutor; out of scope)
- Header layout refactor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for exam mode session completion button
  * Tests now verify "Review & Submit" button renders instead of "Finish exam"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->