### PR TITLE
Bump Stripe SDK to v22 (DEBT-392 Tier 4)

### DIFF
--- a/app/api/webhooks/clerk/handler.ts
+++ b/app/api/webhooks/clerk/handler.ts
@@ -26,6 +26,7 @@ type StripeClient = {
     }) => AsyncIterable<{ id: string; status: string }>;
     cancel: (
       subscriptionId: string,
+      params?: undefined,
       options?: { idempotencyKey?: string },
     ) => Promise<unknown>;
   };

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -4,6 +4,15 @@ import { env } from '@/lib/env';
 
 let stripeInstance: Stripe | null = null;
 
+type StripeApiVersion = NonNullable<
+  ConstructorParameters<typeof Stripe>[1]
+>['apiVersion'];
+
+// stripe-node v22 narrows config typing to the latest API version, while the
+// runtime still accepts older pinned versions. Keep this scoped until the
+// separate Stripe API-version PR advances the pin.
+const STRIPE_API_VERSION = '2026-01-28.clover' as StripeApiVersion;
+
 export function getStripe(): Stripe {
   if (stripeInstance) return stripeInstance;
 
@@ -19,7 +28,7 @@ export function getStripe(): Stripe {
      * Reference: https://stripe.com/docs/upgrades#api-versions
      * Last reviewed: 2026-01-28
      */
-    apiVersion: '2026-01-28.clover',
+    apiVersion: STRIPE_API_VERSION,
     typescript: true,
   });
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "server-only": "^0.0.1",
-    "stripe": "^20.3.0",
+    "stripe": "^22.1.1",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "4.1.18",
     "tw-animate-css": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
       stripe:
-        specifier: ^20.3.0
-        version: 20.3.0(@types/node@22.19.19)
+        specifier: ^22.1.1
+        version: 22.1.1(@types/node@22.19.19)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -5199,11 +5199,11 @@ packages:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
-  stripe@20.3.0:
-    resolution: {integrity: sha512-DYzcmV1MfYhycr1GwjCjeQVYk9Gu8dpxyTlu7qeDCsuguug7oUTxPsUQuZeSf/OPzK7pofqobvOKVqAwlpgf/Q==}
-    engines: {node: '>=16'}
+  stripe@22.1.1:
+    resolution: {integrity: sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=16'
+      '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -11313,7 +11313,7 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
-  stripe@20.3.0(@types/node@22.19.19):
+  stripe@22.1.1(@types/node@22.19.19):
     optionalDependencies:
       '@types/node': 22.19.19
 

--- a/src/adapters/gateways/stripe-payment-gateway.test.ts
+++ b/src/adapters/gateways/stripe-payment-gateway.test.ts
@@ -408,7 +408,7 @@ describe('StripePaymentGateway', () => {
     expect(sessionsRetrieve).toHaveBeenCalledWith('cs_existing', {
       expand: ['line_items'],
     });
-    expect(sessionsExpire).toHaveBeenCalledWith('cs_existing', {
+    expect(sessionsExpire).toHaveBeenCalledWith('cs_existing', undefined, {
       idempotencyKey: 'expire_checkout_session:cs_existing',
     });
     expect(sessionsCreate).toHaveBeenCalledWith(
@@ -453,7 +453,7 @@ describe('StripePaymentGateway', () => {
     expect(sessionsRetrieve).toHaveBeenCalledWith('cs_existing', {
       expand: ['line_items'],
     });
-    expect(sessionsExpire).toHaveBeenCalledWith('cs_existing', {
+    expect(sessionsExpire).toHaveBeenCalledWith('cs_existing', undefined, {
       idempotencyKey: 'expire_checkout_session:cs_existing',
     });
     expect(sessionsCreate).toHaveBeenCalledTimes(1);

--- a/src/adapters/gateways/stripe-subscription-canceler.test.ts
+++ b/src/adapters/gateways/stripe-subscription-canceler.test.ts
@@ -33,10 +33,10 @@ describe('cancelStripeCustomerSubscriptions', () => {
       limit: 100,
     });
     expect(cancel).toHaveBeenCalledTimes(2);
-    expect(cancel).toHaveBeenNthCalledWith(1, 'sub_active', {
+    expect(cancel).toHaveBeenNthCalledWith(1, 'sub_active', undefined, {
       idempotencyKey: 'cancel_subscription:sub_active',
     });
-    expect(cancel).toHaveBeenNthCalledWith(2, 'sub_past_due', {
+    expect(cancel).toHaveBeenNthCalledWith(2, 'sub_past_due', undefined, {
       idempotencyKey: 'cancel_subscription:sub_past_due',
     });
   });
@@ -72,10 +72,10 @@ describe('cancelStripeCustomerSubscriptions', () => {
     ).resolves.toBeUndefined();
 
     expect(cancel).toHaveBeenCalledTimes(2);
-    expect(cancel).toHaveBeenNthCalledWith(1, 'sub_missing', {
+    expect(cancel).toHaveBeenNthCalledWith(1, 'sub_missing', undefined, {
       idempotencyKey: 'cancel_subscription:sub_missing',
     });
-    expect(cancel).toHaveBeenNthCalledWith(2, 'sub_active', {
+    expect(cancel).toHaveBeenNthCalledWith(2, 'sub_active', undefined, {
       idempotencyKey: 'cancel_subscription:sub_active',
     });
     expect(logger.infoCalls).toEqual([

--- a/src/adapters/gateways/stripe-subscription-canceler.ts
+++ b/src/adapters/gateways/stripe-subscription-canceler.ts
@@ -17,7 +17,8 @@ type StripeSubscriptionsClient = {
   }) => AsyncIterable<StripeSubscriptionLike>;
   cancel: (
     subscriptionId: string,
-    input: { idempotencyKey: string },
+    input: undefined,
+    options: { idempotencyKey: string },
   ) => Promise<unknown>;
 };
 
@@ -48,7 +49,7 @@ export async function cancelStripeCustomerSubscriptions(
       await callStripeWithRetry({
         operation: 'subscriptions.cancel',
         fn: () =>
-          stripe.subscriptions.cancel(subscription.id, {
+          stripe.subscriptions.cancel(subscription.id, undefined, {
             idempotencyKey: `cancel_subscription:${subscription.id}`,
           }),
         logger,

--- a/src/adapters/gateways/stripe/stripe-checkout-sessions.test.ts
+++ b/src/adapters/gateways/stripe/stripe-checkout-sessions.test.ts
@@ -468,7 +468,7 @@ describe('createStripeCheckoutSession', () => {
       }),
     ).resolves.toEqual({ url: 'https://stripe/checkout/new' });
 
-    expect(sessionsExpire).toHaveBeenCalledWith('cs_open', {
+    expect(sessionsExpire).toHaveBeenCalledWith('cs_open', undefined, {
       idempotencyKey: 'expire_checkout_session:cs_open',
     });
     expect(sessionsCreate).toHaveBeenCalledTimes(1);
@@ -529,7 +529,7 @@ describe('createStripeCheckoutSession', () => {
       }),
     ).resolves.toEqual({ url: 'https://stripe/checkout/new' });
 
-    expect(sessionsExpire).toHaveBeenCalledWith('cs_open', {
+    expect(sessionsExpire).toHaveBeenCalledWith('cs_open', undefined, {
       idempotencyKey: 'expire_checkout_session:cs_open',
     });
     expect(sessionsCreate).toHaveBeenCalledTimes(1);
@@ -647,7 +647,7 @@ describe('createStripeCheckoutSession', () => {
     ).resolves.toEqual({ url: 'https://stripe/checkout/new' });
 
     expect(sessionsRetrieve).toHaveBeenCalledTimes(1);
-    expect(sessionsExpire).toHaveBeenCalledWith('cs_open', {
+    expect(sessionsExpire).toHaveBeenCalledWith('cs_open', undefined, {
       idempotencyKey: 'expire_checkout_session:cs_open',
     });
     expect(sessionsCreate).toHaveBeenCalledTimes(1);
@@ -674,7 +674,7 @@ describe('createStripeCheckoutSession', () => {
     ).resolves.toEqual({ url: 'https://stripe/checkout/new' });
 
     expect(sessionsRetrieve).toHaveBeenCalledTimes(1);
-    expect(sessionsExpire).toHaveBeenCalledWith('cs_open', {
+    expect(sessionsExpire).toHaveBeenCalledWith('cs_open', undefined, {
       idempotencyKey: 'expire_checkout_session:cs_open',
     });
     expect(sessionsCreate).toHaveBeenCalledTimes(1);

--- a/src/adapters/gateways/stripe/stripe-checkout-sessions.ts
+++ b/src/adapters/gateways/stripe/stripe-checkout-sessions.ts
@@ -246,7 +246,7 @@ export async function createStripeCheckoutSession({
         await callStripeWithRetry({
           operation: 'checkout.sessions.expire',
           fn: () =>
-            stripe.checkout.sessions.expire(existingSession.id, {
+            stripe.checkout.sessions.expire(existingSession.id, undefined, {
               idempotencyKey: `expire_checkout_session:${existingSession.id}`,
             }),
           logger,

--- a/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
@@ -777,12 +777,18 @@ describe('reconcileStripeSubscriptions', () => {
       failures: [],
     });
     expect(stripe.subscriptions.cancel).toHaveBeenCalledTimes(2);
-    expect(stripe.subscriptions.cancel).toHaveBeenNthCalledWith(1, 'sub_keep', {
-      idempotencyKey: 'reconcile_duplicate_subscription:sub_keep',
-    });
+    expect(stripe.subscriptions.cancel).toHaveBeenNthCalledWith(
+      1,
+      'sub_keep',
+      undefined,
+      {
+        idempotencyKey: 'reconcile_duplicate_subscription:sub_keep',
+      },
+    );
     expect(stripe.subscriptions.cancel).toHaveBeenNthCalledWith(
       2,
       'sub_dup_1',
+      undefined,
       { idempotencyKey: 'reconcile_duplicate_subscription:sub_dup_1' },
     );
     await expect(
@@ -854,12 +860,18 @@ describe('reconcileStripeSubscriptions', () => {
       failures: [],
     });
     expect(stripe.subscriptions.cancel).toHaveBeenCalledTimes(2);
-    expect(stripe.subscriptions.cancel).toHaveBeenNthCalledWith(1, 'sub_keep', {
-      idempotencyKey: 'reconcile_duplicate_subscription:sub_keep',
-    });
+    expect(stripe.subscriptions.cancel).toHaveBeenNthCalledWith(
+      1,
+      'sub_keep',
+      undefined,
+      {
+        idempotencyKey: 'reconcile_duplicate_subscription:sub_keep',
+      },
+    );
     expect(stripe.subscriptions.cancel).toHaveBeenNthCalledWith(
       2,
       'sub_dup_1',
+      undefined,
       { idempotencyKey: 'reconcile_duplicate_subscription:sub_dup_1' },
     );
     expect(scenario.logger.infoCalls).toEqual([
@@ -1085,9 +1097,13 @@ describe('reconcileStripeSubscriptions', () => {
       failures: [],
     });
     expect(stripe.subscriptions.cancel).toHaveBeenCalledTimes(1);
-    expect(stripe.subscriptions.cancel).toHaveBeenCalledWith('sub_local', {
-      idempotencyKey: 'reconcile_duplicate_subscription:sub_local',
-    });
+    expect(stripe.subscriptions.cancel).toHaveBeenCalledWith(
+      'sub_local',
+      undefined,
+      {
+        idempotencyKey: 'reconcile_duplicate_subscription:sub_local',
+      },
+    );
     await expect(
       scenario.subscriptions.findByUserId('user_1'),
     ).resolves.toMatchObject({
@@ -1134,9 +1150,13 @@ describe('reconcileStripeSubscriptions', () => {
       failures: [],
     });
     expect(stripe.subscriptions.cancel).toHaveBeenCalledTimes(1);
-    expect(stripe.subscriptions.cancel).toHaveBeenCalledWith('sub_z', {
-      idempotencyKey: 'reconcile_duplicate_subscription:sub_z',
-    });
+    expect(stripe.subscriptions.cancel).toHaveBeenCalledWith(
+      'sub_z',
+      undefined,
+      {
+        idempotencyKey: 'reconcile_duplicate_subscription:sub_z',
+      },
+    );
     await expect(
       scenario.subscriptions.findByExternalSubscriptionId('sub_a'),
     ).resolves.toMatchObject({
@@ -1221,9 +1241,13 @@ describe('reconcileStripeSubscriptions', () => {
       stripeSubscriptionId: local.id,
       error: 'cancel failed',
     });
-    expect(stripe.subscriptions.cancel).toHaveBeenCalledWith('sub_local', {
-      idempotencyKey: 'reconcile_duplicate_subscription:sub_local',
-    });
+    expect(stripe.subscriptions.cancel).toHaveBeenCalledWith(
+      'sub_local',
+      undefined,
+      {
+        idempotencyKey: 'reconcile_duplicate_subscription:sub_local',
+      },
+    );
     await expect(
       scenario.subscriptions.findByExternalSubscriptionId('sub_better'),
     ).resolves.toMatchObject({

--- a/src/adapters/jobs/reconcile-stripe-subscriptions.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions.ts
@@ -242,7 +242,7 @@ export async function reconcileStripeSubscriptions(
                 await callStripeWithRetry({
                   operation: 'subscriptions.cancel',
                   fn: () =>
-                    cancelSubscription(duplicateId, {
+                    cancelSubscription(duplicateId, undefined, {
                       idempotencyKey: `reconcile_duplicate_subscription:${duplicateId}`,
                     }),
                   logger: deps.logger,

--- a/src/adapters/shared/stripe-types.ts
+++ b/src/adapters/shared/stripe-types.ts
@@ -110,6 +110,7 @@ export type StripeClient = {
       ): Promise<StripeCheckoutSessionRetrieved>;
       expire(
         sessionId: string,
+        params?: undefined,
         options?: StripeRequestOptions,
       ): Promise<StripeCheckoutSession>;
     };
@@ -117,6 +118,7 @@ export type StripeClient = {
   subscriptions?: {
     retrieve(
       subscriptionId: string,
+      params?: undefined,
       options?: StripeRequestOptions,
     ): Promise<StripeSubscription>;
     list?(
@@ -125,6 +127,7 @@ export type StripeClient = {
     ): Promise<StripeSubscriptionListResult>;
     cancel?(
       subscriptionId: string,
+      params?: undefined,
       options?: StripeRequestOptions,
     ): Promise<StripeSubscription>;
   };

--- a/tests/e2e/helpers/credential-health-check.ts
+++ b/tests/e2e/helpers/credential-health-check.ts
@@ -280,7 +280,7 @@ const defaultServices: CredentialHealthCheckServices = {
 
   verifyStripeSecretKey: async (stripe) => {
     try {
-      await stripe.accounts.retrieve();
+      await stripe.accounts.retrieve(null);
     } catch (error) {
       if (error instanceof Stripe.errors.StripeAuthenticationError) {
         throw new CredentialValidationError(


### PR DESCRIPTION
## Summary

DEBT-392 Tier 4 — Stripe SDK-only upgrade.

- Bump `stripe` from `^20.3.0` to `^22.1.1`.
- Preserve the existing Stripe API version pin: `STRIPE_API_VERSION = '2026-01-28.clover'` at `lib/stripe.ts:14`, used by Stripe config at `lib/stripe.ts:31`.
- Migrate v22 request-option call sites so empty params are passed before `RequestOptions` where required.
- Update Stripe test doubles and expectations for the new v22 method signatures.

## Upstream Sources Read

- https://github.com/stripe/stripe-node/blob/master/CHANGELOG.md
- https://github.com/stripe/stripe-node/wiki/Migration-guide-for-v21
- https://github.com/stripe/stripe-node/wiki/Migration-guide-for-v22

Verified relevant v21/v22 changes: Node >=18, ES6 class construction, removed callback APIs, removed plain API-key service args, `RequestOptions` must be the last argument, per-request host overrides removed, and type export changes.

## What Changed

- `lib/stripe.ts`: keep the existing API pin via a scoped `StripeApiVersion` cast because stripe-node v22 narrows config typing to the latest SDK API version even though older pinned versions remain runtime-valid.
- Checkout session expiration and subscription cancellation/retrieval call sites now pass `undefined` params before request options.
- E2E Stripe credential health check now calls `stripe.accounts.retrieve(null)` for the v22 no-param overload.
- Tests were updated to assert the v22 params/options call shape.

## Out of Scope

- Stripe API version advancement. That remains a separate DEBT-392 Tier 4 PR after this SDK bump lands.
- No billing behavior, price IDs, webhook semantics, or database schema changes.

## Verification

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- [x] `pnpm test:e2e` — 35/35 passed
- [x] `pnpm audit --json` — unchanged: 0 critical, 0 high, 3 moderate
- [x] Pre-push hook: `pnpm typecheck && pnpm test --run` — 310 files, 2517 tests