### PR TITLE
Implement DEBT-387 three study modes feature card

### DIFF
--- a/components/marketing/marketing-home.test.tsx
+++ b/components/marketing/marketing-home.test.tsx
@@ -105,6 +105,16 @@ describe('components/marketing/marketing-home', () => {
     expect(html).toContain('Study Modes');
   });
 
+  it('renders the three study modes feature card copy', async () => {
+    const html = (await renderDoc()).documentElement.innerHTML;
+
+    expect(html).toContain('Three Study Modes');
+    expect(html).toContain(
+      'Tutor gives immediate feedback, Exam mode simulates real test conditions, and Quick Practice serves one question at a time.',
+    );
+    expect(html).not.toContain('Tutor + Exam Modes');
+  });
+
   it('renders tightened hero subtitle copy', async () => {
     const html = (await renderDoc()).documentElement.innerHTML;
 

--- a/components/marketing/marketing-home.tsx
+++ b/components/marketing/marketing-home.tsx
@@ -32,9 +32,9 @@ const features = [
   },
   {
     icon: Zap,
-    title: 'Tutor + Exam Modes',
+    title: 'Three Study Modes',
     description:
-      'Tutor shows feedback immediately. Exam mode simulates real test conditions.',
+      'Tutor gives immediate feedback, Exam mode simulates real test conditions, and Quick Practice serves one question at a time.',
     wide: false,
   },
   {

--- a/components/theme-token-regression.test.tsx
+++ b/components/theme-token-regression.test.tsx
@@ -282,7 +282,7 @@ describe('theme token regression', () => {
     const doc = new DOMParser().parseFromString(html, 'text/html');
     const featureTitles = [
       'High-Yield Explanations',
-      'Tutor + Exam Modes',
+      'Three Study Modes',
       'Smart Bookmarking',
       'Progress Dashboard',
     ];


### PR DESCRIPTION
## Problem
DEBT-382 correctly updated the landing-page impact stat to `3 Study Modes`, but the Features section still described only `Tutor + Exam Modes`. That made the public marketing page contradict itself about the number of study modes.

## Solution
- Rename the second Features card to `Three Study Modes`.
- Replace its description with the locked DEBT-387 copy covering Tutor, Exam mode, and Quick Practice.
- Keep the card icon (`Zap`), `wide: false`, layout, tokens, impact stats, hero, pricing, and all other cards unchanged.

## TDD Evidence
- RED: updated `components/theme-token-regression.test.tsx` and added `components/marketing/marketing-home.test.tsx` assertions first. Focused run failed against current copy: missing `Three Study Modes`, old title still rendered.
- GREEN: changed the single Features array entry. Focused run passed: 2 files, 32 tests.

## Screenshots
Captured locally from `localhost:3000/`, Features section only:
- Before light: `/tmp/debt-387-screenshots/debt-387-before-light.png`
- Before dark: `/tmp/debt-387-screenshots/debt-387-before-dark.png`
- After light: `/tmp/debt-387-screenshots/debt-387-after-light.png`
- After dark: `/tmp/debt-387-screenshots/debt-387-after-dark.png`

Visual verification confirmed the new title and description render in both light and dark themes with no overlap or layout distortion.

## Test Plan
- `pnpm test --run components/marketing/marketing-home.test.tsx components/theme-token-regression.test.tsx` (RED failed before production edit, GREEN passed after)
- `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
  - typecheck: passed
  - lint: passed with 19 pre-existing file-length warnings
  - unit: 305 files, 2468 tests passed
  - browser: 48 files, 265 tests passed
  - integration: 16 files, 97 tests passed
  - build: passed, 20 static pages
- `E2E_STRIPE_OWNER=local-dev pnpm test:e2e`: 35 passed

## Scope Guard
- Production change is confined to `components/marketing/marketing-home.tsx` Features array entry #2.
- Tests updated only where the old Features title was referenced or missing coverage.
- No debt doc/index archival in this PR; DEBT-387 closure remains post-merge work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated marketing copy for the study modes feature, emphasizing three distinct study modes (Tutor, Exam, and Quick Practice) with descriptions highlighting immediate feedback, realistic test simulation, and individual practice.

* **Tests**
  * Added and updated test cases to verify the updated feature messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->