### PR TITLE
Implement DEBT-388 hero credibility polish

### DIFF
--- a/components/marketing/marketing-home.test.tsx
+++ b/components/marketing/marketing-home.test.tsx
@@ -86,10 +86,44 @@ describe('components/marketing/marketing-home', () => {
 
     expect(html).toContain('Addiction Boards');
     expect(html).toContain(
-      'Authored by a practicing, double board-certified addiction psychiatrist. Grounded in primary literature with citations.',
+      'Authored by a double board-certified addiction psychiatrist. Grounded in primary literature with citations.',
+    );
+    expect(html).not.toContain(
+      'Authored by a practicing, double board-certified addiction psychiatrist.',
     );
     expect(html).toContain('Master the');
     expect(html).toContain('Addiction Boards.');
+  });
+
+  it('renders hero content in the intended decision sequence', async () => {
+    const doc = await renderDoc();
+    const heroSection = doc.querySelector('section[aria-label="Hero"]');
+    const heroText = (heroSection?.textContent ?? '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    const pillIndex = heroText.indexOf('Board prep, built for outcomes');
+    const headingIndex = heroText.indexOf('Master the Addiction Boards.');
+    const subtitleIndex = heroText.indexOf(
+      'High-yield questions with detailed explanations for Addiction Psychiatry and Medicine. Practice with confidence and track your progress.',
+    );
+    const getStartedIndex = heroText.indexOf('Get Started');
+    const viewPricingIndex = heroText.indexOf('View pricing');
+    const credibilityIndex = heroText.indexOf(
+      'Authored by a double board-certified addiction psychiatrist. Grounded in primary literature with citations.',
+    );
+
+    expect(heroSection).not.toBeNull();
+    expect(pillIndex).toBeGreaterThanOrEqual(0);
+    expect(headingIndex).toBeGreaterThanOrEqual(0);
+    expect(subtitleIndex).toBeGreaterThanOrEqual(0);
+    expect(getStartedIndex).toBeGreaterThanOrEqual(0);
+    expect(viewPricingIndex).toBeGreaterThanOrEqual(0);
+    expect(credibilityIndex).toBeGreaterThanOrEqual(0);
+    expect(pillIndex).toBeLessThan(headingIndex);
+    expect(headingIndex).toBeLessThan(subtitleIndex);
+    expect(subtitleIndex).toBeLessThan(getStartedIndex);
+    expect(getStartedIndex).toBeLessThan(viewPricingIndex);
+    expect(viewPricingIndex).toBeLessThan(credibilityIndex);
   });
 
   it('renders impact statistics copy', async () => {

--- a/components/marketing/marketing-home.tsx
+++ b/components/marketing/marketing-home.tsx
@@ -75,17 +75,13 @@ async function MarketingHeroCopy() {
       <p className="inline-flex items-center rounded-full border border-border bg-muted px-3 py-1 text-xs font-medium text-muted-foreground">
         Board prep, built for outcomes
       </p>
-      <p className="mx-auto mt-4 max-w-4xl text-balance text-lg text-muted-foreground leading-relaxed md:text-xl">
-        Authored by a practicing, double board-certified addiction psychiatrist.
-        Grounded in primary literature with citations.
-      </p>
       <h1 className="mt-6 font-display text-5xl font-bold tracking-tight md:text-7xl">
         <span className="block text-foreground">Master the</span>{' '}
         <span className="bg-gradient-to-r from-muted-foreground via-foreground to-muted-foreground bg-clip-text text-transparent">
           Addiction Boards.
         </span>
       </h1>
-      <p className="mx-auto mt-6 max-w-2xl text-balance text-lg text-muted-foreground leading-relaxed md:text-xl">
+      <p className="mx-auto mt-6 max-w-4xl text-balance text-lg text-muted-foreground leading-relaxed md:text-xl">
         High-yield questions with detailed explanations for Addiction Psychiatry
         and Medicine. Practice with confidence and track your progress.
       </p>
@@ -316,6 +312,10 @@ export async function MarketingHomeShell({
                 <Link href={ROUTES.PRICING}>View pricing</Link>
               </Button>
             </div>
+            <p className="mx-auto mt-6 max-w-[34rem] text-base text-muted-foreground leading-relaxed md:text-lg">
+              Authored by a double board-certified addiction psychiatrist.
+              Grounded in primary literature with citations.
+            </p>
           </div>
         </section>
 

--- a/docs/debt/debt-388-hero-credibility-line-concision-and-reposition.md
+++ b/docs/debt/debt-388-hero-credibility-line-concision-and-reposition.md
@@ -31,7 +31,7 @@ This is the visual-polish tail of the landing-page thread, deferred from DEBT-38
 
 ---
 
-## Current State (verified 2026-05-21 against `debt-388-hero-credibility-line` @ `77e48b5e`)
+## Current State (re-verified 2026-05-21 against `debt-388-hero-credibility-line` @ `84b37666`)
 
 | File | Lines | Element | Current |
 |------|-------|---------|---------|
@@ -86,4 +86,4 @@ The credibility line is rendered inside the cached `MarketingHeroCopy` fragment 
 
 ## Implementation Constraints
 
-Per repo memory rules: `feedback_docs_before_code` (review this before code), strict TDD (update the render test first, red, then move/edit), `feedback_full_gate_before_push`, and `feedback_verify_doc_citations_mechanically` (citations verified against `debt-388-hero-credibility-line` @ `77e48b5e` on 2026-05-21; re-verify if the PR opens more than a few commits later).
+Per repo memory rules: `feedback_docs_before_code` (review this before code), strict TDD (update the render test first, red, then move/edit), `feedback_full_gate_before_push`, and `feedback_verify_doc_citations_mechanically` (citations re-verified against `debt-388-hero-credibility-line` @ `84b37666` on 2026-05-21; re-verify if the PR opens more than a few commits later).


### PR DESCRIPTION
## Problem

DEBT-388 locks the final hero credibility polish after DEBT-382/387 shipped:

- the credibility line is too wordy (`practicing,`)
- it sits between the pill and the h1, competing with the hero headline
- the hero subtitle/credibility wrapping needed visual tuning without hard breaks

## Solution

- Re-verified the spec against current code at `84b37666` before implementation and updated the doc provenance.
- Removed the credibility line from cached `MarketingHeroCopy`.
- Re-rendered the static line after the hero CTA row in `MarketingHomeShell`.
- Updated copy to `Authored by a double board-certified addiction psychiatrist. Grounded in primary literature with citations.`
- Tuned wrapping without `<br>`:
  - subtitle: `max-w-4xl text-balance`
  - under-CTA credibility line: `max-w-[34rem]`, `text-base md:text-lg`

## Test Plan

TDD evidence:

- RED: focused `components/marketing/marketing-home.test.tsx` failed on the new wording/order assertions before production code changed.
- GREEN: focused test passed after moving/updating the line.

Full local gate before push:

- `pnpm typecheck`: green
- `pnpm lint`: green, 19 pre-existing file-length warnings only
- `pnpm test --run`: 305 files / 2470 tests passed
- `pnpm test:browser`: 48 files / 265 tests passed
- `pnpm test:integration`: 16 files / 97 tests passed
- `pnpm build`: green, 20 static pages
- `E2E_STRIPE_OWNER=local-dev pnpm test:e2e`: 35 / 35 passed

Visual verification:

- Screenshots captured from deterministic static renders with the built Tailwind CSS:
  - `/tmp/debt-388-screenshots/before-desktop-light-hero.png`
  - `/tmp/debt-388-screenshots/before-desktop-dark-hero.png`
  - `/tmp/debt-388-screenshots/before-mobile-light-hero.png`
  - `/tmp/debt-388-screenshots/before-mobile-dark-hero.png`
  - `/tmp/debt-388-screenshots/after-desktop-light-hero.png`
  - `/tmp/debt-388-screenshots/after-desktop-dark-hero.png`
  - `/tmp/debt-388-screenshots/after-mobile-light-hero.png`
  - `/tmp/debt-388-screenshots/after-mobile-dark-hero.png`

## Scope Guardrails

- No hero h1 copy changes.
- No CTA behavior/routing changes.
- No pricing, stat row, feature, footer, or debt index/archive changes.
- No hard line breaks used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned credibility copy in the hero section to appear after primary call-to-action buttons with refined phrasing and updated styling.

* **Tests**
  * Updated test assertions to verify hero credibility content and validate the text ordering of key page elements.

* **Documentation**
  * Updated technical documentation references for hero credibility changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->