### PR TITLE
Remove top-level postcss dependency (DEBT-392 Tier 6a)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "pino": "^10.3.0",
-    "postcss": "^8.5.15",
     "postgres": "^3.4.8",
     "radix-ui": "^1.4.3",
     "react": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 1.13.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@types/react@19.2.10)(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.10)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@6.0.3)
       '@sentry/nextjs':
         specifier: ^10.53.1
-        version: 10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2)(postcss@8.5.15))
+        version: 10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2))
       '@tailwindcss/postcss':
         specifier: 4.1.18
         version: 4.1.18
@@ -53,9 +53,6 @@ importers:
       pino:
         specifier: ^10.3.0
         version: 10.3.0
-      postcss:
-        specifier: ^8.5.15
-        version: 8.5.15
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
@@ -7987,7 +7984,7 @@ snapshots:
 
   '@sentry/core@10.53.1': {}
 
-  '@sentry/nextjs@10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2)(postcss@8.5.15))':
+  '@sentry/nextjs@10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -7999,7 +7996,7 @@ snapshots:
       '@sentry/opentelemetry': 10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
       '@sentry/react': 10.53.1(react@19.2.4)
       '@sentry/vercel-edge': 10.53.1
-      '@sentry/webpack-plugin': 5.3.0(webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2)(postcss@8.5.15))
+      '@sentry/webpack-plugin': 5.3.0(webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2))
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rollup: 4.60.4
       stacktrace-parser: 0.1.11
@@ -8079,10 +8076,10 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@sentry/core': 10.53.1
 
-  '@sentry/webpack-plugin@5.3.0(webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2)(postcss@8.5.15))':
+  '@sentry/webpack-plugin@5.3.0(webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2))':
     dependencies:
       '@sentry/bundler-plugin-core': 5.3.0
-      webpack: 5.105.0(esbuild@0.25.4)(lightningcss@1.30.2)(postcss@8.5.15)
+      webpack: 5.105.0(esbuild@0.25.4)(lightningcss@1.30.2)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11401,17 +11398,16 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.0(esbuild@0.25.4)(lightningcss@1.30.2)(postcss@8.5.15)(webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2)(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.0(esbuild@0.25.4)(lightningcss@1.30.2)(webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.105.0(esbuild@0.25.4)(lightningcss@1.30.2)(postcss@8.5.15)
+      webpack: 5.105.0(esbuild@0.25.4)(lightningcss@1.30.2)
     optionalDependencies:
       esbuild: 0.25.4
       lightningcss: 1.30.2
-      postcss: 8.5.15
 
   terser@5.48.0:
     dependencies:
@@ -11657,7 +11653,7 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2)(postcss@8.5.15):
+  webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -11681,7 +11677,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(esbuild@0.25.4)(lightningcss@1.30.2)(postcss@8.5.15)(webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2)(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.0(esbuild@0.25.4)(lightningcss@1.30.2)(webpack@5.105.0(esbuild@0.25.4)(lightningcss@1.30.2))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

DEBT-392 Tier 6a: remove the unused top-level `postcss` dependency from `package.json` while preserving transitive build-chain resolution through Next, `@tailwindcss/postcss`, and Vite.

## Verification

- `rg "from ['\"]postcss['\"]|require\\(['\"]postcss['\"]\\)" src/ app/ lib/ tests/ scripts/ components/` → zero direct imports/requires
- `postcss.config.mjs` uses `@tailwindcss/postcss`; it does not import or require top-level `postcss`
- `corepack pnpm why postcss` after removal still resolves `postcss` through Next, `@tailwindcss/postcss`, and Vite
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm typecheck`
- `corepack pnpm lint` (existing excessive-lines warnings only)
- `corepack pnpm test --run` → 310 files / 2517 tests passed
- `corepack pnpm test:browser` → 50 files / 271 tests passed
- `corepack pnpm test:integration` → 18 files / 104 tests passed
- `corepack pnpm build`
- `corepack pnpm test:e2e` → 35/35 passed
- `corepack pnpm audit --json` → 3 moderate, 0 high, 0 critical

## Out of scope

- No PostCSS plugin/config changes
- No transitive dependency overrides
- No attempt to resolve Next's nested `postcss@8.4.31` advisory in this cleanup PR
- No Dependabot or license-baseline work; those remain Tier 6b/6c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed PostCSS dependency from project dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->