### PR TITLE
Bump Zod to v4 (DEBT-392 Tier 4)

### DIFF
--- a/lib/content/schemas.test.ts
+++ b/lib/content/schemas.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 import { QuestionFrontmatterSchema, TagFrontmatterSchema } from './schemas';
 
 const baseQuestionFrontmatter = {
@@ -96,7 +97,7 @@ describe('QuestionFrontmatterSchema', () => {
     if (result.success) {
       throw new Error('Test setup error: expected parse failure');
     }
-    expect(result.error.flatten().fieldErrors.tags).toEqual([
+    expect(z.flattenError(result.error).fieldErrors.tags).toEqual([
       'tag slugs must be unique',
     ]);
   });

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -93,7 +93,7 @@ function validateEnv(): Env {
   const parsed = envSchema.safeParse(process.env);
 
   if (!parsed.success) {
-    logInvalidEnv(parsed.error.flatten().fieldErrors);
+    logInvalidEnv(z.flattenError(parsed.error).fieldErrors);
     throw new Error('Invalid environment variables');
   }
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "tailwindcss": "4.1.18",
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3",
-    "zod": "^3.24.4"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       zod:
-        specifier: ^3.24.4
-        version: 3.24.4
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.3.13
@@ -5747,8 +5747,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod@3.24.4:
-    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -11776,6 +11776,6 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod@3.24.4: {}
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/src/adapters/controllers/action-result.ts
+++ b/src/adapters/controllers/action-result.ts
@@ -1,4 +1,4 @@
-import { ZodError } from 'zod';
+import { ZodError, z } from 'zod';
 import { logger } from '@/lib/logger';
 import type { ApplicationErrorCode } from '@/src/application/errors';
 import { isApplicationError } from '@/src/application/errors';
@@ -40,10 +40,10 @@ export function handleError(
   }
 
   if (error instanceof ZodError) {
-    const flat = error.flatten().fieldErrors;
+    const flat = z.flattenError(error).fieldErrors;
     const fieldErrors: Record<string, string[]> = {};
     for (const [key, value] of Object.entries(flat)) {
-      if (value) fieldErrors[key] = value;
+      if (Array.isArray(value)) fieldErrors[key] = value;
     }
     return err('VALIDATION_ERROR', 'Invalid input', fieldErrors);
   }

--- a/src/adapters/controllers/billing-controller.ts
+++ b/src/adapters/controllers/billing-controller.ts
@@ -7,6 +7,7 @@ import {
   CHECKOUT_SESSION_RATE_LIMIT,
   PORTAL_SESSION_RATE_LIMIT,
 } from '@/src/adapters/shared/rate-limits';
+import { zUuid } from '@/src/adapters/shared/zod-schemas';
 import { ApplicationError } from '@/src/application/errors';
 import type {
   AuthGateway,
@@ -24,7 +25,7 @@ import { createAction } from './create-action';
 import { executeIdempotent } from './shared/execute-idempotent';
 
 const zSubscriptionPlan = z.enum(['monthly', 'annual']);
-const zIdempotencyKey = z.string().uuid();
+const zIdempotencyKey = zUuid;
 
 const CreateCheckoutSessionInputSchema = z
   .object({

--- a/src/adapters/controllers/create-action.ts
+++ b/src/adapters/controllers/create-action.ts
@@ -1,4 +1,4 @@
-import type { ZodType, ZodTypeDef } from 'zod';
+import type { ZodType } from 'zod';
 import type { LoadContainerFn } from '@/lib/controller-helpers';
 import type { Logger } from '@/src/application/ports/logger';
 import type { ActionResult } from './action-result';
@@ -29,7 +29,7 @@ export function createAction<
   TDeps,
   TContainer = unknown,
 >(config: {
-  schema: ZodType<TInput, ZodTypeDef, unknown>;
+  schema: ZodType<TInput, unknown>;
   getDeps: GetDepsFn<TDeps, TContainer>;
   execute: (
     input: TInput,

--- a/src/adapters/controllers/shared/execute-idempotent.ts
+++ b/src/adapters/controllers/shared/execute-idempotent.ts
@@ -1,4 +1,4 @@
-import type { ZodType, ZodTypeDef } from 'zod';
+import type { ZodType } from 'zod';
 import { withIdempotency } from '@/src/adapters/shared/with-idempotency';
 import type { Logger } from '@/src/application/ports/logger';
 import type { IdempotencyKeyRepository } from '@/src/application/ports/repositories';
@@ -29,7 +29,7 @@ export async function executeIdempotent<TOutput>({
   userId: string;
   idempotencyKey: string | null | undefined;
   action: string;
-  outputSchema: ZodType<TOutput, ZodTypeDef, unknown>;
+  outputSchema: ZodType<TOutput, unknown>;
   execute: () => Promise<TOutput>;
 }): Promise<TOutput> {
   if (!idempotencyKey) return execute();

--- a/src/adapters/gateways/stripe/stripe-subscription-normalizer.ts
+++ b/src/adapters/gateways/stripe/stripe-subscription-normalizer.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import { z } from 'zod';
 import type { StripePriceIds } from '@/src/adapters/config/stripe-prices';
 import { getSubscriptionPlanFromPriceId } from '@/src/adapters/config/stripe-prices';
 import {
@@ -134,7 +134,7 @@ export async function retrieveAndNormalizeStripeSubscription(input: {
         eventId: input.event.id,
         type: input.event.type,
         stripeSubscriptionId,
-        error: parsedSubscription.error.flatten(),
+        error: z.flattenError(parsedSubscription.error),
       },
       `Invalid Stripe subscription payload retrieved from ${input.event.type}`,
     );

--- a/src/adapters/gateways/stripe/stripe-webhook-processor.ts
+++ b/src/adapters/gateways/stripe/stripe-webhook-processor.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { StripePriceIds } from '@/src/adapters/config/stripe-prices';
 import { retrieveAndNormalizeStripeSubscription } from '@/src/adapters/gateways/stripe/stripe-subscription-normalizer';
 import {
@@ -26,7 +27,7 @@ async function getSubscriptionUpdateForSubscriptionRefEvent(input: {
       {
         eventId: input.event.id,
         type: input.event.type,
-        error: parsedPayload.error.flatten(),
+        error: z.flattenError(parsedPayload.error),
       },
       `Invalid Stripe ${input.event.type} webhook payload`,
     );
@@ -122,7 +123,7 @@ export async function processStripeWebhookEvent({
       {
         eventId: event.id,
         type: event.type,
-        error: parsedSubscription.error.flatten(),
+        error: z.flattenError(parsedSubscription.error),
       },
       'Invalid Stripe subscription webhook payload',
     );

--- a/src/adapters/gateways/stripe/stripe-webhook-schemas.ts
+++ b/src/adapters/gateways/stripe/stripe-webhook-schemas.ts
@@ -20,7 +20,7 @@ export const stripeSubscriptionSchema = z
     customer: z.string(),
     status: z.string(),
     cancel_at_period_end: z.boolean(),
-    metadata: z.record(z.string()).optional(),
+    metadata: z.record(z.string(), z.string()).optional(),
     items: z.object({
       data: z.array(stripeSubscriptionItemSchema).min(1),
     }),

--- a/src/adapters/repositories/practice-session-params.ts
+++ b/src/adapters/repositories/practice-session-params.ts
@@ -146,9 +146,9 @@ export function parsePracticeSessionParamsJson(
     if (error instanceof z.ZodError) {
       const cleanedFieldErrors: Record<string, string[]> = {};
       for (const [field, messages] of Object.entries(
-        error.flatten().fieldErrors,
+        z.flattenError(error).fieldErrors,
       )) {
-        if (messages) cleanedFieldErrors[field] = messages;
+        if (Array.isArray(messages)) cleanedFieldErrors[field] = messages;
       }
 
       throw new ApplicationError(

--- a/src/adapters/shared/zod-schemas.ts
+++ b/src/adapters/shared/zod-schemas.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { AllQuestionProgressStatuses } from '@/src/domain/value-objects';
 
-export const zUuid = z.string().uuid();
+export const zUuid = z.guid();
 
 export const zDifficulty = z.enum(['easy', 'medium', 'hard']);
 


### PR DESCRIPTION
## Summary

DEBT-392 Tier 4 PR 7: bump `zod` from `^3.24.4` to `^4.4.3`.

Upstream changelog: https://zod.dev/v4/changelog

## What Changed

- Migrated `error.flatten()` call sites to `z.flattenError(...)`.
- Updated Zod generic type signatures after `ZodTypeDef` removal from the public v4 surface.
- Updated Stripe webhook `metadata` from one-argument `z.record(...)` to explicit key/value schema form.
- Kept controller UUID-shaped boundary behavior compatible with the pre-upgrade parser by using Zod 4 `z.guid()` in shared ID schemas.
- Reused the shared ID schema for billing idempotency keys.

## Verification

- `npm view zod version dist-tags --json` -> latest `4.4.3`
- `rg -l "from ['\"]zod['\"]|from 'zod/" src/ app/ lib/ tests/ scripts/ components/ | sort | wc -l` -> 24 current import files after migration
- `rg -n "\.flatten\(|ZodTypeDef|invalid_type_error|required_error|errorMap|z\.record\([^,\n]+\)" src/ app/ lib/ tests/ scripts/ components/` -> no remaining migration blockers except the intentionally migrated two-argument `z.record(...)`
- `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- `pnpm test:e2e` -> first run had one transient Clerk already-signed-in failure; clean rerun passed 35/35
- `pnpm audit --json` -> unchanged at 0 critical / 0 high / 3 moderate

## Out of Scope

- No Stripe SDK/API-version changes.
- No TypeScript/runtime/package-manager changes.
- No unrelated E2E auth-helper changes; the one Clerk sign-in failure did not reproduce on clean rerun.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Upgraded Zod validation library to v4.4.3 for improved error handling and validation capabilities.

* **Bug Fixes**
  * Enhanced validation error reporting and field error extraction across billing, action handling, and data parsing workflows.
  * Improved UUID validation schema for more robust identifier handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->