### PR TITLE
Fix GetStartedCta test env isolation

### DIFF
--- a/components/get-started-cta.test.tsx
+++ b/components/get-started-cta.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { renderToStaticMarkup } from 'react-dom/server';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FakeAuthGateway } from '@/src/application/test-helpers/fakes/fake-gateways';
 import { FakeCheckEntitlementUseCase } from '@/src/application/test-helpers/fakes/fake-use-cases';
 import { createUser } from '@/src/domain/test-helpers/factories';
@@ -16,6 +16,10 @@ vi.mock('next/link', () => ({
 const ORIGINAL_ENV = snapshotProcessEnv();
 
 describe('GetStartedCta', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SKIP_CLERK = 'false';
+  });
+
   afterEach(() => {
     restoreProcessEnv(ORIGINAL_ENV);
     vi.resetModules();


### PR DESCRIPTION
## Summary
- fixes a CI-only unit test isolation failure discovered while triaging DEBT-393 PR #336
- makes the normal `GetStartedCta` entitlement tests explicitly run with `NEXT_PUBLIC_SKIP_CLERK=false`
- preserves the explicit skip-Clerk test by setting `NEXT_PUBLIC_SKIP_CLERK=true` inside that case

## Root cause
Dependabot PR #336 does not receive the normal Clerk secret, so CI evaluates `NEXT_PUBLIC_SKIP_CLERK=true`. The `links to /app/dashboard when user is entitled` test was unintentionally inheriting that global CI environment and rendering the skip-Clerk pricing CTA.

This is not caused by `actions/upload-artifact@v7`; the failure happens in the unit suite before artifact upload.

## Verification
- `NEXT_PUBLIC_SKIP_CLERK=true pnpm test --run components/get-started-cta.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 24 && pnpm db:test:up && DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:migrate && SEED_INCLUDE_PLACEHOLDERS=true DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:seed && pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- `pnpm test:e2e` (35/35 passed)

## Out of scope
- No changes to Dependabot PR #336 branch contents
- No `.github/dependabot.yml` policy changes; those remain DEBT-393 Tier 2
- No upload-artifact merge decision until this lands and #336 is rebased again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test setup with improved environment configuration to ensure consistent test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->