### PR TITLE
feat(exam): promote primary CTA to right slot, move Mark for review to header (DEBT-379)

### DIFF
--- a/app/(app)/app/practice/components/practice-view-exam-actions.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-exam-actions.test.tsx
@@ -4,6 +4,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { createQuestionProps } from './practice-view-test-helpers';
 
 type PracticeViewModule = typeof import('./practice-view');
+type PracticeViewProps = Parameters<PracticeViewModule['PracticeView']>[0];
 
 let PracticeView: PracticeViewModule['PracticeView'];
 
@@ -11,191 +12,174 @@ beforeAll(async () => {
   PracticeView = (await import('./practice-view')).PracticeView;
 });
 
+const noop = () => undefined;
+
+function getButtonLabels(container: Element | null): string[] {
+  return Array.from(container?.querySelectorAll('button') ?? []).map((button) =>
+    (button.textContent ?? '').trim(),
+  );
+}
+
+function parse(html: string): Document {
+  return new DOMParser().parseFromString(html, 'text/html');
+}
+
+function renderExamView(
+  input: {
+    index?: number;
+    total?: number;
+    isMarkedForReview?: boolean;
+    selectedChoiceId?: string | null;
+    props?: Partial<PracticeViewProps>;
+  } = {},
+): string {
+  const question = createQuestionProps();
+
+  return renderToStaticMarkup(
+    <PracticeView
+      sessionInfo={{
+        sessionId: 'session-1',
+        mode: 'exam',
+        index: input.index ?? 0,
+        total: input.total ?? 3,
+        isMarkedForReview: input.isMarkedForReview ?? false,
+      }}
+      loadState={{ status: 'ready' }}
+      question={question}
+      selectedChoiceId={input.selectedChoiceId ?? null}
+      isAnswered={false}
+      submitResult={null}
+      isPending={false}
+      bookmarkStatus="idle"
+      isBookmarked={false}
+      isMarkingForReview={false}
+      onEndSession={noop}
+      onTryAgain={noop}
+      onToggleBookmark={noop}
+      onToggleMarkForReview={noop}
+      onSelectChoice={noop}
+      onNextQuestion={noop}
+      onPreviousQuestion={noop}
+      hasPreviousQuestion={(input.index ?? 0) > 0}
+      hasNextQuestion={(input.index ?? 0) < (input.total ?? 3) - 1}
+      {...input.props}
+    />,
+  );
+}
+
+function renderTutorView(
+  props: Partial<PracticeViewProps> = {},
+  submitResult: PracticeViewProps['submitResult'] = null,
+): string {
+  const question = createQuestionProps();
+
+  return renderToStaticMarkup(
+    <PracticeView
+      sessionInfo={{
+        sessionId: 'session-1',
+        mode: 'tutor',
+        index: 1,
+        total: 3,
+        isMarkedForReview: false,
+      }}
+      loadState={{ status: 'ready' }}
+      question={question}
+      selectedChoiceId={submitResult ? (question.choices[0]?.id ?? null) : null}
+      isAnswered={submitResult !== null}
+      submitResult={submitResult}
+      isPending={false}
+      bookmarkStatus="idle"
+      isBookmarked={false}
+      onEndSession={noop}
+      onTryAgain={noop}
+      onToggleBookmark={noop}
+      onSelectChoice={noop}
+      onNextQuestion={noop}
+      onPreviousQuestion={noop}
+      hasPreviousQuestion={true}
+      hasNextQuestion={true}
+      {...props}
+    />,
+  );
+}
+
+function createCorrectSubmitResult(
+  question = createQuestionProps(),
+): NonNullable<PracticeViewProps['submitResult']> {
+  const choice = question.choices[0];
+  if (!choice) throw new Error('Expected at least one choice');
+
+  return {
+    attemptId: 'attempt-1',
+    isCorrect: true,
+    correctChoiceId: choice.id,
+    explanationMd: 'Because',
+    referenceMd: null,
+    choiceExplanations: [],
+  };
+}
+
 describe('PracticeView exam actions', () => {
-  it('renders exam action bar with Next and Mark for review and no Submit on the first question', () => {
-    const question = createQuestionProps();
-    const selectedChoice = question.choices[0];
-    if (!selectedChoice) {
-      throw new Error('Expected at least one choice');
-    }
-
-    const html = renderToStaticMarkup(
-      <PracticeView
-        sessionInfo={{
-          sessionId: 'session-1',
-          mode: 'exam',
-          index: 0,
-          total: 2,
-          isMarkedForReview: false,
-        }}
-        loadState={{ status: 'ready' }}
-        question={question}
-        selectedChoiceId={selectedChoice.id}
-        isAnswered={false}
-        submitResult={null}
-        isPending={false}
-        bookmarkStatus="idle"
-        isBookmarked={false}
-        onTryAgain={() => undefined}
-        onToggleBookmark={() => undefined}
-        onToggleMarkForReview={() => undefined}
-        onSelectChoice={() => undefined}
-        onNextQuestion={() => undefined}
-        onPreviousQuestion={() => undefined}
-        hasPreviousQuestion={false}
-        hasNextQuestion={true}
-      />,
-    );
-
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+  it('renders first-question exam footer with only the right-slot Next CTA', () => {
+    const html = renderExamView({ index: 0, total: 3 });
+    const doc = parse(html);
     const actionBar = doc.querySelector('[data-testid="bottom-action-bar"]');
-    if (!actionBar) throw new Error('Expected action bar');
-
-    const labels = Array.from(actionBar.querySelectorAll('button')).map(
-      (button) => (button.textContent ?? '').trim(),
+    const primaryGroup = doc.querySelector(
+      '[data-testid="exam-action-primary-group"]',
     );
+    const ctaGroup = doc.querySelector('[data-testid="exam-action-cta-group"]');
 
-    expect(labels).toEqual(['Next', 'Mark for review']);
-    expect(
-      actionBar.querySelectorAll('span[aria-hidden="true"].h-9.min-w-24'),
-    ).toHaveLength(0);
+    expect(actionBar).not.toBeNull();
+    expect(primaryGroup).toBeNull();
+    expect(getButtonLabels(ctaGroup)).toEqual(['Next']);
+    expect(getButtonLabels(actionBar)).toEqual(['Next']);
+    expect(actionBar?.textContent).not.toContain('Mark for review');
     expect(html).not.toContain('>Submit<');
     expect(html).not.toContain('>Previous<');
   });
 
-  it('renders Review & Submit in the bottom bar on the last exam question before submission', () => {
-    const question = createQuestionProps();
-    const selectedChoice = question.choices[0];
-    if (!selectedChoice) {
-      throw new Error('Expected at least one choice');
-    }
-    const html = renderToStaticMarkup(
-      <PracticeView
-        sessionInfo={{
-          sessionId: 'session-1',
-          mode: 'exam',
-          index: 1,
-          total: 2,
-          isMarkedForReview: false,
-        }}
-        loadState={{ status: 'ready' }}
-        question={question}
-        selectedChoiceId={selectedChoice.id}
-        isAnswered={false}
-        submitResult={null}
-        isPending={false}
-        bookmarkStatus="idle"
-        isBookmarked={false}
-        onEndSession={() => undefined}
-        onTryAgain={() => undefined}
-        onToggleBookmark={() => undefined}
-        onToggleMarkForReview={() => undefined}
-        onSelectChoice={() => undefined}
-        onNextQuestion={() => undefined}
-        onPreviousQuestion={() => undefined}
-        hasPreviousQuestion={true}
-        hasNextQuestion={false}
-      />,
-    );
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+  it('renders final-question exam footer with Previous left and Review & Submit right', () => {
+    const html = renderExamView({ index: 2, total: 3 });
+    const doc = parse(html);
     const actionBar = doc.querySelector('[data-testid="bottom-action-bar"]');
-    if (!actionBar) throw new Error('Expected action bar');
-
-    const labels = Array.from(actionBar.querySelectorAll('button')).map(
-      (button) => (button.textContent ?? '').trim(),
-    );
-
-    expect(labels).toEqual(['Previous', 'Review & Submit', 'Mark for review']);
-  });
-
-  it('groups active-exam navigation separately from the mark-for-review affordance', () => {
-    const question = createQuestionProps();
-
-    const html = renderToStaticMarkup(
-      <PracticeView
-        sessionInfo={{
-          sessionId: 'session-1',
-          mode: 'exam',
-          index: 1,
-          total: 3,
-          isMarkedForReview: false,
-        }}
-        loadState={{ status: 'ready' }}
-        question={question}
-        selectedChoiceId={null}
-        isAnswered={false}
-        submitResult={null}
-        isPending={false}
-        bookmarkStatus="idle"
-        isBookmarked={false}
-        isMarkingForReview={false}
-        onEndSession={() => undefined}
-        onTryAgain={() => undefined}
-        onToggleBookmark={() => undefined}
-        onToggleMarkForReview={() => undefined}
-        onSelectChoice={() => undefined}
-        onNextQuestion={() => undefined}
-        onPreviousQuestion={() => undefined}
-        hasPreviousQuestion={true}
-        hasNextQuestion={true}
-      />,
-    );
-
-    const doc = new DOMParser().parseFromString(html, 'text/html');
     const primaryGroup = doc.querySelector(
       '[data-testid="exam-action-primary-group"]',
     );
+    const ctaGroup = doc.querySelector('[data-testid="exam-action-cta-group"]');
+
+    expect(getButtonLabels(primaryGroup)).toEqual(['Previous']);
+    expect(getButtonLabels(ctaGroup)).toEqual(['Review & Submit']);
+    expect(getButtonLabels(actionBar)).toEqual(['Previous', 'Review & Submit']);
+    expect(actionBar?.textContent).not.toContain('Mark for review');
+  });
+
+  it('groups active-exam Previous separately from the right-slot CTA and removes the secondary footer group', () => {
+    const html = renderExamView({ index: 1, total: 3 });
+    const doc = parse(html);
+    const primaryGroup = doc.querySelector(
+      '[data-testid="exam-action-primary-group"]',
+    );
+    const ctaGroup = doc.querySelector('[data-testid="exam-action-cta-group"]');
     const secondaryGroup = doc.querySelector(
       '[data-testid="exam-action-secondary-group"]',
     );
+    const headerActions = doc.querySelector(
+      '[data-testid="question-header-actions"]',
+    );
 
-    expect(
-      Array.from(primaryGroup?.querySelectorAll('button') ?? []).map((button) =>
-        button.textContent?.trim(),
-      ),
-    ).toEqual(['Previous', 'Next']);
-    expect(
-      Array.from(secondaryGroup?.querySelectorAll('button') ?? []).map(
-        (button) => button.textContent?.trim(),
-      ),
-    ).toEqual(['Mark for review']);
+    expect(getButtonLabels(primaryGroup)).toEqual(['Previous']);
+    expect(getButtonLabels(ctaGroup)).toEqual(['Next']);
+    expect(secondaryGroup).toBeNull();
+    expect(getButtonLabels(headerActions)).toEqual(['Mark for review']);
   });
 
   it('describes the last-question Review & Submit action for assistive tech', () => {
-    const question = createQuestionProps();
-
-    const html = renderToStaticMarkup(
-      <PracticeView
-        sessionInfo={{
-          sessionId: 'session-1',
-          mode: 'exam',
-          index: 1,
-          total: 2,
-          isMarkedForReview: false,
-        }}
-        loadState={{ status: 'ready' }}
-        question={question}
-        selectedChoiceId={null}
-        isAnswered={false}
-        submitResult={null}
-        isPending={false}
-        bookmarkStatus="idle"
-        isBookmarked={false}
-        onEndSession={() => undefined}
-        onTryAgain={() => undefined}
-        onToggleBookmark={() => undefined}
-        onToggleMarkForReview={() => undefined}
-        onSelectChoice={() => undefined}
-        onNextQuestion={() => undefined}
-        onPreviousQuestion={() => undefined}
-        hasPreviousQuestion={true}
-      />,
-    );
-
-    const doc = new DOMParser().parseFromString(html, 'text/html');
-    const nextButton = Array.from(doc.querySelectorAll('button')).find(
-      (button) => button.textContent?.trim() === 'Review & Submit',
-    );
+    const html = renderExamView({ index: 1, total: 2 });
+    const doc = parse(html);
+    const ctaGroup = doc.querySelector('[data-testid="exam-action-cta-group"]');
+    const nextButton = Array.from(
+      ctaGroup?.querySelectorAll('button') ?? [],
+    ).find((button) => button.textContent?.trim() === 'Review & Submit');
     const descriptionId = nextButton?.getAttribute('aria-describedby');
     const description = descriptionId
       ? doc.getElementById(descriptionId)
@@ -205,173 +189,159 @@ describe('PracticeView exam actions', () => {
     expect(description?.textContent).toBe('Opens review and submit.');
   });
 
-  it('keeps Next in position 2 on non-final exam questions even when hasNextQuestion is false', () => {
-    const question = createQuestionProps();
-    const html = renderToStaticMarkup(
-      <PracticeView
-        sessionInfo={{
-          sessionId: 'session-1',
-          mode: 'exam',
-          index: 0,
-          total: 2,
-          isMarkedForReview: false,
-        }}
-        loadState={{ status: 'ready' }}
-        question={question}
-        selectedChoiceId={null}
-        isAnswered={false}
-        submitResult={null}
-        isPending={false}
-        bookmarkStatus="idle"
-        isBookmarked={false}
-        onEndSession={() => undefined}
-        onTryAgain={() => undefined}
-        onToggleBookmark={() => undefined}
-        onToggleMarkForReview={() => undefined}
-        onSelectChoice={() => undefined}
-        onNextQuestion={() => undefined}
-        onPreviousQuestion={() => undefined}
-        hasPreviousQuestion={false}
-        hasNextQuestion={false}
-      />,
-    );
-
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+  it('keeps Next as the non-final exam CTA even when hasNextQuestion is false', () => {
+    const html = renderExamView({
+      index: 0,
+      total: 2,
+      props: { hasNextQuestion: false },
+    });
+    const doc = parse(html);
     const actionBar = doc.querySelector('[data-testid="bottom-action-bar"]');
-    if (!actionBar) throw new Error('Expected action bar');
+    const ctaGroup = doc.querySelector('[data-testid="exam-action-cta-group"]');
 
-    const labels = Array.from(actionBar.querySelectorAll('button')).map(
-      (button) => (button.textContent ?? '').trim(),
-    );
-
-    expect(labels).toEqual(['Next', 'Mark for review']);
+    expect(getButtonLabels(ctaGroup)).toEqual(['Next']);
+    expect(getButtonLabels(actionBar)).toEqual(['Next']);
+    expect(actionBar?.textContent).not.toContain('Mark for review');
     expect(html).not.toContain('Review answers');
   });
 
   it('does not render Submit in exam mode', () => {
-    const question = createQuestionProps();
-
-    const html = renderToStaticMarkup(
-      <PracticeView
-        sessionInfo={{
-          sessionId: 'session-1',
-          mode: 'exam',
-          index: 1,
-          total: 2,
-          isMarkedForReview: false,
-        }}
-        loadState={{ status: 'ready' }}
-        question={question}
-        selectedChoiceId={null}
-        isAnswered={false}
-        submitResult={null}
-        isPending={false}
-        bookmarkStatus="idle"
-        isBookmarked={false}
-        onEndSession={() => undefined}
-        onTryAgain={() => undefined}
-        onToggleBookmark={() => undefined}
-        onToggleMarkForReview={() => undefined}
-        onSelectChoice={() => undefined}
-        onNextQuestion={() => undefined}
-        onPreviousQuestion={() => undefined}
-        hasPreviousQuestion={true}
-        hasNextQuestion={false}
-      />,
-    );
+    const html = renderExamView({ index: 1, total: 2 });
 
     expect(html).not.toContain('>Submit<');
   });
 
-  it('keeps exam action bar labels stable when a draft selection exists', () => {
+  it('keeps exam footer labels stable when a draft selection exists', () => {
     const question = createQuestionProps();
     const selectedChoice = question.choices[0];
     if (!selectedChoice) {
       throw new Error('Expected at least one choice');
     }
 
-    const unansweredHtml = renderToStaticMarkup(
-      <PracticeView
-        sessionInfo={{
-          sessionId: 'session-1',
-          mode: 'exam',
-          index: 1,
-          total: 3,
-          isMarkedForReview: false,
-        }}
-        loadState={{ status: 'ready' }}
-        question={question}
-        selectedChoiceId={null}
-        isAnswered={false}
-        submitResult={null}
-        isPending={false}
-        bookmarkStatus="idle"
-        isBookmarked={false}
-        onTryAgain={() => undefined}
-        onToggleBookmark={() => undefined}
-        onToggleMarkForReview={() => undefined}
-        onSelectChoice={() => undefined}
-        onNextQuestion={() => undefined}
-        onPreviousQuestion={() => undefined}
-        hasPreviousQuestion={true}
-        hasNextQuestion={true}
-      />,
-    );
+    const unansweredHtml = renderExamView({ index: 1, total: 3 });
+    const draftedHtml = renderExamView({
+      index: 1,
+      total: 3,
+      selectedChoiceId: selectedChoice.id,
+    });
 
-    const draftedHtml = renderToStaticMarkup(
-      <PracticeView
-        sessionInfo={{
-          sessionId: 'session-1',
-          mode: 'exam',
-          index: 1,
-          total: 3,
-          isMarkedForReview: false,
-        }}
-        loadState={{ status: 'ready' }}
-        question={question}
-        selectedChoiceId={selectedChoice.id}
-        isAnswered={false}
-        submitResult={null}
-        isPending={false}
-        bookmarkStatus="idle"
-        isBookmarked={false}
-        onTryAgain={() => undefined}
-        onToggleBookmark={() => undefined}
-        onToggleMarkForReview={() => undefined}
-        onSelectChoice={() => undefined}
-        onNextQuestion={() => undefined}
-        onPreviousQuestion={() => undefined}
-        hasPreviousQuestion={true}
-        hasNextQuestion={true}
-      />,
-    );
-
-    const unansweredDoc = new DOMParser().parseFromString(
-      unansweredHtml,
-      'text/html',
-    );
-    const draftedDoc = new DOMParser().parseFromString(
-      draftedHtml,
-      'text/html',
-    );
+    const unansweredDoc = parse(unansweredHtml);
+    const draftedDoc = parse(draftedHtml);
     const unansweredActionBar = unansweredDoc.querySelector(
       '[data-testid="bottom-action-bar"]',
     );
     const draftedActionBar = draftedDoc.querySelector(
       '[data-testid="bottom-action-bar"]',
     );
-    if (!unansweredActionBar || !draftedActionBar) {
-      throw new Error('Expected action bar');
-    }
 
-    const unansweredLabels = Array.from(
-      unansweredActionBar.querySelectorAll('button'),
-    ).map((button) => (button.textContent ?? '').trim());
-    const draftedLabels = Array.from(
-      draftedActionBar.querySelectorAll('button'),
-    ).map((button) => (button.textContent ?? '').trim());
+    expect(getButtonLabels(unansweredActionBar)).toEqual(['Previous', 'Next']);
+    expect(getButtonLabels(draftedActionBar)).toEqual(['Previous', 'Next']);
+  });
 
-    expect(unansweredLabels).toEqual(['Previous', 'Next', 'Mark for review']);
-    expect(draftedLabels).toEqual(['Previous', 'Next', 'Mark for review']);
+  it('renders Mark for review in the exam header on every active exam question', () => {
+    const labelsByQuestion = [0, 1, 2].map((index) => {
+      const doc = parse(renderExamView({ index, total: 3 }));
+      return getButtonLabels(
+        doc.querySelector('[data-testid="question-header-actions"]'),
+      );
+    });
+
+    expect(labelsByQuestion).toEqual([
+      ['Mark for review'],
+      ['Mark for review'],
+      ['Mark for review'],
+    ]);
+  });
+
+  it('renders Unmark review with pressed state when the exam question is marked', () => {
+    const html = renderExamView({
+      index: 1,
+      total: 3,
+      isMarkedForReview: true,
+    });
+    const doc = parse(html);
+    const headerActions = doc.querySelector(
+      '[data-testid="question-header-actions"]',
+    );
+    const markButton = headerActions?.querySelector('button');
+
+    expect(getButtonLabels(headerActions)).toEqual(['Unmark review']);
+    expect(markButton?.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('renders unpressed Mark for review when the exam question is unmarked', () => {
+    const html = renderExamView({ index: 1, total: 3 });
+    const doc = parse(html);
+    const headerActions = doc.querySelector(
+      '[data-testid="question-header-actions"]',
+    );
+    const markButton = headerActions?.querySelector('button');
+
+    expect(getButtonLabels(headerActions)).toEqual(['Mark for review']);
+    expect(markButton?.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('disables the header Mark for review button while marking for review', () => {
+    const html = renderExamView({
+      props: { isMarkingForReview: true },
+    });
+    const doc = parse(html);
+    const markButton = doc.querySelector(
+      '[data-testid="question-header-actions"] button',
+    );
+
+    expect(markButton?.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('disables the header Mark for review button while the view is pending', () => {
+    const html = renderExamView({
+      props: { isPending: true },
+    });
+    const doc = parse(html);
+    const markButton = doc.querySelector(
+      '[data-testid="question-header-actions"] button',
+    );
+
+    expect(markButton?.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('disables the header Mark for review button while a question is loading', () => {
+    const html = renderExamView({
+      props: { loadState: { status: 'loading' } },
+    });
+    const doc = parse(html);
+    const markButton = doc.querySelector(
+      '[data-testid="question-header-actions"] button',
+    );
+
+    expect(markButton?.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('does not render Mark for review in the tutor header and preserves End session', () => {
+    const html = renderTutorView();
+    const doc = parse(html);
+    const buttonLabels = getButtonLabels(doc.body);
+
+    expect(buttonLabels).toContain('End session');
+    expect(buttonLabels).not.toContain('Mark for review');
+    expect(buttonLabels).not.toContain('Unmark review');
+  });
+
+  it('preserves tutor footer groups after feedback', () => {
+    const question = createQuestionProps();
+    const html = renderTutorView(
+      { question, hasPreviousQuestion: true, hasNextQuestion: true },
+      createCorrectSubmitResult(question),
+    );
+    const doc = parse(html);
+    const primaryGroup = doc.querySelector(
+      '[data-testid="tutor-action-primary-group"]',
+    );
+    const secondaryGroup = doc.querySelector(
+      '[data-testid="tutor-action-secondary-group"]',
+    );
+
+    expect(getButtonLabels(primaryGroup)).toEqual(['Previous', 'Next']);
+    expect(getButtonLabels(secondaryGroup)).toEqual(['Bookmark']);
   });
 });

--- a/app/(app)/app/practice/components/practice-view-layout.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-layout.test.tsx
@@ -209,6 +209,67 @@ describe('PracticeView layout', () => {
     expect(endButtons).toHaveLength(2);
   });
 
+  it('renders a scoped exam header action rail before the question area', () => {
+    const question = createNextQuestion({
+      questionId: 'question-1',
+      slug: 'question-1',
+      stemMd: 'Stem',
+      difficulty: 'easy',
+    });
+
+    const html = renderToStaticMarkup(
+      <PracticeView
+        title="Exam Session"
+        description="Question 1 of 3 — Explanations shown after you submit the exam."
+        sessionInfo={{
+          sessionId: 'session-1',
+          mode: 'exam',
+          index: 0,
+          total: 3,
+          isMarkedForReview: false,
+        }}
+        loadState={{ status: 'ready' }}
+        question={question}
+        selectedChoiceId={null}
+        isAnswered={false}
+        submitResult={null}
+        isPending={false}
+        bookmarkStatus="idle"
+        isBookmarked={false}
+        onEndSession={() => undefined}
+        onTryAgain={() => undefined}
+        onToggleBookmark={() => undefined}
+        onToggleMarkForReview={() => undefined}
+        onSelectChoice={() => undefined}
+        onNextQuestion={() => undefined}
+      />,
+    );
+
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const headerActions = doc.querySelector(
+      '[data-testid="question-header-actions"]',
+    );
+    const questionPanel = doc.querySelector(
+      '[data-testid="active-question-panel"]',
+    );
+
+    expect(headerActions).not.toBeNull();
+    expect(
+      Array.from(headerActions?.querySelectorAll('button') ?? []).map(
+        (button) => button.textContent?.trim(),
+      ),
+    ).toEqual(['Mark for review']);
+    expect(headerActions?.textContent).not.toContain('End session');
+
+    if (!headerActions) throw new Error('Expected header actions');
+    if (!questionPanel) throw new Error('Expected question panel');
+
+    const position = headerActions.compareDocumentPosition(questionPanel);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
   it('renders a question panel id for navigator aria-controls wiring', () => {
     const html = renderToStaticMarkup(
       <PracticeView

--- a/app/(app)/app/practice/components/practice-view-layout.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-layout.test.tsx
@@ -270,6 +270,53 @@ describe('PracticeView layout', () => {
     );
   });
 
+  it('renders the fallback back link when exam mode has no mark-for-review action', () => {
+    const question = createNextQuestion({
+      questionId: 'question-1',
+      slug: 'question-1',
+      stemMd: 'Stem',
+      difficulty: 'easy',
+    });
+
+    const html = renderToStaticMarkup(
+      <PracticeView
+        title="Exam Session"
+        description="Question 1 of 3 — Explanations shown after you submit the exam."
+        sessionInfo={{
+          sessionId: 'session-1',
+          mode: 'exam',
+          index: 0,
+          total: 3,
+          isMarkedForReview: false,
+        }}
+        loadState={{ status: 'ready' }}
+        question={question}
+        selectedChoiceId={null}
+        isAnswered={false}
+        submitResult={null}
+        isPending={false}
+        bookmarkStatus="idle"
+        isBookmarked={false}
+        onEndSession={() => undefined}
+        onTryAgain={() => undefined}
+        onToggleBookmark={() => undefined}
+        onSelectChoice={() => undefined}
+        onNextQuestion={() => undefined}
+      />,
+    );
+
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const headerActions = doc.querySelector(
+      '[data-testid="question-header-actions"]',
+    );
+    const backLink = headerActions?.querySelector('a');
+
+    expect(headerActions).not.toBeNull();
+    expect(headerActions?.querySelectorAll('button')).toHaveLength(0);
+    expect(backLink?.textContent).toBe('Back to Dashboard');
+    expect(backLink?.getAttribute('href')).toBe(ROUTES.APP_DASHBOARD);
+  });
+
   it('renders a question panel id for navigator aria-controls wiring', () => {
     const html = renderToStaticMarkup(
       <PracticeView

--- a/app/(app)/app/practice/components/practice-view.browser.spec.tsx
+++ b/app/(app)/app/practice/components/practice-view.browser.spec.tsx
@@ -95,7 +95,8 @@ test('supports exam controls and question interactions', async () => {
     />,
   );
 
-  await screen.getByRole('button', { name: 'Mark for review' }).click();
+  const headerActions = screen.getByTestId('question-header-actions');
+  await headerActions.getByRole('button', { name: 'Mark for review' }).click();
   expect(onToggleMarkForReview).toHaveBeenCalledTimes(1);
 
   await expect
@@ -168,10 +169,25 @@ test('renders the exam bottom action bar without sticky shell markers', async ()
     .element(screen.getByTestId('bottom-action-bar'))
     .toBeInTheDocument();
   await expect
-    .element(screen.getByRole('button', { name: 'Next' }))
+    .element(
+      screen
+        .getByTestId('bottom-action-bar')
+        .getByRole('button', { name: 'Next' }),
+    )
     .toBeVisible();
   await expect
-    .element(screen.getByRole('button', { name: 'Mark for review' }))
+    .element(
+      screen
+        .getByTestId('bottom-action-bar')
+        .getByRole('button', { name: 'Mark for review' }),
+    )
+    .not.toBeInTheDocument();
+  await expect
+    .element(
+      screen
+        .getByTestId('question-header-actions')
+        .getByRole('button', { name: 'Mark for review' }),
+    )
     .toBeVisible();
 });
 
@@ -335,7 +351,11 @@ test('disables mutation controls while internal question loading is in progress'
   );
 
   await expect
-    .element(examScreen.getByRole('button', { name: 'Mark for review' }))
+    .element(
+      examScreen
+        .getByTestId('question-header-actions')
+        .getByRole('button', { name: 'Mark for review' }),
+    )
     .toBeDisabled();
   await expect
     .element(examScreen.getByRole('radio', { name: 'Exam Option A' }))
@@ -618,7 +638,10 @@ test('calls onEndSession from the bottom-bar Review & Submit button on the last 
     />,
   );
 
-  await screen.getByRole('button', { name: 'Review & Submit' }).click();
+  await screen
+    .getByTestId('exam-action-cta-group')
+    .getByRole('button', { name: 'Review & Submit' })
+    .click();
   expect(onEndSession).toHaveBeenCalledTimes(1);
 });
 

--- a/app/(app)/app/practice/components/practice-view.tsx
+++ b/app/(app)/app/practice/components/practice-view.tsx
@@ -194,16 +194,13 @@ type ExamActionBarProps = Pick<
   PracticeViewProps,
   | 'hasPreviousQuestion'
   | 'canNavigatePrevious'
-  | 'isMarkingForReview'
   | 'isPending'
   | 'loadState'
   | 'onEndSession'
   | 'onNextQuestion'
   | 'onPreviousQuestion'
-  | 'onToggleMarkForReview'
 > & {
   isLastSessionQuestion: boolean;
-  isMarkedForReview: boolean;
 };
 
 function ExamActionBar(props: ExamActionBarProps) {
@@ -220,25 +217,29 @@ function ExamActionBar(props: ExamActionBarProps) {
     props.isLastSessionQuestion && props.onEndSession
       ? props.onEndSession
       : props.onNextQuestion;
-  const navigationGroup = (
-    <div
-      className="flex flex-wrap items-center gap-3"
-      data-testid="exam-action-primary-group"
-    >
-      {props.onPreviousQuestion ? (
-        props.hasPreviousQuestion ? (
-          <Button
-            type="button"
-            variant="outline"
-            className="rounded-full"
-            disabled={isPreviousDisabled}
-            onClick={props.onPreviousQuestion}
-          >
-            Previous
-          </Button>
-        ) : null
-      ) : null}
+  const navigationGroup =
+    props.onPreviousQuestion && props.hasPreviousQuestion ? (
+      <div
+        className="flex flex-wrap items-center gap-3"
+        data-testid="exam-action-primary-group"
+      >
+        <Button
+          type="button"
+          variant="outline"
+          className="rounded-full"
+          disabled={isPreviousDisabled}
+          onClick={props.onPreviousQuestion}
+        >
+          Previous
+        </Button>
+      </div>
+    ) : null;
 
+  const ctaGroup = (
+    <div
+      className="flex flex-wrap items-center gap-3 sm:ml-auto"
+      data-testid="exam-action-cta-group"
+    >
       {nextActionDescription ? (
         <span id={nextActionDescriptionId} className="sr-only">
           {nextActionDescription}
@@ -264,23 +265,7 @@ function ExamActionBar(props: ExamActionBarProps) {
   return (
     <>
       {navigationGroup}
-      {props.onToggleMarkForReview ? (
-        <div
-          className="flex flex-wrap items-center gap-3 sm:ml-auto"
-          data-testid="exam-action-secondary-group"
-        >
-          <Button
-            type="button"
-            variant="outline"
-            className="rounded-full"
-            aria-pressed={props.isMarkedForReview}
-            disabled={props.isMarkingForReview || isNavigationDisabled}
-            onClick={props.onToggleMarkForReview}
-          >
-            {props.isMarkedForReview ? 'Unmark review' : 'Mark for review'}
-          </Button>
-        </div>
-      ) : null}
+      {ctaGroup}
     </>
   );
 }
@@ -350,14 +335,11 @@ export function PracticeView(props: PracticeViewProps) {
           canNavigatePrevious={props.canNavigatePrevious}
           hasPreviousQuestion={props.hasPreviousQuestion}
           isLastSessionQuestion={isLastSessionQuestion}
-          isMarkedForReview={isMarkedForReview}
-          isMarkingForReview={props.isMarkingForReview}
           isPending={props.isPending}
           loadState={props.loadState}
           onEndSession={props.onEndSession}
           onNextQuestion={props.onNextQuestion}
           onPreviousQuestion={props.onPreviousQuestion}
-          onToggleMarkForReview={props.onToggleMarkForReview}
         />
       ) : (
         <TutorActionBar
@@ -398,7 +380,26 @@ export function PracticeView(props: PracticeViewProps) {
               {description}
             </p>
           </div>
-          <div className="flex items-center gap-3">
+          <div
+            className="flex items-center gap-3"
+            data-testid="question-header-actions"
+          >
+            {isExamMode && props.onToggleMarkForReview ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="rounded-full"
+                aria-pressed={isMarkedForReview}
+                disabled={
+                  props.isMarkingForReview ||
+                  props.isPending ||
+                  props.loadState.status === 'loading'
+                }
+                onClick={props.onToggleMarkForReview}
+              >
+                {isMarkedForReview ? 'Unmark review' : 'Mark for review'}
+              </Button>
+            ) : null}
             {props.onEndSession && !isExamMode ? (
               <Button
                 type="button"
@@ -411,7 +412,8 @@ export function PracticeView(props: PracticeViewProps) {
               >
                 {endSessionLabel}
               </Button>
-            ) : !props.onEndSession ? (
+            ) : !props.onEndSession &&
+              !(isExamMode && props.onToggleMarkForReview) ? (
               <Button
                 asChild
                 variant="link"

--- a/app/(app)/app/practice/components/practice-view.tsx
+++ b/app/(app)/app/practice/components/practice-view.tsx
@@ -412,8 +412,8 @@ export function PracticeView(props: PracticeViewProps) {
               >
                 {endSessionLabel}
               </Button>
-            ) : !props.onEndSession &&
-              !(isExamMode && props.onToggleMarkForReview) ? (
+            ) : (!isExamMode && !props.onEndSession) ||
+              (isExamMode && !props.onToggleMarkForReview) ? (
               <Button
                 asChild
                 variant="link"

--- a/docs/debt/debt-379-exam-action-bar-promote-primary-cta-to-right-slot.md
+++ b/docs/debt/debt-379-exam-action-bar-promote-primary-cta-to-right-slot.md
@@ -2,10 +2,10 @@
 
 **Priority:** P3 (layout-only refactor in a single component; behavior unchanged)
 **Created:** 2026-05-04
-**Source:** Same UX walkthrough that produced DEBT-378 (Claude Design V3 variant pass on 2026-05-04). The user's first-principles reading: exam's terminal / forward CTA should own the footer's far-right eye-anchor, while `Mark for review` should remain available but move out of the footer's primary-action slot. Today's exam footer puts `Next` / `Review & Submit` in the left navigation cluster with `Mark for review` pushed right via `sm:ml-auto`.
+**Source:** Same UX walkthrough that produced DEBT-378 (Claude Design V3 variant pass on 2026-05-04). The user's first-principles reading: exam's terminal / forward CTA should own the footer's far-right eye-anchor, while `Mark for review` should remain available but move out of the footer's primary-action slot. At discovery, the exam footer put `Next` / `Review & Submit` in the left navigation cluster with `Mark for review` pushed right via `sm:ml-auto`.
 **Related:** [DEBT-378 Tutor — drop Submit button (choice click commits) (archived)](../_archive/debt/debt-378-tutor-drop-submit-button-choice-click-commits.md), [DEBT-365 Exam flow affordance and label consistency (archived)](../_archive/debt/debt-365-exam-flow-affordance-and-label-consistency.md), [DEBT-363 Exam shell scroll model and dual-CTA disambiguation (archived)](../_archive/debt/debt-363-exam-shell-scroll-model-and-dual-cta.md), [DEBT-361 Exam last-question Next label (archived)](../_archive/debt/debt-361-exam-last-question-next-label.md), [DEBT-330 Post-exam review action bar bookmark placement (archived)](../_archive/debt/debt-330-review-action-bar-bookmark-placement.md), [Pattern Registry](../frontend/pattern-registry.md), [Frontend Standards](../frontend/standards.md), [Practice Page Docs](../frontend/pages/practice.md)
 
-**Status:** Open. Audit-refined 2026-05-04 against `e44b8380`; audit-corrected 2026-05-05 against `524c856e` after DEBT-378 landed. No production code change yet. Sequenced after DEBT-378 to keep one debt per shipping cycle. DEBT-379 should be re-graded visually after DEBT-378 lands because DEBT-378 already restores tutor/exam footer harmony.
+**Status:** Open. Audit-refined 2026-05-04 against `e44b8380`; audit-corrected 2026-05-05 against `524c856e` after DEBT-378 landed. Implementation is in PR #307 against `dev`; final archive and Resolution text wait for the post-merge archive commit so the actual merge SHA can be cited. Visual re-grade evidence is captured under `artifacts/debt-379-visuals/`.
 
 **Audit correction note (2026-05-05):** Current code has no header-rail assertions in `practice-view-layout.test.tsx`, and `docs/frontend/pattern-registry.md` has no dedicated exam action-bar or header-rail entries. Those tasks are **adds**, not updates. Existing deferred DEBT-379 rows in `docs/frontend/standards.md` and `docs/frontend/pages/practice.md` are updates.
 
@@ -13,7 +13,7 @@
 
 ## Context
 
-Today's exam footer (`app/(app)/app/practice/components/practice-view.tsx:209-285`, `ExamActionBar`):
+Pre-implementation exam footer (`app/(app)/app/practice/components/practice-view.tsx:209-285`, `ExamActionBar`):
 
 | Question | Primary group (left, `data-testid="exam-action-primary-group"`) | Secondary group (right, `sm:ml-auto`, `data-testid="exam-action-secondary-group"`) |
 |----------|------------------------------------------------------------|----------------------------------------------------------------------------------|
@@ -21,7 +21,7 @@ Today's exam footer (`app/(app)/app/practice/components/practice-view.tsx:209-28
 | Q2 | `[Previous]` outline, `[Next]` filled | `[Mark for review]` outline |
 | Q3 | `[Previous]` outline, `[Review & Submit]` filled | `[Mark for review]` outline |
 
-`Next` / `Review & Submit` sits at the inside-right of the navigation cluster. `Mark for review` is pushed to the screen's right edge via `sm:ml-auto`.
+`Next` / `Review & Submit` sat at the inside-right of the navigation cluster. `Mark for review` was pushed to the screen's right edge via `sm:ml-auto`.
 
 Mark for review is a **metadata** action ("flag this question for me to revisit during review-and-submit"). It's not a primary CTA. It's not a navigation control. It's a per-question annotation. Its current right-edge position was shipped by DEBT-365 Concern 3A after borrowing DEBT-330's post-exam review grouping principle: navigation clustered left, metadata separated right. The decision was correct in isolation: nav and metadata are conceptually distinct, so they shouldn't visually mingle.
 
@@ -439,7 +439,7 @@ Quality gates:
 
 ## Implementation Verification Checklist
 
-1. Confirm the exam header rail is currently empty for routed exam sessions. `practice-view.tsx:401-423` renders tutor `End session` when `props.onEndSession && !isExamMode`; exam mode with `onEndSession` renders no header button today.
+1. Baseline confirmed before implementation: routed exam sessions had an empty header rail because `practice-view.tsx:401-423` rendered tutor `End session` only when `props.onEndSession && !isExamMode`; exam mode with `onEndSession` rendered no header button. The shipped refactor fills that rail with `Mark for review` / `Unmark review` when available, and falls back to the back link when no mode-specific header action exists.
 
 2. Preserve existing Mark-for-review pending behavior. If `isMarkingForReview` flips true between click and server confirmation, the moved header button must disable exactly as the footer button did.
 

--- a/docs/debt/debt-379-exam-action-bar-promote-primary-cta-to-right-slot.md
+++ b/docs/debt/debt-379-exam-action-bar-promote-primary-cta-to-right-slot.md
@@ -5,13 +5,15 @@
 **Source:** Same UX walkthrough that produced DEBT-378 (Claude Design V3 variant pass on 2026-05-04). The user's first-principles reading: exam's terminal / forward CTA should own the footer's far-right eye-anchor, while `Mark for review` should remain available but move out of the footer's primary-action slot. Today's exam footer puts `Next` / `Review & Submit` in the left navigation cluster with `Mark for review` pushed right via `sm:ml-auto`.
 **Related:** [DEBT-378 Tutor — drop Submit button (choice click commits) (archived)](../_archive/debt/debt-378-tutor-drop-submit-button-choice-click-commits.md), [DEBT-365 Exam flow affordance and label consistency (archived)](../_archive/debt/debt-365-exam-flow-affordance-and-label-consistency.md), [DEBT-363 Exam shell scroll model and dual-CTA disambiguation (archived)](../_archive/debt/debt-363-exam-shell-scroll-model-and-dual-cta.md), [DEBT-361 Exam last-question Next label (archived)](../_archive/debt/debt-361-exam-last-question-next-label.md), [DEBT-330 Post-exam review action bar bookmark placement (archived)](../_archive/debt/debt-330-review-action-bar-bookmark-placement.md), [Pattern Registry](../frontend/pattern-registry.md), [Frontend Standards](../frontend/standards.md), [Practice Page Docs](../frontend/pages/practice.md)
 
-**Status:** Open. Audit-refined 2026-05-04 against `e44b8380`; no code change yet. Sequenced after DEBT-378 to keep one debt per shipping cycle. DEBT-379 should be re-graded visually after DEBT-378 lands because DEBT-378 already restores tutor/exam footer harmony.
+**Status:** Open. Audit-refined 2026-05-04 against `e44b8380`; audit-corrected 2026-05-05 against `524c856e` after DEBT-378 landed. No production code change yet. Sequenced after DEBT-378 to keep one debt per shipping cycle. DEBT-379 should be re-graded visually after DEBT-378 lands because DEBT-378 already restores tutor/exam footer harmony.
+
+**Audit correction note (2026-05-05):** Current code has no header-rail assertions in `practice-view-layout.test.tsx`, and `docs/frontend/pattern-registry.md` has no dedicated exam action-bar or header-rail entries. Those tasks are **adds**, not updates. Existing deferred DEBT-379 rows in `docs/frontend/standards.md` and `docs/frontend/pages/practice.md` are updates.
 
 ---
 
 ## Context
 
-Today's exam footer (`app/(app)/app/practice/components/practice-view.tsx:223-300`, `ExamActionBar`):
+Today's exam footer (`app/(app)/app/practice/components/practice-view.tsx:209-285`, `ExamActionBar`):
 
 | Question | Primary group (left, `data-testid="exam-action-primary-group"`) | Secondary group (right, `sm:ml-auto`, `data-testid="exam-action-secondary-group"`) |
 |----------|------------------------------------------------------------|----------------------------------------------------------------------------------|
@@ -163,7 +165,7 @@ Mark for review moves out of the footer entirely.
 
 ### Exam header rail — final spec
 
-A new button rendered on every exam question, positioned in the header rail at the right side (mirroring tutor's `End session` placement at `practice-view.tsx:424-435`). Add a stable selector to the header-action rail, e.g. `data-testid="question-header-actions"`, so tests can scope header-vs-footer assertions without class-token or position queries.
+A new button rendered on every exam question, positioned in the header rail at the right side (mirroring tutor's `End session` placement at `practice-view.tsx:402-413`). Add a stable selector to the header-action rail, e.g. `data-testid="question-header-actions"`, so tests can scope header-vs-footer assertions without class-token or position queries.
 
 ```tsx
 const isHeaderActionDisabled =
@@ -202,13 +204,13 @@ The DEBT-361 annotation that connects the Q3 `Review & Submit` button to a hidde
 
 ### File 1: `app/(app)/app/practice/components/practice-view.tsx`
 
-**`ExamActionBar` (lines 223-300):** restructure.
+**`ExamActionBar` (lines 209-285):** restructure.
 
 Removals:
-- Lines 281-296 — entire secondary group containing Mark for review
+- Lines 267-283 — entire secondary group containing Mark for review
 
 Changes:
-- Lines 237-275 — split left Previous group from right CTA group:
+- Lines 223-260 — split left Previous group from right CTA group:
   - Render `Previous` in the left group only when it exists. Suppress the left group entirely on Q1 instead of rendering an empty flex row.
   - Render Next / Review & Submit in a separate right CTA group with `sm:ml-auto`.
   - Maintain the `isLastSessionQuestion` branching for Next ↔ Review & Submit label flip and the `aria-describedby` link.
@@ -217,14 +219,14 @@ Changes:
   - Add `exam-action-cta-group` for the right CTA group.
   - `exam-action-secondary-group` testid is deleted (no secondary group in the footer anymore).
 
-**Header rail JSX (lines ~400-435):** add a new exam-mode Mark for review button.
+**Header rail JSX (lines ~385-423):** add a new exam-mode Mark for review button.
 
-Today line 424-435 is the tutor-only `End session` block. Add a sibling exam-only `Mark for review` / `Unmark review` block alongside it, gated by `isExamMode && props.onToggleMarkForReview`. The header layout already has flex space for a single right-side button in each mode. Add `data-testid="question-header-actions"` to the rail wrapper for scoped assertions.
+Today lines 401-423 contain the header action rail: tutor mode renders `End session` at lines 402-413 when `props.onEndSession && !isExamMode`, and the fallback back link renders only when `!props.onEndSession`. Exam mode with `onEndSession` renders no header button today. Add a sibling exam-only `Mark for review` / `Unmark review` block in that rail, gated by `isExamMode && props.onToggleMarkForReview`. The header layout already has flex space for a single right-side button in each mode. Add `data-testid="question-header-actions"` to the rail wrapper for scoped assertions.
 
 **Props:**
-- `ExamActionBarProps` (lines 207-221) — drops `isMarkingForReview`, `isMarkedForReview`, `onToggleMarkForReview`.
-- `PracticeViewProps` already has `isMarkingForReview?: boolean` and `onToggleMarkForReview?: () => void` at `practice-view.tsx:34,45`.
-- `isMarkedForReview` is not a top-level prop; it is derived from `sessionInfo` at `practice-view.tsx:306` and should be reused by the header button.
+- `ExamActionBarProps` (lines 193-207) — drops `isMarkingForReview`, `isMarkedForReview`, `onToggleMarkForReview`.
+- `PracticeViewProps` already has `isMarkingForReview?: boolean` and `onToggleMarkForReview?: () => void` at `practice-view.tsx:34,44`.
+- `isMarkedForReview` is not a top-level prop; it is derived from `sessionInfo` at `practice-view.tsx:292` and should be reused by the header button.
 
 ### File 2: parent components / page views that pass props to `PracticeView`
 
@@ -238,8 +240,8 @@ Files to verify:
 
 | File | Lines (approx) | Change type |
 |------|----------------|-------------|
-| `practice-view.tsx` ExamActionBar | 223-300 | Restructure: drop secondary group, promote primary CTA to right slot |
-| `practice-view.tsx` header rail | ~400-435 | Add exam-mode Mark for review button alongside tutor `End session` |
+| `practice-view.tsx` ExamActionBar | 209-285 | Restructure: drop secondary group, promote primary CTA to right slot |
+| `practice-view.tsx` header rail | ~385-423 | Add exam-mode Mark for review button alongside tutor `End session` |
 | Total | ~80-120 lines touched | Net flat or small positive (header gains > footer loses) |
 
 Choice button, QuestionCard, controllers, repositories, use cases: zero changes.
@@ -252,10 +254,13 @@ Choice button, QuestionCard, controllers, repositories, use cases: zero changes.
 
 **`practice-view-exam-actions.test.tsx`:**
 
-- Lines 15-66 — Q1 exam action bar, asserts `['Next', 'Mark for review']` — **REWRITE**: Q1 footer asserts `['Next']` only; new test asserts header Mark for review exists.
-- Lines 68-113 — Q3 exam action bar, asserts `['Previous', 'Review & Submit', 'Mark for review']` — **REWRITE**: Q3 footer asserts `['Previous', 'Review & Submit']`; new test asserts header Mark for review exists on Q3.
-- Lines 115-168 — primary/secondary group separation — **REWRITE**: assert footer has no secondary group; assert header rail has the Mark for review button.
-- Lines 170-214 — `aria-describedby` Q3 annotation — **KEEP** (annotation travels with the button to its new right-slot position; test should still pass with possible selector updates).
+- Lines 15-64 — Q1 exam action bar, asserts `['Next', 'Mark for review']` — **REWRITE**: Q1 footer asserts `['Next']` only; new test asserts header Mark for review exists.
+- Lines 66-109 — Q3 exam action bar, asserts `['Previous', 'Review & Submit', 'Mark for review']` — **REWRITE**: Q3 footer asserts `['Previous', 'Review & Submit']`; new test asserts header Mark for review exists on Q3.
+- Lines 111-162 — primary/secondary group separation — **REWRITE**: assert footer has no secondary group; assert header rail has the Mark for review button.
+- Lines 164-206 — `aria-describedby` Q3 annotation — **KEEP** (annotation travels with the button to its new right-slot position; test should still pass with possible selector updates).
+- Lines 208-249 — non-final exam question with `hasNextQuestion=false`, asserts `['Next', 'Mark for review']` — **REWRITE**: footer asserts `['Next']`; header asserts Mark for review exists.
+- Lines 251-284 — no Submit in exam mode — **KEEP**.
+- Lines 286-376 — draft-selection label stability, asserts footer `['Previous', 'Next', 'Mark for review']` — **REWRITE**: footer asserts `['Previous', 'Next']` for both states; header assertions cover Mark for review.
 
 Add new tests:
 - Header rail in exam mode renders `Mark for review` on Q1, Q2, Q3.
@@ -269,16 +274,19 @@ Add new tests:
 
 **`practice-view-layout.test.tsx`:**
 
-- Audit for any layout structure assertions referencing `exam-action-secondary-group` — update to reflect the absence of that group post-refactor.
-- Layout assertions on the question header rail — update to expect a single exam-mode Mark/Unmark button in `data-testid="question-header-actions"`. Do not assert it appears alongside `End session`; exam mode has no header `End session`.
+- Current file has no `exam-action-secondary-group`, `question-header-actions`, `Mark for review`, or header-rail assertions at `524c856e`.
+- **ADD** focused layout assertions that the header action rail exposes `data-testid="question-header-actions"` and contains a single exam-mode Mark/Unmark button. Do not assert it appears alongside `End session`; exam mode has no header `End session`.
+- Preserve the existing page layout assertions (top content, below-heading content, aria-live, question-panel wiring, terminal session action rendering).
 
 ### Browser specs
 
 **`practice-view.browser.spec.tsx`:**
 
 - Tests asserting Mark for review click behavior in the exam footer — **MOVE** the click target to the header rail.
-- Lines 595-648 (Review & Submit click in exam Q3) — verify the click still works after the right-slot move; selector may change but behavior is identical.
-- Lines 91-120 / 122-182 / 262-355 may need selector updates because Mark for review no longer lives in `bottom-action-bar`.
+- Lines 87-116 — Mark for review click behavior — move the click target to the header rail.
+- Lines 118-176 — exam bottom action bar currently asserts global Mark for review visibility — update to prove the footer has no Mark button and the header rail has it.
+- Lines 254-343 — loading disabled state for Mark for review — move the assertion to the header rail.
+- Lines 573-623 — Review & Submit click in exam Q3 — verify the click still works after the right-slot move; selector should scope to `exam-action-cta-group` or the bottom action bar's CTA group.
 
 ### Integration tests
 
@@ -308,9 +316,9 @@ Smaller surface than DEBT-378.
 
 ### `docs/frontend/pattern-registry.md`
 
-- **Exam action bar entry** (search for E-something or look in the action-bar section): update structure to reflect the right-slot promotion.
-- **Mark for review entry:** if registered, update placement note.
-- **Header rail / persistent header pattern:** update to include exam-mode Mark for review alongside tutor-mode `End session`.
+- **ADD** a dedicated active exam action-bar entry. No dedicated exam action-bar entry exists at `524c856e`; do not just append a sentence to an unrelated table row. The new entry must document Previous in the left group, `Next` / `Review & Submit` in `data-testid="exam-action-cta-group"` with `sm:ml-auto`, and no footer Mark-for-review button.
+- **ADD** a dedicated question header rail / persistent header action entry. No dedicated header-rail pattern exists at `524c856e`; the only related references are the Button Variant Usage Guide around lines 539-553 and the generic responsive note around line 1225. The new entry must document tutor-mode `End session` and exam-mode `Mark for review` as mode-specific single-button header rail actions.
+- **Mark for review entry:** if one is created during this work, document that active-exam placement is the question header rail, not the footer.
 
 ### `docs/frontend/standards.md`
 
@@ -403,7 +411,7 @@ Tests:
 
 Docs:
 
-- Pattern Registry exam action bar / header rail entries updated.
+- Pattern Registry exam action bar / header rail entries added.
 - Standards.md primary-CTA-position consolidation rule documented.
 - pages/practice.md exam Action Bar subsection rewritten.
 - This DEBT-379 doc moves to `_archive/debt/` with Resolution section.
@@ -431,7 +439,7 @@ Quality gates:
 
 ## Implementation Verification Checklist
 
-1. Confirm the exam header rail is currently empty for routed exam sessions. `practice-view.tsx:424-444` renders tutor `End session` when `!isExamMode`; exam mode with `onEndSession` renders no header button today.
+1. Confirm the exam header rail is currently empty for routed exam sessions. `practice-view.tsx:401-423` renders tutor `End session` when `props.onEndSession && !isExamMode`; exam mode with `onEndSession` renders no header button today.
 
 2. Preserve existing Mark-for-review pending behavior. If `isMarkingForReview` flips true between click and server confirmation, the moved header button must disable exactly as the footer button did.
 

--- a/docs/frontend/pages/practice.md
+++ b/docs/frontend/pages/practice.md
@@ -2,7 +2,7 @@
 
 **Page:** `/app/practice`
 **Source:** `app/(app)/app/practice/page.tsx` (server) → `practice-page-client.tsx` (client)
-**Last Updated:** 2026-05-04
+**Last Updated:** 2026-05-06
 
 ---
 
@@ -192,7 +192,21 @@ Tutor footer shape is derived from `hasPreviousQuestion` / `hasNextQuestion`; th
 | First/middle question post-feedback (`hasNextQuestion`) | `Previous` when available + filled `Next` | `Bookmark` (`sm:ml-auto`) | Feedback unlocks sequential navigation. |
 | Last question post-feedback (`!hasNextQuestion`) | `Previous` when available + filled `End session` | `Bookmark` (`sm:ml-auto`) | Header `End session` stays visible; the same-label header + footer terminal duplicate is intentional and both call `onEndSession`. |
 
-Exam mode keeps its existing footer contract in this debt. The exam right-slot primary CTA promotion is tracked separately by DEBT-379 and is not part of the DEBT-378 shipped state.
+Exam mode keeps answers draft-only until exam review/finalization. Its active footer places the primary CTA in the right slot:
+
+| State | Exam footer left cluster | Exam footer right cluster | Notes |
+|-------|--------------------------|---------------------------|-------|
+| First question | none | filled `Next` in `data-testid="exam-action-cta-group"` | Empty primary group is suppressed. |
+| Middle question | `Previous` in `data-testid="exam-action-primary-group"` | filled `Next` in `data-testid="exam-action-cta-group"` with `sm:ml-auto` | Draft selections do not change footer labels. |
+| Last question | `Previous` in `data-testid="exam-action-primary-group"` | filled `Review & Submit` in `data-testid="exam-action-cta-group"` with `sm:ml-auto` | Keeps the hidden `Opens review and submit.` description for assistive tech. |
+
+Exam footers do not render `Mark for review`; that toggle belongs to the header rail.
+
+### Header Rail
+
+**Source:** `PracticeView` header action rail (`data-testid="question-header-actions"`)
+
+Tutor mode renders the persistent outline `End session` action in the header whenever `onEndSession` is available. Exam mode renders the persistent outline `Mark for review` / `Unmark review` toggle in the same rail whenever `onToggleMarkForReview` is available, with `aria-pressed` reflecting review state and disabled state following mark-in-flight, pending, and question-loading states.
 
 ### Choice Click Semantics
 

--- a/docs/frontend/pattern-registry.md
+++ b/docs/frontend/pattern-registry.md
@@ -1,6 +1,6 @@
 # Pattern Registry
 
-**Last Updated:** 2026-05-04
+**Last Updated:** 2026-05-06
 **Status:** Canonical — all UI changes MUST conform to this registry
 
 Single source of truth for every visual pattern in the app. If a pattern isn't here, don't invent one — add it here first, get approval, then implement.
@@ -550,7 +550,33 @@ All standalone action buttons in the app use `rounded-full`:
 | Tutor terminal session action | `default` + `rounded-full` | Footer "End session" on the last tutor question after feedback |
 | Error recovery | `outline` (no `rounded-full`) | "Try again", "Return to dashboard" |
 
-**End session usage:** In tutor sessions, `End session` is always present in the header as the low-friction exit and also appears as the filled footer terminal CTA on the last question after feedback has rendered. The duplicate same-label Q3 state is intentional; both buttons call `onEndSession` (DEBT-378). Exam mode still does not expose a header bail button.
+**End session usage:** In tutor sessions, `End session` is always present in the header as the low-friction exit and also appears as the filled footer terminal CTA on the last question after feedback has rendered. The duplicate same-label Q3 state is intentional; both buttons call `onEndSession` (DEBT-378). Exam mode does not expose a header bail button; its header rail owns only the Mark-for-review toggle.
+
+### Active Exam Action Bar
+
+**Source:** `ExamActionBar` in `app/(app)/app/practice/components/practice-view.tsx`
+
+Active exam sessions defer correctness until `Review & Submit`, so the footer is navigation-only. The primary exam CTA must own the right slot.
+
+| Session position | Left group | Right CTA group | Notes |
+|------------------|------------|-----------------|-------|
+| First question | none | filled `Next` in `data-testid="exam-action-cta-group"` | Suppress empty `exam-action-primary-group`; do not render Mark for review in the footer. |
+| Middle question | outline `Previous` in `data-testid="exam-action-primary-group"` | filled `Next` in `data-testid="exam-action-cta-group"` with `sm:ml-auto` | Draft selections do not change footer labels. |
+| Final question | outline `Previous` in `data-testid="exam-action-primary-group"` | filled `Review & Submit` in `data-testid="exam-action-cta-group"` with `sm:ml-auto` | Preserve the `aria-describedby` text: `Opens review and submit.` |
+
+`data-testid="exam-action-secondary-group"` is intentionally absent after DEBT-379; there is no footer secondary group in active exam mode.
+
+### Header Rail / Persistent Header Actions
+
+**Source:** header action rail in `PracticeView` (`data-testid="question-header-actions"`)
+
+The page header action rail holds one mode-specific persistent action:
+
+| Mode | Header action | Notes |
+|------|---------------|-------|
+| Tutor / Quick Practice | outline `End session` when `onEndSession` is provided | This is the low-friction exit and remains independent of the tutor footer terminal CTA. |
+| Exam | outline `Mark for review` / `Unmark review` when `onToggleMarkForReview` is provided | Uses `aria-pressed`, disables while marking, while pending, or while the next question is loading. |
+| No session action | header action link | Falls back to the page-level back link when no session action is available. |
 
 **Removed tutor affordances:** Active tutor sessions no longer render a footer `Submit`, `Submitting…`, pre-feedback `Next`, or footer `View Summary`. Before feedback, the choice cards are the primary action; skip-without-answering is handled by the question navigator in active sessions.
 

--- a/docs/frontend/standards.md
+++ b/docs/frontend/standards.md
@@ -1,6 +1,6 @@
 # Frontend Standards
 
-**Last Updated:** 2026-05-04
+**Last Updated:** 2026-05-06
 
 Canonical reference for all frontend patterns, component usage, accessibility, and styling conventions. Every UI change MUST be consistent with this document. If a pattern isn't documented here, don't invent one — add it here first.
 
@@ -112,9 +112,13 @@ Active practice action bars use mode-specific semantics:
 | Tutor, middle/last question pre-feedback (`hasPreviousQuestion`) | `Previous` only | none | No footer `Submit`, `Submitting…`, or pre-feedback `Next`. Non-sequential skip is via the question navigator in active sessions. |
 | Tutor / Quick Practice, post-feedback non-terminal (`hasNextQuestion`) | `Previous` when available + filled `Next` | `Bookmark` with `sm:ml-auto` when feedback exists | `Next` appears only after feedback has rendered. |
 | Tutor, post-feedback terminal (`!hasNextQuestion`) | `Previous` + filled `End session` | `Bookmark` with `sm:ml-auto` | Header `End session` remains visible too; the duplicate same-label terminal state is intentional. |
-| Exam active session | Existing exam footer contract | Existing exam footer contract | Exam right-slot primary CTA promotion is deferred to DEBT-379 and must not be documented as shipped until that debt lands. |
+| Exam active session, first question | none | filled `Next` in `exam-action-cta-group` | Suppress empty `exam-action-primary-group`; Mark for review lives in the header rail. |
+| Exam active session, middle question | `Previous` only | filled `Next` in `exam-action-cta-group` with `sm:ml-auto` | Draft selections do not change footer labels. |
+| Exam active session, final question | `Previous` only | filled `Review & Submit` in `exam-action-cta-group` with `sm:ml-auto` | Preserve the hidden `Opens review and submit.` description for assistive tech. |
 
 In tutor mode and Quick Practice, the choice cards themselves act as the primary action pre-feedback. The footer carries only backward navigation before feedback and sequential/terminal navigation after feedback.
+
+In exam mode, the primary CTA always sits in the footer right slot. The footer never contains `Mark for review`; the header action rail owns the Mark/Unmark toggle with `aria-pressed` state.
 
 ### Card
 

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -243,9 +243,15 @@ test.describe('practice', () => {
     await expect(
       page.getByRole('button', { name: 'Submit', exact: true }),
     ).toHaveCount(0);
+    const questionHeaderActions = page.getByTestId('question-header-actions');
     await expect(
-      page.getByRole('button', { name: 'Mark for review' }),
+      questionHeaderActions.getByRole('button', { name: 'Mark for review' }),
     ).toBeVisible();
+    await expect(
+      page
+        .getByTestId('bottom-action-bar')
+        .getByRole('button', { name: 'Mark for review' }),
+    ).toHaveCount(0);
     await expect(
       page.getByRole('button', { name: 'Review & Submit' }),
     ).toBeVisible();


### PR DESCRIPTION
Summary

- ExamActionBar primary CTA (Next / Review & Submit) promoted to right slot via data-testid="exam-action-cta-group"; Previous left-only; Q1 suppresses the empty primary group.
- Mark for review relocated to the exam header rail (data-testid="question-header-actions"), preserving aria-pressed, disabled state, and DEBT-361's aria-describedby link on Q3.
- Tutor mode footer + header unchanged (regression-guarded).

Spec

docs/debt/debt-379-exam-action-bar-promote-primary-cta-to-right-slot.md (audit-corrected at 3fe38ebf)

Test plan

- Unit: practice-view-exam-actions, practice-view-layout, full practice slice
- Browser: practice-view.browser.spec footer/header selector moves
- E2E: exam walkthrough Mark for review now in header rail
- Visual: Q1/Q2/Q3 desktop + mobile, marked + unmarked

Visual evidence

- artifacts/debt-379-visuals/report.json
- artifacts/debt-379-visuals/desktop-q1-unmarked.png
- artifacts/debt-379-visuals/desktop-q1-marked.png
- artifacts/debt-379-visuals/desktop-q2-unmarked.png
- artifacts/debt-379-visuals/desktop-q2-marked.png
- artifacts/debt-379-visuals/desktop-q3-unmarked.png
- artifacts/debt-379-visuals/desktop-q3-marked.png
- artifacts/debt-379-visuals/mobile-q1-unmarked.png
- artifacts/debt-379-visuals/mobile-q1-marked.png
- artifacts/debt-379-visuals/mobile-q2-unmarked.png
- artifacts/debt-379-visuals/mobile-q2-marked.png
- artifacts/debt-379-visuals/mobile-q3-unmarked.png
- artifacts/debt-379-visuals/mobile-q3-marked.png

Validation

- pnpm db:test:up
- DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:migrate
- SEED_INCLUDE_PLACEHOLDERS=true DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:seed
- pnpm typecheck
- pnpm lint (existing noExcessiveLinesPerFile warnings only)
- pnpm test --run (302 files / 2416 tests)
- pnpm test:browser (48 files / 265 tests)
- pnpm test:integration (16 files / 97 tests)
- pnpm build
- pnpm test:e2e (35/35)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exam-mode header rail now exposes a "Mark for review" toggle; primary forward CTA is moved to a right-aligned CTA slot.

* **Refactor**
  * Exam action bar reorganized to separate navigation and primary CTA behavior for clearer per-question flows.

* **Tests**
  * Updated and added tests to verify header rail actions, right-slot primary CTA, and exam footer/CTA visibility.

* **Documentation**
  * Expanded docs and standards to describe exam-mode header/footer behavior and accessibility notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->