### PR TITLE
Implement DEBT-389 footer link layout

### DIFF
--- a/components/marketing/marketing-layout.test.tsx
+++ b/components/marketing/marketing-layout.test.tsx
@@ -93,6 +93,33 @@ describe('MarketingLayout', () => {
     expect(signUpLink?.textContent?.trim()).toBe('Sign up');
   });
 
+  it('renders footer links in a single untitled group', async () => {
+    const html = await renderLayout({ authNavSlot: <div>Auth</div> });
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const footer = doc.querySelector('footer');
+
+    expect(footer).not.toBeNull();
+    if (!footer) {
+      throw new Error('Expected marketing footer to exist');
+    }
+
+    const footerLinks = [
+      { href: '/#features', label: 'Features' },
+      { href: ROUTES.PRICING, label: 'Pricing' },
+      { href: ROUTES.SIGN_IN, label: 'Sign in' },
+      { href: ROUTES.SIGN_UP, label: 'Sign up' },
+    ].map(({ href, label }) => {
+      const link = footer.querySelector<HTMLAnchorElement>(`a[href="${href}"]`);
+      expect(link?.textContent?.trim()).toBe(label);
+      return link;
+    });
+
+    const linkGroups = new Set(footerLinks.map((link) => link?.parentElement));
+    expect(linkGroups.size).toBe(1);
+    expect(footer.textContent).not.toContain('Product');
+    expect(footer.textContent).not.toContain('Account');
+  });
+
   it('applies the stronger header brand treatment to the brand link', async () => {
     const html = await renderLayout({ authNavSlot: <div>Auth</div> });
     const doc = new DOMParser().parseFromString(html, 'text/html');

--- a/components/marketing/marketing-layout.tsx
+++ b/components/marketing/marketing-layout.tsx
@@ -79,7 +79,7 @@ async function MarketingFooter({ featuresHref }: { featuresHref: string }) {
   return (
     <footer className="border-t border-border">
       <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
-        <div className="grid gap-8 md:grid-cols-3">
+        <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between">
           <div>
             <p className="font-bold font-heading text-foreground">
               Addiction Boards
@@ -88,27 +88,19 @@ async function MarketingFooter({ featuresHref }: { featuresHref: string }) {
               Board exam preparation for addiction medicine professionals.
             </p>
           </div>
-          <div>
-            <p className="text-sm font-semibold text-foreground">Product</p>
-            <div className="mt-3 flex flex-col gap-2 text-sm text-muted-foreground">
-              <Link href={featuresHref} className={marketingNavLinkClass}>
-                Features
-              </Link>
-              <Link href={ROUTES.PRICING} className={marketingNavLinkClass}>
-                Pricing
-              </Link>
-            </div>
-          </div>
-          <div>
-            <p className="text-sm font-semibold text-foreground">Account</p>
-            <div className="mt-3 flex flex-col gap-2 text-sm text-muted-foreground">
-              <Link href={ROUTES.SIGN_IN} className={marketingNavLinkClass}>
-                Sign in
-              </Link>
-              <Link href={ROUTES.SIGN_UP} className={marketingNavLinkClass}>
-                Sign up
-              </Link>
-            </div>
+          <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-muted-foreground md:justify-end">
+            <Link href={featuresHref} className={marketingNavLinkClass}>
+              Features
+            </Link>
+            <Link href={ROUTES.PRICING} className={marketingNavLinkClass}>
+              Pricing
+            </Link>
+            <Link href={ROUTES.SIGN_IN} className={marketingNavLinkClass}>
+              Sign in
+            </Link>
+            <Link href={ROUTES.SIGN_UP} className={marketingNavLinkClass}>
+              Sign up
+            </Link>
           </div>
         </div>
         <div className="mt-8 border-t border-border pt-8 text-sm text-muted-foreground">


### PR DESCRIPTION
## Problem

DEBT-389 identified that the marketing footer's three equal columns over-structure four short links. The Product/Account columns leave the right side visually unanchored on desktop.

## Solution

- Replace the footer `grid gap-8 md:grid-cols-3` with a brand-left / links-right flex layout.
- Preserve the brand `<p>`, tagline, copyright, all four link labels, and all href sources.
- Remove the `Product` and `Account` label headings and render Features / Pricing / Sign in / Sign up in one footer link group.

## Test Plan

TDD:
- RED: `pnpm test --run components/marketing/marketing-layout.test.tsx` failed on the new single-link-group assertion against the old two-column footer.
- GREEN: same focused suite passed after the footer layout change: 10 tests passed.

Full local gate before push:
- `pnpm typecheck`: green
- `pnpm lint`: green with 19 pre-existing file-length warnings
- `pnpm test --run`: 305 files, 2469 tests passed
- `pnpm test:browser`: 48 files, 265 tests passed
- `pnpm test:integration`: 16 files, 97 tests passed
- `pnpm build`: green, 20 static pages generated
- `E2E_STRIPE_OWNER=local-dev pnpm test:e2e`: 35/35 passed

Pre-push hook:
- `pnpm typecheck && pnpm test --run`: green, 2469 tests passed

## Visual Verification

Captured before/after screenshots locally in `/tmp/debt-389-screenshots/`:

Before:
- `/tmp/debt-389-screenshots/before-clean-desktop-light.png`
- `/tmp/debt-389-screenshots/before-clean-desktop-dark.png`
- `/tmp/debt-389-screenshots/before-clean-mobile-light.png`
- `/tmp/debt-389-screenshots/before-clean-mobile-dark.png`

After:
- `/tmp/debt-389-screenshots/after-clean-desktop-light.png`
- `/tmp/debt-389-screenshots/after-clean-desktop-dark.png`
- `/tmp/debt-389-screenshots/after-clean-mobile-light.png`
- `/tmp/debt-389-screenshots/after-clean-mobile-dark.png`

Verified:
- Desktop: brand/tagline left, four links anchored to the right edge, no dead right zone.
- Mobile: links wrap cleanly under the brand block, no overflow.

## Scope Guardrails

- Footer layout only.
- No copy changes.
- No route/href changes.
- Header, hero, stats, features, pricing, final CTA, debt docs, and index untouched.

Spec: `docs/debt/debt-389-footer-layout-brand-left-links-right.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for footer rendering and navigation link validation.

* **Style**
  * Redesigned footer layout with responsive flex-based design for improved adaptability.
  * Simplified footer navigation with consolidated links (Features, Pricing, Sign in, Sign up).
  * Removed section headings for a cleaner navigation structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->