### PR TITLE
Bump CI actions for Node 24 runtime (DEBT-392 Tier 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
       NODE_ENV: test
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/addiction_boards_test
 
+      # DEBT-392 Tier 1: opt JS actions into the Node 24 runtime before
+      # GitHub flips the default (observed runner deadline 2026-06-02;
+      # public changelog deadline 2026-06-16). Lets us surface any
+      # Node-24-incompatible action in our chain before the forced flip.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
       # App base URL used by redirects / Playwright baseURL
       NEXT_PUBLIC_APP_URL: http://127.0.0.1:3000
 
@@ -68,7 +74,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.8
         with:
           version: 10.9.0
           run_install: false
@@ -125,7 +131,7 @@ jobs:
         run: pnpm test:browser:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/**/coverage-final.json


### PR DESCRIPTION
## Summary

Resolves DEBT-392 Tier 1 (the hard-deadline tier). GitHub forces JS actions to the Node 24 runtime by default on **2026-06-02** (per the runner warning observed on PR #320's merge CI) / **2026-06-16** (per the public changelog). Without this bump CI starts failing on that date.

## Changes (`.github/workflows/ci.yml` only)

1. `pnpm/action-setup@v4` → `@v6.0.8` (v4 runs on Node 20).
2. `codecov/codecov-action@v5` → `@v6.0.1` (v5.5.4 still pins `actions/github-script@v7.0.1` on Node 20; v6.0.0 was the first checked release moving to `@v8.0.0` on Node 24; v6.0.1 is current latest).
3. Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` in job env so any remaining Node-20 transitive actions surface now rather than after GitHub flips the default.

## Test plan

The actual validation is this PR's CI run — local typecheck/lint/tests can't validate workflow changes. Expected outcome:

- [x] Pre-push hook green locally (typecheck + 2516 tests)
- [ ] GitHub Actions CI succeeds on this PR
- [ ] No Node-20 deprecation warning in the CI log (search for "Node.js 20 actions are deprecated")
- [ ] Codecov upload step succeeds with v6.0.1

## Out of scope

DEBT-392 Tiers 2–6 (production security, lockfile hygiene, major upgrades, runtime alignment, cleanup/automation) — each shipped as its own PR per the doc.

## Skipped

CodeRabbit review (free-tier rate limit). Merge gate is GitHub Actions CI + Vercel preview only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow environment to enforce Node 24 runtime for JavaScript actions.
  * Upgraded build and code coverage tools to latest versions for improved compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->