### PR TITLE
Advance Stripe API pin to Dahlia (DEBT-392 Tier 4)

### DIFF
--- a/lib/stripe.test.ts
+++ b/lib/stripe.test.ts
@@ -71,7 +71,7 @@ describe('getStripe', () => {
     expect(first).toMatchObject({
       apiKey: 'sk_test_dummy',
       options: {
-        apiVersion: '2026-01-28.clover',
+        apiVersion: '2026-04-22.dahlia',
         typescript: true,
       },
     });

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -4,14 +4,7 @@ import { env } from '@/lib/env';
 
 let stripeInstance: Stripe | null = null;
 
-type StripeApiVersion = NonNullable<
-  ConstructorParameters<typeof Stripe>[1]
->['apiVersion'];
-
-// stripe-node v22 narrows config typing to the latest API version, while the
-// runtime still accepts older pinned versions. Keep this scoped until the
-// separate Stripe API-version PR advances the pin.
-const STRIPE_API_VERSION = '2026-01-28.clover' as StripeApiVersion;
+const STRIPE_API_VERSION = '2026-04-22.dahlia';
 
 export function getStripe(): Stripe {
   if (stripeInstance) return stripeInstance;
@@ -26,7 +19,7 @@ export function getStripe(): Stripe {
      * - Verifying webhooks + checkout flows in a staging environment
      *
      * Reference: https://stripe.com/docs/upgrades#api-versions
-     * Last reviewed: 2026-01-28
+     * Last reviewed: 2026-05-24
      */
     apiVersion: STRIPE_API_VERSION,
     typescript: true,

--- a/tests/fixtures/stripe/customer.subscription.paused.json
+++ b/tests/fixtures/stripe/customer.subscription.paused.json
@@ -1,7 +1,7 @@
 {
   "id": "evt_2",
   "object": "event",
-  "api_version": "2026-01-28.clover",
+  "api_version": "2026-04-22.dahlia",
   "created": 1700000001,
   "livemode": false,
   "pending_webhooks": 1,

--- a/tests/fixtures/stripe/customer.subscription.pending_update_applied.json
+++ b/tests/fixtures/stripe/customer.subscription.pending_update_applied.json
@@ -1,7 +1,7 @@
 {
   "id": "evt_4",
   "object": "event",
-  "api_version": "2026-01-28.clover",
+  "api_version": "2026-04-22.dahlia",
   "created": 1700000003,
   "livemode": false,
   "pending_webhooks": 1,

--- a/tests/fixtures/stripe/customer.subscription.pending_update_expired.json
+++ b/tests/fixtures/stripe/customer.subscription.pending_update_expired.json
@@ -1,7 +1,7 @@
 {
   "id": "evt_5",
   "object": "event",
-  "api_version": "2026-01-28.clover",
+  "api_version": "2026-04-22.dahlia",
   "created": 1700000004,
   "livemode": false,
   "pending_webhooks": 1,

--- a/tests/fixtures/stripe/customer.subscription.resumed.json
+++ b/tests/fixtures/stripe/customer.subscription.resumed.json
@@ -1,7 +1,7 @@
 {
   "id": "evt_3",
   "object": "event",
-  "api_version": "2026-01-28.clover",
+  "api_version": "2026-04-22.dahlia",
   "created": 1700000002,
   "livemode": false,
   "pending_webhooks": 1,

--- a/tests/fixtures/stripe/customer.subscription.updated.json
+++ b/tests/fixtures/stripe/customer.subscription.updated.json
@@ -1,7 +1,7 @@
 {
   "id": "evt_1",
   "object": "event",
-  "api_version": "2026-01-28.clover",
+  "api_version": "2026-04-22.dahlia",
   "created": 1700000000,
   "livemode": false,
   "pending_webhooks": 1,


### PR DESCRIPTION
## Summary

DEBT-392 Tier 4 — Stripe API version pin advance.

- Advance the application Stripe request-version pin from `2026-01-28.clover` to `2026-04-22.dahlia`.
- Remove the temporary stripe-node v22 older-pin type cast; the pin now matches the SDK's typed current API version.
- Update `getStripe` unit expectation and synthetic Stripe webhook fixture `api_version` metadata.

## Upstream Sources Read

- https://docs.stripe.com/upgrades
- https://docs.stripe.com/changelog
- https://github.com/stripe/stripe-node/blob/master/CHANGELOG.md

Stripe's upgrade docs distinguish named major releases from monthly releases and note that monthly releases within the same named major are backward-compatible. The current Stripe docs metadata marks `2026-04-22.dahlia` as the GA current version for stripe-node 22.1.x.

## What Changed

- `lib/stripe.ts`: `STRIPE_API_VERSION` now uses `2026-04-22.dahlia`.
- `lib/stripe.test.ts`: expectation updated to the new pin.
- `tests/fixtures/stripe/*.json`: synthetic webhook fixture `api_version` metadata updated to the new pin. No fixture object-shape changes were needed.

## Out of Scope

- Stripe SDK bump — already landed in #331.
- Stripe Dashboard account-default or webhook endpoint version changes. This PR updates the application request-version pin only; dashboard/workbench changes remain an operational action.
- Billing behavior, price IDs, webhook event handling logic, and database schema.

## Verification

- [x] `pnpm typecheck && pnpm test --run lib/stripe.test.ts src/adapters/gateways/stripe-payment-gateway.test.ts src/adapters/gateways/stripe/stripe-webhook-processor.test.ts src/adapters/gateways/stripe/stripe-subscription-normalizer.test.ts src/adapters/controllers/stripe-webhook-controller.test.ts src/adapters/jobs/reconcile-stripe-subscriptions.test.ts`
- [x] `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- [x] `pnpm test:e2e` — 35/35 passed
- [x] `pnpm audit --json` — unchanged: 0 critical, 0 high, 3 moderate
- [x] Pre-push hook: `pnpm typecheck && pnpm test --run` — 310 files, 2517 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Stripe API integration to the latest version (2026-04-22.dahlia), improving compatibility with current Stripe service standards. Updated all related test fixtures and configurations accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->