### PR TITLE
Add license baseline snapshot (DEBT-392 Tier 6c)

### DIFF
--- a/docs/dev/deployment-environments.md
+++ b/docs/dev/deployment-environments.md
@@ -170,6 +170,7 @@ When changing environment configuration, verify all of the following:
 
 - [deployment-procedure.md](./deployment-procedure.md)
 - [database-rollbacks.md](./database-rollbacks.md)
+- [license-baseline.md](./license-baseline.md)
 - [BUG-079](../_archive/bugs/bug-079-preview-dev-environment-verification-failures.md)
 - [BUG-080](../_archive/bugs/bug-080-vercel-env-var-deployment-issues.md)
 - [proxy.ts](../../proxy.ts)

--- a/docs/dev/deployment-procedure.md
+++ b/docs/dev/deployment-procedure.md
@@ -155,5 +155,6 @@ The seed script is fully idempotent. See [Content Pipeline §16: Seed Idempotenc
 ## Related
 
 - [Deployment Environments](./deployment-environments.md) — Env var scoping, Clerk/Stripe/Neon config
+- [License Baseline](./license-baseline.md) — Production dependency license distribution and review-worthy exceptions
 - [Content Pipeline](../practice-engine/content-pipeline.md) — MDX → seed → DB flow
 - [SPEC-033 §14](../_archive/specs/spec-033-tag-taxonomy-migration.md) — Tag taxonomy DB sync procedure

--- a/docs/dev/license-baseline.md
+++ b/docs/dev/license-baseline.md
@@ -1,0 +1,78 @@
+# License Baseline
+
+**Last Reviewed:** 2026-05-25
+
+This document records the production dependency license baseline for the app. It is a snapshot, not legal advice. The goal is to make future dependency/license drift visible during dependency hygiene work.
+
+Regenerate with:
+
+```bash
+pnpm licenses list --prod --long --json
+```
+
+The raw JSON output includes absolute local `node_modules` paths, so the repo tracks the normalized distribution and review-worthy package names rather than committing the machine-local output verbatim.
+
+---
+
+## Scope
+
+- Command: `pnpm licenses list --prod --long --json`
+- Package manager: `pnpm@10.33.4`
+- Runtime alignment: Node 24
+- Dependency scope: production graph only (`--prod`)
+- Total package records: 793
+
+---
+
+## Distribution
+
+| License | Package records | Baseline policy |
+|---|---:|---|
+| MIT | 634 | Approved |
+| Apache-2.0 | 72 | Approved |
+| ISC | 39 | Approved |
+| BSD-3-Clause | 18 | Approved |
+| BSD-2-Clause | 8 | Approved |
+| BlueOak-1.0.0 | 6 | Approved |
+| FSL-1.1-MIT | 2 | Requires review |
+| Unknown | 2 | Requires review; do not introduce new unknown-license packages |
+| Unlicense | 2 | Approved |
+| 0BSD | 2 | Approved |
+| MPL-2.0 | 2 | Approved for current dependency graph; review before adding new direct dependencies |
+| LGPL-3.0-or-later | 1 | Requires review |
+| CC-BY-4.0 | 1 | Approved for metadata/data dependency only; review before adding runtime code dependencies |
+| CC0-1.0 | 1 | Approved |
+| (MIT OR Apache-2.0) | 1 | Approved |
+| LGPL-3.0-only | 1 | Requires review |
+| (MIT OR CC0-1.0) | 1 | Approved |
+
+---
+
+## Review-Worthy Entries
+
+These entries are allowed in the current resolved tree, but any new direct dependency or material usage expansion under these licenses requires explicit review.
+
+| License | Package | Version | Why allowed now | Policy |
+|---|---|---:|---|---|
+| FSL-1.1-MIT | `@sentry/cli` | 2.58.6 | Existing Sentry CLI tooling dependency. | Approved for current tree; review before adding new FSL packages. |
+| FSL-1.1-MIT | `@sentry/cli-darwin` | 2.58.6 | Existing Sentry CLI platform binary. | Approved for current tree; review before adding new FSL packages. |
+| LGPL-3.0-only | `rpc-websockets` | 9.3.9 | Transitive JSON-RPC/WebSocket package through the current dependency graph. | Requires review before direct use or new LGPL dependency additions. |
+| LGPL-3.0-or-later | `@img/sharp-libvips-darwin-arm64` | 1.2.4 | Prebuilt libvips dependency used by `sharp` on macOS ARM. | Approved for current image-processing dependency; review before adding new LGPL packages. |
+| Unknown | `eyes` | 0.1.8 | Transitive value-inspection utility in the current graph. | Do not add new unknown-license packages; replace if this becomes direct/runtime-critical. |
+| Unknown | `text-encoding-utf-8` | 1.0.2 | Transitive UTF-8 Encoding API polyfill in the current graph. | Do not add new unknown-license packages; replace if this becomes direct/runtime-critical. |
+
+---
+
+## Operating Rules
+
+1. Do not add a new direct dependency with `Unknown`, `FSL-*`, or `LGPL-*` licensing without explicit review.
+2. If `pnpm licenses list --prod --long --json` introduces a new license bucket, update this baseline in the same dependency PR or file a dedicated follow-up.
+3. If a package moves from a permissive license to a restricted or unknown license, treat that as a dependency-hygiene finding, not a routine patch.
+4. This baseline does not enforce CI. A license allowlist check can be added later after this snapshot is accepted.
+
+---
+
+## Related
+
+- [DEBT-392 Dependency Hygiene Audit](../debt/debt-392-dependency-hygiene-audit.md)
+- [Deployment Procedure](./deployment-procedure.md)


### PR DESCRIPTION
## Summary

DEBT-392 Tier 6c: add the production dependency license baseline snapshot.

The doc records the normalized output from `pnpm licenses list --prod --long --json`, including license distribution counts, review-worthy FSL/LGPL/Unknown entries, and operating rules for future dependency PRs. The raw JSON is not committed because it contains absolute local `node_modules` paths.

## What changed

- Added `docs/dev/license-baseline.md`
- Cross-linked it from `docs/dev/deployment-environments.md`
- Cross-linked it from `docs/dev/deployment-procedure.md`

## Verification

- `pnpm licenses list --prod --long --json` → 793 production package records
- Verified review-worthy entries:
  - `FSL-1.1-MIT`: `@sentry/cli@2.58.6`, `@sentry/cli-darwin@2.58.6`
  - `LGPL-3.0-only`: `rpc-websockets@9.3.9`
  - `LGPL-3.0-or-later`: `@img/sharp-libvips-darwin-arm64@1.2.4`
  - `Unknown`: `eyes@0.1.8`, `text-encoding-utf-8@1.0.2`
- `corepack pnpm typecheck`
- `corepack pnpm lint` (existing excessive-lines warnings only)
- `corepack pnpm test --run` → 310 files / 2517 tests passed
- `corepack pnpm test:browser` → 50 files / 271 tests passed
- `corepack pnpm test:integration` → 18 files / 104 tests passed
- `corepack pnpm build`
- `corepack pnpm test:e2e` → 35/35 passed
- `corepack pnpm audit --json` → 3 moderate, 0 high, 0 critical

## Out of scope

- No CI license allowlist check in this PR
- No dependency changes
- No legal interpretation beyond the documented engineering baseline/policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive production dependency license baseline documentation, including license distribution details and review guidelines for permitted exceptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->