### PR TITLE
Add exam mode timer auto-submit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,11 +140,16 @@ pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test
 
 **If the local authenticated billing E2E environment is available, also run before every `git push`:**
 
-That means the full Playwright prereqs documented in `docs/dev/testing-infrastructure.md#environment-variables-for-e2e` are present (typically via `.env.local`): `DATABASE_URL`, `CLERK_SECRET_KEY`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `E2E_CLERK_USER_USERNAME`, `E2E_CLERK_USER_PASSWORD`, `STRIPE_SECRET_KEY`, and `NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY`.
+That means the full Playwright prereqs documented in `docs/dev/testing-infrastructure.md#environment-variables-for-e2e` are present (typically via `.env.local`): `DATABASE_URL`, `CLERK_SECRET_KEY`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `E2E_CLERK_USER_USERNAME`, `E2E_CLERK_USER_PASSWORD`, `E2E_STRIPE_OWNER`, `STRIPE_SECRET_KEY`, and `NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY`.
 
 ```bash
 # Quick file check when you rely on .env.local:
-rg '^(DATABASE_URL|CLERK_SECRET_KEY|NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY|E2E_CLERK_USER_USERNAME|E2E_CLERK_USER_PASSWORD|STRIPE_SECRET_KEY|NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY)=' .env.local
+rg '^(DATABASE_URL|CLERK_SECRET_KEY|NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY|E2E_CLERK_USER_USERNAME|E2E_CLERK_USER_PASSWORD|E2E_STRIPE_OWNER|STRIPE_SECRET_KEY|NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY)=' .env.local
+
+# If the current branch includes new db/migrations since the target DB was last updated,
+# first confirm .env.local is non-production, then migrate that target:
+node -e "require('dotenv').config({ path: '.env.local' }); const u = new URL(process.env.DATABASE_URL); console.log(u.hostname)"
+env -u DATABASE_URL pnpm db:migrate
 
 lsof -ti:3000 | xargs kill -9 2>/dev/null
 pnpm test:e2e
@@ -573,11 +578,16 @@ pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test
 
 If the local authenticated billing E2E environment is available, also run:
 
-That means the full Playwright prereqs documented in `docs/dev/testing-infrastructure.md#environment-variables-for-e2e` are present (typically via `.env.local`): `DATABASE_URL`, `CLERK_SECRET_KEY`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `E2E_CLERK_USER_USERNAME`, `E2E_CLERK_USER_PASSWORD`, `STRIPE_SECRET_KEY`, and `NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY`.
+That means the full Playwright prereqs documented in `docs/dev/testing-infrastructure.md#environment-variables-for-e2e` are present (typically via `.env.local`): `DATABASE_URL`, `CLERK_SECRET_KEY`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `E2E_CLERK_USER_USERNAME`, `E2E_CLERK_USER_PASSWORD`, `E2E_STRIPE_OWNER`, `STRIPE_SECRET_KEY`, and `NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY`.
 
 ```bash
 # Quick file check when you rely on .env.local:
-rg '^(DATABASE_URL|CLERK_SECRET_KEY|NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY|E2E_CLERK_USER_USERNAME|E2E_CLERK_USER_PASSWORD|STRIPE_SECRET_KEY|NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY)=' .env.local
+rg '^(DATABASE_URL|CLERK_SECRET_KEY|NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY|E2E_CLERK_USER_USERNAME|E2E_CLERK_USER_PASSWORD|E2E_STRIPE_OWNER|STRIPE_SECRET_KEY|NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY)=' .env.local
+
+# If the current branch includes new db/migrations since the target DB was last updated,
+# first confirm .env.local is non-production, then migrate that target:
+node -e "require('dotenv').config({ path: '.env.local' }); const u = new URL(process.env.DATABASE_URL); console.log(u.hostname)"
+env -u DATABASE_URL pnpm db:migrate
 
 lsof -ti:3000 | xargs kill -9 2>/dev/null
 pnpm test:e2e

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,11 +93,16 @@ pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test
 
 If the local authenticated billing E2E environment is available, also run E2E after the build:
 
-That means the full Playwright prereqs documented in `docs/dev/testing-infrastructure.md#environment-variables-for-e2e` are present (typically via `.env.local`): `DATABASE_URL`, `CLERK_SECRET_KEY`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `E2E_CLERK_USER_USERNAME`, `E2E_CLERK_USER_PASSWORD`, `STRIPE_SECRET_KEY`, and `NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY`.
+That means the full Playwright prereqs documented in `docs/dev/testing-infrastructure.md#environment-variables-for-e2e` are present (typically via `.env.local`): `DATABASE_URL`, `CLERK_SECRET_KEY`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `E2E_CLERK_USER_USERNAME`, `E2E_CLERK_USER_PASSWORD`, `E2E_STRIPE_OWNER`, `STRIPE_SECRET_KEY`, and `NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY`.
 
 ```bash
 # Quick file check when you rely on .env.local:
-rg '^(DATABASE_URL|CLERK_SECRET_KEY|NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY|E2E_CLERK_USER_USERNAME|E2E_CLERK_USER_PASSWORD|STRIPE_SECRET_KEY|NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY)=' .env.local
+rg '^(DATABASE_URL|CLERK_SECRET_KEY|NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY|E2E_CLERK_USER_USERNAME|E2E_CLERK_USER_PASSWORD|E2E_STRIPE_OWNER|STRIPE_SECRET_KEY|NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY)=' .env.local
+
+# If the current branch includes new db/migrations since the target DB was last updated,
+# first confirm .env.local is non-production, then migrate that target:
+node -e "require('dotenv').config({ path: '.env.local' }); const u = new URL(process.env.DATABASE_URL); console.log(u.hostname)"
+env -u DATABASE_URL pnpm db:migrate
 
 lsof -ti:3000 | xargs kill -9 2>/dev/null
 pnpm test:e2e

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-active-question.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-active-question.browser.spec.tsx
@@ -45,6 +45,9 @@ test('renders active question branch with navigator and navigation callback', as
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'exam',
+
+        deadlineAt: '2099-05-22T12:02:24.000Z',
+
         index: 0,
         total: 2,
         isMarkedForReview: false,
@@ -96,6 +99,9 @@ test('does not render Review & Submit in the active exam-question header', async
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'exam',
+
+        deadlineAt: '2099-05-22T12:02:24.000Z',
+
         index: 0,
         total: 2,
         isMarkedForReview: false,
@@ -141,6 +147,9 @@ test('keeps End session in the active tutor-question header', async () => {
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 0,
         total: 2,
         isMarkedForReview: false,
@@ -215,6 +224,9 @@ test('wires navigator aria-controls to an existing question panel id', async () 
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'exam',
+
+        deadlineAt: '2099-05-22T12:02:24.000Z',
+
         index: 0,
         total: 2,
         isMarkedForReview: false,
@@ -274,6 +286,9 @@ test('renders navigator error with retry action', async () => {
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'exam',
+
+        deadlineAt: '2099-05-22T12:02:24.000Z',
+
         index: 0,
         total: 2,
         isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-focus-restoration.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-focus-restoration.browser.spec.tsx
@@ -63,6 +63,7 @@ function renderQuestionNavigationHarness() {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'exam',
+          deadlineAt: '2099-05-22T12:02:24.000Z',
           index: questionIndex,
           total: 2,
           isMarkedForReview: false,
@@ -170,6 +171,9 @@ test('restores the question panel when next-question navigation enters loading b
           sessionInfo={{
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -246,6 +250,9 @@ test('restores the question panel when navigation fails before the question id c
           sessionInfo={{
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -324,6 +331,9 @@ test('restores the question panel when retrying from an in-panel load error', as
           sessionInfo={{
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 0,
             total: 2,
             isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-question-navigation.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-question-navigation.browser.spec.tsx
@@ -49,6 +49,9 @@ test('renders Previous button in the session answering branch', async () => {
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 1,
         total: 2,
         isMarkedForReview: false,
@@ -123,6 +126,9 @@ test('hasPreviousQuestion is false when current question is first in navigator',
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 0,
         total: 2,
         isMarkedForReview: false,
@@ -165,6 +171,9 @@ test('hasPreviousQuestion is false on the first question when navigator is missi
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 0,
         total: 2,
         isMarkedForReview: false,
@@ -207,6 +216,9 @@ test('renders Previous when navigator is missing but sessionInfo indicates a pri
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 1,
         total: 2,
         isMarkedForReview: false,
@@ -271,6 +283,9 @@ test('routes the last exam-question footer Review & Submit button through onEndS
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'exam',
+
+        deadlineAt: '2099-05-22T12:02:24.000Z',
+
         index: 1,
         total: 2,
         isMarkedForReview: false,
@@ -344,6 +359,9 @@ test('hasPreviousQuestion is true when current question is not first', async () 
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 1,
         total: 2,
         isMarkedForReview: false,
@@ -421,6 +439,9 @@ test('routes the last tutor-question footer End session button through onEndSess
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 1,
         total: 2,
         isMarkedForReview: false,
@@ -512,6 +533,9 @@ test('clicking Next in a completed session navigates to the next available quest
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 1,
         total: 4,
         isMarkedForReview: false,
@@ -523,6 +547,9 @@ test('clicking Next in a completed session navigates to the next available quest
         session: {
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 1,
           total: 4,
           isMarkedForReview: false,
@@ -594,6 +621,9 @@ test('clicking Next falls back to onNextQuestion when id-based navigation is una
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 0,
         total: 3,
         isMarkedForReview: false,
@@ -605,6 +635,9 @@ test('clicking Next falls back to onNextQuestion when id-based navigation is una
         session: {
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 0,
           total: 3,
           isMarkedForReview: false,
@@ -681,6 +714,9 @@ test("clicking Previous calls onNavigateQuestion with the previous question's ID
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 1,
         total: 2,
         isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useId, useMemo, useRef } from 'react';
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+} from 'react';
 import { PracticeView } from '@/app/(app)/app/practice/components/practice-view';
 import {
   fireAndForget,
@@ -31,6 +38,7 @@ export type PracticeSessionPageViewProps = {
   reviewLoadState?: LoadState;
   navigator?: GetPracticeSessionReviewOutput | null;
   navigatorLoadState?: LoadState;
+  examTimer?: ReactNode;
   sessionInfo: NextQuestion['session'];
   loadState: LoadState;
   question: NextQuestion | null;
@@ -250,6 +258,7 @@ export function PracticeSessionPageView(props: PracticeSessionPageViewProps) {
         ) : undefined
       }
       sessionInfo={props.sessionInfo}
+      examTimer={props.examTimer}
       loadState={props.loadState}
       question={props.question}
       selectedChoiceId={props.selectedChoiceId}

--- a/app/(app)/app/practice/[sessionId]/hooks/practice-session-page-controller.browser.fixtures.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/practice-session-page-controller.browser.fixtures.ts
@@ -25,6 +25,7 @@ type PreviousSubmissionFixture = {
 type QuestionSessionFixture = {
   sessionId?: string;
   mode: PracticeMode;
+  deadlineAt?: string | null;
   index: number;
   total: number;
   isMarkedForReview: boolean;
@@ -90,6 +91,9 @@ export function createQuestionResponse(input: QuestionFixtureInput) {
     session: {
       sessionId: input.session.sessionId ?? 'session-1',
       mode: input.session.mode,
+      deadlineAt:
+        input.session.deadlineAt ??
+        (input.session.mode === 'exam' ? '2099-05-22T12:02:24.000Z' : null),
       index: input.session.index,
       total: input.session.total,
       isMarkedForReview: input.session.isMarkedForReview,

--- a/app/(app)/app/practice/[sessionId]/hooks/practice-session-page-controller.browser.fixtures.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/practice-session-page-controller.browser.fixtures.ts
@@ -92,8 +92,11 @@ export function createQuestionResponse(input: QuestionFixtureInput) {
       sessionId: input.session.sessionId ?? 'session-1',
       mode: input.session.mode,
       deadlineAt:
-        input.session.deadlineAt ??
-        (input.session.mode === 'exam' ? '2099-05-22T12:02:24.000Z' : null),
+        input.session.deadlineAt !== undefined
+          ? input.session.deadlineAt
+          : input.session.mode === 'exam'
+            ? '2099-05-22T12:02:24.000Z'
+            : null,
       index: input.session.index,
       total: input.session.total,
       isMarkedForReview: input.session.isMarkedForReview,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.browser.spec.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { useExamTimer } from './use-exam-timer';
+
+function TimerProbe(props: {
+  initialDeadlineAt: string | null;
+  isExamActive?: boolean;
+  onExpire: () => void;
+}) {
+  const [deadlineAt, setDeadlineAt] = useState(props.initialDeadlineAt);
+  const timer = useExamTimer({
+    deadlineAt,
+    isExamActive: props.isExamActive ?? true,
+    onExpire: props.onExpire,
+  });
+
+  return (
+    <>
+      <div data-testid="remaining">
+        {timer ? String(timer.remainingSeconds) : ''}
+      </div>
+      <div data-testid="expired">{timer ? String(timer.isExpired) : ''}</div>
+      <button
+        type="button"
+        onClick={() => setDeadlineAt('2026-05-22T11:59:59.000Z')}
+      >
+        move-deadline-past
+      </button>
+    </>
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useExamTimer', () => {
+  it('counts down from the absolute deadline', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    const onExpire = vi.fn();
+
+    const screen = await render(
+      <TimerProbe
+        initialDeadlineAt="2026-05-22T12:00:03.000Z"
+        onExpire={onExpire}
+      />,
+    );
+
+    await expect
+      .element(screen.getByTestId('remaining'))
+      .toHaveTextContent('3');
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect
+      .element(screen.getByTestId('remaining'))
+      .toHaveTextContent('2');
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect
+      .element(screen.getByTestId('remaining'))
+      .toHaveTextContent('0');
+    await expect
+      .element(screen.getByTestId('expired'))
+      .toHaveTextContent('true');
+    expect(onExpire).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires once when returning after the deadline has passed', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    const onExpire = vi.fn();
+
+    const screen = await render(
+      <TimerProbe
+        initialDeadlineAt="2026-05-22T12:05:00.000Z"
+        onExpire={onExpire}
+      />,
+    );
+
+    await expect
+      .element(screen.getByTestId('remaining'))
+      .toHaveTextContent('300');
+
+    vi.setSystemTime(new Date('2026-05-22T12:06:00.000Z'));
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    await expect
+      .element(screen.getByTestId('remaining'))
+      .toHaveTextContent('0');
+    expect(onExpire).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new Event('focus'));
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-latches when a future deadline is replaced by a past deadline', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    const onExpire = vi.fn();
+
+    const screen = await render(
+      <TimerProbe
+        initialDeadlineAt="2026-05-22T12:05:00.000Z"
+        onExpire={onExpire}
+      />,
+    );
+
+    await screen.getByRole('button', { name: 'move-deadline-past' }).click();
+
+    await expect
+      .element(screen.getByTestId('remaining'))
+      .toHaveTextContent('0');
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null and never fires when no exam deadline exists', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    const onExpire = vi.fn();
+
+    const screen = await render(
+      <TimerProbe initialDeadlineAt={null} onExpire={onExpire} />,
+    );
+
+    await expect.element(screen.getByTestId('remaining')).toHaveTextContent('');
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+});

--- a/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { MS_PER_SECOND } from '@/src/domain/services';
+
+export type ExamTimerState = {
+  remainingSeconds: number;
+  isExpired: boolean;
+};
+
+export type UseExamTimerInput = {
+  deadlineAt: string | null;
+  isExamActive: boolean;
+  onExpire: () => void;
+};
+
+function computeRemainingSeconds(deadlineMs: number, nowMs: number): number {
+  return Math.max(0, Math.ceil((deadlineMs - nowMs) / MS_PER_SECOND));
+}
+
+function computeState(deadlineMs: number | null): ExamTimerState | null {
+  if (deadlineMs === null) return null;
+  const remainingSeconds = computeRemainingSeconds(deadlineMs, Date.now());
+  return {
+    remainingSeconds,
+    isExpired: remainingSeconds === 0,
+  };
+}
+
+function parseDeadline(deadlineAt: string | null): number | null {
+  if (deadlineAt === null) return null;
+  const deadlineMs = Date.parse(deadlineAt);
+  return Number.isFinite(deadlineMs) ? deadlineMs : null;
+}
+
+export function useExamTimer(input: UseExamTimerInput): ExamTimerState | null {
+  const onExpireRef = useRef(input.onExpire);
+  const firedDeadlineMsRef = useRef<number | null>(null);
+  const deadlineMs =
+    input.isExamActive && input.deadlineAt !== null
+      ? parseDeadline(input.deadlineAt)
+      : null;
+  const [state, setState] = useState<ExamTimerState | null>(() =>
+    computeState(deadlineMs),
+  );
+
+  useEffect(() => {
+    onExpireRef.current = input.onExpire;
+  }, [input.onExpire]);
+
+  useEffect(() => {
+    function update() {
+      const nextState = computeState(deadlineMs);
+      setState(nextState);
+      if (
+        !nextState?.isExpired ||
+        deadlineMs === null ||
+        firedDeadlineMsRef.current === deadlineMs
+      ) {
+        return;
+      }
+
+      firedDeadlineMsRef.current = deadlineMs;
+      onExpireRef.current();
+    }
+
+    update();
+
+    if (deadlineMs === null) return;
+
+    const intervalId = window.setInterval(update, MS_PER_SECOND);
+    document.addEventListener('visibilitychange', update);
+    window.addEventListener('focus', update);
+
+    return () => {
+      window.clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', update);
+      window.removeEventListener('focus', update);
+    };
+  }, [deadlineMs]);
+
+  return deadlineMs === null ? null : state;
+}

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-mark-for-review.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-mark-for-review.browser.spec.tsx
@@ -53,6 +53,9 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
         sessionInfo: {
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 10,
           isMarkedForReview: false,
@@ -98,6 +101,9 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
       (sessionUpdater as (prev: unknown) => unknown)({
         sessionId: 'session-1',
         mode: 'exam',
+
+        deadlineAt: '2099-05-22T12:02:24.000Z',
+
         index: 0,
         total: 10,
         isMarkedForReview: false,
@@ -105,6 +111,9 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
     ).toEqual({
       sessionId: 'session-1',
       mode: 'exam',
+
+      deadlineAt: '2099-05-22T12:02:24.000Z',
+
       index: 0,
       total: 10,
       isMarkedForReview: true,
@@ -155,6 +164,9 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
         sessionInfo: {
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 10,
           isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-mark-for-review.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-mark-for-review.test.tsx
@@ -66,6 +66,7 @@ describe('usePracticeSessionMarkForReview', () => {
     const sessionInfo = {
       sessionId: 'session-1',
       mode: 'exam' as const,
+      deadlineAt: '2099-05-22T12:02:24.000Z',
       index: 0,
       total: 10,
       isMarkedForReview: false,
@@ -127,6 +128,9 @@ describe('usePracticeSessionMarkForReview', () => {
         sessionInfo: {
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 10,
           isMarkedForReview: false,
@@ -170,6 +174,9 @@ describe('usePracticeSessionMarkForReview', () => {
         sessionInfo: {
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 10,
           isMarkedForReview: false,
@@ -214,6 +221,9 @@ describe('usePracticeSessionMarkForReview', () => {
           sessionInfo: {
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 0,
             total: 10,
             isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-answer-flow.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-answer-flow.browser.spec.tsx
@@ -34,6 +34,9 @@ describe('usePracticeSessionPageController (browser)', () => {
             choices: [CHOICE_1, CHOICE_2, CHOICE_3],
             session: {
               mode: 'exam',
+
+              deadlineAt: '2099-05-22T12:02:24.000Z',
+
               index: 0,
               total: 2,
               isMarkedForReview: false,
@@ -48,6 +51,9 @@ describe('usePracticeSessionPageController (browser)', () => {
             choices: [CHOICE_1, CHOICE_2, CHOICE_3],
             session: {
               mode: 'exam',
+
+              deadlineAt: '2099-05-22T12:02:24.000Z',
+
               index: 1,
               total: 2,
               isMarkedForReview: false,
@@ -109,6 +115,9 @@ describe('usePracticeSessionPageController (browser)', () => {
         session: {
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 0,
           total: 10,
           isMarkedForReview: false,
@@ -155,6 +164,9 @@ describe('usePracticeSessionPageController (browser)', () => {
         session: {
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 0,
           total: 10,
           isMarkedForReview: false,
@@ -215,6 +227,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           session: {
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -231,6 +246,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           session: {
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 1,
             total: 2,
             isMarkedForReview: false,
@@ -287,6 +305,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           session: {
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -302,6 +323,9 @@ describe('usePracticeSessionPageController (browser)', () => {
             session: {
               sessionId: 'session-1',
               mode: 'exam',
+
+              deadlineAt: '2099-05-22T12:02:24.000Z',
+
               index: 1,
               total: 2,
               isMarkedForReview: false,
@@ -319,6 +343,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           session: {
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -388,6 +415,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           session: {
             sessionId: 'session-1',
             mode: 'tutor',
+
+            deadlineAt: null,
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -406,6 +436,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           session: {
             sessionId: 'session-1',
             mode: 'tutor',
+
+            deadlineAt: null,
+
             index: 1,
             total: 2,
             isMarkedForReview: false,
@@ -424,6 +457,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           session: {
             sessionId: 'session-1',
             mode: 'tutor',
+
+            deadlineAt: null,
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -555,6 +591,9 @@ describe('usePracticeSessionPageController (browser)', () => {
         session: {
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 2,
           isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-bookmark-mark.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-bookmark-mark.browser.spec.tsx
@@ -30,6 +30,9 @@ describe('usePracticeSessionPageController (browser)', () => {
         session: {
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 0,
           total: 10,
           isMarkedForReview: false,
@@ -76,6 +79,9 @@ describe('usePracticeSessionPageController (browser)', () => {
         session: {
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 0,
           total: 10,
           isMarkedForReview: false,
@@ -129,6 +135,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           session: {
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -145,6 +154,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           session: {
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 1,
             total: 2,
             isMarkedForReview: false,
@@ -225,6 +237,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           session: {
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -241,6 +256,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           session: {
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 1,
             total: 2,
             isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-init-load.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-init-load.browser.spec.tsx
@@ -124,6 +124,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           questionId: 'question-1',
           session: {
             mode: 'tutor',
+
+            deadlineAt: null,
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -188,6 +191,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           questionId: 'question-1',
           session: {
             mode: 'tutor',
+
+            deadlineAt: null,
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -243,6 +249,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           questionId: 'question-1',
           session: {
             mode: 'tutor',
+
+            deadlineAt: null,
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -309,6 +318,9 @@ describe('usePracticeSessionPageController (browser)', () => {
             questionId: 'question-1',
             session: {
               mode: 'tutor',
+
+              deadlineAt: null,
+
               index: 0,
               total: 2,
               isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-review-stage.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-review-stage.browser.spec.tsx
@@ -45,6 +45,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           choices: [CHOICE_1, CHOICE_2, CHOICE_3],
           session: {
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -233,6 +236,9 @@ describe('usePracticeSessionPageController (browser)', () => {
         session: {
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 1,
           isMarkedForReview: false,
@@ -332,6 +338,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           session: {
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 0,
             total: 2,
             isMarkedForReview: false,
@@ -348,6 +357,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           session: {
             sessionId: 'session-1',
             mode: 'exam',
+
+            deadlineAt: '2099-05-22T12:02:24.000Z',
+
             index: 1,
             total: 2,
             isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-test-helpers.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-test-helpers.ts
@@ -129,6 +129,7 @@ export function mockExamReviewNavigationSession() {
           choices: [CHOICE_1, CHOICE_2, CHOICE_3],
           session: {
             mode: 'exam',
+            deadlineAt: '2099-05-22T12:02:24.000Z',
             index: questionIndex,
             total: 3,
             isMarkedForReview: false,
@@ -153,6 +154,9 @@ export function mockExamReviewNavigationSession() {
         choices: [CHOICE_1, CHOICE_2, CHOICE_3],
         session: {
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 2,
           total: 3,
           isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-timer.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-timer.browser.spec.tsx
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { ok } from '@/tests/test-helpers/ok';
+import {
+  createQuestionResponse,
+  createReviewResponse,
+} from './practice-session-page-controller.browser.fixtures';
+import {
+  CHOICE_1,
+  CHOICE_2,
+  CHOICE_3,
+  errorResult,
+  finalizeExamAnswersMock,
+  getNextQuestionMock,
+  getPracticeSessionSummaryMock,
+  mockBookmarksAndReview,
+  PracticeSessionPageControllerReviewProbe,
+  saveExamDraftAnswerMock,
+  setupPracticeSessionPageControllerBrowserSpec,
+} from './use-practice-session-page-controller-test-helpers';
+
+setupPracticeSessionPageControllerBrowserSpec();
+
+function mockActiveTimedExam(deadlineAt: string) {
+  getPracticeSessionSummaryMock.mockResolvedValue(
+    errorResult('CONFLICT', 'Practice session has not ended'),
+  );
+  getNextQuestionMock.mockResolvedValue(
+    ok(
+      createQuestionResponse({
+        questionId: 'question-1',
+        choices: [CHOICE_1, CHOICE_2, CHOICE_3],
+        session: {
+          mode: 'exam',
+          deadlineAt,
+          index: 0,
+          total: 1,
+          isMarkedForReview: false,
+        },
+      }),
+    ),
+  );
+  mockBookmarksAndReview(
+    createReviewResponse({
+      mode: 'exam',
+      totalCount: 1,
+      answeredCount: 0,
+      markedCount: 0,
+    }),
+  );
+}
+
+function mockFinalizeSummary() {
+  finalizeExamAnswersMock.mockResolvedValue(
+    ok({
+      sessionId: 'session-1',
+      endedAt: '2026-05-22T12:01:12.000Z',
+      mode: 'exam',
+      questionCount: 1,
+      totals: {
+        answered: 0,
+        correct: 0,
+        accuracy: 0,
+        durationSeconds: 72,
+      },
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('usePracticeSessionPageController timer expiry', () => {
+  it('finalizes once on timer expiry even when the final draft save is rejected', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    mockActiveTimedExam('2026-05-22T12:00:01.000Z');
+    mockFinalizeSummary();
+    saveExamDraftAnswerMock.mockResolvedValue(
+      errorResult('CONFLICT', 'Exam time has expired'),
+    );
+
+    const screen = await render(<PracticeSessionPageControllerReviewProbe />);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('question');
+    await screen.getByRole('button', { name: 'select-choice-1' }).click();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    expect(saveExamDraftAnswerMock).toHaveBeenCalledTimes(1);
+    expect(finalizeExamAnswersMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(finalizeExamAnswersMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('manual Review & Submit after expiry proceeds to finalization after a rejected draft save', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    mockActiveTimedExam('2026-05-22T12:00:01.000Z');
+    mockFinalizeSummary();
+    saveExamDraftAnswerMock.mockResolvedValue(
+      errorResult('CONFLICT', 'Exam time has expired'),
+    );
+
+    const screen = await render(<PracticeSessionPageControllerReviewProbe />);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('question');
+    await screen.getByRole('button', { name: 'select-choice-1' }).click();
+    vi.setSystemTime(new Date('2026-05-22T12:00:02.000Z'));
+
+    await screen.getByRole('button', { name: 'review-answers' }).click();
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    expect(saveExamDraftAnswerMock).toHaveBeenCalledTimes(1);
+    expect(finalizeExamAnswersMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller.ts
@@ -1,5 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  createElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { usePracticeSessionQuestionFlow } from '@/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow';
+import { ExamTimer } from '@/app/(app)/app/practice/components/exam-timer';
 import { usePracticeQuestionBookmarks } from '@/app/(app)/app/practice/hooks/use-practice-question-bookmarks';
 import {
   getActionResultErrorMessage,
@@ -23,6 +31,7 @@ import {
   submitAnswer,
 } from '@/src/adapters/controllers/question-controller';
 import type { PracticeSessionPageViewProps } from '../components/practice-session-page-view';
+import { useExamTimer } from './use-exam-timer';
 import { usePracticeSessionMarkForReview } from './use-practice-session-mark-for-review';
 import { usePracticeSessionReviewStage } from './use-practice-session-review-stage';
 
@@ -38,6 +47,7 @@ export function usePracticeSessionPageController(
 ): PracticeSessionPageControllerOutput {
   const isMounted = useIsMounted();
   const bootstrapRequestIdRef = useRef(0);
+  const expiryFinalizeInFlightRef = useRef(false);
   const [shouldRetryBootstrap, setShouldRetryBootstrap] = useState(false);
 
   const questionFlow = usePracticeSessionQuestionFlow({
@@ -85,6 +95,50 @@ export function usePracticeSessionPageController(
     question: currentPostExamBookmarkQuestion ?? questionFlow.question,
     isMounted,
   });
+
+  const finalizeExpiredExam = useCallback(() => {
+    if (expiryFinalizeInFlightRef.current) return;
+    expiryFinalizeInFlightRef.current = true;
+
+    void (async () => {
+      try {
+        await questionFlow.saveCurrentExamDraft();
+      } catch (error) {
+        if (isMounted()) {
+          reportClientError(error, {
+            component: 'UsePracticeSessionPageController',
+            action: 'saveCurrentExamDraftOnTimerExpire',
+          });
+        }
+      }
+
+      if (!isMounted()) return;
+      await reviewStage.finalizeExamSession();
+    })();
+  }, [
+    isMounted,
+    questionFlow.saveCurrentExamDraft,
+    reviewStage.finalizeExamSession,
+  ]);
+
+  const isTimerActive =
+    questionFlow.sessionMode === 'exam' &&
+    typeof questionFlow.sessionInfo?.deadlineAt === 'string' &&
+    !reviewStage.summary &&
+    !reviewStage.review &&
+    !reviewStage.postExamSummary &&
+    !reviewStage.postExamReview;
+  const timerState = useExamTimer({
+    deadlineAt: questionFlow.sessionInfo?.deadlineAt ?? null,
+    isExamActive: isTimerActive,
+    onExpire: finalizeExpiredExam,
+  });
+  const examTimer = timerState
+    ? createElement(ExamTimer, {
+        remainingSeconds: timerState.remainingSeconds,
+        isExpired: timerState.isExpired,
+      })
+    : undefined;
 
   const bootstrapSessionSummary = useCallback(() => {
     const requestId = bootstrapRequestIdRef.current + 1;
@@ -189,6 +243,7 @@ export function usePracticeSessionPageController(
     reviewLoadState: reviewStage.reviewLoadState,
     navigator: reviewStage.navigator,
     navigatorLoadState: reviewStage.navigatorLoadState,
+    examTimer,
     sessionInfo: questionFlow.sessionInfo,
     loadState: questionFlow.loadState,
     question: questionFlow.question,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow-click-commit.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow-click-commit.browser.spec.tsx
@@ -21,6 +21,7 @@ function createSessionQuestion(
     session: {
       sessionId: 'session-1',
       mode,
+      deadlineAt: mode === 'exam' ? '2099-05-22T12:02:24.000Z' : null,
       index: 0,
       total: 2,
       isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.browser.spec.tsx
@@ -90,6 +90,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
     harness.result.current.applySessionInfo({
       sessionId: 'session-1',
       mode: 'tutor',
+
+      deadlineAt: null,
+
       index: 0,
       total: 2,
       isMarkedForReview: false,
@@ -126,6 +129,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
               session: {
                 sessionId: 'session-1',
                 mode: 'exam',
+
+                deadlineAt: '2099-05-22T12:02:24.000Z',
+
                 index: 1,
                 total: 2,
                 isMarkedForReview: false,
@@ -144,6 +150,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             session: {
               sessionId: 'session-1',
               mode: 'exam',
+
+              deadlineAt: '2099-05-22T12:02:24.000Z',
+
               index: 0,
               total: 2,
               isMarkedForReview: false,
@@ -214,6 +223,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             session: {
               sessionId: 'session-1',
               mode: 'exam',
+
+              deadlineAt: '2099-05-22T12:02:24.000Z',
+
               index: 0,
               total: 2,
               isMarkedForReview: false,
@@ -228,6 +240,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             session: {
               sessionId: 'session-1',
               mode: 'exam',
+
+              deadlineAt: '2099-05-22T12:02:24.000Z',
+
               index: 1,
               total: 2,
               isMarkedForReview: false,
@@ -287,6 +302,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
               session: {
                 sessionId: 'session-1',
                 mode: 'exam',
+
+                deadlineAt: '2099-05-22T12:02:24.000Z',
+
                 index: 0,
                 total: 2,
                 isMarkedForReview: false,
@@ -309,6 +327,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
               session: {
                 sessionId: 'session-1',
                 mode: 'exam',
+
+                deadlineAt: '2099-05-22T12:02:24.000Z',
+
                 index: 1,
                 total: 2,
                 isMarkedForReview: false,
@@ -327,6 +348,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             session: {
               sessionId: 'session-1',
               mode: 'exam',
+
+              deadlineAt: '2099-05-22T12:02:24.000Z',
+
               index: 0,
               total: 2,
               isMarkedForReview: false,
@@ -448,6 +472,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
               session: {
                 sessionId: 'session-1',
                 mode: 'exam',
+
+                deadlineAt: '2099-05-22T12:02:24.000Z',
+
                 index: 0,
                 total: 2,
                 isMarkedForReview: false,
@@ -470,6 +497,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
               session: {
                 sessionId: 'session-1',
                 mode: 'exam',
+
+                deadlineAt: '2099-05-22T12:02:24.000Z',
+
                 index: 1,
                 total: 2,
                 isMarkedForReview: false,
@@ -488,6 +518,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             session: {
               sessionId: 'session-1',
               mode: 'exam',
+
+              deadlineAt: '2099-05-22T12:02:24.000Z',
+
               index: 0,
               total: 2,
               isMarkedForReview: false,
@@ -602,6 +635,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
               session: {
                 sessionId: 'session-2',
                 mode: 'exam',
+
+                deadlineAt: '2099-05-22T12:02:24.000Z',
+
                 index: 0,
                 total: 2,
                 isMarkedForReview: false,
@@ -624,6 +660,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
               session: {
                 sessionId: 'session-1',
                 mode: 'exam',
+
+                deadlineAt: '2099-05-22T12:02:24.000Z',
+
                 index: 1,
                 total: 2,
                 isMarkedForReview: false,
@@ -642,6 +681,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             session: {
               sessionId: 'session-1',
               mode: 'exam',
+
+              deadlineAt: '2099-05-22T12:02:24.000Z',
+
               index: 0,
               total: 2,
               isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
@@ -252,6 +252,9 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     input.sessionInfo = {
       sessionId: 'session-1',
       mode: 'exam',
+
+      deadlineAt: '2099-05-22T12:02:24.000Z',
+
       index: 0,
       total: 2,
       isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.ts
@@ -198,7 +198,19 @@ export function usePracticeSessionReviewStage(
       try {
         if (input.sessionMode === 'exam') {
           const saved = await input.saveCurrentExamDraft();
-          if (!saved) return;
+          if (!saved) {
+            const deadlineAt = input.sessionInfo?.deadlineAt ?? null;
+            const deadlineMs =
+              deadlineAt === null
+                ? Number.POSITIVE_INFINITY
+                : Date.parse(deadlineAt);
+            const isExpired =
+              Number.isFinite(deadlineMs) && Date.now() >= deadlineMs;
+            if (isExpired) {
+              await finalizeExamSession();
+            }
+            return;
+          }
         }
       } catch (error) {
         if (!input.isMounted()) return;
@@ -217,8 +229,10 @@ export function usePracticeSessionReviewStage(
   }, [
     input.isMounted,
     input.saveCurrentExamDraft,
+    input.sessionInfo?.deadlineAt,
     input.sessionMode,
     input.setLoadState,
+    finalizeExamSession,
     reviewStage.onEndSession,
   ]);
   const onFinalizeReview = useCallback(async (): Promise<void> => {
@@ -256,6 +270,7 @@ export function usePracticeSessionReviewStage(
     navigatorLoadState,
     isInReviewStage: reviewStage.isInReviewStage,
     isReviewQuestionActive: reviewStage.isReviewQuestionActive,
+    finalizeExamSession,
     onEndSession,
     onRetryReview: reviewStage.onRetryReview,
     onRetryNavigator,

--- a/app/(app)/app/practice/[sessionId]/page.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/page.test.tsx
@@ -735,6 +735,9 @@ describe('app/(app)/app/practice/[sessionId]', () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 2,
           isMarkedForReview: false,

--- a/app/(app)/app/practice/[sessionId]/practice-session-page-logic.test.ts
+++ b/app/(app)/app/practice/[sessionId]/practice-session-page-logic.test.ts
@@ -99,6 +99,9 @@ describe('practice-session-page-logic', () => {
             session: {
               sessionId: 'session-1',
               mode: 'tutor',
+
+              deadlineAt: null,
+
               index: 1,
               total: 2,
             },
@@ -113,6 +116,9 @@ describe('practice-session-page-logic', () => {
             session: {
               sessionId: 'session-1',
               mode: 'tutor',
+
+              deadlineAt: null,
+
               index: 0,
               total: 2,
             },
@@ -148,6 +154,9 @@ describe('practice-session-page-logic', () => {
               session: {
                 sessionId: 'session-1',
                 mode: 'tutor',
+
+                deadlineAt: null,
+
                 index: 0,
                 total: 2,
               },
@@ -900,6 +909,9 @@ describe('practice-session-page-logic effects', () => {
         sessionInfo: {
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 0,
           total: 2,
         },
@@ -930,6 +942,9 @@ describe('practice-session-page-logic effects', () => {
         sessionInfo: {
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 0,
           total: 2,
         },
@@ -964,6 +979,9 @@ describe('practice-session-page-logic effects', () => {
         sessionInfo: {
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 0,
           total: 2,
         },
@@ -996,6 +1014,9 @@ describe('practice-session-page-logic effects', () => {
         sessionInfo: {
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 0,
           total: 2,
         },

--- a/app/(app)/app/practice/components/exam-timer.test.tsx
+++ b/app/(app)/app/practice/components/exam-timer.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+let ExamTimer: typeof import('./exam-timer').ExamTimer;
+
+beforeAll(async () => {
+  ExamTimer = (await import('./exam-timer')).ExamTimer;
+});
+
+describe('ExamTimer', () => {
+  it('renders compact MM:SS timer text with timer semantics', () => {
+    const html = renderToStaticMarkup(
+      <ExamTimer remainingSeconds={754} isExpired={false} />,
+    );
+
+    expect(html).toContain('role="timer"');
+    expect(html).toContain('aria-label="Exam time remaining"');
+    expect(html).toContain('Time left');
+    expect(html).toContain('12:34');
+  });
+
+  it.each([
+    [300, '5 minutes remaining'],
+    [60, '1 minute remaining'],
+    [30, '30 seconds remaining'],
+  ])('announces the %s second milestone', (remainingSeconds, announcement) => {
+    const html = renderToStaticMarkup(
+      <ExamTimer remainingSeconds={remainingSeconds} isExpired={false} />,
+    );
+
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain(announcement);
+  });
+
+  it('announces expiry assertively', () => {
+    const html = renderToStaticMarkup(
+      <ExamTimer remainingSeconds={0} isExpired={true} />,
+    );
+
+    expect(html).toContain('aria-live="assertive"');
+    expect(html).toContain('Time is up. Submitting your exam.');
+  });
+
+  it('uses a static warning color without motion classes in the final stretch', () => {
+    const html = renderToStaticMarkup(
+      <ExamTimer remainingSeconds={45} isExpired={false} />,
+    );
+
+    expect(html).toContain('text-destructive');
+    expect(html).not.toContain('animate-');
+    expect(html).not.toContain('motion-safe');
+  });
+});

--- a/app/(app)/app/practice/components/exam-timer.tsx
+++ b/app/(app)/app/practice/components/exam-timer.tsx
@@ -1,0 +1,70 @@
+import { cn } from '@/lib/utils';
+
+export const EXAM_TIMER_WARNING_SECONDS = 60;
+export const EXAM_TIMER_MILESTONE_SECONDS = {
+  fiveMinutes: 300,
+  oneMinute: 60,
+  thirtySeconds: 30,
+} as const;
+
+export type ExamTimerProps = {
+  remainingSeconds: number;
+  isExpired: boolean;
+};
+
+function formatRemainingSeconds(remainingSeconds: number): string {
+  const safeSeconds = Math.max(0, Math.floor(remainingSeconds));
+  const minutes = Math.floor(safeSeconds / 60);
+  const seconds = safeSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+function getMilestoneAnnouncement(remainingSeconds: number): string | null {
+  if (remainingSeconds === EXAM_TIMER_MILESTONE_SECONDS.fiveMinutes) {
+    return '5 minutes remaining';
+  }
+  if (remainingSeconds === EXAM_TIMER_MILESTONE_SECONDS.oneMinute) {
+    return '1 minute remaining';
+  }
+  if (remainingSeconds === EXAM_TIMER_MILESTONE_SECONDS.thirtySeconds) {
+    return '30 seconds remaining';
+  }
+  return null;
+}
+
+export function ExamTimer(props: ExamTimerProps) {
+  const isWarning =
+    props.remainingSeconds <= EXAM_TIMER_WARNING_SECONDS || props.isExpired;
+  const milestoneAnnouncement = getMilestoneAnnouncement(
+    props.remainingSeconds,
+  );
+
+  return (
+    <div
+      role="timer"
+      aria-label="Exam time remaining"
+      className={cn(
+        'inline-flex min-w-24 items-center justify-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-sm font-medium tabular-nums',
+        isWarning
+          ? 'border-destructive/40 text-destructive'
+          : 'text-foreground',
+      )}
+    >
+      <span className="text-muted-foreground text-xs font-normal">
+        Time left
+      </span>
+      <span aria-hidden="true">
+        {formatRemainingSeconds(props.remainingSeconds)}
+      </span>
+      <span className="sr-only">
+        {formatRemainingSeconds(props.remainingSeconds)}
+      </span>
+      <span className="sr-only" aria-live="polite">
+        {milestoneAnnouncement ?? ''}
+      </span>
+      <span className="sr-only" aria-live="assertive">
+        {props.isExpired ? 'Time is up. Submitting your exam.' : ''}
+      </span>
+    </div>
+  );
+}

--- a/app/(app)/app/practice/components/practice-view-answer-feedback.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-answer-feedback.test.tsx
@@ -62,6 +62,9 @@ describe('PracticeView answer feedback', () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 0,
           total: 3,
           isMarkedForReview: false,
@@ -109,6 +112,9 @@ describe('PracticeView answer feedback', () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 1,
           total: 3,
           isMarkedForReview: false,
@@ -199,6 +205,9 @@ describe('PracticeView answer feedback', () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 1,
           total: 2,
           isMarkedForReview: false,

--- a/app/(app)/app/practice/components/practice-view-bookmarks.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-bookmarks.test.tsx
@@ -58,6 +58,9 @@ describe('PracticeView bookmarks', () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 10,
           isMarkedForReview: false,
@@ -88,6 +91,9 @@ describe('PracticeView bookmarks', () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 0,
           total: 10,
           isMarkedForReview: false,
@@ -124,6 +130,9 @@ describe('PracticeView bookmarks', () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 0,
           total: 10,
           isMarkedForReview: false,
@@ -166,6 +175,9 @@ describe('PracticeView bookmarks', () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'tutor',
+
+          deadlineAt: null,
+
           index: 0,
           total: 10,
           isMarkedForReview: false,

--- a/app/(app)/app/practice/components/practice-view-exam-actions.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-exam-actions.test.tsx
@@ -40,6 +40,7 @@ function renderExamView(
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'exam',
+        deadlineAt: '2099-05-22T12:02:24.000Z',
         index: input.index ?? 0,
         total: input.total ?? 3,
         isMarkedForReview: input.isMarkedForReview ?? false,
@@ -78,6 +79,9 @@ function renderTutorView(
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 1,
         total: 3,
         isMarkedForReview: false,

--- a/app/(app)/app/practice/components/practice-view-layout.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-layout.test.tsx
@@ -224,6 +224,9 @@ describe('PracticeView layout', () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 3,
           isMarkedForReview: false,
@@ -270,6 +273,83 @@ describe('PracticeView layout', () => {
     );
   });
 
+  it('renders the exam timer only in the exam header action rail', () => {
+    const question = createNextQuestion({
+      questionId: 'question-1',
+      slug: 'question-1',
+      stemMd: 'Stem',
+      difficulty: 'easy',
+    });
+
+    const examHtml = renderToStaticMarkup(
+      <PracticeView
+        title="Exam Session"
+        description="Question 1 of 3 — Explanations shown after you submit the exam."
+        sessionInfo={{
+          sessionId: 'session-1',
+          mode: 'exam',
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+          index: 0,
+          total: 3,
+          isMarkedForReview: false,
+        }}
+        examTimer={<span data-testid="exam-timer-probe">12:34</span>}
+        loadState={{ status: 'ready' }}
+        question={question}
+        selectedChoiceId={null}
+        isAnswered={false}
+        submitResult={null}
+        isPending={false}
+        bookmarkStatus="idle"
+        isBookmarked={false}
+        onEndSession={() => undefined}
+        onTryAgain={() => undefined}
+        onToggleBookmark={() => undefined}
+        onToggleMarkForReview={() => undefined}
+        onSelectChoice={() => undefined}
+        onNextQuestion={() => undefined}
+      />,
+    );
+
+    const tutorHtml = renderToStaticMarkup(
+      <PracticeView
+        title="Tutor Session"
+        description="Question 1 of 3 — Explanations shown after each answer."
+        sessionInfo={{
+          sessionId: 'session-1',
+          mode: 'tutor',
+          deadlineAt: null,
+          index: 0,
+          total: 3,
+          isMarkedForReview: false,
+        }}
+        examTimer={<span data-testid="exam-timer-probe">12:34</span>}
+        loadState={{ status: 'ready' }}
+        question={question}
+        selectedChoiceId={null}
+        isAnswered={false}
+        submitResult={null}
+        isPending={false}
+        bookmarkStatus="idle"
+        isBookmarked={false}
+        onEndSession={() => undefined}
+        onTryAgain={() => undefined}
+        onToggleBookmark={() => undefined}
+        onToggleMarkForReview={() => undefined}
+        onSelectChoice={() => undefined}
+        onNextQuestion={() => undefined}
+      />,
+    );
+
+    const doc = new DOMParser().parseFromString(examHtml, 'text/html');
+    expect(
+      doc
+        .querySelector('[data-testid="question-header-actions"]')
+        ?.querySelector('[data-testid="exam-timer-probe"]')?.textContent,
+    ).toBe('12:34');
+    expect(tutorHtml).not.toContain('exam-timer-probe');
+  });
+
   it('renders the fallback back link when exam mode has no mark-for-review action', () => {
     const question = createNextQuestion({
       questionId: 'question-1',
@@ -285,6 +365,9 @@ describe('PracticeView layout', () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 3,
           isMarkedForReview: false,

--- a/app/(app)/app/practice/components/practice-view-navigation.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-navigation.test.tsx
@@ -184,6 +184,9 @@ describe('PracticeView navigation', () => {
       sessionInfo: {
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 2,
         total: 3,
         isMarkedForReview: false,
@@ -234,6 +237,9 @@ describe('PracticeView navigation', () => {
       sessionInfo: {
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 2,
         total: 3,
         isMarkedForReview: false,
@@ -289,6 +295,9 @@ describe('PracticeView navigation', () => {
       sessionInfo: {
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 0,
         total: 3,
         isMarkedForReview: false,
@@ -334,6 +343,9 @@ describe('PracticeView navigation', () => {
       sessionInfo: {
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 1,
         total: 3,
         isMarkedForReview: false,
@@ -377,6 +389,9 @@ describe('PracticeView navigation', () => {
       sessionInfo: {
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 1,
         total: 3,
         isMarkedForReview: false,
@@ -428,6 +443,9 @@ describe('PracticeView navigation', () => {
       sessionInfo: {
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 0,
         total: 3,
         isMarkedForReview: false,
@@ -484,6 +502,9 @@ describe('PracticeView navigation', () => {
       sessionInfo: {
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 2,
         total: 3,
         isMarkedForReview: false,
@@ -540,6 +561,9 @@ describe('PracticeView navigation', () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 2,
           isMarkedForReview: false,

--- a/app/(app)/app/practice/components/practice-view.browser.spec.tsx
+++ b/app/(app)/app/practice/components/practice-view.browser.spec.tsx
@@ -23,6 +23,9 @@ function ExamPracticeViewHarness(input: {
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'exam',
+
+        deadlineAt: '2099-05-22T12:02:24.000Z',
+
         index: 0,
         total: 10,
         isMarkedForReview: false,
@@ -122,6 +125,9 @@ test('renders the exam bottom action bar without sticky shell markers', async ()
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'exam',
+
+        deadlineAt: '2099-05-22T12:02:24.000Z',
+
         index: 0,
         total: 2,
         isMarkedForReview: false,
@@ -314,6 +320,9 @@ test('disables mutation controls while internal question loading is in progress'
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'exam',
+
+        deadlineAt: '2099-05-22T12:02:24.000Z',
+
         index: 0,
         total: 10,
         isMarkedForReview: false,
@@ -368,6 +377,9 @@ test('disables choice selection after a submit in exam mode', async () => {
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'exam',
+
+        deadlineAt: '2099-05-22T12:02:24.000Z',
+
         index: 0,
         total: 10,
         isMarkedForReview: false,
@@ -475,6 +487,9 @@ test('does not scroll feedback in exam mode', async () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 10,
           isMarkedForReview: false,
@@ -598,6 +613,9 @@ test('calls onEndSession from the bottom-bar Review & Submit button on the last 
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'exam',
+
+        deadlineAt: '2099-05-22T12:02:24.000Z',
+
         index: 1,
         total: 2,
         isMarkedForReview: false,
@@ -654,6 +672,9 @@ test('calls onEndSession from the bottom-bar End session button on the last tuto
       sessionInfo={{
         sessionId: 'session-1',
         mode: 'tutor',
+
+        deadlineAt: null,
+
         index: 1,
         total: 2,
         isMarkedForReview: false,

--- a/app/(app)/app/practice/components/practice-view.tsx
+++ b/app/(app)/app/practice/components/practice-view.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import type { ReactNode } from 'react';
 import { useEffect, useId, useRef } from 'react';
 import { ErrorCard } from '@/components/error-card';
 import { QuestionSurfaceBody } from '@/components/question/question-surface-body';
@@ -22,6 +23,7 @@ export type PracticeViewProps = {
   };
   topContent?: React.ReactNode;
   belowHeadingContent?: React.ReactNode;
+  examTimer?: ReactNode;
   sessionInfo?: NextQuestion['session'];
   loadState: LoadState;
   question: NextQuestion | null;
@@ -373,6 +375,7 @@ export function PracticeView(props: PracticeViewProps) {
             className="flex items-center gap-3"
             data-testid="question-header-actions"
           >
+            {isExamMode ? props.examTimer : null}
             {isExamMode && props.onToggleMarkForReview ? (
               <Button
                 type="button"

--- a/app/(app)/app/practice/page.test.tsx
+++ b/app/(app)/app/practice/page.test.tsx
@@ -165,6 +165,9 @@ describe('app/(app)/app/practice', () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 10,
           isMarkedForReview: true,
@@ -238,6 +241,9 @@ describe('app/(app)/app/practice', () => {
         sessionInfo={{
           sessionId: 'session-1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 10,
         }}

--- a/app/(app)/app/practice/shared/question-flow-actions.test.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions.test.ts
@@ -692,6 +692,9 @@ describe('question-flow-actions', () => {
         session: {
           sessionId: 'session_1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 2,
           draftSelectedChoiceId: 'choice_1',
@@ -749,6 +752,9 @@ describe('question-flow-actions', () => {
         session: {
           sessionId: 'session_1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 2,
           draftSelectedChoiceId: 'choice_1',
@@ -798,6 +804,9 @@ describe('question-flow-actions', () => {
         session: {
           sessionId: 'session_1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 2,
           draftSelectedChoiceId: 'choice_1',
@@ -835,6 +844,9 @@ describe('question-flow-actions', () => {
         session: {
           sessionId: 'session_1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 2,
         },
@@ -875,6 +887,9 @@ describe('question-flow-actions', () => {
         session: {
           sessionId: 'session_1',
           mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
           index: 0,
           total: 2,
         },

--- a/app/(app)/app/practice/shared/use-question-flow-core.browser.spec.tsx
+++ b/app/(app)/app/practice/shared/use-question-flow-core.browser.spec.tsx
@@ -69,6 +69,9 @@ function QuestionFlowCoreProbe() {
               session: {
                 sessionId: 'session_1',
                 mode: 'tutor',
+
+                deadlineAt: null,
+
                 index: 0,
                 total: 1,
                 latestSelectedChoiceId: 'choice_2',
@@ -115,6 +118,9 @@ function QuestionFlowCoreProbe() {
               session: {
                 sessionId: 'session_1',
                 mode: 'exam',
+
+                deadlineAt: '2099-05-22T12:02:24.000Z',
+
                 index: 0,
                 total: 1,
                 draftSelectedChoiceId: 'choice_2',
@@ -140,6 +146,9 @@ function QuestionFlowCoreProbe() {
               session: {
                 sessionId: 'session_1',
                 mode: 'exam',
+
+                deadlineAt: '2099-05-22T12:02:24.000Z',
+
                 index: 0,
                 total: 1,
                 draftSelectedChoiceId: null,

--- a/docs/debt/debt-391-local-e2e-schema-drift-preflight.md
+++ b/docs/debt/debt-391-local-e2e-schema-drift-preflight.md
@@ -1,0 +1,83 @@
+# DEBT-391: Local E2E Needs a Full Schema-Drift Preflight
+
+**Priority:** P2
+**Created:** 2026-05-23
+**Source:** Local authenticated E2E failed after SPEC-040 because the Neon `dev` branch behind `.env.local` had not been migrated to migrations `0017`/`0018`.
+**Related:** [Deployment Environments](../dev/deployment-environments.md), [Deployment Procedure](../dev/deployment-procedure.md), [Testing Infrastructure](../dev/testing-infrastructure.md), [SPEC-040](../specs/spec-040-omitted-exam-answer-scoring.md), [DEBT-390](./debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md)
+
+**Status:** Active
+
+---
+
+## Problem
+
+Local authenticated E2E can run against a database that is behind the checked-out migration journal.
+
+The current local E2E path loads `.env.local`: `playwright.config.ts:4-7` says it prefers `.env.local` and then `.env`. The global setup always runs before the Chromium project: `tests/e2e/global.setup.ts:7-11` calls `runE2ECredentialHealthCheck()`, `seedTestSubscription()`, `runE2EUserStateReset()`, and `clerkSetup()`.
+
+That preflight catches connectivity and one historical schema contract, but not full migration drift. `tests/e2e/helpers/credential-health-check.ts:141-149` verifies `SELECT 1`, and `credential-health-check.ts:152-181` checks only whether `idempotency_keys.completed_at` exists. There is no comparison between `db/migrations/meta/_journal.json` and `drizzle.__drizzle_migrations`, and no contract check for the current write-path tables.
+
+SPEC-040 made this visible. Migration `db/migrations/0017_flaky_ser_duncan.sql:1-4` makes `attempts.selected_choice_id` nullable, adds `attempts.is_omitted`, and adds the two CHECK constraints. Migration `db/migrations/0018_backfill-omitted-exam-attempts.sql:2-42` backfills omitted-incorrect attempts where no session/question attempt exists. When local `.env.local` targeted the Neon `dev` branch before those migrations had been applied, pages and auth still loaded, but answer-submission E2E paths failed with a generic "Failed to insert attempt" instead of a targeted "this database is behind migrations" error.
+
+CI did not catch this local drift because CI uses its own fresh Postgres service. `.github/workflows/ci.yml:35-38` sets a CI-local `DATABASE_URL`, `.github/workflows/ci.yml:105-109` runs `pnpm db:migrate` and `pnpm db:seed`, and `.github/workflows/ci.yml:187-189` runs `pnpm test:e2e` only after that setup.
+
+---
+
+## Why Existing Docs Were Not Enough
+
+The source-of-truth docs already say the right operational rule. `docs/dev/deployment-environments.md:101-141` documents that missing migrations cause write failures and that the fix is running `pnpm db:migrate` against the exact target database. `docs/dev/deployment-procedure.md:8-16` states that Vercel deploys code only and does not run migrations or seeds. `docs/dev/deployment-procedure.md:40-45` makes target-environment migration a manual operator step, separate from CI.
+
+The gap is automation and placement:
+
+- Local E2E starts successfully even when the target database is behind the current migration journal.
+- The failure appears later as an application write error, not as an environment/setup error.
+- The quick E2E instructions historically listed credentials but did not force the operator to think about `.env.local` schema freshness.
+
+---
+
+## Required Remediation
+
+Implement a local E2E schema-drift preflight before any mutating E2E setup runs.
+
+The preflight should:
+
+1. Read the expected migration list from `db/migrations/meta/_journal.json`.
+2. Query `drizzle.__drizzle_migrations` on the active `DATABASE_URL`.
+3. Fail fast when the target database is missing migrations present in the repo.
+4. Print a clear, non-secret remediation message, such as:
+
+```text
+E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS
+The database used by .env.local is behind the repo migration journal.
+Missing migrations: 0017_flaky_ser_duncan, 0018_backfill-omitted-exam-attempts.
+Confirm this is the intended non-production database, then run: env -u DATABASE_URL pnpm db:migrate
+```
+
+This belongs in the E2E preflight path before `seedTestSubscription()` because `tests/e2e/global.setup.ts:7-11` currently calls the credential health check before seeding and user-state reset. The check should be independently unit-tested alongside `tests/e2e/helpers/credential-health-check.test.ts`.
+
+---
+
+## Public-Safety Boundary
+
+Do document environment roles, branch names such as Neon `main`/`dev`, and commands.
+
+Do not commit:
+
+- full `DATABASE_URL` values
+- Neon endpoint hostnames
+- database passwords
+- account ids
+- Vercel/Neon project ids
+- Clerk or Stripe secrets
+
+The existing environment docs intentionally follow this rule: `docs/dev/deployment-environments.md:5-7` says the repo records the contract while provider-specific private values stay in the providers.
+
+---
+
+## Acceptance Criteria
+
+- `pnpm test:e2e` fails before the Playwright browser project when `.env.local` points at a database missing repo migrations.
+- The failure message names the missing migration tags without printing credentials.
+- A fully migrated local E2E database continues through the existing credential, Stripe, Clerk, and reset checks.
+- The check works for CI's fresh Postgres path as well as `.env.local`.
+- The implementation preserves the rule that CI validates migrations on CI Postgres but does not migrate Vercel/Neon Preview or Production databases.

--- a/docs/debt/index.md
+++ b/docs/debt/index.md
@@ -1,7 +1,7 @@
 # Technical Debt Register
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-05-21 (DEBT-388 resolved and archived — PR #316 moved the hero credibility line out of the cached `MarketingHeroCopy` to below the CTA row, dropped `practicing`, and tuned wrapping (no hard `<br>`). This **closes the landing-page polish thread**: DEBT-382 (numbers/hero/credibility) → 387 (3 study modes) → 389 (footer) → 388 (credibility reposition), all shipped. main and dev synced at `9755dd48`.)
+**Last Updated:** 2026-05-23 (DEBT-391 added for local E2E schema-drift preflight after the SPEC-040 `attempts.is_omitted` migration drifted behind the Neon `dev` branch and local authenticated E2E failed with generic attempt-insert errors.)
 
 ---
 
@@ -22,8 +22,9 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 | [DEBT-349](./debt-349-cross-request-published-content-caching.md) | Optional Tier 2 cross-request caching for immutable published questions and tag lists after DEBT-344 shipped request-scoped dedup | P3 | — |
 | [DEBT-381](./debt-381-question-content-typography-audit-and-preference-path.md) | Question content typography audit — Quick Practice, Tutor, and Exam are already unified at the Typography Policy Medium content tier. Do not globally shrink question text; if needed later, add a user-selectable Markdown/content-size preference while leaving UI chrome unchanged. | P3 | — |
 | [DEBT-390](./debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md) | Omitted exam questions are recorded as *unattempted*, not *incorrect* — accuracy % already counts blanks against the total denominator (`practice-session-summary.ts:46`), but `finalize-exam-answers.ts:86-88` drops undrafted questions so they create no `attempts` row and surface as "unattempted" in review/history/status-filters. `attempts.selected_choice_id` is `NOT NULL` (`db/schema.ts:437-439`), so representing an omitted-incorrect answer needs a domain + schema change. **Prerequisite for [SPEC-039](../specs/spec-039-exam-mode-timer.md)** (timer auto-submit hits this path). | P2 | — |
+| [DEBT-391](./debt-391-local-e2e-schema-drift-preflight.md) | Local authenticated E2E can run against a stale `.env.local` Neon branch because the current preflight checks only database connectivity and one historical idempotency schema contract, not the full Drizzle migration journal. Add a full migration-journal/schema-drift preflight so local E2E fails fast with a targeted migration instruction instead of surfacing generic write-path errors mid-suite. | P2 | — |
 
-**Next Debt ID:** DEBT-391
+**Next Debt ID:** DEBT-392
 
 ---
 

--- a/docs/dev/deployment-environments.md
+++ b/docs/dev/deployment-environments.md
@@ -1,6 +1,6 @@
 # Deployment Environments: Source of Truth
 
-**Last Reviewed (code/docs):** 2026-03-17
+**Last Reviewed (code/docs):** 2026-05-23
 
 This document is the repo-backed source of truth for environment scoping and the operator checklist around Clerk, Stripe, Postgres/Neon, and Vercel.
 
@@ -20,6 +20,16 @@ It intentionally avoids hard-coding private dashboard values that the repo canno
 ### Core isolation rule
 
 Production, Preview, and local development must never share the same live database or live billing/auth keys.
+
+### Current Vercel/Neon Branch Contract
+
+The current Vercel + Neon setup uses one Neon project with isolated database branches:
+
+- Vercel **Production** targets the Neon `main` branch.
+- Vercel **Preview** and **Development** target the Neon `dev` branch.
+- Local `.env.local` should be pulled from or kept equivalent to the Vercel Development environment, so local app runtime and authenticated local E2E also target the Neon `dev` branch.
+
+Do not hard-code branch hostnames, account ids, passwords, or connection strings in the repo. Verify those values through the Vercel Storage dashboard, Vercel environment variables, or a local redacted host check before running migrations.
 
 ---
 
@@ -116,7 +126,19 @@ DATABASE_URL="<preview-or-dev-connection-string>" pnpm db:migrate
 DATABASE_URL="<production-connection-string>" pnpm db:migrate
 ```
 
+For local authenticated E2E, the target database is the `DATABASE_URL` in `.env.local`. Confirm that it is a non-production Neon branch first, then run migrations against that file's target:
+
+```bash
+# Prints only the host, not the password.
+node -e "require('dotenv').config({ path: '.env.local' }); const u = new URL(process.env.DATABASE_URL); console.log(u.hostname)"
+
+# Use .env.local deliberately by clearing any shell-level DATABASE_URL override.
+env -u DATABASE_URL pnpm db:migrate
+```
+
 Historical example: PR #169 added `claimed_at` to `idempotency_keys`; the code deployed before the non-production database was migrated, which broke write paths until `pnpm db:migrate` was run.
+
+Historical example: SPEC-040 added `attempts.is_omitted` plus two CHECK constraints in migrations `0017` and `0018`; local E2E answer-submission flows failed with "Failed to insert attempt" until the Neon `dev` branch was migrated.
 
 ### Clerk Development Mode Can Re-Authenticate After Stripe Checkout
 

--- a/docs/dev/deployment-procedure.md
+++ b/docs/dev/deployment-procedure.md
@@ -1,7 +1,7 @@
 # Deployment Procedure
 
 > **Parent:** [Deployment Environments](./deployment-environments.md)
-> **Last Updated:** 2026-03-17
+> **Last Updated:** 2026-05-23
 
 ---
 
@@ -71,9 +71,10 @@ DATABASE_URL="<target>" pnpm db:seed
 
 | Environment | How to Connect | DATABASE_URL Source |
 |-------------|---------------|---------------------|
-| **Local** | Direct (already in `.env.local`) | `.env.local` |
-| **Preview / shared non-production** | Use your provider CLI/dashboard to fetch the non-production connection string | Provider secret manager / CLI output |
-| **Production** | Use your provider CLI/dashboard to fetch the production connection string | Provider secret manager / CLI output |
+| **Local app / local E2E** | Direct (already in `.env.local`) | `.env.local`, expected to match Vercel Development and the Neon `dev` branch |
+| **Preview / shared non-production** | Use your provider CLI/dashboard to fetch the non-production connection string | Vercel Preview/Development env vars, currently the Neon `dev` branch |
+| **Production** | Use your provider CLI/dashboard to fetch the production connection string | Vercel Production env vars, currently the Neon `main` branch |
+| **Local integration tests** | Docker Postgres on `localhost:5434` | `.env.test` or explicit `DATABASE_URL=postgresql://postgres:postgres@localhost:5434/addiction_boards_test` |
 
 Example for preview/production:
 
@@ -87,6 +88,17 @@ If you are using Neon, fetch the connection string for the intended branch first
 **Caution:** Always double-check which database/branch you're targeting. Running migrations or seeds against the wrong environment can corrupt data. Production operations should be done deliberately and verified immediately.
 
 **Optional helper:** `pnpm db:seed:all -- --plan` pulls Vercel Development, Preview, and Production env files into a temp directory, compares them with local `.env.local`, and shows the unique seed targets without writing data. `pnpm db:seed:all` then imports drafts as published and seeds each unique `DATABASE_URL` once. It does **not** run migrations; keep using `pnpm db:migrate` separately when schema changes are involved.
+
+For local authenticated E2E after pulling code with new migrations, migrate the `.env.local` target before running the suite. Confirm the host without printing credentials, then run Drizzle against `.env.local` deliberately:
+
+```bash
+node -e "require('dotenv').config({ path: '.env.local' }); const u = new URL(process.env.DATABASE_URL); console.log(u.hostname)"
+env -u DATABASE_URL pnpm db:migrate
+lsof -ti:3000 | xargs kill -9 2>/dev/null
+pnpm test:e2e
+```
+
+This is separate from `pnpm test:integration`, which uses the Docker Postgres database and has its own migration/seed setup.
 
 ---
 

--- a/docs/dev/testing-infrastructure.md
+++ b/docs/dev/testing-infrastructure.md
@@ -124,6 +124,16 @@ These can be provided via `.env.local` (loaded by `playwright.config.ts`) or CI 
 
 Individual spec files still use `test.skip(!hasClerkCredentials, ...)`, but that guard does **not** replace suite setup: `global.setup.ts` runs a preflight and seed/reset pass before the Chromium project starts. Missing or invalid credentials therefore fail the suite fast instead of silently skipping it.
 
+Local E2E uses the database in `.env.local`, not the Docker database used by `pnpm test:integration`. After pulling code with new Drizzle migrations, migrate the `.env.local` target before running E2E:
+
+```bash
+node -e "require('dotenv').config({ path: '.env.local' }); const u = new URL(process.env.DATABASE_URL); console.log(u.hostname)"
+env -u DATABASE_URL pnpm db:migrate
+pnpm test:e2e
+```
+
+The current preflight checks connectivity and selected schema contracts, but it does not compare the target database against the full Drizzle migration journal. See [DEBT-391](../debt/debt-391-local-e2e-schema-drift-preflight.md).
+
 ### Test Data Seeding
 
 Subscription data is seeded via the Stripe API and direct DB writes in `global.setup.ts` — **no Stripe UI automation**.

--- a/lib/container/use-cases.ts
+++ b/lib/container/use-cases.ts
@@ -34,6 +34,20 @@ export function createUseCaseFactories(input: {
   gateways: GatewayFactories;
 }): UseCaseFactories {
   const { primitives, repositories, gateways } = input;
+  const createFinalizeExamAnswersUseCase = () =>
+    new FinalizeExamAnswersUseCase(
+      repositories.createQuestionRepository(),
+      repositories.createAttemptRepository(),
+      repositories.createPracticeSessionRepository(),
+      async (fn) =>
+        primitives.db.transaction(async (tx) =>
+          fn({
+            questions: repositories.createQuestionRepository(tx),
+            attempts: repositories.createAttemptRepository(tx),
+            sessions: repositories.createPracticeSessionRepository(tx),
+          }),
+        ),
+    );
 
   return {
     createCheckEntitlementUseCase: () =>
@@ -62,24 +76,12 @@ export function createUseCaseFactories(input: {
       new EndPracticeSessionUseCase(
         repositories.createPracticeSessionRepository(),
       ),
-    createFinalizeExamAnswersUseCase: () =>
-      new FinalizeExamAnswersUseCase(
-        repositories.createQuestionRepository(),
-        repositories.createAttemptRepository(),
-        repositories.createPracticeSessionRepository(),
-        async (fn) =>
-          primitives.db.transaction(async (tx) =>
-            fn({
-              questions: repositories.createQuestionRepository(tx),
-              attempts: repositories.createAttemptRepository(tx),
-              sessions: repositories.createPracticeSessionRepository(tx),
-            }),
-          ),
-      ),
+    createFinalizeExamAnswersUseCase,
     createSaveExamDraftAnswerUseCase: () =>
       new SaveExamDraftAnswerUseCase(
         repositories.createQuestionRepository(),
         repositories.createPracticeSessionRepository(),
+        primitives.now,
       ),
     createGetNextQuestionUseCase: () =>
       new GetNextQuestionUseCase(
@@ -87,6 +89,9 @@ export function createUseCaseFactories(input: {
         repositories.createAttemptRepository(),
         repositories.createPracticeSessionRepository(),
         primitives.now,
+        {
+          execute: (input) => createFinalizeExamAnswersUseCase().execute(input),
+        },
       ),
     createGetPreviousAttemptUseCase: () =>
       new GetPreviousAttemptUseCase(

--- a/src/adapters/controllers/practice-controller-exam-draft.test.ts
+++ b/src/adapters/controllers/practice-controller-exam-draft.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { MAX_DRAFT_CUMULATIVE_MS } from '@/src/adapters/shared/validation-limits';
+import { ApplicationError } from '@/src/application/errors';
 import { saveExamDraftAnswer } from './practice-controller';
 import { createDeps } from './practice-controller-test-helpers';
 
@@ -167,6 +168,30 @@ describe('practice-controller', () => {
           cumulativeMs: 50_000,
         },
       ]);
+    });
+
+    it('surfaces expired exam draft saves as a CONFLICT ActionResult', async () => {
+      const deps = createDeps({
+        saveDraftThrows: new ApplicationError(
+          'CONFLICT',
+          'Exam time has expired',
+        ),
+      });
+
+      const result = await saveExamDraftAnswer(
+        {
+          sessionId: '11111111-1111-1111-1111-111111111111',
+          questionId: '22222222-2222-2222-2222-222222222222',
+          selectedChoiceId: '33333333-3333-3333-3333-333333333333',
+          cumulativeMs: 50_000,
+        },
+        deps,
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        error: { code: 'CONFLICT', message: 'Exam time has expired' },
+      });
     });
 
     it('returns VALIDATION_ERROR when the saved draft payload is malformed', async () => {

--- a/src/adapters/controllers/question-controller-exam-timer.test.ts
+++ b/src/adapters/controllers/question-controller-exam-timer.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 import {
   FakeAuthGateway,

--- a/src/adapters/controllers/question-controller-exam-timer.test.ts
+++ b/src/adapters/controllers/question-controller-exam-timer.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import {
+  FakeAuthGateway,
+  FakeCheckEntitlementUseCase,
+  FakeGetNextQuestionUseCase,
+  FakeIdempotencyKeyRepository,
+  FakeLogger,
+  FakeRateLimiter,
+  FakeSubmitAnswerUseCase,
+} from '@/src/application/test-helpers/fakes';
+import type { GetNextQuestionOutput } from '@/src/application/use-cases/get-next-question';
+import { createUser } from '@/src/domain/test-helpers';
+import type { QuestionControllerDeps } from './question-controller';
+import { getNextQuestion } from './question-controller';
+
+const sessionId = '11111111-1111-1111-1111-111111111111';
+
+function createActiveQuestion(
+  deadlineAt: string | null,
+): GetNextQuestionOutput {
+  return {
+    questionId: 'q_1',
+    slug: 'q-1',
+    stemMd: 'Stem',
+    difficulty: 'easy',
+    choices: [
+      {
+        id: 'choice_1',
+        label: 'A',
+        textMd: 'Choice',
+        sortOrder: 1,
+      },
+    ],
+    session: {
+      sessionId,
+      mode: deadlineAt ? 'exam' : 'tutor',
+      deadlineAt,
+      index: 0,
+      total: 2,
+      isMarkedForReview: false,
+      latestSelectedChoiceId: null,
+      latestIsCorrect: null,
+      draftSelectedChoiceId: null,
+      draftCumulativeMs: 0,
+    },
+  };
+}
+
+function createDeps(
+  getNextQuestionOutput: GetNextQuestionOutput,
+): QuestionControllerDeps {
+  return {
+    authGateway: new FakeAuthGateway(createUser({ id: 'user_1' })),
+    logger: new FakeLogger(),
+    rateLimiter: new FakeRateLimiter(),
+    idempotencyKeyRepository: new FakeIdempotencyKeyRepository(),
+    now: () => new Date('2026-05-22T12:00:00Z'),
+    checkEntitlementUseCase: new FakeCheckEntitlementUseCase({
+      isEntitled: true,
+      reason: null,
+      subscriptionStatus: 'active',
+      hasActiveSubscriptionPeriod: true,
+    }),
+    getNextQuestionUseCase: new FakeGetNextQuestionUseCase(
+      getNextQuestionOutput,
+    ),
+    submitAnswerUseCase: new FakeSubmitAnswerUseCase({
+      attemptId: '44444444-4444-4444-4444-444444444444',
+      isCorrect: true,
+      correctChoiceId: '55555555-5555-5555-5555-555555555555',
+      explanationMd: 'Because...',
+      referenceMd: null,
+      choiceExplanations: [],
+    }),
+  };
+}
+
+describe('question-controller exam timer payloads', () => {
+  it('returns deadlineAt in active exam session payloads', async () => {
+    const deadlineAt = '2026-05-22T12:02:24.000Z';
+
+    const result = await getNextQuestion(
+      { sessionId },
+      createDeps(createActiveQuestion(deadlineAt)),
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        session: {
+          mode: 'exam',
+          deadlineAt,
+        },
+      },
+    });
+  });
+
+  it('returns null deadlineAt in active tutor session payloads', async () => {
+    const result = await getNextQuestion(
+      { sessionId },
+      createDeps(createActiveQuestion(null)),
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        session: {
+          mode: 'tutor',
+          deadlineAt: null,
+        },
+      },
+    });
+  });
+});

--- a/src/application/use-cases/get-next-question-navigation.test.ts
+++ b/src/application/use-cases/get-next-question-navigation.test.ts
@@ -43,6 +43,9 @@ describe('GetNextQuestionUseCase', () => {
     expect(result?.session).toEqual({
       sessionId: SESSION_ID,
       mode: 'tutor',
+
+      deadlineAt: null,
+
       index: 1,
       total: 2,
       isMarkedForReview: false,
@@ -76,6 +79,9 @@ describe('GetNextQuestionUseCase', () => {
     expect(result?.session).toMatchObject({
       sessionId: SESSION_ID,
       mode: 'tutor',
+
+      deadlineAt: null,
+
       index: 1,
       total: 2,
     });
@@ -181,6 +187,9 @@ describe('GetNextQuestionUseCase', () => {
     expect(result?.session).toMatchObject({
       sessionId: SESSION_ID,
       mode: 'tutor',
+
+      deadlineAt: null,
+
       index: 1,
       total: 3,
     });
@@ -255,12 +264,76 @@ describe('GetNextQuestionUseCase', () => {
     expect(result?.session).toEqual({
       sessionId: SESSION_ID,
       mode: 'tutor',
+
+      deadlineAt: null,
+
       index: 0,
       total: 3,
       isMarkedForReview: false,
       latestSelectedChoiceId: null,
       latestIsCorrect: null,
     });
+  });
+
+  it('includes the server-derived exam deadline on active exam session payloads', async () => {
+    const q1 = createSingleChoiceQuestion('q1', 'c1');
+    const q2 = createSingleChoiceQuestion('q2', 'c2');
+
+    const session = createPracticeSession({
+      mode: 'exam',
+      questionIds: ['q1', 'q2'],
+      questionStates: [createQuestionState('q1'), createQuestionState('q2')],
+      startedAt: new Date('2026-05-22T12:00:00.000Z'),
+    });
+
+    const { getNextQuestion } = createTestDeps({
+      questions: [q1, q2],
+      sessions: [session],
+      now: () => new Date('2026-05-22T12:00:30.000Z'),
+    });
+
+    const result = await getNextQuestion.execute({
+      userId: USER_ID,
+      sessionId: SESSION_ID,
+    });
+
+    expect(result?.session).toMatchObject({
+      mode: 'exam',
+      deadlineAt: '2026-05-22T12:02:24.000Z',
+    });
+  });
+
+  it('finalizes an expired active exam instead of serving another question', async () => {
+    const q1 = createSingleChoiceQuestion('q1', 'c1');
+    const finalizerInputs: Array<{ userId: string; sessionId: string }> = [];
+
+    const session = createPracticeSession({
+      mode: 'exam',
+      questionIds: ['q1'],
+      questionStates: [createQuestionState('q1')],
+      startedAt: new Date('2026-05-22T12:00:00.000Z'),
+    });
+
+    const { getNextQuestion } = createTestDeps({
+      questions: [q1],
+      sessions: [session],
+      now: () => new Date('2026-05-22T12:01:12.000Z'),
+      expiredExamFinalizer: {
+        execute: async (input) => {
+          finalizerInputs.push(input);
+        },
+      },
+    });
+
+    await expect(
+      getNextQuestion.execute({
+        userId: USER_ID,
+        sessionId: SESSION_ID,
+      }),
+    ).resolves.toBeNull();
+    expect(finalizerInputs).toEqual([
+      { userId: USER_ID, sessionId: SESSION_ID },
+    ]);
   });
 
   it('throws NOT_FOUND when next session question is not published', async () => {

--- a/src/application/use-cases/get-next-question-navigation.test.ts
+++ b/src/application/use-cases/get-next-question-navigation.test.ts
@@ -336,6 +336,35 @@ describe('GetNextQuestionUseCase', () => {
     ]);
   });
 
+  it('throws INTERNAL_ERROR when an expired active exam has no finalizer configured', async () => {
+    const q1 = createSingleChoiceQuestion('q1', 'c1');
+
+    const session = createPracticeSession({
+      mode: 'exam',
+      questionIds: ['q1'],
+      questionStates: [createQuestionState('q1')],
+      startedAt: new Date('2026-05-22T12:00:00.000Z'),
+    });
+
+    const { getNextQuestion } = createTestDeps({
+      questions: [q1],
+      sessions: [session],
+      now: () => new Date('2026-05-22T12:01:12.000Z'),
+    });
+
+    await expect(
+      getNextQuestion.execute({
+        userId: USER_ID,
+        sessionId: SESSION_ID,
+      }),
+    ).rejects.toEqual(
+      new ApplicationError(
+        'INTERNAL_ERROR',
+        'Expired exam finalizer is not configured',
+      ),
+    );
+  });
+
   it('throws NOT_FOUND when next session question is not published', async () => {
     const questionId = 'q1';
 

--- a/src/application/use-cases/get-next-question-test-helpers.ts
+++ b/src/application/use-cases/get-next-question-test-helpers.ts
@@ -32,6 +32,9 @@ type TestDepsOverrides = {
   attempts?: ConstructorParameters<typeof FakeAttemptRepository>[0];
   sessions?: ConstructorParameters<typeof FakePracticeSessionRepository>[0];
   now?: () => Date;
+  expiredExamFinalizer?: {
+    execute: (input: { userId: string; sessionId: string }) => Promise<unknown>;
+  };
 };
 
 export function createTestDeps(overrides: TestDepsOverrides = {}) {
@@ -45,6 +48,7 @@ export function createTestDeps(overrides: TestDepsOverrides = {}) {
     attemptRepo,
     sessionRepo,
     overrides.now,
+    overrides.expiredExamFinalizer,
   );
 
   return { questionRepo, attemptRepo, sessionRepo, getNextQuestion };

--- a/src/application/use-cases/get-next-question.ts
+++ b/src/application/use-cases/get-next-question.ts
@@ -1,7 +1,9 @@
 import type { Question } from '@/src/domain/entities';
 import {
+  computeExamDeadline,
   createDefaultQuestionState,
   createSeed,
+  isExamExpired,
   selectNextQuestionId,
   shouldShowExplanation,
   shuffleWithSeed,
@@ -48,6 +50,7 @@ export type NextQuestion = {
     mode: PracticeMode;
     index: number; // 0-based index within session
     total: number;
+    deadlineAt: string | null;
     isMarkedForReview?: boolean;
     latestSelectedChoiceId?: string | null;
     latestIsCorrect?: boolean | null;
@@ -74,6 +77,10 @@ export type GetNextQuestionInput =
 
 export type GetNextQuestionOutput = NextQuestion | null;
 
+export type ExpiredExamFinalizer = {
+  execute: (input: { userId: string; sessionId: string }) => Promise<unknown>;
+};
+
 function getSessionSelectedChoiceId(
   session: {
     mode: PracticeMode;
@@ -95,6 +102,7 @@ export class GetNextQuestionUseCase {
     private readonly attempts: AttemptMostRecentAnsweredAtReader,
     private readonly sessions: PracticeSessionRepository,
     private readonly now: () => Date = () => new Date(),
+    private readonly expiredExamFinalizer?: ExpiredExamFinalizer,
   ) {}
 
   async execute(input: GetNextQuestionInput): Promise<GetNextQuestionOutput> {
@@ -166,6 +174,16 @@ export class GetNextQuestionUseCase {
     }
     if (session.endedAt) {
       throw new ApplicationError('CONFLICT', 'Practice session already ended');
+    }
+    if (isExamExpired(session, this.now())) {
+      if (!this.expiredExamFinalizer) {
+        throw new ApplicationError(
+          'INTERNAL_ERROR',
+          'Expired exam finalizer is not configured',
+        );
+      }
+      await this.expiredExamFinalizer.execute({ userId, sessionId });
+      return null;
     }
 
     const stateByQuestionId = new Map(
@@ -247,6 +265,7 @@ export class GetNextQuestionUseCase {
         mode: session.mode,
         index: targetIndex,
         total: session.questionIds.length,
+        deadlineAt: computeExamDeadline(session)?.toISOString() ?? null,
         isMarkedForReview: targetState.markedForReview,
         latestSelectedChoiceId: targetState.latestSelectedChoiceId,
         latestIsCorrect: showCorrectness ? targetState.latestIsCorrect : null,

--- a/src/application/use-cases/save-exam-draft-answer.test.ts
+++ b/src/application/use-cases/save-exam-draft-answer.test.ts
@@ -270,6 +270,73 @@ describe('SaveExamDraftAnswerUseCase', () => {
     );
   });
 
+  it('rejects draft saves after the server-derived exam deadline', async () => {
+    const useCase = new SaveExamDraftAnswerUseCase(
+      new FakeQuestionRepository([]),
+      new FakePracticeSessionRepository([
+        createPracticeSession({
+          id: 'session-1',
+          userId: 'user-1',
+          mode: 'exam',
+          questionIds: ['q1'],
+          startedAt: new Date('2026-05-22T12:00:00.000Z'),
+        }),
+      ]),
+      () => new Date('2026-05-22T12:01:12.000Z'),
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+        questionId: 'q1',
+        selectedChoiceId: 'choice-1',
+        cumulativeMs: 5_000,
+      }),
+    ).rejects.toEqual(
+      new ApplicationError('CONFLICT', 'Exam time has expired'),
+    );
+  });
+
+  it('allows draft saves before the server-derived exam deadline', async () => {
+    const sessions = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: 'session-1',
+        userId: 'user-1',
+        mode: 'exam',
+        questionIds: ['q1'],
+        startedAt: new Date('2026-05-22T12:00:00.000Z'),
+      }),
+    ]);
+    const questions = new FakeQuestionRepository([
+      createQuestion({
+        id: 'q1',
+        choices: [
+          createChoice({ id: 'choice-1', questionId: 'q1', label: 'A' }),
+          createChoice({ id: 'choice-2', questionId: 'q1', label: 'B' }),
+        ],
+      }),
+    ]);
+    const useCase = new SaveExamDraftAnswerUseCase(
+      questions,
+      sessions,
+      () => new Date('2026-05-22T12:01:11.999Z'),
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+        questionId: 'q1',
+        selectedChoiceId: 'choice-1',
+        cumulativeMs: 5_000,
+      }),
+    ).resolves.toMatchObject({
+      questionId: 'q1',
+      draftSelectedChoiceId: 'choice-1',
+    });
+  });
+
   it('rejects missing sessions', async () => {
     const useCase = new SaveExamDraftAnswerUseCase(
       new FakeQuestionRepository([]),

--- a/src/application/use-cases/save-exam-draft-answer.ts
+++ b/src/application/use-cases/save-exam-draft-answer.ts
@@ -4,7 +4,7 @@ import type {
   QuestionRepository,
 } from '@/src/application/ports/repositories';
 import type { PracticeSessionQuestionState } from '@/src/domain/entities';
-import { MS_PER_SECOND } from '@/src/domain/services';
+import { isExamExpired, MS_PER_SECOND } from '@/src/domain/services';
 import { SUBMIT_ANSWER_MAX_TIME_SPENT_SECONDS } from './submit-answer';
 
 export type SaveExamDraftAnswerInput = {
@@ -24,6 +24,7 @@ export class SaveExamDraftAnswerUseCase {
   constructor(
     private readonly questions: QuestionRepository,
     private readonly sessions: PracticeSessionRepository,
+    private readonly now: () => Date = () => new Date(),
   ) {}
 
   async execute(
@@ -49,6 +50,10 @@ export class SaveExamDraftAnswerUseCase {
         'CONFLICT',
         'Cannot modify a completed session',
       );
+    }
+
+    if (isExamExpired(session, this.now())) {
+      throw new ApplicationError('CONFLICT', 'Exam time has expired');
     }
 
     const question = await this.questions.findPublishedById(input.questionId);

--- a/src/domain/services/exam-timer.test.ts
+++ b/src/domain/services/exam-timer.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { createPracticeSession } from '@/src/domain/test-helpers';
+import {
+  computeExamAllotmentSeconds,
+  computeExamDeadline,
+  isExamExpired,
+  remainingExamSeconds,
+} from './exam-timer';
+import { EXAM_SECONDS_PER_QUESTION } from './time-constants';
+
+describe('exam timer domain service', () => {
+  it('locks the exam per-question allotment to the board-derived constant', () => {
+    expect(EXAM_SECONDS_PER_QUESTION).toBe(72);
+  });
+
+  it('computes a whole-block allotment for exam sessions only', () => {
+    const exam = createPracticeSession({
+      mode: 'exam',
+      questionIds: ['q1', 'q2', 'q3'],
+    });
+    const tutor = createPracticeSession({
+      mode: 'tutor',
+      questionIds: ['q1', 'q2', 'q3'],
+    });
+
+    expect(computeExamAllotmentSeconds(exam)).toBe(216);
+    expect(computeExamAllotmentSeconds(tutor)).toBeNull();
+  });
+
+  it('computes the deadline from startedAt plus the exam allotment', () => {
+    const session = createPracticeSession({
+      mode: 'exam',
+      questionIds: ['q1', 'q2'],
+      startedAt: new Date('2026-05-22T12:00:00.000Z'),
+    });
+
+    expect(computeExamDeadline(session)).toEqual(
+      new Date('2026-05-22T12:02:24.000Z'),
+    );
+  });
+
+  it('returns null deadline for tutor sessions', () => {
+    const session = createPracticeSession({
+      mode: 'tutor',
+      startedAt: new Date('2026-05-22T12:00:00.000Z'),
+    });
+
+    expect(computeExamDeadline(session)).toBeNull();
+  });
+
+  it('computes remaining seconds from the absolute deadline and clamps at zero', () => {
+    const session = createPracticeSession({
+      mode: 'exam',
+      questionIds: ['q1'],
+      startedAt: new Date('2026-05-22T12:00:00.000Z'),
+    });
+
+    expect(
+      remainingExamSeconds(session, new Date('2026-05-22T12:00:30.000Z')),
+    ).toBe(42);
+    expect(
+      remainingExamSeconds(session, new Date('2026-05-22T12:01:12.000Z')),
+    ).toBe(0);
+    expect(
+      remainingExamSeconds(session, new Date('2026-05-22T12:01:13.000Z')),
+    ).toBe(0);
+  });
+
+  it('returns Infinity remaining time and never expires for tutor sessions', () => {
+    const session = createPracticeSession({
+      mode: 'tutor',
+      questionIds: ['q1'],
+      startedAt: new Date('2026-05-22T12:00:00.000Z'),
+    });
+
+    expect(
+      remainingExamSeconds(session, new Date('2026-05-22T13:00:00.000Z')),
+    ).toBe(Number.POSITIVE_INFINITY);
+    expect(isExamExpired(session, new Date('2026-05-22T13:00:00.000Z'))).toBe(
+      false,
+    );
+  });
+
+  it('expires at and after the server-derived deadline', () => {
+    const session = createPracticeSession({
+      mode: 'exam',
+      questionIds: ['q1'],
+      startedAt: new Date('2026-05-22T12:00:00.000Z'),
+    });
+
+    expect(isExamExpired(session, new Date('2026-05-22T12:01:11.999Z'))).toBe(
+      false,
+    );
+    expect(isExamExpired(session, new Date('2026-05-22T12:01:12.000Z'))).toBe(
+      true,
+    );
+    expect(isExamExpired(session, new Date('2026-05-22T12:01:13.000Z'))).toBe(
+      true,
+    );
+  });
+});

--- a/src/domain/services/exam-timer.ts
+++ b/src/domain/services/exam-timer.ts
@@ -1,0 +1,34 @@
+import type { PracticeSession } from '../entities';
+import { EXAM_SECONDS_PER_QUESTION, MS_PER_SECOND } from './time-constants';
+
+export function computeExamAllotmentSeconds(
+  session: PracticeSession,
+): number | null {
+  if (session.mode !== 'exam') return null;
+  return session.questionIds.length * EXAM_SECONDS_PER_QUESTION;
+}
+
+export function computeExamDeadline(session: PracticeSession): Date | null {
+  const allotmentSeconds = computeExamAllotmentSeconds(session);
+  if (allotmentSeconds === null) return null;
+  return new Date(
+    session.startedAt.getTime() + allotmentSeconds * MS_PER_SECOND,
+  );
+}
+
+export function remainingExamSeconds(
+  session: PracticeSession,
+  now: Date,
+): number {
+  const deadline = computeExamDeadline(session);
+  if (deadline === null) return Number.POSITIVE_INFINITY;
+  return Math.max(
+    0,
+    Math.floor((deadline.getTime() - now.getTime()) / MS_PER_SECOND),
+  );
+}
+
+export function isExamExpired(session: PracticeSession, now: Date): boolean {
+  const deadline = computeExamDeadline(session);
+  return deadline !== null && now.getTime() >= deadline.getTime();
+}

--- a/src/domain/services/index.ts
+++ b/src/domain/services/index.ts
@@ -3,6 +3,12 @@ export {
   isEntitled,
   type NonEntitledReason,
 } from './entitlement';
+export {
+  computeExamAllotmentSeconds,
+  computeExamDeadline,
+  isExamExpired,
+  remainingExamSeconds,
+} from './exam-timer';
 export { type GradeResult, gradeAnswer } from './grading';
 export {
   type AttemptHistory,
@@ -26,4 +32,9 @@ export {
   computeStreak,
   filterAttemptsInWindow,
 } from './statistics';
-export { DAY_MS, MS_PER_SECOND, SECONDS_PER_DAY } from './time-constants';
+export {
+  DAY_MS,
+  EXAM_SECONDS_PER_QUESTION,
+  MS_PER_SECOND,
+  SECONDS_PER_DAY,
+} from './time-constants';

--- a/src/domain/services/time-constants.ts
+++ b/src/domain/services/time-constants.ts
@@ -1,3 +1,4 @@
 export const MS_PER_SECOND = 1000;
+export const EXAM_SECONDS_PER_QUESTION = 72;
 export const DAY_MS = 86_400_000;
 export const SECONDS_PER_DAY = DAY_MS / MS_PER_SECOND;

--- a/tests/integration/exam-timer.integration.test.ts
+++ b/tests/integration/exam-timer.integration.test.ts
@@ -1,0 +1,192 @@
+import { randomUUID } from 'node:crypto';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { DrizzleAttemptRepository } from '@/src/adapters/repositories/drizzle-attempt-repository';
+import { DrizzlePracticeSessionRepository } from '@/src/adapters/repositories/drizzle-practice-session-repository';
+import { DrizzleQuestionRepository } from '@/src/adapters/repositories/drizzle-question-repository';
+import { FinalizeExamAnswersUseCase } from '@/src/application/use-cases/finalize-exam-answers';
+import { GetNextQuestionUseCase } from '@/src/application/use-cases/get-next-question';
+import { SaveExamDraftAnswerUseCase } from '@/src/application/use-cases/save-exam-draft-answer';
+import {
+  cleanupAfterEach,
+  closeConnection,
+  createCleanupState,
+  createIntegrationDb,
+  createQuestion,
+  createUser,
+} from './helpers';
+
+const { db, sql } = createIntegrationDb();
+const cleanup = createCleanupState();
+
+afterEach(async () => {
+  await cleanupAfterEach(db, cleanup);
+});
+
+afterAll(async () => {
+  await closeConnection(sql);
+});
+
+function createFinalizeExamAnswersUseCase(input: { now: () => Date }) {
+  return new FinalizeExamAnswersUseCase(
+    new DrizzleQuestionRepository(db),
+    new DrizzleAttemptRepository(db),
+    new DrizzlePracticeSessionRepository(db, input.now),
+    async (fn) =>
+      db.transaction(async (tx) =>
+        fn({
+          questions: new DrizzleQuestionRepository(tx),
+          attempts: new DrizzleAttemptRepository(tx),
+          sessions: new DrizzlePracticeSessionRepository(tx, input.now),
+        }),
+      ),
+  );
+}
+
+describe('exam timer integration', () => {
+  it('rejects draft saves after expiry and finalizes omitted rows as incorrect', async () => {
+    let now = new Date('2026-05-22T12:00:00.000Z');
+    const clock = () => now;
+    const user = await createUser(db, cleanup);
+    const firstQuestion = await createQuestion(db, cleanup, {
+      slug: `it-exam-timer-a-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const secondQuestion = await createQuestion(db, cleanup, {
+      slug: `it-exam-timer-b-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const questions = new DrizzleQuestionRepository(db);
+    const attempts = new DrizzleAttemptRepository(db);
+    const sessions = new DrizzlePracticeSessionRepository(db, clock);
+    const saveDraft = new SaveExamDraftAnswerUseCase(
+      questions,
+      sessions,
+      clock,
+    );
+    const finalize = createFinalizeExamAnswersUseCase({ now: clock });
+
+    const session = await sessions.create({
+      userId: user.id,
+      mode: 'exam',
+      paramsJson: {
+        count: 2,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [firstQuestion.id, secondQuestion.id],
+      },
+    });
+
+    now = new Date(session.startedAt.getTime() + 144_000);
+    await expect(
+      saveDraft.execute({
+        userId: user.id,
+        sessionId: session.id,
+        questionId: firstQuestion.id,
+        selectedChoiceId: firstQuestion.correctChoiceId,
+        cumulativeMs: 30_000,
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Exam time has expired',
+    });
+
+    const summary = await finalize.execute({
+      userId: user.id,
+      sessionId: session.id,
+    });
+
+    expect(summary).toMatchObject({
+      sessionId: session.id,
+      mode: 'exam',
+      questionCount: 2,
+      totals: {
+        answered: 0,
+        correct: 0,
+        accuracy: 0,
+      },
+    });
+
+    const endedSession = await sessions.findByIdAndUserId(session.id, user.id);
+    expect(endedSession?.endedAt).toEqual(now);
+
+    const sessionAttempts = await attempts.findBySessionId(session.id, user.id);
+    expect(sessionAttempts).toHaveLength(2);
+    expect(sessionAttempts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          questionId: firstQuestion.id,
+          outcome: { kind: 'omitted' },
+          isCorrect: false,
+        }),
+        expect.objectContaining({
+          questionId: secondQuestion.id,
+          outcome: { kind: 'omitted' },
+          isCorrect: false,
+        }),
+      ]),
+    );
+  });
+
+  it('derives identical active exam deadlines across reloads from persisted startedAt', async () => {
+    let now = new Date('2026-05-22T12:00:00.000Z');
+    const clock = () => now;
+    const user = await createUser(db, cleanup);
+    const firstQuestion = await createQuestion(db, cleanup, {
+      slug: `it-exam-timer-reload-a-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const secondQuestion = await createQuestion(db, cleanup, {
+      slug: `it-exam-timer-reload-b-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const questions = new DrizzleQuestionRepository(db);
+    const attempts = new DrizzleAttemptRepository(db);
+    const sessions = new DrizzlePracticeSessionRepository(db, clock);
+
+    const session = await sessions.create({
+      userId: user.id,
+      mode: 'exam',
+      paramsJson: {
+        count: 2,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [firstQuestion.id, secondQuestion.id],
+      },
+    });
+
+    const expectedDeadline = new Date(
+      session.startedAt.getTime() + 144_000,
+    ).toISOString();
+
+    now = new Date(session.startedAt.getTime() + 30_000);
+    const firstLoad = await new GetNextQuestionUseCase(
+      questions,
+      attempts,
+      sessions,
+      clock,
+      createFinalizeExamAnswersUseCase({ now: clock }),
+    ).execute({
+      userId: user.id,
+      sessionId: session.id,
+    });
+
+    now = new Date(session.startedAt.getTime() + 60_000);
+    const reload = await new GetNextQuestionUseCase(
+      questions,
+      attempts,
+      sessions,
+      clock,
+      createFinalizeExamAnswersUseCase({ now: clock }),
+    ).execute({
+      userId: user.id,
+      sessionId: session.id,
+    });
+
+    expect(firstLoad?.session?.deadlineAt).toBe(expectedDeadline);
+    expect(reload?.session?.deadlineAt).toBe(firstLoad?.session?.deadlineAt);
+  });
+});


### PR DESCRIPTION
## Summary
- add pure exam timer domain utilities and the 72-second per-question constant
- thread server-derived deadlineAt through active exam question payloads and reject draft saves after expiry
- route expired active exam reads through FinalizeExamAnswersUseCase, reusing SPEC-040 omitted-attempt scoring
- add the client countdown hook, ExamTimer UI, exam-header placement, and auto-submit wiring with a best-effort final draft save
- cover the flow with unit, browser, controller, and integration tests

## Verification
- pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build
- pnpm test:e2e attempted, but setup failed before tests because E2E_STRIPE_OWNER is missing while STRIPE_SECRET_KEY is real

## Scope boundaries
- no SPEC-040 schema/backfill changes
- no gradeAnswer changes
- no tutor timer, quick-practice timer, per-question timer, pause/resume, or scheduled reaper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visible countdown timer in timed exam practice sessions with milestone announcements and warning styling; timer only shown in exam mode.
  * Sessions now auto-finalize when the exam deadline passes, transitioning the UI to the summary view.

* **Bug Fixes**
  * Prevent late draft saves after the exam deadline; expiry finalization runs once to avoid duplicate submissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->