### PR TITLE
Bump dotenv to v17 (DEBT-392 Tier 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ rg '^(DATABASE_URL|CLERK_SECRET_KEY|NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY|E2E_CLERK_
 
 # If the current branch includes new db/migrations since the target DB was last updated,
 # first confirm .env.local is non-production, then migrate that exact target:
-LOCAL_E2E_DATABASE_URL="$(node -e "require('dotenv').config({ path: '.env.local' }); const url = process.env.DATABASE_URL; if (!url) throw new Error('Missing DATABASE_URL in .env.local'); process.stdout.write(url)")"
+LOCAL_E2E_DATABASE_URL="$(node -e "require('dotenv').config({ path: '.env.local', quiet: true }); const url = process.env.DATABASE_URL; if (!url) throw new Error('Missing DATABASE_URL in .env.local'); process.stdout.write(url)")"
 node -e "const u = new URL(process.argv[1]); console.log(u.hostname)" "$LOCAL_E2E_DATABASE_URL"
 DATABASE_URL="$LOCAL_E2E_DATABASE_URL" pnpm db:migrate
 
@@ -589,7 +589,7 @@ rg '^(DATABASE_URL|CLERK_SECRET_KEY|NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY|E2E_CLERK_
 
 # If the current branch includes new db/migrations since the target DB was last updated,
 # first confirm .env.local is non-production, then migrate that exact target:
-LOCAL_E2E_DATABASE_URL="$(node -e "require('dotenv').config({ path: '.env.local' }); const url = process.env.DATABASE_URL; if (!url) throw new Error('Missing DATABASE_URL in .env.local'); process.stdout.write(url)")"
+LOCAL_E2E_DATABASE_URL="$(node -e "require('dotenv').config({ path: '.env.local', quiet: true }); const url = process.env.DATABASE_URL; if (!url) throw new Error('Missing DATABASE_URL in .env.local'); process.stdout.write(url)")"
 node -e "const u = new URL(process.argv[1]); console.log(u.hostname)" "$LOCAL_E2E_DATABASE_URL"
 DATABASE_URL="$LOCAL_E2E_DATABASE_URL" pnpm db:migrate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ rg '^(DATABASE_URL|CLERK_SECRET_KEY|NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY|E2E_CLERK_
 
 # If the current branch includes new db/migrations since the target DB was last updated,
 # first confirm .env.local is non-production, then migrate that exact target:
-LOCAL_E2E_DATABASE_URL="$(node -e "require('dotenv').config({ path: '.env.local' }); const url = process.env.DATABASE_URL; if (!url) throw new Error('Missing DATABASE_URL in .env.local'); process.stdout.write(url)")"
+LOCAL_E2E_DATABASE_URL="$(node -e "require('dotenv').config({ path: '.env.local', quiet: true }); const url = process.env.DATABASE_URL; if (!url) throw new Error('Missing DATABASE_URL in .env.local'); process.stdout.write(url)")"
 node -e "const u = new URL(process.argv[1]); console.log(u.hostname)" "$LOCAL_E2E_DATABASE_URL"
 DATABASE_URL="$LOCAL_E2E_DATABASE_URL" pnpm db:migrate
 

--- a/docs/dev/deployment-environments.md
+++ b/docs/dev/deployment-environments.md
@@ -130,7 +130,7 @@ For local authenticated E2E, the target database is the `DATABASE_URL` in `.env.
 
 ```bash
 # Prints only the host, not the password.
-LOCAL_E2E_DATABASE_URL="$(node -e "require('dotenv').config({ path: '.env.local' }); const url = process.env.DATABASE_URL; if (!url) throw new Error('Missing DATABASE_URL in .env.local'); process.stdout.write(url)")"
+LOCAL_E2E_DATABASE_URL="$(node -e "require('dotenv').config({ path: '.env.local', quiet: true }); const url = process.env.DATABASE_URL; if (!url) throw new Error('Missing DATABASE_URL in .env.local'); process.stdout.write(url)")"
 node -e "const u = new URL(process.argv[1]); console.log(u.hostname)" "$LOCAL_E2E_DATABASE_URL"
 
 # Migrate only the target you just verified.

--- a/docs/dev/deployment-procedure.md
+++ b/docs/dev/deployment-procedure.md
@@ -92,7 +92,7 @@ If you are using Neon, fetch the connection string for the intended branch first
 For local authenticated E2E after pulling code with new migrations, migrate the `.env.local` target before running the suite. Confirm the host without printing credentials, then run Drizzle against `.env.local` deliberately:
 
 ```bash
-LOCAL_E2E_DATABASE_URL="$(node -e "require('dotenv').config({ path: '.env.local' }); const url = process.env.DATABASE_URL; if (!url) throw new Error('Missing DATABASE_URL in .env.local'); process.stdout.write(url)")"
+LOCAL_E2E_DATABASE_URL="$(node -e "require('dotenv').config({ path: '.env.local', quiet: true }); const url = process.env.DATABASE_URL; if (!url) throw new Error('Missing DATABASE_URL in .env.local'); process.stdout.write(url)")"
 node -e "const u = new URL(process.argv[1]); console.log(u.hostname)" "$LOCAL_E2E_DATABASE_URL"
 DATABASE_URL="$LOCAL_E2E_DATABASE_URL" pnpm db:migrate
 lsof -ti:3000 | xargs kill -9 2>/dev/null

--- a/docs/dev/testing-infrastructure.md
+++ b/docs/dev/testing-infrastructure.md
@@ -127,7 +127,7 @@ Individual spec files still use `test.skip(!hasClerkCredentials, ...)`, but that
 Local E2E uses the database in `.env.local`, not the Docker database used by `pnpm test:integration`. After pulling code with new Drizzle migrations, migrate the `.env.local` target before running E2E:
 
 ```bash
-LOCAL_E2E_DATABASE_URL="$(node -e "require('dotenv').config({ path: '.env.local' }); const url = process.env.DATABASE_URL; if (!url) throw new Error('Missing DATABASE_URL in .env.local'); process.stdout.write(url)")"
+LOCAL_E2E_DATABASE_URL="$(node -e "require('dotenv').config({ path: '.env.local', quiet: true }); const url = process.env.DATABASE_URL; if (!url) throw new Error('Missing DATABASE_URL in .env.local'); process.stdout.write(url)")"
 node -e "const u = new URL(process.argv[1]); console.log(u.hostname)" "$LOCAL_E2E_DATABASE_URL"
 DATABASE_URL="$LOCAL_E2E_DATABASE_URL" pnpm db:migrate
 lsof -ti:3000 | xargs kill -9 2>/dev/null
@@ -252,8 +252,8 @@ import { config } from 'dotenv';
 import { chromium } from '@playwright/test';
 
 async function main() {
-  config({ path: '.env.local' });
-  config({ path: '.env' });
+  config({ path: '.env.local', quiet: true });
+  config({ path: '.env', quiet: true });
 
   const baseURL = process.env.NEXT_PUBLIC_APP_URL || 'http://127.0.0.1:3000';
   const username = process.env.E2E_CLERK_USER_USERNAME;

--- a/docs/tooling/agent-browser.md
+++ b/docs/tooling/agent-browser.md
@@ -68,7 +68,7 @@ set -a && source .env.local && set +a
 Or via Node (shell-safe):
 
 ```bash
-EMAIL=$(node -e "require('dotenv').config({path:'.env.local'});require('dotenv').config({path:'.env'});process.stdout.write(process.env.E2E_CLERK_USER_USERNAME||'')")
+EMAIL=$(node -e "require('dotenv').config({path:'.env.local', quiet:true});require('dotenv').config({path:'.env', quiet:true});process.stdout.write(process.env.E2E_CLERK_USER_USERNAME||'')")
 ```
 
 ---

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -3,8 +3,8 @@ import type { Config } from 'drizzle-kit';
 
 // Prefer `.env.local` for developer-specific secrets, with `.env` as a fallback.
 // Never override explicitly provided environment variables.
-config({ path: '.env.local', override: false });
-config({ path: '.env', override: false });
+config({ path: '.env.local', override: false, quiet: true });
+config({ path: '.env', override: false, quiet: true });
 
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@tailwindcss/postcss": "4.1.18",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "dotenv": "^16.5.0",
+    "dotenv": "^17.4.2",
     "drizzle-kit": "^0.31.8",
     "drizzle-orm": "^0.45.2",
     "fast-glob": "^3.3.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,8 +3,8 @@ import { config } from 'dotenv';
 
 // Prefer `.env.local` for developer-specific secrets, with `.env` as a fallback.
 // Never override explicitly provided environment variables.
-config({ path: '.env.local' });
-config({ path: '.env' });
+config({ path: '.env.local', quiet: true });
+config({ path: '.env', quiet: true });
 
 const baseURL = process.env.NEXT_PUBLIC_APP_URL || 'http://127.0.0.1:3000';
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,8 +3,8 @@ import { config } from 'dotenv';
 
 // Prefer `.env.local` for developer-specific secrets, with `.env` as a fallback.
 // Never override explicitly provided environment variables.
-config({ path: '.env.local', quiet: true });
-config({ path: '.env', quiet: true });
+config({ path: '.env.local', override: false, quiet: true });
+config({ path: '.env', override: false, quiet: true });
 
 const baseURL = process.env.NEXT_PUBLIC_APP_URL || 'http://127.0.0.1:3000';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       dotenv:
-        specifier: ^16.5.0
-        version: 16.5.0
+        specifier: ^17.4.2
+        version: 17.4.2
       drizzle-kit:
         specifier: ^0.31.8
         version: 0.31.8
@@ -3411,6 +3411,10 @@ packages:
 
   dotenv@17.2.2:
     resolution: {integrity: sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   drizzle-kit@0.31.8:
@@ -9058,6 +9062,8 @@ snapshots:
   dotenv@16.5.0: {}
 
   dotenv@17.2.2: {}
+
+  dotenv@17.4.2: {}
 
   drizzle-kit@0.31.8:
     dependencies:

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -8,8 +8,8 @@ import { readSeedQuestionFiles } from './seed/file-reader';
 import { archivePlaceholderQuestions } from './seed/placeholder-archiver';
 import { syncQuestionsFromFiles } from './seed/question-syncer';
 
-dotenv.config({ path: '.env.local' });
-dotenv.config({ path: '.env' });
+dotenv.config({ path: '.env.local', quiet: true });
+dotenv.config({ path: '.env', quiet: true });
 
 export async function runSeed(): Promise<void> {
   const databaseUrl = process.env.DATABASE_URL;

--- a/tests/shared/load-dotenv-file.ts
+++ b/tests/shared/load-dotenv-file.ts
@@ -4,7 +4,7 @@ export function loadDotenvFileOrThrow(
   path: string,
   options?: { override?: boolean },
 ): void {
-  const result = config({ path, override: options?.override });
+  const result = config({ path, override: options?.override, quiet: true });
   if (result.error) {
     throw result.error;
   }


### PR DESCRIPTION
## Summary

DEBT-392 Tier 4 — dotenv major upgrade. This bumps the repo's direct `dotenv` dependency from `16.5.0` to `17.4.2`.

## Upstream verification

- Changelog: https://github.com/motdotla/dotenv/blob/v17.4.2/CHANGELOG.md
- `npm view dotenv version versions --json` verified latest `17.4.2`.
- v17 load-bearing behavior change: `quiet` defaults to `false`, so dotenv emits runtime logs by default.

## What changed

- Bumped `dotenv` `^16.5.0` -> `^17.4.2` in `package.json` and lockfile.
- Added `quiet: true` to all direct dotenv config loads to preserve pre-v17 stdout behavior:
  - `drizzle.config.ts`
  - `playwright.config.ts`
  - `scripts/seed.ts`
  - `tests/shared/load-dotenv-file.ts`
- Updated repo docs/snippets that read `.env.local` inside shell command substitution so dotenv logs cannot corrupt captured values:
  - `AGENTS.md`
  - `CLAUDE.md`
  - `docs/dev/deployment-environments.md`
  - `docs/dev/deployment-procedure.md`
  - `docs/dev/testing-infrastructure.md`
  - `docs/tooling/agent-browser.md`

## Verification

- [x] Grep direct dotenv usage: `rg "require\\('dotenv'\\)\\.config\\(|config\\(\\{[^\\n]*path: ['\"]\\.env|dotenv\\.config\\(" ...`
- [x] `node -e "require('dotenv').config({ path: '.env.local', quiet: true }); process.stdout.write(process.env.DATABASE_URL ? 'url-ok' : 'missing')"` prints only `url-ok`
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm dedupe --check`
- [x] `pnpm audit --json` -> `0 critical / 0 high / 3 moderate`
- [x] `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- [x] E2E env present (`8` required keys), so ran `lsof -ti:3000 | xargs kill -9 2>/dev/null; pnpm test:e2e` -> `35 passed`

## Observed but out of scope

- E2E still prints one dotenv banner from `@clerk/testing`'s own transitive `dotenv@17.2.2` loader during global setup. That is third-party behavior, not our direct dotenv path, and this PR does not patch vendor internals.
- No Stripe API pin, Zod, TypeScript, lucide, jsdom, or runtime-alignment work is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reduced console/output noise in environment setup examples and E2E instructions by silencing dotenv logs.

* **Chores**
  * Applied quiet dotenv loading across docs, tooling, test config, and scripts.
  * Updated dotenv dependency to ^17.4.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->