### PR TITLE
Bump lucide-react to v1 (DEBT-392 Tier 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "drizzle-orm": "^0.45.2",
     "fast-glob": "^3.3.3",
     "gray-matter": "^4.0.3",
-    "lucide-react": "^0.563.0",
+    "lucide-react": "^1.16.0",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "pino": "^10.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       lucide-react:
-        specifier: ^0.563.0
-        version: 0.563.0(react@19.2.4)
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.4)
       next:
         specifier: 16.2.6
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -4242,8 +4242,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.563.0:
-    resolution: {integrity: sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==}
+  lucide-react@1.16.0:
+    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -9892,7 +9892,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.563.0(react@19.2.4):
+  lucide-react@1.16.0(react@19.2.4):
     dependencies:
       react: 19.2.4
 


### PR DESCRIPTION
## Summary

DEBT-392 Tier 4 PR 3: bump `lucide-react` from `^0.563.0` to `^1.16.0`.

This is a leaf UI icon-library major upgrade. No app code needed migration because all current imports are still exported by `lucide-react@1.16.0` and the package continues to support React 19.

## Upstream verification

- Latest version: `npm view lucide-react@latest version dist-tags engines peerDependencies dependencies --json` -> `1.16.0`; peer dependency includes `react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0`.
- Release notes read: https://github.com/lucide-icons/lucide/releases/tag/1.0.1
- v1 migration notes checked: brand icons removed, UMD build removed, `aria-hidden` defaults on icons, framework context providers added. Our usage is named React icon components only, with no brand icons or UMD usage.

## Icon export audit

Import sites verified with:

```sh
rg "from ['\"]lucide-react['\"]" app/ components/ src/ lib/ -n
```

Current imported icon names verified present from `require('lucide-react')` after installing `1.16.0`:

- `ArrowRight`
- `BarChart3`
- `BookOpen`
- `Bookmark`
- `Check`
- `CheckIcon`
- `ChevronDown`
- `ChevronDownIcon`
- `ChevronRightIcon`
- `ChevronUpIcon`
- `CircleIcon`
- `Menu`
- `Moon`
- `Sun`
- `X`
- `Zap`

## Out of scope

- No UI redesign or icon replacement.
- No unrelated dependency updates.
- No runtime alignment, zod, TypeScript, Stripe, jsdom, or lint-staged work.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- [x] `lsof -ti:3000 | xargs kill -9 2>/dev/null; pnpm test:e2e` -> 35 passed
- [x] `pnpm audit --json` -> 0 critical / 0 high / 3 moderate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the icon library dependency to the latest stable version, bringing potential enhancements and improved compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->