### PR TITLE
Implement DEBT-385 Clover invoice subscription-ref extraction

### DIFF
--- a/docs/debt/debt-385-stripe-invoice-event-subscription-ref-schema-drift.md
+++ b/docs/debt/debt-385-stripe-invoice-event-subscription-ref-schema-drift.md
@@ -4,7 +4,7 @@
 **Created:** 2026-05-14
 **Source:** Filed from DEBT-384 after live Stripe payload inspection found invoice events no longer expose the subscription reference at the root field our schema reads.
 **Related:** [DEBT-384](../_archive/debt/debt-384-stripe-webhook-error-rate-investigation.md)
-**Status:** Active — documented only. DEBT-384 has shipped and been archived; this remains a separate follow-up.
+**Status:** Active — implementation in PR #312, pending user grade and merge. DEBT-384 has shipped and been archived; this remains a separate follow-up.
 
 **Origin:** The app is pinned to Stripe API version `2026-01-28.clover` at `lib/stripe.ts:22`. The value changed from `2025-04-30.basil` to Clover in commit `d9f3cbe4` (`Fix Stripe API version for updated stripe SDK`) on 2026-01-31, and commit `84b4c0463` only moved that already-Clover pin into lazy initialization. Current Clover invoice events expose the subscription reference at `data.object.parent.subscription_details.subscription`, so this schema drift has been possible since the Clover pin.
 
@@ -19,17 +19,17 @@ data.object.subscription: null
 data.object.parent.subscription_details.subscription: "sub_..."
 ```
 
-Before this debt was fixed, the subscription-reference schema only read root-level `subscription` via `stripeCheckoutSessionSchema`, and `stripeEventWithSubscriptionRefSchema` was a direct alias of that root-only schema. `getSubscriptionUpdateForSubscriptionRefEvent` received no root-level reference for these invoice events, so it returned `undefined`. The webhook controller then marked the event processed and returned 200 with no subscription update.
+At the time this debt was filed, the subscription-reference schema only read root-level `subscription` via `stripeCheckoutSessionSchema`, and `stripeEventWithSubscriptionRefSchema` was a direct alias of that root-only schema. `getSubscriptionUpdateForSubscriptionRefEvent` received no root-level reference for these invoice events, so it returned `undefined`. The webhook controller then marked the event processed and returned 200 with no subscription update.
 
-That is a silent no-op, not a delivery failure.
+That was a silent no-op, not a delivery failure.
 
 ---
 
 ## Why This Is Debt
 
-The current behavior is masked because Stripe usually emits parallel `customer.subscription.updated` events for the same billing-cycle state changes, and that subscription-event path retrieves and normalizes the subscription correctly. If Stripe emits an invoice-event-only transition, or if endpoint configuration misses the parallel subscription event, the app can silently miss a subscription state update while still returning 200 to Stripe.
+The pre-fix behavior was masked because Stripe usually emits parallel `customer.subscription.updated` events for the same billing-cycle state changes, and that subscription-event path retrieves and normalizes the subscription correctly. If Stripe emits an invoice-event-only transition, or if endpoint configuration misses the parallel subscription event, the app could silently miss a subscription state update while still returning 200 to Stripe.
 
-This is separate from DEBT-384's missing subscription metadata failure. DEBT-384 returns 500 on `customer.subscription.*` events for out-of-band subscriptions. DEBT-385 returns 200 on invoice events while doing nothing because the subscription reference is not found.
+This is separate from DEBT-384's missing subscription metadata failure. DEBT-384 returned 500 on `customer.subscription.*` events for out-of-band subscriptions. Before this fix, DEBT-385 returned 200 on invoice events while doing nothing because the subscription reference was not found.
 
 ---
 

--- a/docs/debt/debt-385-stripe-invoice-event-subscription-ref-schema-drift.md
+++ b/docs/debt/debt-385-stripe-invoice-event-subscription-ref-schema-drift.md
@@ -19,7 +19,7 @@ data.object.subscription: null
 data.object.parent.subscription_details.subscription: "sub_..."
 ```
 
-The current schema at `src/adapters/gateways/stripe/stripe-webhook-schemas.ts:25-32` only reads root-level `subscription` via `stripeCheckoutSessionSchema`, which is also aliased as `stripeEventWithSubscriptionRefSchema` at line 34. `getSubscriptionUpdateForSubscriptionRefEvent` in `src/adapters/gateways/stripe/stripe-webhook-processor.ts:13-51` receives no root-level reference for these invoice events, so it returns `undefined`. The webhook controller then marks the event processed and returns 200 with no subscription update.
+Before this debt was fixed, the subscription-reference schema only read root-level `subscription` via `stripeCheckoutSessionSchema`, and `stripeEventWithSubscriptionRefSchema` was a direct alias of that root-only schema. `getSubscriptionUpdateForSubscriptionRefEvent` received no root-level reference for these invoice events, so it returned `undefined`. The webhook controller then marked the event processed and returned 200 with no subscription update.
 
 That is a silent no-op, not a delivery failure.
 

--- a/docs/debt/debt-385-stripe-invoice-event-subscription-ref-schema-drift.md
+++ b/docs/debt/debt-385-stripe-invoice-event-subscription-ref-schema-drift.md
@@ -6,6 +6,8 @@
 **Related:** [DEBT-384](../_archive/debt/debt-384-stripe-webhook-error-rate-investigation.md)
 **Status:** Active — documented only. DEBT-384 has shipped and been archived; this remains a separate follow-up.
 
+**Origin:** The app is pinned to Stripe API version `2026-01-28.clover` at `lib/stripe.ts:22`. The value changed from `2025-04-30.basil` to Clover in commit `d9f3cbe4` (`Fix Stripe API version for updated stripe SDK`) on 2026-01-31, and commit `84b4c0463` only moved that already-Clover pin into lazy initialization. Current Clover invoice events expose the subscription reference at `data.object.parent.subscription_details.subscription`, so this schema drift has been possible since the Clover pin.
+
 ---
 
 ## Confirmed Finding
@@ -17,7 +19,7 @@ data.object.subscription: null
 data.object.parent.subscription_details.subscription: "sub_..."
 ```
 
-The current schema at `src/adapters/gateways/stripe/stripe-webhook-schemas.ts:25-32` only reads root-level `subscription` via `stripeCheckoutSessionSchema`, which is also aliased as `stripeEventWithSubscriptionRefSchema` at line 34. `getSubscriptionUpdateForSubscriptionRefEvent` in `src/adapters/gateways/stripe/stripe-webhook-processor.ts:13-49` receives no root-level reference for these invoice events, so it returns `undefined`. The webhook controller then marks the event processed and returns 200 with no subscription update.
+The current schema at `src/adapters/gateways/stripe/stripe-webhook-schemas.ts:25-32` only reads root-level `subscription` via `stripeCheckoutSessionSchema`, which is also aliased as `stripeEventWithSubscriptionRefSchema` at line 34. `getSubscriptionUpdateForSubscriptionRefEvent` in `src/adapters/gateways/stripe/stripe-webhook-processor.ts:13-51` receives no root-level reference for these invoice events, so it returns `undefined`. The webhook controller then marks the event processed and returns 200 with no subscription update.
 
 That is a silent no-op, not a delivery failure.
 
@@ -45,7 +47,7 @@ Expected test surfaces:
 
 - `src/adapters/gateways/stripe/stripe-webhook-processor.test.ts`
 - `src/adapters/gateways/stripe-payment-gateway.test.ts`
-- `src/adapters/gateways/stripe/stripe-webhook-schemas.ts`
+- `src/adapters/gateways/stripe/stripe-webhook-schemas.test.ts` (new)
 
 Use a real fixture shape matching the observed Stripe payload. Avoid hard-coding behavior to a single event ID.
 

--- a/src/adapters/gateways/stripe-payment-gateway.test.ts
+++ b/src/adapters/gateways/stripe-payment-gateway.test.ts
@@ -697,6 +697,55 @@ describe('StripePaymentGateway', () => {
     expect(subscriptionsRetrieve).toHaveBeenCalledWith(subscription.id);
   });
 
+  it('normalizes invoice.payment_succeeded events with a nested Clover subscription reference', async () => {
+    const subscriptionEvent = loadJsonFixture<{
+      data: { object: { id: string } };
+    }>('stripe/customer.subscription.updated.json');
+    const subscription = subscriptionEvent.data.object;
+
+    const constructedEvent = {
+      id: 'evt_invoice_success_nested_1',
+      type: 'invoice.payment_succeeded',
+      data: {
+        object: {
+          id: 'in_test_REDACTED',
+          object: 'invoice',
+          subscription: null,
+          parent: {
+            type: 'subscription_details',
+            subscription_details: {
+              subscription: subscription.id,
+            },
+          },
+        },
+      },
+    };
+    const { stripe, constructEvent, subscriptionsRetrieve } = createStripeMock({
+      withSubscriptions: true,
+    });
+    constructEvent.mockReturnValue(constructedEvent);
+    subscriptionsRetrieve.mockResolvedValue(subscription);
+    const gateway = createGateway(stripe);
+
+    await expect(
+      gateway.processWebhookEvent('raw_body', 'sig_1'),
+    ).resolves.toEqual({
+      eventId: 'evt_invoice_success_nested_1',
+      type: 'invoice.payment_succeeded',
+      subscriptionUpdate: {
+        userId: 'user_1',
+        externalCustomerId: 'cus_123',
+        externalSubscriptionId: 'sub_123',
+        plan: 'monthly',
+        status: 'active',
+        currentPeriodEnd: new Date(1_700_000_000 * 1000),
+        cancelAtPeriodEnd: false,
+      },
+    });
+
+    expect(subscriptionsRetrieve).toHaveBeenCalledWith(subscription.id);
+  });
+
   it('throws INVALID_WEBHOOK_PAYLOAD when invoice.payment_failed payload shape is invalid', async () => {
     const constructedEvent = {
       id: 'evt_bad_invoice_payload',

--- a/src/adapters/gateways/stripe/stripe-webhook-processor.test.ts
+++ b/src/adapters/gateways/stripe/stripe-webhook-processor.test.ts
@@ -199,6 +199,180 @@ describe('processStripeWebhookEvent', () => {
     expect(stripe.subscriptions?.retrieve).toHaveBeenCalledWith('sub_123');
   });
 
+  it('retrieves and includes subscriptionUpdate for invoice.payment_succeeded events with a nested Clover subscription reference', async () => {
+    const logger = new FakeLogger();
+    const stripe = createStripeClient({
+      eventFactory: () => ({
+        id: 'evt_invoice_success_nested',
+        type: 'invoice.payment_succeeded',
+        data: {
+          object: {
+            id: 'in_test_REDACTED',
+            object: 'invoice',
+            subscription: null,
+            parent: {
+              type: 'subscription_details',
+              subscription_details: {
+                subscription: 'sub_test_REDACTED_nested_success',
+              },
+            },
+          },
+        },
+      }),
+    });
+
+    const result = await processStripeWebhookEvent({
+      stripe,
+      webhookSecret: 'whsec_test',
+      rawBody: '{}',
+      signature: 'sig_test',
+      priceIds,
+      logger,
+    });
+
+    expect(result).toEqual({
+      eventId: 'evt_invoice_success_nested',
+      type: 'invoice.payment_succeeded',
+      subscriptionUpdate: {
+        userId: 'user_1',
+        externalCustomerId: 'cus_123',
+        externalSubscriptionId: 'sub_123',
+        plan: 'monthly',
+        status: 'active',
+        currentPeriodEnd: new Date(1_800_000_000 * 1000),
+        cancelAtPeriodEnd: false,
+      },
+    });
+    expect(stripe.subscriptions?.retrieve).toHaveBeenCalledWith(
+      'sub_test_REDACTED_nested_success',
+    );
+  });
+
+  it('retrieves and includes subscriptionUpdate for invoice.payment_failed events with a nested Clover subscription reference', async () => {
+    const logger = new FakeLogger();
+    const stripe = createStripeClient({
+      eventFactory: () => ({
+        id: 'evt_invoice_failed_nested',
+        type: 'invoice.payment_failed',
+        data: {
+          object: {
+            id: 'in_test_REDACTED',
+            object: 'invoice',
+            subscription: null,
+            parent: {
+              type: 'subscription_details',
+              subscription_details: {
+                subscription: 'sub_test_REDACTED_nested_failed',
+              },
+            },
+          },
+        },
+      }),
+    });
+
+    const result = await processStripeWebhookEvent({
+      stripe,
+      webhookSecret: 'whsec_test',
+      rawBody: '{}',
+      signature: 'sig_test',
+      priceIds,
+      logger,
+    });
+
+    expect(result).toEqual({
+      eventId: 'evt_invoice_failed_nested',
+      type: 'invoice.payment_failed',
+      subscriptionUpdate: {
+        userId: 'user_1',
+        externalCustomerId: 'cus_123',
+        externalSubscriptionId: 'sub_123',
+        plan: 'monthly',
+        status: 'active',
+        currentPeriodEnd: new Date(1_800_000_000 * 1000),
+        cancelAtPeriodEnd: false,
+      },
+    });
+    expect(stripe.subscriptions?.retrieve).toHaveBeenCalledWith(
+      'sub_test_REDACTED_nested_failed',
+    );
+  });
+
+  it('prefers nested invoice subscription references over legacy root references when both are present', async () => {
+    const logger = new FakeLogger();
+    const stripe = createStripeClient({
+      eventFactory: () => ({
+        id: 'evt_invoice_both_refs',
+        type: 'invoice.payment_succeeded',
+        data: {
+          object: {
+            id: 'in_test_REDACTED',
+            object: 'invoice',
+            subscription: 'sub_test_REDACTED_legacy_root',
+            parent: {
+              type: 'subscription_details',
+              subscription_details: {
+                subscription: 'sub_test_REDACTED_clover_nested',
+              },
+            },
+          },
+        },
+      }),
+    });
+
+    await processStripeWebhookEvent({
+      stripe,
+      webhookSecret: 'whsec_test',
+      rawBody: '{}',
+      signature: 'sig_test',
+      priceIds,
+      logger,
+    });
+
+    // Current Clover invoice payloads put the authoritative subscription
+    // reference in parent.subscription_details; root is legacy fallback only.
+    expect(stripe.subscriptions?.retrieve).toHaveBeenCalledWith(
+      'sub_test_REDACTED_clover_nested',
+    );
+  });
+
+  it('returns base result for invoice events when no subscription reference exists', async () => {
+    const logger = new FakeLogger();
+    const stripe = createStripeClient({
+      eventFactory: () => ({
+        id: 'evt_invoice_no_ref',
+        type: 'invoice.payment_succeeded',
+        data: {
+          object: {
+            id: 'in_test_REDACTED',
+            object: 'invoice',
+            subscription: null,
+            parent: {
+              type: 'subscription_details',
+              subscription_details: {
+                subscription: null,
+              },
+            },
+          },
+        },
+      }),
+    });
+
+    await expect(
+      processStripeWebhookEvent({
+        stripe,
+        webhookSecret: 'whsec_test',
+        rawBody: '{}',
+        signature: 'sig_test',
+        priceIds,
+        logger,
+      }),
+    ).resolves.toEqual({
+      eventId: 'evt_invoice_no_ref',
+      type: 'invoice.payment_succeeded',
+    });
+    expect(stripe.subscriptions?.retrieve).not.toHaveBeenCalled();
+  });
+
   it('normalizes and includes subscriptionUpdate for customer.subscription.updated events', async () => {
     const logger = new FakeLogger();
     const subscription = createSubscriptionFixture();

--- a/src/adapters/gateways/stripe/stripe-webhook-processor.ts
+++ b/src/adapters/gateways/stripe/stripe-webhook-processor.ts
@@ -5,6 +5,7 @@ import type { WebhookEventResult } from '@/src/application/ports/gateways';
 import type { Logger } from '@/src/application/ports/logger';
 import { retrieveAndNormalizeStripeSubscription } from './stripe-subscription-normalizer';
 import {
+  extractSubscriptionRef,
   stripeEventWithSubscriptionRefSchema,
   stripeSubscriptionSchema,
   subscriptionEventTypes,
@@ -37,7 +38,7 @@ async function getSubscriptionUpdateForSubscriptionRefEvent(input: {
   }
 
   const payload = parsedPayload.data;
-  const subscriptionRef = payload.subscription;
+  const subscriptionRef = extractSubscriptionRef(payload);
   if (!subscriptionRef) return undefined;
 
   return retrieveAndNormalizeStripeSubscription({

--- a/src/adapters/gateways/stripe/stripe-webhook-processor.ts
+++ b/src/adapters/gateways/stripe/stripe-webhook-processor.ts
@@ -1,15 +1,15 @@
 import type { StripePriceIds } from '@/src/adapters/config/stripe-prices';
-import type { StripeClient } from '@/src/adapters/shared/stripe-types';
-import { ApplicationError } from '@/src/application/errors';
-import type { WebhookEventResult } from '@/src/application/ports/gateways';
-import type { Logger } from '@/src/application/ports/logger';
-import { retrieveAndNormalizeStripeSubscription } from './stripe-subscription-normalizer';
+import { retrieveAndNormalizeStripeSubscription } from '@/src/adapters/gateways/stripe/stripe-subscription-normalizer';
 import {
   extractSubscriptionRef,
   stripeEventWithSubscriptionRefSchema,
   stripeSubscriptionSchema,
   subscriptionEventTypes,
-} from './stripe-webhook-schemas';
+} from '@/src/adapters/gateways/stripe/stripe-webhook-schemas';
+import type { StripeClient } from '@/src/adapters/shared/stripe-types';
+import { ApplicationError } from '@/src/application/errors';
+import type { WebhookEventResult } from '@/src/application/ports/gateways';
+import type { Logger } from '@/src/application/ports/logger';
 
 async function getSubscriptionUpdateForSubscriptionRefEvent(input: {
   stripe: StripeClient;

--- a/src/adapters/gateways/stripe/stripe-webhook-schemas.test.ts
+++ b/src/adapters/gateways/stripe/stripe-webhook-schemas.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractSubscriptionRef,
+  stripeEventWithSubscriptionRefSchema,
+} from './stripe-webhook-schemas';
+
+const CLOVER_NESTED_SUBSCRIPTION_REF = 'sub_test_REDACTED_nested';
+const LEGACY_ROOT_SUBSCRIPTION_REF = 'sub_test_REDACTED_root';
+
+function createCloverInvoicePayload() {
+  return {
+    id: 'in_test_REDACTED',
+    object: 'invoice',
+    subscription: null,
+    parent: {
+      type: 'subscription_details',
+      subscription_details: {
+        subscription: CLOVER_NESTED_SUBSCRIPTION_REF,
+      },
+    },
+  };
+}
+
+describe('stripeEventWithSubscriptionRefSchema', () => {
+  it('extracts the nested Clover subscription reference from invoice payloads', () => {
+    const parsed = stripeEventWithSubscriptionRefSchema.parse(
+      createCloverInvoicePayload(),
+    );
+
+    expect(extractSubscriptionRef(parsed)).toBe(CLOVER_NESTED_SUBSCRIPTION_REF);
+  });
+
+  it('extracts the legacy root subscription reference from checkout payloads', () => {
+    const parsed = stripeEventWithSubscriptionRefSchema.parse({
+      id: 'cs_test_REDACTED',
+      object: 'checkout.session',
+      subscription: LEGACY_ROOT_SUBSCRIPTION_REF,
+    });
+
+    expect(extractSubscriptionRef(parsed)).toBe(LEGACY_ROOT_SUBSCRIPTION_REF);
+  });
+
+  it('returns null when neither root nor nested subscription reference exists', () => {
+    const parsed = stripeEventWithSubscriptionRefSchema.parse({
+      id: 'in_test_REDACTED',
+      object: 'invoice',
+      subscription: null,
+      parent: {
+        type: 'subscription_details',
+        subscription_details: {
+          subscription: null,
+        },
+      },
+    });
+
+    expect(extractSubscriptionRef(parsed)).toBeNull();
+  });
+
+  it('preserves passthrough semantics for unrelated extra fields', () => {
+    const parsed = stripeEventWithSubscriptionRefSchema.parse({
+      ...createCloverInvoicePayload(),
+      billing_reason: 'subscription_cycle',
+      custom_extra_field: {
+        still: 'present',
+      },
+    });
+
+    expect(parsed).toMatchObject({
+      billing_reason: 'subscription_cycle',
+      custom_extra_field: {
+        still: 'present',
+      },
+    });
+    expect(extractSubscriptionRef(parsed)).toBe(CLOVER_NESTED_SUBSCRIPTION_REF);
+  });
+});

--- a/src/adapters/gateways/stripe/stripe-webhook-schemas.test.ts
+++ b/src/adapters/gateways/stripe/stripe-webhook-schemas.test.ts
@@ -40,6 +40,20 @@ describe('stripeEventWithSubscriptionRefSchema', () => {
     expect(extractSubscriptionRef(parsed)).toBe(LEGACY_ROOT_SUBSCRIPTION_REF);
   });
 
+  it('extracts an expanded object-shaped subscription reference', () => {
+    const expandedSubscriptionRef = {
+      id: 'sub_test_REDACTED_expanded',
+      status: 'active',
+    };
+    const parsed = stripeEventWithSubscriptionRefSchema.parse({
+      id: 'cs_test_REDACTED',
+      object: 'checkout.session',
+      subscription: expandedSubscriptionRef,
+    });
+
+    expect(extractSubscriptionRef(parsed)).toEqual(expandedSubscriptionRef);
+  });
+
   it('returns null when neither root nor nested subscription reference exists', () => {
     const parsed = stripeEventWithSubscriptionRefSchema.parse({
       id: 'in_test_REDACTED',

--- a/src/adapters/gateways/stripe/stripe-webhook-schemas.ts
+++ b/src/adapters/gateways/stripe/stripe-webhook-schemas.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 
+const stripeSubscriptionRefSchema = z.union([
+  z.string(),
+  z.object({ id: z.string() }).passthrough(),
+]);
+
 export const stripeSubscriptionItemSchema = z
   .object({
     current_period_end: z.number(),
@@ -24,23 +29,47 @@ export const stripeSubscriptionSchema = z
 
 export const stripeCheckoutSessionSchema = z
   .object({
-    subscription: z
-      .union([z.string(), z.object({ id: z.string() }).passthrough()])
+    subscription: stripeSubscriptionRefSchema.nullable().optional(),
+  })
+  .passthrough();
+
+const stripeInvoiceSubscriptionRefSchema = z
+  .object({
+    parent: z
+      .object({
+        subscription_details: z
+          .object({
+            subscription: stripeSubscriptionRefSchema.nullable().optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
       .nullable()
       .optional(),
   })
   .passthrough();
 
-export const stripeEventWithSubscriptionRefSchema = stripeCheckoutSessionSchema;
+// Clover invoice events moved the subscription ref under parent; keep root
+// support for Checkout Session payloads and older compatible invoice shapes.
+export const stripeEventWithSubscriptionRefSchema =
+  stripeCheckoutSessionSchema.merge(stripeInvoiceSubscriptionRefSchema);
 
 export type StripeEventWithSubscriptionRef = z.infer<
-  typeof stripeCheckoutSessionSchema
+  typeof stripeEventWithSubscriptionRefSchema
 >;
 
-export type StripeSubscriptionRef = Exclude<
-  StripeEventWithSubscriptionRef['subscription'],
-  null | undefined
->;
+export type StripeSubscriptionRef = z.infer<typeof stripeSubscriptionRefSchema>;
+
+export function extractSubscriptionRef(
+  payload: StripeEventWithSubscriptionRef,
+): StripeSubscriptionRef | null {
+  return (
+    payload.parent?.subscription_details?.subscription ??
+    payload.subscription ??
+    null
+  );
+}
 
 export const subscriptionEventTypes = new Set([
   'customer.subscription.created',


### PR DESCRIPTION
## Problem
- Stripe API version `2026-01-28.clover` emits invoice subscription refs at `data.object.parent.subscription_details.subscription`, while our webhook schema only read root `data.object.subscription`.
- That made `invoice.payment_succeeded` / `invoice.payment_failed` return 200 with no subscription update, masked by parallel `customer.subscription.updated` events.

## Solution
- Add `extractSubscriptionRef(payload)` in the Stripe webhook schema adapter.
- Prefer the nested Clover invoice ref, fall back to root legacy/Checkout refs, and return `null` when neither exists.
- Wire `getSubscriptionUpdateForSubscriptionRefEvent` to the extractor. No new event types, no domain/application changes.

## Acceptance Criteria
- [x] `invoice.payment_succeeded` and `invoice.payment_failed` payloads with `parent.subscription_details.subscription` produce a subscription update.
- [x] Root-level `subscription` remains supported for Checkout Session and older compatible payloads.
- [x] Missing subscription reference still returns no subscription update intentionally.
- [x] Tests cover both nested and root-level reference locations.

## TDD Evidence
- RED: `54161954` added failing schema/processor/gateway tests. `pnpm typecheck` failed on missing `extractSubscriptionRef`; focused tests failed on nested invoice refs being ignored.
- GREEN: `6f3443ff` added the schema extractor and processor wiring; focused Stripe tests pass.

## Test Plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (19 pre-existing file-length warnings)
- [x] `pnpm test --run` — 305 files, 2465 tests passed
- [x] `pnpm test:browser` — 48 files, 265 tests passed
- [x] `pnpm test:integration` — 16 files, 97 tests passed
- [x] `pnpm build`
- [x] `E2E_STRIPE_OWNER=local-dev pnpm test:e2e` — 35 passed

## Reconciliation Safety
- Reconciliation cron is untouched per DEBT-385 out-of-scope.
- DEBT-384 metadata-missing skip, DEBT-386 owner-mismatch skip, E2E seed, endpoint config, Stripe Dashboard state, and Stripe API version pin are untouched.

## Spec
- `docs/debt/debt-385-stripe-invoice-event-subscription-ref-schema-drift.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhooks now recognize and prefer nested Clover-style subscription references and normalize subscription data when present; events without a subscription still process successfully (HTTP 200) without creating updates.

* **Tests**
  * Added tests covering invoice/checkout variations, nested-reference precedence, normalization when root subscription is null, and no-subscription cases.

* **Documentation**
  * Updated docs to explain the schema-drift origin (Stripe API version change) and expanded expected test surfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->