### PR TITLE
Implement DEBT-386 E2E Stripe owner scoping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_***
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_***
 STRIPE_SECRET_KEY=sk_test_***
 STRIPE_WEBHOOK_SECRET=whsec_***
+# Optional. Set on preview/test webhook deployments to skip explicit E2E
+# subscription events owned by a different E2E environment.
+# STRIPE_WEBHOOK_E2E_OWNER=vercel-dev-preview
 
 # Stripe Price IDs - Create products at https://dashboard.stripe.com/test/products
 # Pro Annual: $199/year
@@ -52,6 +55,8 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # CLERK_SECRET_KEY, and NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY from above.
 E2E_CLERK_USER_USERNAME=
 E2E_CLERK_USER_PASSWORD=
+# Required when running E2E subscription seeding with real Stripe credentials.
+E2E_STRIPE_OWNER=local-dev
 
 # =============================================================================
 # CRON / JOBS (Required in production runtime)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
           require_non_empty NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY
           require_non_empty E2E_CLERK_USER_USERNAME
           require_non_empty E2E_CLERK_USER_PASSWORD
+          require_non_empty E2E_STRIPE_OWNER
 
           require_not_dummy CLERK_SECRET_KEY sk_test_dummy
           require_not_dummy NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY pk_test_dummy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       # Clerk E2E user creds (username/password auth enabled)
       E2E_CLERK_USER_USERNAME: ${{ secrets.E2E_CLERK_USER_USERNAME }}
       E2E_CLERK_USER_PASSWORD: ${{ secrets.E2E_CLERK_USER_PASSWORD }}
+      E2E_STRIPE_OWNER: github-ci
 
     steps:
       - name: Checkout

--- a/app/api/cron/reconcile-stripe-subscriptions/route.ts
+++ b/app/api/cron/reconcile-stripe-subscriptions/route.ts
@@ -171,6 +171,7 @@ export async function POST(req: Request) {
           annual: container.env.NEXT_PUBLIC_STRIPE_PRICE_ID_ANNUAL,
         },
         logger: container.logger,
+        webhookE2EOwner: container.env.STRIPE_WEBHOOK_E2E_OWNER,
         listLocalSubscriptions: async ({ limit, offset }) => {
           const rows = await container.db.query.stripeSubscriptions.findMany({
             columns: {

--- a/docs/debt/debt-386-e2e-stripe-customer-ownership-drift-webhook-500s.md
+++ b/docs/debt/debt-386-e2e-stripe-customer-ownership-drift-webhook-500s.md
@@ -4,7 +4,7 @@
 **Created:** 2026-05-15
 **Source:** Follow-up investigation after DEBT-384 was merged, archived, and the debt register was synchronized. Stripe still showed undelivered test-mode webhook events after PR #310, but the payloads no longer matched the missing-`metadata.user_id` failure that DEBT-384 fixed.
 **Related:** [DEBT-384 archived](../_archive/debt/debt-384-stripe-webhook-error-rate-investigation.md), [DEBT-385 invoice schema drift](./debt-385-stripe-invoice-event-subscription-ref-schema-drift.md), [DEBT-293 E2E shared state](../_archive/debt/debt-293-e2e-shared-state-structural-flakiness.md), [DEBT-306 Stripe customer search/create race](../_archive/debt/debt-306-stripe-customer-search-create-race.md)
-**Status:** Active - documented only. No code fix has been attempted. Live mode has zero currently undelivered events as of the 2026-05-15 snapshot below; the active failure is on the shared Stripe test-mode endpoint used by the dev preview.
+**Status:** Active - implementation branch in progress. The code-fixable T2/T3 work is implemented on `debt-386-e2e-stripe-owner-scoping` and awaits PR review/merge; post-merge Stripe Dashboard ops remain pending. Live mode has zero currently undelivered events as of the 2026-05-15 snapshot below; the active failure is on the shared Stripe test-mode endpoint used by the dev preview.
 
 ---
 
@@ -23,6 +23,19 @@ The confirmed source is cross-environment ownership drift in the E2E Stripe seed
 This is not a production payment incident today, but it keeps the test webhook retry queue noisy, keeps the Stripe dashboard error rate scary, and can mask future real webhook failures.
 
 All raw Stripe IDs, internal user UUIDs, and emails in this doc are redacted to stable aliases. Use the verification commands below to retrieve live values when implementing.
+
+---
+
+## Implementation Status
+
+Branch `debt-386-e2e-stripe-owner-scoping` implements the code portion of this debt:
+
+- T2: `tests/e2e/helpers/seed-test-user.ts` now requires `E2E_STRIPE_OWNER` when real Stripe credentials are used, stamps `e2e_owner` metadata on E2E-created customers/subscriptions, filters customer reuse by owner, filters active subscription reuse by owner, and preserves same-owner `metadata.user_id` repair without mutating other-owner subscriptions.
+- T3: `src/adapters/gateways/stripe/stripe-subscription-normalizer.ts` now stamps a typed `STRIPE_ERROR` field marker for explicit `metadata.e2e_owner` mismatch when `STRIPE_WEBHOOK_E2E_OWNER` is configured. `src/adapters/controllers/stripe-webhook-controller.ts` catches only that marker, logs `reason: 'e2e_owner_mismatch'`, returns 200 without claiming the event, and leaves all other Stripe errors fail-closed.
+- Reconcile safety: `src/adapters/jobs/reconcile-stripe-subscriptions.ts` receives the same optional owner configuration and records a row failure rather than skipping when a configured owner mismatch is encountered.
+- Configuration: `.env.example` documents `E2E_STRIPE_OWNER` and `STRIPE_WEBHOOK_E2E_OWNER`; `.github/workflows/ci.yml` sets CI E2E ownership to `github-ci`; `lib/env.ts` accepts optional `STRIPE_WEBHOOK_E2E_OWNER`; `lib/container/gateways.ts` threads it through constructor injection.
+
+This doc should remain active until the PR is merged and the post-merge ops checklist below is completed or explicitly deferred.
 
 ---
 
@@ -453,13 +466,12 @@ Expected after a correct fix:
 
 ---
 
-## Open Questions Before Implementation
+## Decisions Applied During Implementation
 
-1. What owner value should the deployed dev-preview webhook accept?
-2. Should local developer E2E runs use a developer-specific owner value, or should they avoid real Stripe writes by default?
-3. Should CI use a stable owner (`github-ci`) or a per-run owner? Stable owner limits Stripe object growth; per-run owner maximizes isolation but requires cleanup.
-4. Should `E2E_STRIPE_OWNER` be mandatory whenever `STRIPE_SECRET_KEY` is real and `pnpm test:e2e` runs?
-5. Should endpoint config (`customer.subscription.created`) be completed as a manual ops step alongside this work or tracked separately?
+1. Deployed dev-preview webhook owner: `STRIPE_WEBHOOK_E2E_OWNER=vercel-dev-preview`.
+2. CI E2E owner: `E2E_STRIPE_OWNER=github-ci`.
+3. Local developer owner default: `local-dev` only when Stripe credentials are dummy; real Stripe credentials require an explicit `E2E_STRIPE_OWNER`.
+4. `customer.subscription.created` endpoint config remains out of scope for code and stays in the post-merge ops checklist.
 
 ---
 

--- a/docs/debt/index.md
+++ b/docs/debt/index.md
@@ -1,7 +1,7 @@
 # Technical Debt Register
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-05-15 (DEBT-386 filed for E2E Stripe customer ownership drift after post-DEBT-384 webhook retry investigation)
+**Last Updated:** 2026-05-15 (DEBT-386 implementation branch adds owner-scoped E2E Stripe seeding and explicit owner-mismatch webhook skip; PR review pending)
 
 ---
 
@@ -23,7 +23,7 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 | [DEBT-381](./debt-381-question-content-typography-audit-and-preference-path.md) | Question content typography audit — Quick Practice, Tutor, and Exam are already unified at the Typography Policy Medium content tier. Do not globally shrink question text; if needed later, add a user-selectable Markdown/content-size preference while leaving UI chrome unchanged. | P3 | — |
 | [DEBT-382](./debt-382-landing-page-content-refresh-question-count-and-author-credibility.md) | Landing page content refresh — update stale question-count/study-mode/author-credibility copy. `900+` remains the locked direction, but implementation must first preserve portable evidence for the local 948-question imported-content count or replace it with a tracked source count. | P3 | — |
 | [DEBT-385](./debt-385-stripe-invoice-event-subscription-ref-schema-drift.md) | Stripe invoice event subscription-reference schema drift — current Stripe invoice payloads expose the subscription at `data.object.parent.subscription_details.subscription`, while our schema reads root-level `data.object.subscription`. Invoice events therefore 200 with no subscription update, currently masked by parallel `customer.subscription.updated` events. Filed from DEBT-384; not implemented in that PR. | P2 | — |
-| [DEBT-386](./debt-386-e2e-stripe-customer-ownership-drift-webhook-500s.md) | E2E Stripe customer ownership drift — after DEBT-384, current undelivered test-mode webhook retries are no longer missing metadata. They are `customer.subscription.updated` events with `metadata.user_id` present, failing because shared E2E Stripe customer/subscription state is rebound across independent DB-local user IDs and the dev webhook correctly rejects `Stripe customer id is already mapped to a different user`. | P2 | — |
+| [DEBT-386](./debt-386-e2e-stripe-customer-ownership-drift-webhook-500s.md) | E2E Stripe customer ownership drift — implementation branch adds explicit E2E Stripe owner scoping (`E2E_STRIPE_OWNER`) for seeded customers/subscriptions, adds `STRIPE_WEBHOOK_E2E_OWNER` owner-mismatch skip at the webhook boundary only, and keeps reconciliation fail-closed. Still active until PR review/merge and post-merge Stripe Dashboard ops (`customer.subscription.created` endpoint config + retry verification). | P2 | — |
 
 **Next Debt ID:** DEBT-387
 

--- a/docs/dev/testing-infrastructure.md
+++ b/docs/dev/testing-infrastructure.md
@@ -115,6 +115,7 @@ CLERK_SECRET_KEY=sk_test_...
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
 E2E_CLERK_USER_USERNAME=test@example.com
 E2E_CLERK_USER_PASSWORD=your-password
+E2E_STRIPE_OWNER=local-dev
 STRIPE_SECRET_KEY=sk_test_...
 NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY=price_...
 ```
@@ -137,15 +138,15 @@ The setup project currently runs three steps, in this order:
    - Stripe monthly price-ID validity
 2. `seedTestSubscription()` idempotently ensures:
    - the E2E user exists in `users`
-   - a Stripe customer exists and is mirrored in `stripe_customers`
-   - an active subscription exists and is mirrored in `stripe_subscriptions`
+   - a Stripe customer exists for the current `E2E_STRIPE_OWNER` and is mirrored in `stripe_customers`
+   - an active owner-scoped subscription exists and is mirrored in `stripe_subscriptions`
 3. `runE2EUserStateReset()` clears mutable user state and reseeds a deterministic baseline
 
 `seedTestSubscription()` ensures:
 
 1. The test user exists in the `users` table (matched by email, Clerk user ID resolved via Clerk API)
-2. A Stripe customer exists (checked in DB, then Stripe API, created if needed) and is mirrored in `stripe_customers`
-3. An active subscription exists (using `pm_card_visa` test payment method) and is mirrored in `stripe_subscriptions`
+2. A Stripe customer exists for `metadata.e2e_owner === E2E_STRIPE_OWNER` (checked in DB, then Stripe API, created if needed) and is mirrored in `stripe_customers`
+3. An active owner-scoped subscription exists (using `pm_card_visa` test payment method) and is mirrored in `stripe_subscriptions`
 
 `global.setup.ts` also seeds a deterministic baseline for the shared authenticated E2E user once per suite run. That suite-level reset is not enough for mutating specs on its own: any spec that writes sessions, attempts, or bookmarks should call `runE2EUserStateReset()` in `beforeEach` so every test starts from the same baseline rather than inheriting artifacts from earlier files or retries.
 
@@ -335,6 +336,7 @@ E2E runs in CI via Playwright (see `.github/workflows/ci.yml`):
   env:
     E2E_CLERK_USER_USERNAME: ${{ secrets.E2E_CLERK_USER_USERNAME }}
     E2E_CLERK_USER_PASSWORD: ${{ secrets.E2E_CLERK_USER_PASSWORD }}
+    E2E_STRIPE_OWNER: github-ci
 ```
 
 ### Required Secrets
@@ -343,6 +345,7 @@ E2E runs in CI via Playwright (see `.github/workflows/ci.yml`):
 | ------ | ------- |
 | `E2E_CLERK_USER_USERNAME` | Test Clerk account username (email) |
 | `E2E_CLERK_USER_PASSWORD` | Test Clerk account password |
+| `E2E_STRIPE_OWNER` | Stripe test customer/subscription owner namespace (`github-ci` in CI; `local-dev` or a developer-specific value locally) |
 | `CLERK_SECRET_KEY` | Clerk API key (used to resolve Clerk user ID during seeding) |
 | `STRIPE_SECRET_KEY` | Stripe API key (used to create test subscriptions during seeding) |
 | `DATABASE_URL` | Postgres connection string (used for direct DB writes during seeding) |

--- a/lib/container/gateways.ts
+++ b/lib/container/gateways.ts
@@ -29,6 +29,7 @@ export function createGatewayFactories(input: {
       new StripePaymentGateway({
         stripe: primitives.getStripe(),
         webhookSecret: primitives.env.STRIPE_WEBHOOK_SECRET,
+        webhookE2EOwner: primitives.env.STRIPE_WEBHOOK_E2E_OWNER,
         priceIds: stripePriceIds,
         logger: primitives.logger,
       }),

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -49,6 +49,7 @@ const envSchema = z.object({
   STRIPE_SECRET_KEY: z.string().min(1),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1),
   STRIPE_WEBHOOK_SECRET: z.string().min(1),
+  STRIPE_WEBHOOK_E2E_OWNER: z.string().min(1).optional(),
   NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY: z
     .string()
     .min(1)

--- a/src/adapters/controllers/stripe-webhook-controller.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { STRIPE_SUBSCRIPTION_METADATA_E2E_OWNER_FIELD } from '@/src/adapters/shared/stripe-subscription-errors';
 import { ApplicationError } from '@/src/application/errors';
 import {
   FakeLogger,
@@ -157,6 +158,36 @@ describe('processStripeWebhook', () => {
         },
       }),
       msg: 'Skipping Stripe subscription webhook with missing metadata.user_id',
+    });
+  });
+
+  it('skips subscription webhooks whose e2e owner differs from this webhook owner', async () => {
+    const paymentGateway = new ThrowingPaymentGateway(
+      new ApplicationError(
+        'STRIPE_ERROR',
+        'Stripe subscription metadata.e2e_owner does not match this webhook owner',
+        {
+          [STRIPE_SUBSCRIPTION_METADATA_E2E_OWNER_FIELD]: ['mismatch'],
+        },
+      ),
+    );
+
+    const { deps, stripeEvents, logger } = createDeps({ paymentGateway });
+
+    await expect(
+      processStripeWebhook(deps, { rawBody: 'raw', signature: 'sig' }),
+    ).resolves.toBeUndefined();
+
+    expect(stripeEvents.snapshot()).toEqual([]);
+    expect(logger.warnCalls).toContainEqual({
+      context: expect.objectContaining({
+        reason: 'e2e_owner_mismatch',
+        code: 'STRIPE_ERROR',
+        fieldErrors: {
+          [STRIPE_SUBSCRIPTION_METADATA_E2E_OWNER_FIELD]: ['mismatch'],
+        },
+      }),
+      msg: 'Skipping Stripe subscription webhook from a different E2E owner',
     });
   });
 

--- a/src/adapters/controllers/stripe-webhook-controller.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.ts
@@ -1,5 +1,8 @@
 import { STACK_TRACE_LIMIT } from '@/src/adapters/shared/error-logging-constants';
-import { isMissingStripeSubscriptionUserIdError } from '@/src/adapters/shared/stripe-subscription-errors';
+import {
+  isE2EOwnerMismatchEvent,
+  isMissingStripeSubscriptionUserIdError,
+} from '@/src/adapters/shared/stripe-subscription-errors';
 import { isApplicationError } from '@/src/application/errors';
 import type { PaymentGateway } from '@/src/application/ports/gateways';
 import type { Logger } from '@/src/application/ports/logger';
@@ -76,6 +79,18 @@ export async function processStripeWebhook(
           fieldErrors: error.fieldErrors,
         },
         'Skipping Stripe subscription webhook with missing metadata.user_id',
+      );
+      return;
+    }
+
+    if (isE2EOwnerMismatchEvent(error)) {
+      deps.logger.warn(
+        {
+          reason: 'e2e_owner_mismatch',
+          code: error.code,
+          fieldErrors: error.fieldErrors,
+        },
+        'Skipping Stripe subscription webhook from a different E2E owner',
       );
       return;
     }

--- a/src/adapters/gateways/stripe-payment-gateway.ts
+++ b/src/adapters/gateways/stripe-payment-gateway.ts
@@ -24,6 +24,7 @@ export type StripePaymentGatewayDeps = {
   webhookSecret: string;
   priceIds: StripePriceIds;
   logger: Logger;
+  webhookE2EOwner?: string;
 };
 
 export class StripePaymentGateway implements PaymentGateway {
@@ -77,6 +78,7 @@ export class StripePaymentGateway implements PaymentGateway {
       signature,
       priceIds: this.deps.priceIds,
       logger: this.deps.logger,
+      webhookE2EOwner: this.deps.webhookE2EOwner,
     });
   }
 }

--- a/src/adapters/gateways/stripe/stripe-subscription-normalizer.test.ts
+++ b/src/adapters/gateways/stripe/stripe-subscription-normalizer.test.ts
@@ -136,6 +136,23 @@ describe('normalizeStripeSubscriptionUpdate', () => {
     ).not.toThrow();
   });
 
+  it('does not throw when webhook owner matches event e2e_owner metadata', () => {
+    const logger = new FakeLogger();
+
+    const result = normalizeStripeSubscriptionUpdate({
+      subscription: createSubscriptionFixture({
+        e2eOwner: 'vercel-dev-preview',
+      }),
+      eventId: 'evt_1',
+      type: 'customer.subscription.updated',
+      priceIds,
+      logger,
+      webhookE2EOwner: 'vercel-dev-preview',
+    });
+
+    expect(result.userId).toBe('user_1');
+  });
+
   it('does not throw when webhook owner is configured but event has no e2e_owner metadata', () => {
     const logger = new FakeLogger();
 

--- a/src/adapters/gateways/stripe/stripe-subscription-normalizer.test.ts
+++ b/src/adapters/gateways/stripe/stripe-subscription-normalizer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { StripePriceIds } from '@/src/adapters/config/stripe-prices';
+import { STRIPE_SUBSCRIPTION_METADATA_E2E_OWNER_FIELD } from '@/src/adapters/shared/stripe-subscription-errors';
 import type { StripeClient } from '@/src/adapters/shared/stripe-types';
 import { FakeLogger } from '@/src/application/test-helpers/fakes';
 import {
@@ -15,12 +16,16 @@ const priceIds: StripePriceIds = {
 function createSubscriptionFixture(overrides?: {
   status?: string;
   userId?: string | null;
+  e2eOwner?: string;
   priceId?: string;
 }) {
   const metadata: Record<string, string> | undefined =
     overrides?.userId === null
       ? undefined
-      : { user_id: overrides?.userId ?? 'user_1' };
+      : {
+          user_id: overrides?.userId ?? 'user_1',
+          ...(overrides?.e2eOwner ? { e2e_owner: overrides.e2eOwner } : {}),
+        };
 
   return {
     id: 'sub_123',
@@ -93,6 +98,57 @@ describe('normalizeStripeSubscriptionUpdate', () => {
         stripeCustomerId: 'cus_123',
       },
     });
+  });
+
+  it('throws STRIPE_ERROR when subscription e2e_owner differs from configured webhook owner', () => {
+    const logger = new FakeLogger();
+
+    expect(() =>
+      normalizeStripeSubscriptionUpdate({
+        subscription: createSubscriptionFixture({ e2eOwner: 'github-ci' }),
+        eventId: 'evt_1',
+        type: 'customer.subscription.updated',
+        priceIds,
+        logger,
+        webhookE2EOwner: 'vercel-dev-preview',
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: 'STRIPE_ERROR',
+        fieldErrors: {
+          [STRIPE_SUBSCRIPTION_METADATA_E2E_OWNER_FIELD]: ['mismatch'],
+        },
+      }),
+    );
+  });
+
+  it('does not throw for e2e_owner metadata when webhook owner is unset', () => {
+    const logger = new FakeLogger();
+
+    expect(() =>
+      normalizeStripeSubscriptionUpdate({
+        subscription: createSubscriptionFixture({ e2eOwner: 'github-ci' }),
+        eventId: 'evt_1',
+        type: 'customer.subscription.updated',
+        priceIds,
+        logger,
+      }),
+    ).not.toThrow();
+  });
+
+  it('does not throw when webhook owner is configured but event has no e2e_owner metadata', () => {
+    const logger = new FakeLogger();
+
+    expect(() =>
+      normalizeStripeSubscriptionUpdate({
+        subscription: createSubscriptionFixture(),
+        eventId: 'evt_1',
+        type: 'customer.subscription.updated',
+        priceIds,
+        logger,
+        webhookE2EOwner: 'vercel-dev-preview',
+      }),
+    ).not.toThrow();
   });
 
   it('throws STRIPE_ERROR when subscription status is invalid', () => {

--- a/src/adapters/gateways/stripe/stripe-subscription-normalizer.ts
+++ b/src/adapters/gateways/stripe/stripe-subscription-normalizer.ts
@@ -1,7 +1,10 @@
 import type { z } from 'zod';
 import type { StripePriceIds } from '@/src/adapters/config/stripe-prices';
 import { getSubscriptionPlanFromPriceId } from '@/src/adapters/config/stripe-prices';
-import { STRIPE_SUBSCRIPTION_METADATA_USER_ID_FIELD } from '@/src/adapters/shared/stripe-subscription-errors';
+import {
+  STRIPE_SUBSCRIPTION_METADATA_E2E_OWNER_FIELD,
+  STRIPE_SUBSCRIPTION_METADATA_USER_ID_FIELD,
+} from '@/src/adapters/shared/stripe-subscription-errors';
 import type { StripeClient } from '@/src/adapters/shared/stripe-types';
 import { ApplicationError } from '@/src/application/errors';
 import type { WebhookEventResult } from '@/src/application/ports/gateways';
@@ -23,6 +26,7 @@ export function normalizeStripeSubscriptionUpdate(input: {
   type: string;
   priceIds: StripePriceIds;
   logger: Logger;
+  webhookE2EOwner?: string;
 }): NonNullable<WebhookEventResult['subscriptionUpdate']> {
   const { subscription } = input;
   const userId = subscription.metadata?.user_id;
@@ -41,6 +45,21 @@ export function normalizeStripeSubscriptionUpdate(input: {
       'Stripe subscription metadata.user_id is required',
       {
         [STRIPE_SUBSCRIPTION_METADATA_USER_ID_FIELD]: ['required'],
+      },
+    );
+  }
+
+  const eventE2EOwner = subscription.metadata?.e2e_owner;
+  if (
+    input.webhookE2EOwner &&
+    eventE2EOwner &&
+    eventE2EOwner !== input.webhookE2EOwner
+  ) {
+    throw new ApplicationError(
+      'STRIPE_ERROR',
+      'Stripe subscription metadata.e2e_owner does not match this webhook owner',
+      {
+        [STRIPE_SUBSCRIPTION_METADATA_E2E_OWNER_FIELD]: ['mismatch'],
       },
     );
   }
@@ -87,6 +106,7 @@ export async function retrieveAndNormalizeStripeSubscription(input: {
   event: { id: string; type: string };
   priceIds: StripePriceIds;
   logger: Logger;
+  webhookE2EOwner?: string;
 }): Promise<NonNullable<WebhookEventResult['subscriptionUpdate']>> {
   const stripeSubscriptionId =
     typeof input.subscriptionRef === 'string'
@@ -131,5 +151,6 @@ export async function retrieveAndNormalizeStripeSubscription(input: {
     type: input.event.type,
     priceIds: input.priceIds,
     logger: input.logger,
+    webhookE2EOwner: input.webhookE2EOwner,
   });
 }

--- a/src/adapters/gateways/stripe/stripe-webhook-processor.ts
+++ b/src/adapters/gateways/stripe/stripe-webhook-processor.ts
@@ -15,6 +15,7 @@ async function getSubscriptionUpdateForSubscriptionRefEvent(input: {
   event: ReturnType<StripeClient['webhooks']['constructEvent']>;
   priceIds: StripePriceIds;
   logger: Logger;
+  webhookE2EOwner?: string;
 }): Promise<WebhookEventResult['subscriptionUpdate'] | undefined> {
   const parsedPayload = stripeEventWithSubscriptionRefSchema.safeParse(
     input.event.data.object,
@@ -45,6 +46,7 @@ async function getSubscriptionUpdateForSubscriptionRefEvent(input: {
     event: input.event,
     priceIds: input.priceIds,
     logger: input.logger,
+    webhookE2EOwner: input.webhookE2EOwner,
   });
 }
 
@@ -55,6 +57,7 @@ export async function processStripeWebhookEvent({
   signature,
   priceIds,
   logger,
+  webhookE2EOwner,
 }: {
   stripe: StripeClient;
   webhookSecret: string;
@@ -62,6 +65,7 @@ export async function processStripeWebhookEvent({
   signature: string;
   priceIds: StripePriceIds;
   logger: Logger;
+  webhookE2EOwner?: string;
 }): Promise<WebhookEventResult> {
   let event: ReturnType<StripeClient['webhooks']['constructEvent']>;
   try {
@@ -99,6 +103,7 @@ export async function processStripeWebhookEvent({
         event,
         priceIds,
         logger,
+        webhookE2EOwner,
       });
 
     return subscriptionUpdate ? { ...result, subscriptionUpdate } : result;
@@ -133,6 +138,7 @@ export async function processStripeWebhookEvent({
     event,
     priceIds,
     logger,
+    webhookE2EOwner,
   });
 
   return { ...result, subscriptionUpdate };

--- a/src/adapters/jobs/reconcile-stripe-subscriptions-types.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions-types.ts
@@ -29,6 +29,7 @@ export type ReconcileStripeSubscriptionsDeps = {
   stripe: StripeClient;
   priceIds: StripePriceIds;
   logger: Logger;
+  webhookE2EOwner?: string;
   listLocalSubscriptions: (
     input: ReconcileStripeSubscriptionsInput,
   ) => Promise<readonly StripeSubscriptionRefRow[]>;

--- a/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
@@ -45,6 +45,7 @@ type ReconciliationTestScenarioInput = {
   subscriptions?: FakeSubscriptionRepository;
   logger?: FakeLogger;
   transaction?: ReconciliationDeps['transaction'];
+  webhookE2EOwner?: string;
 };
 
 function createSubscriptionFixture(input: {
@@ -54,6 +55,7 @@ function createSubscriptionFixture(input: {
   status?: StripeSubscriptionStatus;
   currentPeriodEnd?: number;
   priceId?: string;
+  e2eOwner?: string;
 }): StripeSubscriptionFixture {
   const subscriptionEvent = loadJsonFixture<{
     data: { object: StripeSubscriptionFixture };
@@ -65,7 +67,11 @@ function createSubscriptionFixture(input: {
     id: input.id,
     customer: input.customerId ?? 'cus_123',
     status: input.status ?? 'active',
-    metadata: { ...(base.metadata ?? {}), user_id: input.userId },
+    metadata: {
+      ...(base.metadata ?? {}),
+      user_id: input.userId,
+      ...(input.e2eOwner ? { e2e_owner: input.e2eOwner } : {}),
+    },
     items: {
       ...base.items,
       data: [
@@ -200,6 +206,7 @@ function createReconciliationTestScenario(
         stripe,
         priceIds: { monthly: 'price_m', annual: 'price_a' },
         logger,
+        webhookE2EOwner: input.webhookE2EOwner,
         listLocalSubscriptions,
         transaction,
       },
@@ -474,6 +481,39 @@ describe('reconcileStripeSubscriptions', () => {
       context: expect.objectContaining({
         stripeSubscriptionId: 'sub_missing_metadata',
         error: 'Stripe subscription metadata.user_id is required',
+      }),
+      msg: 'Stripe subscription reconciliation failed',
+    });
+  });
+
+  it('keeps reconciliation fail-closed when Stripe subscription e2e owner differs from configured owner', async () => {
+    const ownerMismatchSubscription = createUserSubscriptionFixture(
+      'sub_owner_mismatch',
+      {
+        e2eOwner: 'github-ci',
+      },
+    );
+    const stripe = createStripeFromFixtures({
+      fixtures: [{ fixture: ownerMismatchSubscription }],
+    });
+    const scenario = createReconciliationTestScenario({
+      stripe,
+      localSubscriptions: [row('user_1', 'sub_owner_mismatch')],
+      webhookE2EOwner: 'vercel-dev-preview',
+    });
+
+    const result = await scenario.run();
+
+    expectSingleFailure(result, {
+      stripeSubscriptionId: 'sub_owner_mismatch',
+      error:
+        'Stripe subscription metadata.e2e_owner does not match this webhook owner',
+    });
+    expect(scenario.logger.errorCalls).toContainEqual({
+      context: expect.objectContaining({
+        stripeSubscriptionId: 'sub_owner_mismatch',
+        error:
+          'Stripe subscription metadata.e2e_owner does not match this webhook owner',
       }),
       msg: 'Stripe subscription reconciliation failed',
     });

--- a/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
@@ -104,6 +104,7 @@ function createUserSubscriptionFixture(
     status: input.status,
     currentPeriodEnd: input.currentPeriodEnd,
     priceId: input.priceId,
+    e2eOwner: input.e2eOwner,
   });
 }
 

--- a/src/adapters/jobs/reconcile-stripe-subscriptions.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions.ts
@@ -97,6 +97,7 @@ export async function reconcileStripeSubscriptions(
             },
             priceIds: deps.priceIds,
             logger: deps.logger,
+            webhookE2EOwner: deps.webhookE2EOwner,
           });
 
         if (localSubscriptionUpdate.userId !== row.userId) {
@@ -158,6 +159,7 @@ export async function reconcileStripeSubscriptions(
             },
             priceIds: deps.priceIds,
             logger: deps.logger,
+            webhookE2EOwner: deps.webhookE2EOwner,
           });
 
           if (blockingUpdate.userId !== row.userId) {

--- a/src/adapters/shared/stripe-subscription-errors.ts
+++ b/src/adapters/shared/stripe-subscription-errors.ts
@@ -4,6 +4,8 @@ import {
 } from '@/src/application/errors';
 
 export const STRIPE_SUBSCRIPTION_METADATA_USER_ID_FIELD = 'metadata.user_id';
+export const STRIPE_SUBSCRIPTION_METADATA_E2E_OWNER_FIELD =
+  'metadata.e2e_owner';
 
 export function isMissingStripeSubscriptionUserIdError(
   error: unknown,
@@ -13,6 +15,18 @@ export function isMissingStripeSubscriptionUserIdError(
     error.code === 'STRIPE_ERROR' &&
     error.fieldErrors?.[STRIPE_SUBSCRIPTION_METADATA_USER_ID_FIELD]?.includes(
       'required',
+    ) === true
+  );
+}
+
+export function isE2EOwnerMismatchEvent(
+  error: unknown,
+): error is ApplicationError {
+  return (
+    isApplicationError(error) &&
+    error.code === 'STRIPE_ERROR' &&
+    error.fieldErrors?.[STRIPE_SUBSCRIPTION_METADATA_E2E_OWNER_FIELD]?.includes(
+      'mismatch',
     ) === true
   );
 }

--- a/tests/e2e/helpers/seed-test-user.test.ts
+++ b/tests/e2e/helpers/seed-test-user.test.ts
@@ -195,6 +195,74 @@ describe('seedTestSubscription', () => {
     expect(subscriptionsCreate).not.toHaveBeenCalled();
   });
 
+  it('reconciles Stripe when the DB customer is remapped even if a local subscription row is active', async () => {
+    postgresMock.mockReturnValueOnce(
+      createSqlClient([
+        [{ id: 'user_123' }],
+        [{ stripe_customer_id: 'cus_other_owner' }],
+        [],
+        [
+          {
+            stripe_subscription_id: 'sub_stale_local',
+            status: 'active',
+            current_period_end: '2999-01-01T00:00:00.000Z',
+          },
+        ],
+        [],
+      ]),
+    );
+    customersRetrieve.mockResolvedValueOnce({
+      id: 'cus_other_owner',
+      metadata: {
+        user_id: 'other_user',
+        clerk_user_id: 'other_clerk',
+        e2e_owner: 'local-dev',
+      },
+      invoice_settings: {},
+    });
+    customersRetrieve.mockResolvedValueOnce({
+      id: 'cus_current_owner',
+      metadata: {
+        user_id: 'user_123',
+        clerk_user_id: 'clerk_user_123',
+        e2e_owner: 'github-ci',
+      },
+      invoice_settings: {},
+    });
+    customersList.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'cus_current_owner',
+          metadata: {
+            user_id: 'user_123',
+            clerk_user_id: 'clerk_user_123',
+            e2e_owner: 'github-ci',
+          },
+        },
+      ],
+    });
+
+    await expect(seedTestSubscription()).resolves.toBeUndefined();
+
+    expect(customersRetrieve).toHaveBeenCalledWith('cus_other_owner');
+    expect(customersList).toHaveBeenCalledWith({
+      email: 'e2e-test@addictionboards.com',
+      limit: 100,
+    });
+    expect(subscriptionsList).toHaveBeenCalledWith({
+      customer: 'cus_current_owner',
+      limit: 100,
+    });
+    expect(subscriptionsCreate).toHaveBeenCalledWith({
+      customer: 'cus_current_owner',
+      items: [{ price: 'price_monthly' }],
+      metadata: {
+        user_id: 'user_123',
+        e2e_owner: 'github-ci',
+      },
+    });
+  });
+
   it('does not reuse a Stripe customer found by email when its metadata.e2e_owner differs from current owner', async () => {
     customersList.mockResolvedValueOnce({
       data: [

--- a/tests/e2e/helpers/seed-test-user.test.ts
+++ b/tests/e2e/helpers/seed-test-user.test.ts
@@ -10,6 +10,7 @@ function createEnv(): Record<string, string> {
     STRIPE_SECRET_KEY: 'sk_test_123',
     CLERK_SECRET_KEY: 'sk_clerk_123',
     E2E_CLERK_USER_USERNAME: 'e2e-test@addictionboards.com',
+    E2E_STRIPE_OWNER: 'github-ci',
     NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY: 'price_monthly',
   };
 }
@@ -26,6 +27,7 @@ function createSqlClient(results: unknown[]) {
 describe('seedTestSubscription', () => {
   let seedTestSubscription: SeedTestSubscription;
   let postgresMock: ReturnType<typeof vi.fn>;
+  let customersList: ReturnType<typeof vi.fn>;
   let customersCreate: ReturnType<typeof vi.fn>;
   let subscriptionsList: ReturnType<typeof vi.fn>;
   let subscriptionsCreate: ReturnType<typeof vi.fn>;
@@ -47,6 +49,7 @@ describe('seedTestSubscription', () => {
     }));
 
     customersCreate = vi.fn(async () => ({ id: 'cus_123' }));
+    customersList = vi.fn(async () => ({ data: [] }));
     subscriptionsCreate = vi.fn(async () => ({
       id: 'sub_123',
       items: {
@@ -61,7 +64,7 @@ describe('seedTestSubscription', () => {
     subscriptionsUpdate = vi.fn(async () => ({}));
     const stripeClient = {
       customers: {
-        list: vi.fn(async () => ({ data: [] })),
+        list: customersList,
         create: customersCreate,
         retrieve: vi.fn(async () => ({
           id: 'cus_123',
@@ -101,7 +104,17 @@ describe('seedTestSubscription', () => {
     vi.restoreAllMocks();
   });
 
-  it('creates E2E Stripe customer and subscription with user metadata', async () => {
+  it('refuses to seed when E2E_STRIPE_OWNER is unset and STRIPE_SECRET_KEY is non-dummy', async () => {
+    vi.stubEnv('E2E_STRIPE_OWNER', '');
+
+    await expect(seedTestSubscription()).rejects.toThrow(
+      'E2E_STRIPE_OWNER is required when STRIPE_SECRET_KEY is real',
+    );
+
+    expect(postgresMock).not.toHaveBeenCalled();
+  });
+
+  it('creates E2E Stripe customer and subscription with owner-scoped metadata', async () => {
     await expect(seedTestSubscription()).resolves.toBeUndefined();
 
     expect(customersCreate).toHaveBeenCalledWith({
@@ -109,6 +122,7 @@ describe('seedTestSubscription', () => {
       metadata: {
         user_id: 'user_123',
         clerk_user_id: 'clerk_user_123',
+        e2e_owner: 'github-ci',
       },
     });
     expect(subscriptionsCreate).toHaveBeenCalledWith({
@@ -116,17 +130,141 @@ describe('seedTestSubscription', () => {
       items: [{ price: 'price_monthly' }],
       metadata: {
         user_id: 'user_123',
+        e2e_owner: 'github-ci',
       },
     });
   });
 
-  it('repairs reused active E2E subscriptions that are missing user metadata', async () => {
+  it('does not reuse a Stripe customer found by email when its metadata.e2e_owner differs from current owner', async () => {
+    customersList.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'cus_other_owner',
+          metadata: {
+            user_id: 'other_user',
+            clerk_user_id: 'other_clerk',
+            e2e_owner: 'local-dev',
+          },
+        },
+      ],
+    });
+
+    await expect(seedTestSubscription()).resolves.toBeUndefined();
+
+    expect(customersCreate).toHaveBeenCalledWith({
+      email: 'e2e-test@addictionboards.com',
+      metadata: {
+        user_id: 'user_123',
+        clerk_user_id: 'clerk_user_123',
+        e2e_owner: 'github-ci',
+      },
+    });
+    expect(subscriptionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: 'cus_123',
+      }),
+    );
+  });
+
+  it('creates a new owner-scoped customer when none match the current owner', async () => {
+    customersList.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'cus_without_owner',
+          metadata: {
+            user_id: 'legacy_user',
+          },
+        },
+        {
+          id: 'cus_other_owner',
+          metadata: {
+            user_id: 'other_user',
+            e2e_owner: 'local-dev',
+          },
+        },
+      ],
+    });
+
+    await expect(seedTestSubscription()).resolves.toBeUndefined();
+
+    expect(customersCreate).toHaveBeenCalledWith({
+      email: 'e2e-test@addictionboards.com',
+      metadata: {
+        user_id: 'user_123',
+        clerk_user_id: 'clerk_user_123',
+        e2e_owner: 'github-ci',
+      },
+    });
+  });
+
+  it('does not patch metadata.user_id on an active subscription whose metadata.e2e_owner differs from current owner', async () => {
+    customersList.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'cus_current_owner',
+          metadata: {
+            user_id: 'user_123',
+            clerk_user_id: 'clerk_user_123',
+            e2e_owner: 'github-ci',
+          },
+        },
+      ],
+    });
+    subscriptionsList.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'sub_other_owner',
+          status: 'active',
+          metadata: {
+            user_id: 'other_user',
+            e2e_owner: 'local-dev',
+          },
+          items: {
+            data: [
+              {
+                current_period_end: 1_800_000_000,
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    await expect(seedTestSubscription()).resolves.toBeUndefined();
+
+    expect(subscriptionsUpdate).not.toHaveBeenCalled();
+    expect(subscriptionsCreate).toHaveBeenCalledWith({
+      customer: 'cus_current_owner',
+      items: [{ price: 'price_monthly' }],
+      metadata: {
+        user_id: 'user_123',
+        e2e_owner: 'github-ci',
+      },
+    });
+  });
+
+  it('reuses a same-owner active subscription and patches its user_id when DB-local user differs', async () => {
+    customersList.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'cus_current_owner',
+          metadata: {
+            user_id: 'old_user',
+            clerk_user_id: 'clerk_user_123',
+            e2e_owner: 'github-ci',
+          },
+        },
+      ],
+    });
     subscriptionsList.mockResolvedValueOnce({
       data: [
         {
           id: 'sub_existing',
           status: 'active',
-          metadata: {},
+          metadata: {
+            user_id: 'old_user',
+            e2e_owner: 'github-ci',
+          },
           items: {
             data: [
               {
@@ -144,6 +282,7 @@ describe('seedTestSubscription', () => {
     expect(subscriptionsUpdate).toHaveBeenCalledWith('sub_existing', {
       metadata: {
         user_id: 'user_123',
+        e2e_owner: 'github-ci',
       },
     });
   });

--- a/tests/e2e/helpers/seed-test-user.test.ts
+++ b/tests/e2e/helpers/seed-test-user.test.ts
@@ -29,7 +29,9 @@ describe('seedTestSubscription', () => {
   let postgresMock: ReturnType<typeof vi.fn>;
   let customersList: ReturnType<typeof vi.fn>;
   let customersCreate: ReturnType<typeof vi.fn>;
+  let customersRetrieve: ReturnType<typeof vi.fn>;
   let subscriptionsList: ReturnType<typeof vi.fn>;
+  let subscriptionsCancel: ReturnType<typeof vi.fn>;
   let subscriptionsCreate: ReturnType<typeof vi.fn>;
   let subscriptionsUpdate: ReturnType<typeof vi.fn>;
 
@@ -50,6 +52,10 @@ describe('seedTestSubscription', () => {
 
     customersCreate = vi.fn(async () => ({ id: 'cus_123' }));
     customersList = vi.fn(async () => ({ data: [] }));
+    customersRetrieve = vi.fn(async () => ({
+      id: 'cus_123',
+      invoice_settings: {},
+    }));
     subscriptionsCreate = vi.fn(async () => ({
       id: 'sub_123',
       items: {
@@ -61,15 +67,13 @@ describe('seedTestSubscription', () => {
       },
     }));
     subscriptionsList = vi.fn(async () => ({ data: [] }));
+    subscriptionsCancel = vi.fn(async () => ({}));
     subscriptionsUpdate = vi.fn(async () => ({}));
     const stripeClient = {
       customers: {
         list: customersList,
         create: customersCreate,
-        retrieve: vi.fn(async () => ({
-          id: 'cus_123',
-          invoice_settings: {},
-        })),
+        retrieve: customersRetrieve,
         update: vi.fn(async () => ({})),
       },
       paymentMethods: {
@@ -77,7 +81,7 @@ describe('seedTestSubscription', () => {
       },
       subscriptions: {
         list: subscriptionsList,
-        cancel: vi.fn(async () => ({})),
+        cancel: subscriptionsCancel,
         create: subscriptionsCreate,
         update: subscriptionsUpdate,
       },
@@ -114,6 +118,30 @@ describe('seedTestSubscription', () => {
     expect(postgresMock).not.toHaveBeenCalled();
   });
 
+  it('falls back to local-dev owner only when Stripe credentials are dummy', async () => {
+    vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_dummy');
+    vi.stubEnv('E2E_STRIPE_OWNER', '');
+
+    await expect(seedTestSubscription()).resolves.toBeUndefined();
+
+    expect(customersCreate).toHaveBeenCalledWith({
+      email: 'e2e-test@addictionboards.com',
+      metadata: {
+        user_id: 'user_123',
+        clerk_user_id: 'clerk_user_123',
+        e2e_owner: 'local-dev',
+      },
+    });
+    expect(subscriptionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: {
+          user_id: 'user_123',
+          e2e_owner: 'local-dev',
+        },
+      }),
+    );
+  });
+
   it('creates E2E Stripe customer and subscription with owner-scoped metadata', async () => {
     await expect(seedTestSubscription()).resolves.toBeUndefined();
 
@@ -133,6 +161,38 @@ describe('seedTestSubscription', () => {
         e2e_owner: 'github-ci',
       },
     });
+  });
+
+  it('reuses an owner-scoped DB-mapped customer and returns early when local subscription is still active', async () => {
+    postgresMock.mockReturnValueOnce(
+      createSqlClient([
+        [{ id: 'user_123' }],
+        [{ stripe_customer_id: 'cus_existing' }],
+        [
+          {
+            stripe_subscription_id: 'sub_existing',
+            status: 'active',
+            current_period_end: '2999-01-01T00:00:00.000Z',
+          },
+        ],
+      ]),
+    );
+    customersRetrieve.mockResolvedValueOnce({
+      id: 'cus_existing',
+      metadata: {
+        user_id: 'user_123',
+        clerk_user_id: 'clerk_user_123',
+        e2e_owner: 'github-ci',
+      },
+      invoice_settings: {},
+    });
+
+    await expect(seedTestSubscription()).resolves.toBeUndefined();
+
+    expect(customersRetrieve).toHaveBeenCalledWith('cus_existing');
+    expect(customersList).not.toHaveBeenCalled();
+    expect(subscriptionsList).not.toHaveBeenCalled();
+    expect(subscriptionsCreate).not.toHaveBeenCalled();
   });
 
   it('does not reuse a Stripe customer found by email when its metadata.e2e_owner differs from current owner', async () => {
@@ -195,6 +255,67 @@ describe('seedTestSubscription', () => {
         e2e_owner: 'github-ci',
       },
     });
+  });
+
+  it('cancels non-active subscriptions only when they match the current owner', async () => {
+    customersList.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'cus_current_owner',
+          metadata: {
+            user_id: 'user_123',
+            clerk_user_id: 'clerk_user_123',
+            e2e_owner: 'github-ci',
+          },
+        },
+      ],
+    });
+    subscriptionsList.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'sub_canceled_current_owner',
+          status: 'canceled',
+          metadata: {
+            user_id: 'user_123',
+            e2e_owner: 'github-ci',
+          },
+          items: {
+            data: [
+              {
+                current_period_end: 1_700_000_000,
+              },
+            ],
+          },
+        },
+        {
+          id: 'sub_canceled_other_owner',
+          status: 'canceled',
+          metadata: {
+            user_id: 'other_user',
+            e2e_owner: 'local-dev',
+          },
+          items: {
+            data: [
+              {
+                current_period_end: 1_700_000_000,
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    await expect(seedTestSubscription()).resolves.toBeUndefined();
+
+    expect(subscriptionsCancel).toHaveBeenCalledTimes(1);
+    expect(subscriptionsCancel).toHaveBeenCalledWith(
+      'sub_canceled_current_owner',
+    );
+    expect(subscriptionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: 'cus_current_owner',
+      }),
+    );
   });
 
   it('does not patch metadata.user_id on an active subscription whose metadata.e2e_owner differs from current owner', async () => {

--- a/tests/e2e/helpers/seed-test-user.test.ts
+++ b/tests/e2e/helpers/seed-test-user.test.ts
@@ -24,6 +24,17 @@ function createSqlClient(results: unknown[]) {
   });
 }
 
+function createStripeList<T>(firstPage: T[], allPages = firstPage) {
+  return {
+    data: firstPage,
+    async *[Symbol.asyncIterator]() {
+      for (const item of allPages) {
+        yield item;
+      }
+    },
+  };
+}
+
 describe('seedTestSubscription', () => {
   let seedTestSubscription: SeedTestSubscription;
   let postgresMock: ReturnType<typeof vi.fn>;
@@ -51,7 +62,7 @@ describe('seedTestSubscription', () => {
     }));
 
     customersCreate = vi.fn(async () => ({ id: 'cus_123' }));
-    customersList = vi.fn(async () => ({ data: [] }));
+    customersList = vi.fn(() => createStripeList([]));
     customersRetrieve = vi.fn(async () => ({
       id: 'cus_123',
       invoice_settings: {},
@@ -66,7 +77,7 @@ describe('seedTestSubscription', () => {
         ],
       },
     }));
-    subscriptionsList = vi.fn(async () => ({ data: [] }));
+    subscriptionsList = vi.fn(() => createStripeList([]));
     subscriptionsCancel = vi.fn(async () => ({}));
     subscriptionsUpdate = vi.fn(async () => ({}));
     const stripeClient = {
@@ -229,8 +240,8 @@ describe('seedTestSubscription', () => {
       },
       invoice_settings: {},
     });
-    customersList.mockResolvedValueOnce({
-      data: [
+    customersList.mockReturnValueOnce(
+      createStripeList([
         {
           id: 'cus_current_owner',
           metadata: {
@@ -239,8 +250,8 @@ describe('seedTestSubscription', () => {
             e2e_owner: 'github-ci',
           },
         },
-      ],
-    });
+      ]),
+    );
 
     await expect(seedTestSubscription()).resolves.toBeUndefined();
 
@@ -264,8 +275,8 @@ describe('seedTestSubscription', () => {
   });
 
   it('does not reuse a Stripe customer found by email when its metadata.e2e_owner differs from current owner', async () => {
-    customersList.mockResolvedValueOnce({
-      data: [
+    customersList.mockReturnValueOnce(
+      createStripeList([
         {
           id: 'cus_other_owner',
           metadata: {
@@ -274,8 +285,8 @@ describe('seedTestSubscription', () => {
             e2e_owner: 'local-dev',
           },
         },
-      ],
-    });
+      ]),
+    );
 
     await expect(seedTestSubscription()).resolves.toBeUndefined();
 
@@ -295,8 +306,8 @@ describe('seedTestSubscription', () => {
   });
 
   it('creates a new owner-scoped customer when none match the current owner', async () => {
-    customersList.mockResolvedValueOnce({
-      data: [
+    customersList.mockReturnValueOnce(
+      createStripeList([
         {
           id: 'cus_without_owner',
           metadata: {
@@ -310,8 +321,8 @@ describe('seedTestSubscription', () => {
             e2e_owner: 'local-dev',
           },
         },
-      ],
-    });
+      ]),
+    );
 
     await expect(seedTestSubscription()).resolves.toBeUndefined();
 
@@ -326,8 +337,8 @@ describe('seedTestSubscription', () => {
   });
 
   it('cancels non-active subscriptions only when they match the current owner', async () => {
-    customersList.mockResolvedValueOnce({
-      data: [
+    customersList.mockReturnValueOnce(
+      createStripeList([
         {
           id: 'cus_current_owner',
           metadata: {
@@ -336,10 +347,10 @@ describe('seedTestSubscription', () => {
             e2e_owner: 'github-ci',
           },
         },
-      ],
-    });
-    subscriptionsList.mockResolvedValueOnce({
-      data: [
+      ]),
+    );
+    subscriptionsList.mockReturnValueOnce(
+      createStripeList([
         {
           id: 'sub_canceled_current_owner',
           status: 'canceled',
@@ -370,8 +381,8 @@ describe('seedTestSubscription', () => {
             ],
           },
         },
-      ],
-    });
+      ]),
+    );
 
     await expect(seedTestSubscription()).resolves.toBeUndefined();
 
@@ -387,8 +398,8 @@ describe('seedTestSubscription', () => {
   });
 
   it('does not patch metadata.user_id on an active subscription whose metadata.e2e_owner differs from current owner', async () => {
-    customersList.mockResolvedValueOnce({
-      data: [
+    customersList.mockReturnValueOnce(
+      createStripeList([
         {
           id: 'cus_current_owner',
           metadata: {
@@ -397,10 +408,10 @@ describe('seedTestSubscription', () => {
             e2e_owner: 'github-ci',
           },
         },
-      ],
-    });
-    subscriptionsList.mockResolvedValueOnce({
-      data: [
+      ]),
+    );
+    subscriptionsList.mockReturnValueOnce(
+      createStripeList([
         {
           id: 'sub_other_owner',
           status: 'active',
@@ -416,8 +427,8 @@ describe('seedTestSubscription', () => {
             ],
           },
         },
-      ],
-    });
+      ]),
+    );
 
     await expect(seedTestSubscription()).resolves.toBeUndefined();
 
@@ -433,8 +444,8 @@ describe('seedTestSubscription', () => {
   });
 
   it('reuses a same-owner active subscription and patches its user_id when DB-local user differs', async () => {
-    customersList.mockResolvedValueOnce({
-      data: [
+    customersList.mockReturnValueOnce(
+      createStripeList([
         {
           id: 'cus_current_owner',
           metadata: {
@@ -443,10 +454,10 @@ describe('seedTestSubscription', () => {
             e2e_owner: 'github-ci',
           },
         },
-      ],
-    });
-    subscriptionsList.mockResolvedValueOnce({
-      data: [
+      ]),
+    );
+    subscriptionsList.mockReturnValueOnce(
+      createStripeList([
         {
           id: 'sub_existing',
           status: 'active',
@@ -462,8 +473,8 @@ describe('seedTestSubscription', () => {
             ],
           },
         },
-      ],
-    });
+      ]),
+    );
 
     await expect(seedTestSubscription()).resolves.toBeUndefined();
 
@@ -474,5 +485,99 @@ describe('seedTestSubscription', () => {
         e2e_owner: 'github-ci',
       },
     });
+  });
+
+  it('finds an owner-scoped customer beyond the first Stripe list page', async () => {
+    const firstPageCustomer = {
+      id: 'cus_other_owner',
+      metadata: {
+        user_id: 'other_user',
+        clerk_user_id: 'other_clerk',
+        e2e_owner: 'local-dev',
+      },
+    };
+    const secondPageCustomer = {
+      id: 'cus_second_page_current_owner',
+      metadata: {
+        user_id: 'user_123',
+        clerk_user_id: 'clerk_user_123',
+        e2e_owner: 'github-ci',
+      },
+    };
+    customersList.mockReturnValueOnce(
+      createStripeList(
+        [firstPageCustomer],
+        [firstPageCustomer, secondPageCustomer],
+      ),
+    );
+
+    await expect(seedTestSubscription()).resolves.toBeUndefined();
+
+    expect(customersCreate).not.toHaveBeenCalled();
+    expect(subscriptionsList).toHaveBeenCalledWith({
+      customer: 'cus_second_page_current_owner',
+      limit: 100,
+    });
+    expect(subscriptionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: 'cus_second_page_current_owner',
+      }),
+    );
+  });
+
+  it('reuses an active owner-scoped subscription beyond the first Stripe list page', async () => {
+    const firstPageSubscription = {
+      id: 'sub_first_page_other_owner',
+      status: 'active',
+      metadata: {
+        user_id: 'other_user',
+        e2e_owner: 'local-dev',
+      },
+      items: {
+        data: [
+          {
+            current_period_end: 1_800_000_000,
+          },
+        ],
+      },
+    };
+    const secondPageSubscription = {
+      id: 'sub_second_page_current_owner',
+      status: 'active',
+      metadata: {
+        user_id: 'user_123',
+        e2e_owner: 'github-ci',
+      },
+      items: {
+        data: [
+          {
+            current_period_end: 1_800_000_000,
+          },
+        ],
+      },
+    };
+    customersList.mockReturnValueOnce(
+      createStripeList([
+        {
+          id: 'cus_current_owner',
+          metadata: {
+            user_id: 'user_123',
+            clerk_user_id: 'clerk_user_123',
+            e2e_owner: 'github-ci',
+          },
+        },
+      ]),
+    );
+    subscriptionsList.mockReturnValueOnce(
+      createStripeList(
+        [firstPageSubscription],
+        [firstPageSubscription, secondPageSubscription],
+      ),
+    );
+
+    await expect(seedTestSubscription()).resolves.toBeUndefined();
+
+    expect(subscriptionsCreate).not.toHaveBeenCalled();
+    expect(subscriptionsUpdate).not.toHaveBeenCalled();
   });
 });

--- a/tests/e2e/helpers/seed-test-user.ts
+++ b/tests/e2e/helpers/seed-test-user.ts
@@ -4,6 +4,11 @@ import Stripe from 'stripe';
 const DEFAULT_LOCAL_E2E_STRIPE_OWNER = 'local-dev';
 const STRIPE_LIST_LIMIT = 100;
 
+type StripeCustomerSeedResult = {
+  stripeCustomerId: string;
+  canTrustLocalSubscriptionRow: boolean;
+};
+
 /**
  * Idempotent seed function that ensures the E2E test user has:
  * 1. A row in the `users` table
@@ -46,7 +51,7 @@ export async function seedTestSubscription(): Promise<void> {
     const userId = await ensureDbUser(sql, clerkUserId, email);
 
     // ── 3. Ensure Stripe customer + DB mirror ─────────────────────────
-    const stripeCustomerId = await ensureStripeCustomer(
+    const stripeCustomer = await ensureStripeCustomer(
       sql,
       stripe,
       userId,
@@ -60,9 +65,10 @@ export async function seedTestSubscription(): Promise<void> {
       sql,
       stripe,
       userId,
-      stripeCustomerId,
+      stripeCustomer.stripeCustomerId,
       priceId,
       e2eStripeOwner,
+      stripeCustomer.canTrustLocalSubscriptionRow,
     );
   } finally {
     await sql.end();
@@ -140,7 +146,7 @@ async function ensureStripeCustomer(
   clerkUserId: string,
   email: string,
   e2eStripeOwner: string,
-): Promise<string> {
+): Promise<StripeCustomerSeedResult> {
   // Check DB first
   const [existing] = await sql`
     SELECT stripe_customer_id FROM stripe_customers WHERE user_id = ${userId}
@@ -153,7 +159,10 @@ async function ensureStripeCustomer(
       !('deleted' in existingCustomer && existingCustomer.deleted) &&
       hasE2EOwner(existingCustomer.metadata, e2eStripeOwner)
     ) {
-      return existing.stripe_customer_id as string;
+      return {
+        stripeCustomerId: existing.stripe_customer_id as string,
+        canTrustLocalSubscriptionRow: true,
+      };
     }
   }
 
@@ -189,7 +198,10 @@ async function ensureStripeCustomer(
       SET stripe_customer_id = EXCLUDED.stripe_customer_id
   `;
 
-  return stripeCustomerId;
+  return {
+    stripeCustomerId,
+    canTrustLocalSubscriptionRow: false,
+  };
 }
 
 // ── Stripe subscription ──────────────────────────────────────────────────
@@ -201,6 +213,7 @@ async function ensureActiveSubscription(
   stripeCustomerId: string,
   priceId: string,
   e2eStripeOwner: string,
+  canTrustLocalSubscriptionRow: boolean,
 ): Promise<void> {
   // Check if we already have an active subscription with time remaining
   const [existing] = await sql`
@@ -210,6 +223,7 @@ async function ensureActiveSubscription(
   `;
 
   if (
+    canTrustLocalSubscriptionRow &&
     existing &&
     existing.status === 'active' &&
     new Date(existing.current_period_end as string) > new Date()

--- a/tests/e2e/helpers/seed-test-user.ts
+++ b/tests/e2e/helpers/seed-test-user.ts
@@ -2,7 +2,7 @@ import postgres from 'postgres';
 import Stripe from 'stripe';
 
 const DEFAULT_LOCAL_E2E_STRIPE_OWNER = 'local-dev';
-const STRIPE_LIST_LIMIT = 100;
+const STRIPE_PAGE_SIZE = 100;
 
 type StripeCustomerSeedResult = {
   stripeCustomerId: string;
@@ -99,6 +99,40 @@ function hasE2EOwner(
   return metadata?.e2e_owner === e2eStripeOwner;
 }
 
+async function findOwnerMatchedStripeCustomer(
+  stripe: Stripe,
+  email: string,
+  e2eStripeOwner: string,
+): Promise<Stripe.Customer | undefined> {
+  for await (const customer of stripe.customers.list({
+    email,
+    limit: STRIPE_PAGE_SIZE,
+  })) {
+    if (hasE2EOwner(customer.metadata, e2eStripeOwner)) {
+      return customer;
+    }
+  }
+}
+
+async function listOwnerMatchedStripeSubscriptions(
+  stripe: Stripe,
+  stripeCustomerId: string,
+  e2eStripeOwner: string,
+): Promise<Stripe.Subscription[]> {
+  const ownerMatchedSubscriptions: Stripe.Subscription[] = [];
+
+  for await (const subscription of stripe.subscriptions.list({
+    customer: stripeCustomerId,
+    limit: STRIPE_PAGE_SIZE,
+  })) {
+    if (hasE2EOwner(subscription.metadata, e2eStripeOwner)) {
+      ownerMatchedSubscriptions.push(subscription);
+    }
+  }
+
+  return ownerMatchedSubscriptions;
+}
+
 // ── Clerk ────────────────────────────────────────────────────────────────
 
 async function resolveClerkUserId(
@@ -167,13 +201,11 @@ async function ensureStripeCustomer(
   }
 
   // Check Stripe (may exist from a previous run not mirrored in DB)
-  const customers = await stripe.customers.list({
-    email,
-    limit: STRIPE_LIST_LIMIT,
-  });
   let stripeCustomerId: string;
-  const ownerMatchedCustomer = customers.data.find((customer) =>
-    hasE2EOwner(customer.metadata, e2eStripeOwner),
+  const ownerMatchedCustomer = await findOwnerMatchedStripeCustomer(
+    stripe,
+    email,
+    e2eStripeOwner,
   );
 
   if (ownerMatchedCustomer) {
@@ -246,12 +278,10 @@ async function ensureActiveSubscription(
   }
 
   // Cancel any non-active subscriptions on this customer to avoid conflicts
-  const subs = await stripe.subscriptions.list({
-    customer: stripeCustomerId,
-    limit: STRIPE_LIST_LIMIT,
-  });
-  const ownerMatchedSubscriptions = subs.data.filter((subscription) =>
-    hasE2EOwner(subscription.metadata, e2eStripeOwner),
+  const ownerMatchedSubscriptions = await listOwnerMatchedStripeSubscriptions(
+    stripe,
+    stripeCustomerId,
+    e2eStripeOwner,
   );
   for (const sub of ownerMatchedSubscriptions) {
     if (sub.status !== 'active') {

--- a/tests/e2e/helpers/seed-test-user.ts
+++ b/tests/e2e/helpers/seed-test-user.ts
@@ -1,6 +1,9 @@
 import postgres from 'postgres';
 import Stripe from 'stripe';
 
+const DEFAULT_LOCAL_E2E_STRIPE_OWNER = 'local-dev';
+const STRIPE_LIST_LIMIT = 100;
+
 /**
  * Idempotent seed function that ensures the E2E test user has:
  * 1. A row in the `users` table
@@ -15,6 +18,7 @@ export async function seedTestSubscription(): Promise<void> {
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
   const clerkSecretKey = process.env.CLERK_SECRET_KEY;
   const email = process.env.E2E_CLERK_USER_USERNAME;
+  const e2eStripeOwner = resolveE2EStripeOwner(stripeSecretKey);
   const priceId = process.env.NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY;
 
   if (
@@ -48,6 +52,7 @@ export async function seedTestSubscription(): Promise<void> {
       userId,
       clerkUserId,
       email,
+      e2eStripeOwner,
     );
 
     // ── 4. Ensure active subscription + DB mirror ─────────────────────
@@ -57,10 +62,35 @@ export async function seedTestSubscription(): Promise<void> {
       userId,
       stripeCustomerId,
       priceId,
+      e2eStripeOwner,
     );
   } finally {
     await sql.end();
   }
+}
+
+function isDummyStripeSecretKey(stripeSecretKey: string): boolean {
+  return stripeSecretKey === 'sk_test_dummy';
+}
+
+function resolveE2EStripeOwner(stripeSecretKey: string | undefined): string {
+  const configuredOwner = process.env.E2E_STRIPE_OWNER?.trim();
+  if (configuredOwner) return configuredOwner;
+
+  if (stripeSecretKey && !isDummyStripeSecretKey(stripeSecretKey)) {
+    throw new Error(
+      'E2E_STRIPE_OWNER is required when STRIPE_SECRET_KEY is real',
+    );
+  }
+
+  return DEFAULT_LOCAL_E2E_STRIPE_OWNER;
+}
+
+function hasE2EOwner(
+  metadata: Stripe.Metadata | null | undefined,
+  e2eStripeOwner: string,
+): boolean {
+  return metadata?.e2e_owner === e2eStripeOwner;
 }
 
 // ── Clerk ────────────────────────────────────────────────────────────────
@@ -109,25 +139,43 @@ async function ensureStripeCustomer(
   userId: string,
   clerkUserId: string,
   email: string,
+  e2eStripeOwner: string,
 ): Promise<string> {
   // Check DB first
   const [existing] = await sql`
     SELECT stripe_customer_id FROM stripe_customers WHERE user_id = ${userId}
   `;
-  if (existing) return existing.stripe_customer_id as string;
+  if (existing) {
+    const existingCustomer = await stripe.customers.retrieve(
+      existing.stripe_customer_id as string,
+    );
+    if (
+      !('deleted' in existingCustomer && existingCustomer.deleted) &&
+      hasE2EOwner(existingCustomer.metadata, e2eStripeOwner)
+    ) {
+      return existing.stripe_customer_id as string;
+    }
+  }
 
   // Check Stripe (may exist from a previous run not mirrored in DB)
-  const customers = await stripe.customers.list({ email, limit: 1 });
+  const customers = await stripe.customers.list({
+    email,
+    limit: STRIPE_LIST_LIMIT,
+  });
   let stripeCustomerId: string;
+  const ownerMatchedCustomer = customers.data.find((customer) =>
+    hasE2EOwner(customer.metadata, e2eStripeOwner),
+  );
 
-  if (customers.data.length > 0) {
-    stripeCustomerId = customers.data[0].id;
+  if (ownerMatchedCustomer) {
+    stripeCustomerId = ownerMatchedCustomer.id;
   } else {
     const customer = await stripe.customers.create({
       email,
       metadata: {
         user_id: userId,
         clerk_user_id: clerkUserId,
+        e2e_owner: e2eStripeOwner,
       },
     });
     stripeCustomerId = customer.id;
@@ -152,6 +200,7 @@ async function ensureActiveSubscription(
   userId: string,
   stripeCustomerId: string,
   priceId: string,
+  e2eStripeOwner: string,
 ): Promise<void> {
   // Check if we already have an active subscription with time remaining
   const [existing] = await sql`
@@ -185,16 +234,21 @@ async function ensureActiveSubscription(
   // Cancel any non-active subscriptions on this customer to avoid conflicts
   const subs = await stripe.subscriptions.list({
     customer: stripeCustomerId,
-    limit: 100,
+    limit: STRIPE_LIST_LIMIT,
   });
-  for (const sub of subs.data) {
+  const ownerMatchedSubscriptions = subs.data.filter((subscription) =>
+    hasE2EOwner(subscription.metadata, e2eStripeOwner),
+  );
+  for (const sub of ownerMatchedSubscriptions) {
     if (sub.status !== 'active') {
       await stripe.subscriptions.cancel(sub.id);
     }
   }
 
   // If there's an active sub in Stripe already, reuse it
-  const activeSub = subs.data.find((s) => s.status === 'active');
+  const activeSub = ownerMatchedSubscriptions.find(
+    (s) => s.status === 'active',
+  );
   let subscriptionId: string;
   let currentPeriodEnd: Date;
 
@@ -204,6 +258,7 @@ async function ensureActiveSubscription(
         metadata: {
           ...(activeSub.metadata ?? {}),
           user_id: userId,
+          e2e_owner: e2eStripeOwner,
         },
       });
     }
@@ -217,6 +272,7 @@ async function ensureActiveSubscription(
       items: [{ price: priceId }],
       metadata: {
         user_id: userId,
+        e2e_owner: e2eStripeOwner,
       },
     });
     subscriptionId = subscription.id;


### PR DESCRIPTION
## Problem

DEBT-386 documents the post-DEBT-384 Stripe webhook retry source: shared E2E Stripe test customers/subscriptions were being rebound across independent DB-local user IDs, causing the dev-preview webhook to reject `Stripe customer id is already mapped to a different user` and return 500.

## Solution

- Scope E2E Stripe seeding by explicit owner metadata via `E2E_STRIPE_OWNER`, including customer/subscription filtering and same-owner-only metadata repair.
- Add a typed `metadata.e2e_owner` mismatch marker through the Stripe subscription normalizer and skip only that marker at the webhook-controller boundary.
- Preserve fail-closed behavior for reconciliation and real ownership conflicts; no broad `CONFLICT` suppression.
- Document `E2E_STRIPE_OWNER` / `STRIPE_WEBHOOK_E2E_OWNER` and update the active DEBT-386 register entry.

Spec: `docs/debt/debt-386-e2e-stripe-customer-ownership-drift-webhook-500s.md`

## T3 design decision

The owner-mismatch path mirrors DEBT-384: it reuses `ApplicationError('STRIPE_ERROR')` and disambiguates via `fieldErrors['metadata.e2e_owner'] = ['mismatch']`. The controller catches only that typed marker, logs `reason: 'e2e_owner_mismatch'`, returns 200, and does not claim `stripe_events`. Message string matching is intentionally avoided.

## Reconcile safety

`reconcileStripeSubscriptions` receives the optional owner configuration and remains fail-closed: a configured owner mismatch becomes a row failure, not a skip. The regression test proves the cron path still records a failure for mismatched owner metadata.

## Test plan

- [x] RED: `pnpm test --run tests/e2e/helpers/seed-test-user.test.ts` failed with 5 expected failures before E2E seed implementation.
- [x] GREEN: `pnpm test --run tests/e2e/helpers/seed-test-user.test.ts`
- [x] RED: `pnpm test --run src/adapters/gateways/stripe/stripe-subscription-normalizer.test.ts src/adapters/controllers/stripe-webhook-controller.test.ts src/adapters/jobs/reconcile-stripe-subscriptions.test.ts` failed with 3 expected failures before webhook implementation.
- [x] GREEN: focused 4-file regression suite, 58 tests passed.
- [x] `pnpm typecheck`
- [x] `pnpm lint` (19 existing oversized-file warnings only)
- [x] `pnpm test --run` (304 files, 2449 tests)
- [x] `pnpm test:browser` (48 files, 265 tests)
- [x] `pnpm test:integration` (16 files, 97 tests)
- [x] `pnpm build`
- [x] `E2E_STRIPE_OWNER=local-dev pnpm test:e2e` (35 passed)

## Post-merge ops checklist

- Re-run `stripe events list --delivery-success=false --limit 100`.
- Set `STRIPE_WEBHOOK_E2E_OWNER=vercel-dev-preview` on the dev-preview webhook deployment environment before relying on skip behavior there.
- Add `customer.subscription.created` to both Stripe webhook endpoint event lists.
- Optionally cancel stale non-owner test subscriptions after verifying no new owner-drift retries accumulate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded E2E tests to enforce and validate owner-scoped Stripe customer/subscription seeding and owner-aware reconciliation behavior.

* **Bug Fixes**
  * Webhook handling now skips explicit E2E-owner-mismatched events and makes reconciliation fail/record failures for owner mismatches.

* **Chores**
  * Added and required E2E Stripe owner environment variables for local and CI runs; CI now validates the owner is set.

* **Documentation**
  * Updated testing and debt docs with E2E Stripe owner guidance and operational notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->