### PR TITLE
Add Dependabot dependency monitoring (DEBT-392 Tier 6b)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

DEBT-392 Tier 6b: add Dependabot version updates for npm and GitHub Actions.

The repository default branch is `main`, but this dependency-hygiene work flows through `dev` before syncing to `main`, so scheduled version-update PRs target `dev`.

## Configuration

- npm ecosystem, root directory
- github-actions ecosystem, root directory
- Weekly schedule: Monday 09:00 America/New_York
- Open PR limit: 5 per ecosystem
- Minor/patch updates grouped per ecosystem
- Major updates left as separate PRs by keeping them out of the groups
- No auto-merge configured
- Security updates left on GitHub's default Dependabot behavior

## Verification

- `find . -maxdepth 3 \( -name 'renovate.json' -o -name '.renovaterc' -o -name '.renovaterc.json' -o -path './.github/dependabot.yml' -o -path './.github/dependabot.yaml' \) -print` → no prior config
- `ruby -e 'require "yaml"; p YAML.load_file(".github/dependabot.yml")'`
- `corepack pnpm typecheck`
- `corepack pnpm lint` (existing excessive-lines warnings only)
- `corepack pnpm test --run` → 310 files / 2517 tests passed
- `corepack pnpm test:browser` → 50 files / 271 tests passed
- `corepack pnpm test:integration` → 18 files / 104 tests passed
- `corepack pnpm build`
- `corepack pnpm test:e2e` → 35/35 passed
- `corepack pnpm audit --json` → 3 moderate, 0 high, 0 critical

## Out of scope

- No dependency upgrades in this PR
- No automerge
- No Renovate config
- No license-baseline work; that remains Tier 6c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration for managing repository dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->