### PR TITLE
feat(exam): cluster Previous + primary CTA in unified left group (DEBT-380)

### DIFF
--- a/app/(app)/app/practice/components/practice-view-exam-actions.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-exam-actions.test.tsx
@@ -120,40 +120,45 @@ function createCorrectSubmitResult(
 }
 
 describe('PracticeView exam actions', () => {
-  it('renders first-question exam footer with only the right-slot Next CTA', () => {
+  it('renders first-question exam footer with only the Next CTA in the unified left cluster', () => {
     const html = renderExamView({ index: 0, total: 3 });
     const doc = parse(html);
     const actionBar = doc.querySelector('[data-testid="bottom-action-bar"]');
     const primaryGroup = doc.querySelector(
       '[data-testid="exam-action-primary-group"]',
     );
-    const ctaGroup = doc.querySelector('[data-testid="exam-action-cta-group"]');
 
     expect(actionBar).not.toBeNull();
-    expect(primaryGroup).toBeNull();
-    expect(getButtonLabels(ctaGroup)).toEqual(['Next']);
+    expect(getButtonLabels(primaryGroup)).toEqual(['Next']);
     expect(getButtonLabels(actionBar)).toEqual(['Next']);
     expect(actionBar?.textContent).not.toContain('Mark for review');
+    expect(
+      doc.querySelector('[data-testid="exam-action-cta-group"]'),
+    ).toBeNull();
     expect(html).not.toContain('>Submit<');
     expect(html).not.toContain('>Previous<');
   });
 
-  it('renders final-question exam footer with Previous left and Review & Submit right', () => {
+  it('renders final-question exam footer with Previous and Review & Submit in the unified left cluster', () => {
     const html = renderExamView({ index: 2, total: 3 });
     const doc = parse(html);
     const actionBar = doc.querySelector('[data-testid="bottom-action-bar"]');
     const primaryGroup = doc.querySelector(
       '[data-testid="exam-action-primary-group"]',
     );
-    const ctaGroup = doc.querySelector('[data-testid="exam-action-cta-group"]');
 
-    expect(getButtonLabels(primaryGroup)).toEqual(['Previous']);
-    expect(getButtonLabels(ctaGroup)).toEqual(['Review & Submit']);
+    expect(getButtonLabels(primaryGroup)).toEqual([
+      'Previous',
+      'Review & Submit',
+    ]);
     expect(getButtonLabels(actionBar)).toEqual(['Previous', 'Review & Submit']);
     expect(actionBar?.textContent).not.toContain('Mark for review');
+    expect(
+      doc.querySelector('[data-testid="exam-action-cta-group"]'),
+    ).toBeNull();
   });
 
-  it('groups active-exam Previous separately from the right-slot CTA and removes the secondary footer group', () => {
+  it('groups active-exam Previous and Next together and removes right-side footer groups', () => {
     const html = renderExamView({ index: 1, total: 3 });
     const doc = parse(html);
     const primaryGroup = doc.querySelector(
@@ -167,18 +172,25 @@ describe('PracticeView exam actions', () => {
       '[data-testid="question-header-actions"]',
     );
 
-    expect(getButtonLabels(primaryGroup)).toEqual(['Previous']);
-    expect(getButtonLabels(ctaGroup)).toEqual(['Next']);
+    expect(getButtonLabels(primaryGroup)).toEqual(['Previous', 'Next']);
+    expect(ctaGroup).toBeNull();
     expect(secondaryGroup).toBeNull();
+    expect(
+      doc.querySelector(
+        '[data-testid="bottom-action-bar"] [class*="sm:ml-auto"]',
+      ),
+    ).toBeNull();
     expect(getButtonLabels(headerActions)).toEqual(['Mark for review']);
   });
 
   it('describes the last-question Review & Submit action for assistive tech', () => {
     const html = renderExamView({ index: 1, total: 2 });
     const doc = parse(html);
-    const ctaGroup = doc.querySelector('[data-testid="exam-action-cta-group"]');
+    const primaryGroup = doc.querySelector(
+      '[data-testid="exam-action-primary-group"]',
+    );
     const nextButton = Array.from(
-      ctaGroup?.querySelectorAll('button') ?? [],
+      primaryGroup?.querySelectorAll('button') ?? [],
     ).find((button) => button.textContent?.trim() === 'Review & Submit');
     const descriptionId = nextButton?.getAttribute('aria-describedby');
     const description = descriptionId
@@ -197,11 +209,16 @@ describe('PracticeView exam actions', () => {
     });
     const doc = parse(html);
     const actionBar = doc.querySelector('[data-testid="bottom-action-bar"]');
-    const ctaGroup = doc.querySelector('[data-testid="exam-action-cta-group"]');
+    const primaryGroup = doc.querySelector(
+      '[data-testid="exam-action-primary-group"]',
+    );
 
-    expect(getButtonLabels(ctaGroup)).toEqual(['Next']);
+    expect(getButtonLabels(primaryGroup)).toEqual(['Next']);
     expect(getButtonLabels(actionBar)).toEqual(['Next']);
     expect(actionBar?.textContent).not.toContain('Mark for review');
+    expect(
+      doc.querySelector('[data-testid="exam-action-cta-group"]'),
+    ).toBeNull();
     expect(html).not.toContain('Review answers');
   });
 

--- a/app/(app)/app/practice/components/practice-view.browser.spec.tsx
+++ b/app/(app)/app/practice/components/practice-view.browser.spec.tsx
@@ -639,7 +639,7 @@ test('calls onEndSession from the bottom-bar Review & Submit button on the last 
   );
 
   await screen
-    .getByTestId('exam-action-cta-group')
+    .getByTestId('exam-action-primary-group')
     .getByRole('button', { name: 'Review & Submit' })
     .click();
   expect(onEndSession).toHaveBeenCalledTimes(1);

--- a/app/(app)/app/practice/components/practice-view.tsx
+++ b/app/(app)/app/practice/components/practice-view.tsx
@@ -217,12 +217,12 @@ function ExamActionBar(props: ExamActionBarProps) {
     props.isLastSessionQuestion && props.onEndSession
       ? props.onEndSession
       : props.onNextQuestion;
-  const navigationGroup =
-    props.onPreviousQuestion && props.hasPreviousQuestion ? (
-      <div
-        className="flex flex-wrap items-center gap-3"
-        data-testid="exam-action-primary-group"
-      >
+  const navigationGroup = (
+    <div
+      className="flex flex-wrap items-center gap-3"
+      data-testid="exam-action-primary-group"
+    >
+      {props.onPreviousQuestion && props.hasPreviousQuestion ? (
         <Button
           type="button"
           variant="outline"
@@ -232,14 +232,8 @@ function ExamActionBar(props: ExamActionBarProps) {
         >
           Previous
         </Button>
-      </div>
-    ) : null;
+      ) : null}
 
-  const ctaGroup = (
-    <div
-      className="flex flex-wrap items-center gap-3 sm:ml-auto"
-      data-testid="exam-action-cta-group"
-    >
       {nextActionDescription ? (
         <span id={nextActionDescriptionId} className="sr-only">
           {nextActionDescription}
@@ -262,12 +256,7 @@ function ExamActionBar(props: ExamActionBarProps) {
     </div>
   );
 
-  return (
-    <>
-      {navigationGroup}
-      {ctaGroup}
-    </>
-  );
+  return navigationGroup;
 }
 
 export function PracticeView(props: PracticeViewProps) {

--- a/docs/debt/debt-380-exam-footer-cluster-previous-and-primary-cta-mirror-tutor.md
+++ b/docs/debt/debt-380-exam-footer-cluster-previous-and-primary-cta-mirror-tutor.md
@@ -1,0 +1,375 @@
+# DEBT-380: Exam Footer — Cluster Previous + Primary CTA Together, Mirror Tutor's Left-Cluster Pattern
+
+**Priority:** P3 (layout-only refactor in a single component; behavior unchanged)
+**Created:** 2026-05-07
+**Source:** Visual grading walkthrough on 2026-05-07 after DEBT-378 + DEBT-379 shipped to `main` at `578dffb8`. Side-by-side comparison of tutor mode post-feedback (`[Previous, Next]` clustered left, `[Bookmark]` right via `sm:ml-auto`) and exam mode (`[Previous]` alone left, `[Next]` / `[Review & Submit]` orphaned right via `sm:ml-auto`). User's first-principles read: tutor's clustered-nav pattern is the better cross-mode shape; exam's split nav reads as a broken pair across a wide gap. DEBT-379 promoted exam's primary CTA to the right slot under "right slot owns the eye-anchor" theory, but DEBT-379's own spec admitted the rationale was unmeasured (*"supporting rationale, not measured user-error proof"*). With both modes now shipped and visually graded, the unmeasured argument loses to the measured cross-mode disharmony.
+**Related:** [DEBT-379 Exam action bar — primary CTA to right slot, Mark for review to header (archived, partially superseded by this debt)](../_archive/debt/debt-379-exam-action-bar-promote-primary-cta-to-right-slot.md), [DEBT-378 Tutor — drop Submit button (choice click commits) (archived)](../_archive/debt/debt-378-tutor-drop-submit-button-choice-click-commits.md), [DEBT-365 Exam flow affordance and label consistency (archived)](../_archive/debt/debt-365-exam-flow-affordance-and-label-consistency.md), [DEBT-361 Exam last-question Next label (archived)](../_archive/debt/debt-361-exam-last-question-next-label.md), [DEBT-330 Post-exam review action bar bookmark placement (archived)](../_archive/debt/debt-330-review-action-bar-bookmark-placement.md), [Pattern Registry](../frontend/pattern-registry.md), [Frontend Standards](../frontend/standards.md), [Practice Page Docs](../frontend/pages/practice.md)
+
+**Status:** Open. No production code change yet. This debt **partially supersedes DEBT-379**: it reverts DEBT-379's footer right-slot promotion of the exam primary CTA while preserving DEBT-379's header-rail relocation of `Mark for review`. The supersession is intentional and design-driven, not a mistake — DEBT-379's right-slot promotion was a defensible call against pre-shipped state, but post-ship visual grading vs. tutor mode showed that cross-mode harmony beats the unmeasured eye-anchor argument.
+
+---
+
+## Context
+
+Today's exam footer (`app/(app)/app/practice/components/practice-view.tsx:206-271`, `ExamActionBar`):
+
+| Question | Left (`exam-action-primary-group`) | Right (`exam-action-cta-group`, `sm:ml-auto`) |
+|----------|------------------------------------|------------------------------------------------|
+| Q1 | _suppressed_ (no Previous) | filled `[Next]` |
+| Q2 | outline `[Previous]` | filled `[Next]` |
+| Q3 | outline `[Previous]` | filled `[Review & Submit]` (`aria-describedby` "Opens review and submit.") |
+
+Today's tutor footer (`practice-view.tsx:102-191`, `TutorActionBar`) — for cross-mode comparison:
+
+| State | Left (`tutor-action-primary-group`) | Right (`tutor-action-secondary-group`, `sm:ml-auto`) |
+|-------|--------------------------------------|------------------------------------------------------|
+| Q1 pre-feedback | _none_ | _none_ (choice cards are primary) |
+| Q1 post-feedback | filled `[Next]` | outline `[Bookmark]` |
+| Q2/Q3 pre-feedback | outline `[Previous]` | _none_ |
+| Q2 post-feedback | outline `[Previous]`, filled `[Next]` | outline `[Bookmark]` |
+| Q3 post-feedback | outline `[Previous]`, filled `[End session]` | outline `[Bookmark]` |
+
+The asymmetry is concrete: tutor renders `[Previous, Next]` and `[Previous, End session]` as a single navigation cluster in the left group; exam splits navigation across the row with `Previous` alone left and `Next` / `Review & Submit` right via `sm:ml-auto`.
+
+Mark for review continues to live in the exam header rail (`data-testid="question-header-actions"`) per DEBT-379 — that part is correct and stays.
+
+---
+
+## Why This Is Debt
+
+### Cross-mode disharmony
+
+Tutor and exam are sibling modes rendered through the same `PracticeView` shell. Their footers reading as different shapes for the same task — sequential question navigation — creates user-visible inconsistency. DEBT-379's spec acknowledged this risk obliquely: *"Once DEBT-378 ships … tutor and exam have the SAME structure: navigation left, metadata right."* But DEBT-379 then went the OPPOSITE direction in exam, splitting nav left/right while tutor kept nav clustered. The "SAME structure" prediction did not survive DEBT-379.
+
+### The split breaks the navigation pair
+
+`Previous` and `Next` are conceptually one control (the question stepper). Visually splitting them across a wide footer with an `ml-auto` gap forces the user's eye to jump between two zones to perform one cognitive operation. Tutor mode keeps them adjacent. Exam mode now does not.
+
+### DEBT-379's eye-anchor rationale was explicitly unmeasured
+
+Quoting DEBT-379's own Why-This-Is-Debt section: *"This is supporting rationale, not measured user-error proof: we do not currently have analytics showing students click Mark for review when they meant Next. The concrete evidence is the user's design walkthrough and visual discomfort with the right-edge metadata slot in the active exam footer."*
+
+DEBT-379 was right to fix the right-edge-metadata problem (Mark for review was in the right slot competing for eye-anchor with Next). It moved Mark for review to the header rail, which solved the metadata-right-slot problem. But it then went one step further and promoted the primary CTA to the now-vacant right slot, which created a new problem: nav split. The first move (header relocation) was correct. The second move (right-slot promotion) is what this debt undoes.
+
+### Exam's right-slot occupant after DEBT-380 is "nothing," and that's fine
+
+Tutor pre-feedback already establishes the precedent: the footer has only a left cluster, no `sm:ml-auto` right group. The footer doesn't feel broken in tutor pre-feedback because the screen reads as "one cluster of navigation." Exam mode after DEBT-380 will look the same: left cluster only, no right group. Mark for review continues to anchor the exam header rail; the footer is purely navigation.
+
+### The DEBT-361 `aria-describedby` invariant must continue to travel
+
+Q3's `Review & Submit` button has a hidden description span linked via `aria-describedby` resolving to `"Opens review and submit."` That linkage was preserved through DEBT-379's restructure (the span moved with the button into `ctaGroup`). DEBT-380 must preserve it again: the span travels with the button into the unified left cluster.
+
+---
+
+## Options
+
+### Option A — Single left cluster, no right group (recommended)
+
+```
+Q1: [Next filled]
+Q2: [Previous outline] [Next filled]
+Q3: [Previous outline] [Review & Submit filled]
+```
+
+Layout: render only `data-testid="exam-action-primary-group"` containing both Previous (when applicable) and the forward/terminal CTA. Drop the `exam-action-cta-group` testid entirely. No `sm:ml-auto` group in exam mode.
+
+**Pros:**
+- Mirrors tutor's `tutor-action-primary-group` clustering pattern exactly.
+- Smallest production diff (collapse two groups into one).
+- Q1 still suppresses Previous; the cluster is `[Next]`-only on Q1 (still cleanly left-aligned, no orphaning).
+- Cross-mode harmony: both modes have a single left cluster + optional metadata right (tutor has Bookmark; exam has nothing because Mark for review moved to header).
+
+**Cons:**
+- Reverts DEBT-379's right-slot eye-anchor positioning. Honest accounting: DEBT-379 was P3 layout-only, and its right-slot rationale was unmeasured; design iteration is expected at P3.
+- The `exam-action-cta-group` testid that DEBT-379 introduced becomes dead. Removing it means tests written against it must move to `exam-action-primary-group` selectors.
+
+### Option B — Single left cluster, plus a right slot for some future affordance
+
+Speculative. No concrete affordance in scope. Ruled out per `feedback_no_speculative_debt`: don't reserve real estate for hypothetical future buttons.
+
+### Option C — Keep DEBT-379's split
+
+Status quo. Ruled out by the user's visual grade and the cross-mode disharmony argument above.
+
+### Recommendation
+
+**Option A.** Smallest production diff, restores cross-mode harmony, preserves DEBT-379's correct decision (Mark for review in header rail), reverts only DEBT-379's incorrect decision (CTA in right slot).
+
+---
+
+## The Refactor (Option A)
+
+### Exam footer — final spec
+
+| Question position | Left cluster (`exam-action-primary-group`) | Right group |
+|-------------------|---------------------------------------------|-------------|
+| Q1 | filled `[Next]` (single button, cluster contains only the CTA) | _none_ |
+| Q2 | outline `[Previous]`, filled `[Next]` | _none_ |
+| Q3 | outline `[Previous]`, filled `[Review & Submit]` (preserves `aria-describedby` "Opens review and submit.") | _none_ |
+
+`exam-action-cta-group` testid is removed. All exam footer buttons live inside `exam-action-primary-group`.
+
+### Header rail — unchanged from DEBT-379
+
+The exam header rail (`data-testid="question-header-actions"`) continues to render the `Mark for review` / `Unmark review` toggle exactly as DEBT-379 shipped it. `aria-pressed`, disabled state (`isMarkingForReview || isPending || loadState.status === 'loading'`), label flip, and the back-link fallback gating widened in DEBT-379 (`(!isExamMode && !props.onEndSession) || (isExamMode && !props.onToggleMarkForReview)`) all stay byte-identical.
+
+### Tutor mode — unchanged
+
+`TutorActionBar` is not touched. Tutor footer matrix and tutor header rail remain byte-identical to DEBT-378's shipped state. Quick Practice (which inherits `TutorActionBar`) is also untouched.
+
+---
+
+## Production Diff
+
+### File: `app/(app)/app/practice/components/practice-view.tsx`
+
+**`ExamActionBar` (lines 206-271):** restructure.
+
+Removals:
+- Lines 238-263 — entire `ctaGroup` block. Move its inner contents (Next/Review & Submit button, hidden description span) into the left `navigationGroup`.
+
+Changes:
+- Lines 220-236 — `navigationGroup` becomes the single render group. Conditions:
+  - Always render the `data-testid="exam-action-primary-group"` div when there is at least one button to show (i.e., always — Q1 still has `[Next]`).
+  - Render `Previous` first when `props.onPreviousQuestion && props.hasPreviousQuestion`. Suppress on Q1.
+  - Render the forward/terminal CTA (Next or Review & Submit) immediately after Previous (or as the only child on Q1). Preserve the `aria-describedby` linkage and the hidden description span on Q3.
+- Lines 265-270 — return becomes `<>{navigationGroup}</>` (no separate ctaGroup).
+
+Selector cleanup:
+- Keep `data-testid="exam-action-primary-group"` for the unified cluster.
+- Delete `data-testid="exam-action-cta-group"` (no separate right group).
+
+The DEBT-361 hidden description span (`useId()` → `nextActionDescriptionId`) and the button's `aria-describedby` link must remain co-located inside the same cluster. The simplest implementation: keep the span and button adjacent in the JSX tree under `exam-action-primary-group`.
+
+### Other files
+
+`PracticeView` callsite (`practice-view.tsx:333-344`): no prop changes. `ExamActionBarProps` type does not change shape (it doesn't currently expose anything specific to the right slot).
+
+`practice-session-page-view.tsx`, `quick-practice-client.tsx`: no changes. Quick Practice does not render `ExamActionBar`.
+
+### Summary of production changes
+
+| File | Lines (approx) | Change type |
+|------|----------------|-------------|
+| `practice-view.tsx` `ExamActionBar` | 206-271 | Collapse two groups into one; delete `exam-action-cta-group` testid |
+| Total | ~30-50 lines touched | Net negative LOC (one group deletion) |
+
+Choice button, QuestionCard, controllers, repositories, use cases, hooks: zero changes.
+
+---
+
+## Test Diff
+
+### Unit tests
+
+**`practice-view-exam-actions.test.tsx`:**
+
+Currently the tests assert specific group membership. After DEBT-380, the assertions need to move from `exam-action-cta-group` to `exam-action-primary-group`.
+
+Tests to rewrite (line ranges from current HEAD `578dffb8`):
+
+- `'renders first-question exam footer with only the right-slot Next CTA'` — rename to `'renders first-question exam footer with only the Next CTA in the unified left cluster'`. Assertions change from:
+  - `expect(primaryGroup).toBeNull()` → `expect(getButtonLabels(primaryGroup)).toEqual(['Next'])`
+  - `expect(getButtonLabels(ctaGroup)).toEqual(['Next'])` → DELETE (no ctaGroup)
+  - `expect(getButtonLabels(actionBar)).toEqual(['Next'])` — KEEP
+  - `expect(actionBar?.textContent).not.toContain('Mark for review')` — KEEP
+  - Add: `expect(doc.querySelector('[data-testid="exam-action-cta-group"]')).toBeNull()` (negative assertion that the testid is gone)
+
+- `'renders final-question exam footer with Previous left and Review & Submit right'` — rename and rewrite:
+  - `expect(getButtonLabels(primaryGroup)).toEqual(['Previous'])` → `expect(getButtonLabels(primaryGroup)).toEqual(['Previous', 'Review & Submit'])`
+  - `expect(getButtonLabels(ctaGroup)).toEqual(['Review & Submit'])` → DELETE
+  - `expect(getButtonLabels(actionBar)).toEqual(['Previous', 'Review & Submit'])` — KEEP
+
+- `'groups active-exam Previous separately from the right-slot CTA and removes the secondary footer group'` — rewrite to reflect single-cluster:
+  - `expect(getButtonLabels(primaryGroup)).toEqual(['Previous'])` → `expect(getButtonLabels(primaryGroup)).toEqual(['Previous', 'Next'])`
+  - `expect(getButtonLabels(ctaGroup)).toEqual(['Next'])` → DELETE
+  - `expect(secondaryGroup).toBeNull()` — KEEP (regression guard)
+  - `expect(getButtonLabels(headerActions)).toEqual(['Mark for review'])` — KEEP (header unchanged)
+  - Add: `expect(doc.querySelector('[data-testid="exam-action-cta-group"]')).toBeNull()`
+
+- `'describes the last-question Review & Submit action for assistive tech'` — update to scope the find to `exam-action-primary-group` instead of `exam-action-cta-group`. The hidden description span and `aria-describedby` linkage MUST still resolve to `"Opens review and submit."`
+
+- `'keeps Next as the non-final exam CTA even when hasNextQuestion is false'` — selector update `exam-action-cta-group` → `exam-action-primary-group`.
+
+- All disabled-state and aria-pressed tests for the header `Mark for review` button — UNCHANGED (header rail not touched).
+
+- Tutor regression guards — UNCHANGED (tutor not touched).
+
+**`practice-view-navigation.test.tsx`:**
+
+- UNCHANGED. This remains the load-bearing tutor footer matrix coverage for Q1/Q2/Q3 pre/post-feedback states.
+
+**`practice-view-layout.test.tsx`:**
+
+- The DEBT-379 regression test `'renders the fallback back link when exam mode has no mark-for-review action'` — UNCHANGED (header rail not touched).
+- The DEBT-379 test `'renders a scoped exam header action rail before the question area'` — UNCHANGED.
+
+### Browser specs
+
+**`practice-view.browser.spec.tsx`:**
+
+- Tests scoped to `exam-action-cta-group` (the `Review & Submit` click test around line 642) — update selector to `exam-action-primary-group`.
+- Tests scoped to `question-header-actions` (Mark for review click, disabled state) — UNCHANGED.
+- Tests scoped to `bottom-action-bar` for global presence — UNCHANGED.
+
+### Integration tests
+
+None expected. No use-case-layer change.
+
+### E2E tests
+
+**`tests/e2e/practice.spec.ts`:**
+
+- Exam walkthrough already scopes Mark for review to `question-header-actions` (DEBT-379) — UNCHANGED.
+- No `exam-action-cta-group` references exist in this file at `578dffb8`; existing bottom-action-bar scoped `Review & Submit` assertions remain valid.
+
+### Test count summary
+
+| Test type | Files affected | Assertions changed (estimate) |
+|-----------|----------------|-------------------------------|
+| Unit | 1 (`practice-view-exam-actions.test.tsx`) | 8-15 |
+| Browser | 1 (`practice-view.browser.spec.tsx`) | 2-4 |
+| Layout | 0 (header-rail tests untouched) | 0 |
+| Integration | 0 | 0 |
+| E2E | 0 | 0 |
+| **Total** | **2-3 files** | **~10-20 assertions** |
+
+Smaller surface than DEBT-379.
+
+---
+
+## Design Doc Diff
+
+### `docs/frontend/pattern-registry.md`
+
+- **Active Exam Action Bar entry** (added by DEBT-379, see lines around the "Active Exam Action Bar" section): rewrite the matrix to show a single left cluster on every question. Remove references to `exam-action-cta-group` and `sm:ml-auto`. Add a sentence: *"All active exam footer buttons live in `data-testid=\"exam-action-primary-group\"`; there is no footer right group. Mark for review continues to live in the question header rail per DEBT-379."*
+- **Header Rail / Persistent Header Actions entry** (added by DEBT-379): UNCHANGED.
+
+### `docs/frontend/standards.md`
+
+- Active practice action bars table — rewrite the three exam rows to drop `sm:ml-auto` and put both Previous and the CTA in the left cluster.
+- The existing prose *"In exam mode, the primary CTA always sits in the footer right slot. The footer never contains `Mark for review`; the header action rail owns the Mark/Unmark toggle with `aria-pressed` state."* — rewrite to: *"In exam mode, the footer renders a single left cluster containing Previous (when applicable) and the forward/terminal CTA (`Next` / `Review & Submit`). The footer never contains `Mark for review`; the header action rail owns the Mark/Unmark toggle with `aria-pressed` state."*
+
+### `docs/frontend/pages/practice.md`
+
+- Active Session Action Bar exam matrix table — rewrite to drop `sm:ml-auto` and unify into the left cluster.
+- Header Rail subsection — UNCHANGED.
+
+### Archived debt docs
+
+Do NOT edit archived DEBT-379 / DEBT-378 / DEBT-365 / DEBT-330 docs. The supersession of DEBT-379's right-slot promotion is recorded in this DEBT-380 doc and (post-merge) in this doc's archived `## Resolution` section. Archived docs stay as historical record of what was true at their time.
+
+---
+
+## Edge Cases & Implementation Notes
+
+### Q1 with only `[Next]` in the cluster
+
+Today's footer renders an empty primary group on Q1 (suppressed) and `[Next]` alone in the right group. After DEBT-380, Q1 renders only the unified primary group with `[Next]` as its single child. This is functionally identical to tutor's "Q1 post-feedback shows only `[Next]`" pattern. The flex layout already handles single-child cases — no new alignment work needed.
+
+### `aria-describedby` linkage on Q3
+
+The hidden description span and the button's `aria-describedby` attribute must remain in the same render tree. Both currently live in `ctaGroup`; the refactor moves both into the unified `navigationGroup`. The id constant (`nextActionDescriptionId` from `useId()`) is local to the component and continues to resolve.
+
+### Mobile responsive
+
+`flex flex-wrap` on `exam-action-primary-group` allows wrapping at narrow breakpoints. Single-cluster layout is actually friendlier to mobile than the split layout, because there's no `sm:ml-auto` push that creates a wide gap on intermediate breakpoints.
+
+### Tab order
+
+Single-cluster nav makes tab order simpler. After DEBT-380 the order is: navigator pills → header `Mark for review` → question stem → choice buttons → footer `Previous` → footer CTA. This is more linear than the DEBT-379 split where tab moved from `Previous` (left) across the gap to the CTA (right).
+
+### Visual hierarchy
+
+The forward/terminal CTA continues to use `variant="default"` (filled). Previous continues to use `variant="outline"`. The hierarchy is the same; only their adjacency changes.
+
+### Will the footer feel "empty" with no right group?
+
+Tutor's pre-feedback footer is the precedent: when there's no metadata to render, the footer is left-cluster only. Visual grade did not flag tutor's pre-feedback state as broken. Exam's footer post-DEBT-380 will mirror that pattern.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| DEBT-379's `exam-action-cta-group` testid is referenced by tests; deleting it breaks them | Mechanically update every reference per the Test Diff section. CR will catch any missed reference. |
+| `aria-describedby` linkage breaks during JSX restructure | Hidden span and the button stay co-located in the same cluster. A unit test asserts the linked span's text content survives the move. |
+| Future debt re-promotes the CTA to the right slot, churning these tests again | Acceptable risk. Design iteration at P3 is expected; testid stability is not the priority over visual rightness. If the right-slot pattern re-emerges with measured evidence, the tests can be updated again. |
+| Quick Practice somehow inherits the broken split | Quick Practice renders the non-exam `PracticeView` branch, so it uses `TutorActionBar` rather than `ExamActionBar`. No change needed; `practice-view-exam-actions.test.tsx` keeps tutor header/footer smoke guards, and `practice-view-navigation.test.tsx` remains the load-bearing full tutor footer matrix regression suite. |
+| User expectation that the right slot exists in exam mode after DEBT-379 was just shipped | This debt's existence acknowledges the change. Post-merge archive ritual updates `pattern-registry.md` and `standards.md` so future readers see the unified pattern as canonical. |
+
+---
+
+## Acceptance Criteria
+
+Production:
+
+- `app/(app)/app/practice/components/practice-view.tsx`:
+  - `ExamActionBar` renders a single `data-testid="exam-action-primary-group"` div containing Previous (when applicable) and the forward/terminal CTA.
+  - `data-testid="exam-action-cta-group"` is removed entirely.
+  - No `sm:ml-auto` class in `ExamActionBar`'s rendered output.
+  - Q1: cluster contains `[Next]` only.
+  - Q2: cluster contains `[Previous]` + `[Next]`.
+  - Q3: cluster contains `[Previous]` + `[Review & Submit]` and preserves the `aria-describedby` link to a hidden span containing `"Opens review and submit."`.
+  - Header rail JSX byte-identical to DEBT-379's shipped state.
+  - `TutorActionBar`: zero changes.
+
+Tests:
+
+- All exam Q1/Q2/Q3 footer assertions updated to expect a unified left cluster.
+- `exam-action-cta-group` testid asserted absent (negative assertion).
+- Q3 `aria-describedby` link still resolves to the `"Opens review and submit."` span.
+- Tutor regression guards: byte-identical, still green. `practice-view-exam-actions.test.tsx` keeps the tutor header and one post-feedback footer smoke guard, while `practice-view-navigation.test.tsx` remains the load-bearing full tutor footer matrix coverage.
+- Quick Practice regression: not directly tested in this PR (untouched), but Quick Practice continues through the non-exam `PracticeView` branch and therefore the unchanged `TutorActionBar`.
+
+Docs:
+
+- Pattern Registry Active Exam Action Bar entry rewritten for unified cluster.
+- Standards.md exam rows rewritten; right-slot prose updated to single-cluster prose.
+- pages/practice.md exam Action Bar subsection rewritten.
+- This DEBT-380 doc moves to `_archive/debt/` post-merge with `## Resolution` section.
+- Debt index updated.
+
+Quality gates:
+
+- Local full gate green (typecheck, lint, unit, browser, integration, build, E2E).
+- CodeRabbit explicit `APPROVED` on the latest PR head.
+- Visual QA on active exam states: Q1, Q2, Q3 desktop and mobile; include marked and unmarked header states. Tutor and Quick Practice visual states re-graded to confirm zero unintended drift.
+
+---
+
+## Out of Scope
+
+- **Tutor mode changes** — DEBT-378 owns tutor; DEBT-379 left it unchanged; DEBT-380 leaves it unchanged. Tutor's footer matrix is the canonical pattern this debt aligns exam to.
+- **Quick Practice changes** — Quick Practice renders `TutorActionBar`, so it inherits tutor's pattern automatically. No quick-practice file is touched.
+- **Mark for review relocation** — DEBT-379 already moved it to the header rail. DEBT-380 does not move it back to the footer or anywhere else.
+- **Bookmark vs. Mark for review unification** — DEBT-379 explicitly deferred this as a future product decision; DEBT-380 inherits that deferral.
+- **Adding a new right-slot affordance to exam footer** — speculative per `feedback_no_speculative_debt`. If a future need emerges with measured evidence, file separately.
+- **Renaming `exam-action-primary-group`** — the testid stays; only its membership broadens.
+- **Choice button or QuestionCard changes** — not touched.
+- **Re-grading DEBT-379's header-rail relocation** — DEBT-379's header decision is correct and stays.
+
+---
+
+## Implementation Verification Checklist
+
+1. Confirm current `ExamActionBar` shape at `practice-view.tsx:206-271` before editing: two render groups (`navigationGroup` lines 220-236, `ctaGroup` lines 238-263), `sm:ml-auto` on the right group, separate testids.
+
+2. Confirm the DEBT-361 hidden description span and `aria-describedby` linkage live inside `ctaGroup` today (lines 243-256). Both must travel together into the unified cluster.
+
+3. Confirm `TutorActionBar` clustering at `practice-view.tsx:120-161` is the pattern to mirror: single `flex flex-wrap items-center gap-3` div with `tutor-action-primary-group` containing all nav buttons. DEBT-380's exam refactor should produce structurally analogous JSX.
+
+4. Confirm header rail JSX at `practice-view.tsx:380-415` is unchanged in this debt — DO NOT modify the header-rail block.
+
+5. Confirm callers of `PracticeView` do not pass anything that depends on `exam-action-cta-group` existing. `PracticeView` callsite for `ExamActionBar` is at `practice-view.tsx:333-344`. `practice-session-page-view.tsx` and `quick-practice-client.tsx` do not reference the cta-group testid.
+
+6. Confirm test files mechanically (per `feedback_verify_doc_citations_mechanically`) before claiming readiness:
+   - `practice-view-exam-actions.test.tsx` — list every reference to `exam-action-cta-group`. Update all of them.
+   - `practice-view-layout.test.tsx` — verify only header-rail assertions exist, leave them untouched.
+   - `practice-view.browser.spec.tsx` — list every reference to `exam-action-cta-group`. Update all of them.
+   - `tests/e2e/practice.spec.ts` — verify there are no references to `exam-action-cta-group`; keep existing bottom-action-bar scoped `Review & Submit` assertions.
+
+7. Run tutor regression tests after every edit to prove `TutorActionBar` shape is byte-identical.
+
+8. Visual QA after typecheck + tests: capture exam Q1/Q2/Q3 desktop + mobile, marked + unmarked header states. Compare against tutor screenshots from DEBT-378 era to confirm cross-mode harmony.

--- a/docs/debt/debt-380-exam-footer-cluster-previous-and-primary-cta-mirror-tutor.md
+++ b/docs/debt/debt-380-exam-footer-cluster-previous-and-primary-cta-mirror-tutor.md
@@ -65,7 +65,7 @@ Q3's `Review & Submit` button has a hidden description span linked via `aria-des
 
 ### Option A — Single left cluster, no right group (recommended)
 
-```
+```text
 Q1: [Next filled]
 Q2: [Previous outline] [Next filled]
 Q3: [Previous outline] [Review & Submit filled]

--- a/docs/debt/index.md
+++ b/docs/debt/index.md
@@ -1,7 +1,7 @@
 # Technical Debt Register
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-05-06 (DEBT-379 resolved)
+**Last Updated:** 2026-05-07 (DEBT-380 opened)
 
 ---
 
@@ -20,8 +20,9 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 | [DEBT-332](./debt-332-security-posture-audit.md) | Security posture audit — Clerk strict CSP report-only is deployed and verified in production/dev, no RLS (accepted architecture decision); remaining work is billing-flow `form-action` verification plus enforcing mode or explicitly accepting the residual report-only posture | P2 | — |
 | [DEBT-337](./debt-337-future-feedback-enhancements.md) | Future feedback & practice enhancements (F2/F3/F5/F6/F7) — clinical pearl field, reference styling, running score, card collapse, difficulty tags; parked | P4 | — |
 | [DEBT-349](./debt-349-cross-request-published-content-caching.md) | Optional Tier 2 cross-request caching for immutable published questions and tag lists after DEBT-344 shipped request-scoped dedup | P3 | — |
+| [DEBT-380](./debt-380-exam-footer-cluster-previous-and-primary-cta-mirror-tutor.md) | Cluster exam footer Previous + primary CTA (`Next` / `Review & Submit`) into a single left group, mirroring tutor's `tutor-action-primary-group` pattern. Partially supersedes DEBT-379: keeps DEBT-379's header-rail relocation of `Mark for review`, reverts DEBT-379's right-slot promotion of the primary CTA. Cross-mode disharmony was the trigger — tutor clusters `[Previous, Next]` together, exam splits them via `sm:ml-auto`. DEBT-379's eye-anchor rationale was explicitly unmeasured per its own spec. After DEBT-380, both modes have the same footer shape: single left cluster + optional metadata right (Bookmark in tutor post-feedback; nothing in exam since Mark for review lives in the header rail). Estimated ~30-50 production LOC, ~10-20 assertions across 2-3 files | P3 | — |
 
-**Next Debt ID:** DEBT-380
+**Next Debt ID:** DEBT-381
 
 ---
 

--- a/docs/frontend/pages/practice.md
+++ b/docs/frontend/pages/practice.md
@@ -192,13 +192,13 @@ Tutor footer shape is derived from `hasPreviousQuestion` / `hasNextQuestion`; th
 | First/middle question post-feedback (`hasNextQuestion`) | `Previous` when available + filled `Next` | `Bookmark` (`sm:ml-auto`) | Feedback unlocks sequential navigation. |
 | Last question post-feedback (`!hasNextQuestion`) | `Previous` when available + filled `End session` | `Bookmark` (`sm:ml-auto`) | Header `End session` stays visible; the same-label header + footer terminal duplicate is intentional and both call `onEndSession`. |
 
-Exam mode keeps answers draft-only until exam review/finalization. Its active footer places the primary CTA in the right slot:
+Exam mode keeps answers draft-only until exam review/finalization. Its active footer keeps sequential navigation in a single left cluster:
 
 | State | Exam footer left cluster | Exam footer right cluster | Notes |
 |-------|--------------------------|---------------------------|-------|
-| First question | none | filled `Next` in `data-testid="exam-action-cta-group"` | Empty primary group is suppressed. |
-| Middle question | `Previous` in `data-testid="exam-action-primary-group"` | filled `Next` in `data-testid="exam-action-cta-group"` with `sm:ml-auto` | Draft selections do not change footer labels. |
-| Last question | `Previous` in `data-testid="exam-action-primary-group"` | filled `Review & Submit` in `data-testid="exam-action-cta-group"` with `sm:ml-auto` | Keeps the hidden `Opens review and submit.` description for assistive tech. |
+| First question | filled `Next` in `data-testid="exam-action-primary-group"` | none | No empty Previous placeholder. |
+| Middle question | `Previous` + filled `Next` in `data-testid="exam-action-primary-group"` | none | Draft selections do not change footer labels. |
+| Last question | `Previous` + filled `Review & Submit` in `data-testid="exam-action-primary-group"` | none | Keeps the hidden `Opens review and submit.` description for assistive tech. |
 
 Exam footers do not render `Mark for review`; that toggle belongs to the header rail.
 

--- a/docs/frontend/pattern-registry.md
+++ b/docs/frontend/pattern-registry.md
@@ -556,15 +556,15 @@ All standalone action buttons in the app use `rounded-full`:
 
 **Source:** `ExamActionBar` in `app/(app)/app/practice/components/practice-view.tsx`
 
-Active exam sessions defer correctness until `Review & Submit`, so the footer is navigation-only. The primary exam CTA must own the right slot.
+Active exam sessions defer correctness until `Review & Submit`, so the footer is navigation-only. Previous and the forward / terminal CTA stay together in one left cluster to mirror tutor-mode navigation.
 
-| Session position | Left group | Right CTA group | Notes |
-|------------------|------------|-----------------|-------|
-| First question | none | filled `Next` in `data-testid="exam-action-cta-group"` | Suppress empty `exam-action-primary-group`; do not render Mark for review in the footer. |
-| Middle question | outline `Previous` in `data-testid="exam-action-primary-group"` | filled `Next` in `data-testid="exam-action-cta-group"` with `sm:ml-auto` | Draft selections do not change footer labels. |
-| Final question | outline `Previous` in `data-testid="exam-action-primary-group"` | filled `Review & Submit` in `data-testid="exam-action-cta-group"` with `sm:ml-auto` | Preserve the `aria-describedby` text: `Opens review and submit.` |
+| Session position | Left group | Right group | Notes |
+|------------------|------------|-------------|-------|
+| First question | filled `Next` in `data-testid="exam-action-primary-group"` | none | No empty Previous placeholder; do not render Mark for review in the footer. |
+| Middle question | outline `Previous` + filled `Next` in `data-testid="exam-action-primary-group"` | none | Draft selections do not change footer labels. |
+| Final question | outline `Previous` + filled `Review & Submit` in `data-testid="exam-action-primary-group"` | none | Preserve the `aria-describedby` text: `Opens review and submit.` |
 
-`data-testid="exam-action-secondary-group"` is intentionally absent after DEBT-379; there is no footer secondary group in active exam mode.
+All active exam footer buttons live in `data-testid="exam-action-primary-group"`; there is no footer right group. `data-testid="exam-action-cta-group"` and `data-testid="exam-action-secondary-group"` are intentionally absent after DEBT-380. Mark for review continues to live in the question header rail.
 
 ### Header Rail / Persistent Header Actions
 

--- a/docs/frontend/standards.md
+++ b/docs/frontend/standards.md
@@ -112,13 +112,13 @@ Active practice action bars use mode-specific semantics:
 | Tutor, middle/last question pre-feedback (`hasPreviousQuestion`) | `Previous` only | none | No footer `Submit`, `Submitting…`, or pre-feedback `Next`. Non-sequential skip is via the question navigator in active sessions. |
 | Tutor / Quick Practice, post-feedback non-terminal (`hasNextQuestion`) | `Previous` when available + filled `Next` | `Bookmark` with `sm:ml-auto` when feedback exists | `Next` appears only after feedback has rendered. |
 | Tutor, post-feedback terminal (`!hasNextQuestion`) | `Previous` + filled `End session` | `Bookmark` with `sm:ml-auto` | Header `End session` remains visible too; the duplicate same-label terminal state is intentional. |
-| Exam active session, first question | none | filled `Next` in `exam-action-cta-group` | Suppress empty `exam-action-primary-group`; Mark for review lives in the header rail. |
-| Exam active session, middle question | `Previous` only | filled `Next` in `exam-action-cta-group` with `sm:ml-auto` | Draft selections do not change footer labels. |
-| Exam active session, final question | `Previous` only | filled `Review & Submit` in `exam-action-cta-group` with `sm:ml-auto` | Preserve the hidden `Opens review and submit.` description for assistive tech. |
+| Exam active session, first question | filled `Next` in `exam-action-primary-group` | none | No empty Previous placeholder; Mark for review lives in the header rail. |
+| Exam active session, middle question | `Previous` + filled `Next` in `exam-action-primary-group` | none | Draft selections do not change footer labels. |
+| Exam active session, final question | `Previous` + filled `Review & Submit` in `exam-action-primary-group` | none | Preserve the hidden `Opens review and submit.` description for assistive tech. |
 
 In tutor mode and Quick Practice, the choice cards themselves act as the primary action pre-feedback. The footer carries only backward navigation before feedback and sequential/terminal navigation after feedback.
 
-In exam mode, the primary CTA always sits in the footer right slot. The footer never contains `Mark for review`; the header action rail owns the Mark/Unmark toggle with `aria-pressed` state.
+In exam mode, the footer renders a single left cluster containing Previous when applicable and the forward / terminal CTA (`Next` / `Review & Submit`). The footer never contains `Mark for review`; the header action rail owns the Mark/Unmark toggle with `aria-pressed` state.
 
 ### Card
 

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -1,7 +1,12 @@
+import { setDefaultResultOrder } from 'node:dns';
 import path from 'node:path';
 import react from '@vitejs/plugin-react';
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
+
+// Vitest Browser opens Chromium against a localhost Vite server. Prefer IPv4 so
+// environments with a broken ::1 loopback do not hang before tests import.
+setDefaultResultOrder('ipv4first');
 
 (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
 


### PR DESCRIPTION
## Summary

- Cluster exam footer `Previous` + forward/terminal CTA (`Next` / `Review & Submit`) into a single `exam-action-primary-group`, mirroring tutor's `tutor-action-primary-group` pattern.
- Delete `exam-action-cta-group` testid and remove the `sm:ml-auto` split.
- DEBT-361 invariant preserved: Q3 `aria-describedby` "Opens review and submit." linkage continues to resolve inside the unified cluster.
- DEBT-379's header-rail Mark for review block: byte-identical, untouched.
- `TutorActionBar` and Quick Practice: zero changes (regression-guarded by `practice-view-exam-actions.test.tsx`).

## Why

Post-ship visual grading after DEBT-379 surfaced cross-mode disharmony: tutor clusters `[Previous, Next]` together; exam splits them across `sm:ml-auto`. DEBT-379's eye-anchor rationale was explicitly unmeasured per its own spec. DEBT-380 partially supersedes DEBT-379: keeps the correct decision (Mark for review in header rail), reverts the incorrect one (CTA promoted to right slot).

## Spec

`docs/debt/debt-380-exam-footer-cluster-previous-and-primary-cta-mirror-tutor.md`

## Test plan

- [ ] Unit: `practice-view-exam-actions.test.tsx` — Q1/Q2/Q3 footer assertions updated to expect single left cluster; negative assertion that `exam-action-cta-group` is gone; `aria-describedby` invariant test scoped to new selector.
- [ ] Browser: `practice-view.browser.spec.tsx` Review & Submit click selector updated to `exam-action-primary-group`.
- [ ] Layout: `practice-view-layout.test.tsx` header-rail tests untouched (DEBT-379 regression preserved).
- [ ] Tutor regression guards: `practice-view-exam-actions.test.tsx` `'preserves tutor footer groups after feedback'` and `'does not render Mark for review in the tutor header and preserves End session'` still green.

## Quality gates green at push

- `pnpm typecheck`: pass
- `pnpm lint`: pass with pre-existing oversized-file warnings only
- `pnpm test --run`: 302 files / 2417 tests
- `pnpm test:browser`: 48 files / 265 tests
- `pnpm test:integration`: 16 files / 97 tests
- `pnpm build`: pass
- `pnpm test:e2e`: 35/35 (9.2m)
- Pre-push hook: typecheck + 2417 unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified exam footer so navigation buttons (Previous + primary CTAs like Next / Review & Submit) render together in a single left-aligned cluster for consistent footer layout.
* **Documentation**
  * Updated practice and standards docs to reflect the new footer cluster and header ownership of the Mark/Unmark control.
* **Tests**
  * Updated tests to assert the unified footer cluster and remove expectations for the removed right-side CTA group.
* **Chores**
  * Test runner network resolution preference set to prefer IPv4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->