### PR TITLE
Harden Dependabot update policy (DEBT-393 Tier 2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,15 +10,48 @@ updates:
       time: '09:00'
       timezone: America/New_York
     open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: chore(deps)
+    ignore:
+      - dependency-name: '@types/node'
+        update-types:
+          - version-update:semver-major
     groups:
       npm-minor-and-patch:
+        applies-to: version-updates
         patterns:
           - '*'
+        exclude-patterns:
+          - '@biomejs/biome'
         update-types:
           - minor
           - patch
+      biome:
+        applies-to: version-updates
+        patterns:
+          - '@biomejs/biome'
+        update-types:
+          - minor
+          - patch
+          - major
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+      time: '09:00'
+      timezone: America/New_York
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - '*'
 
   - package-ecosystem: github-actions
     directory: /
@@ -29,12 +62,30 @@ updates:
       time: '09:00'
       timezone: America/New_York
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: chore(deps)
     groups:
       actions-minor-and-patch:
+        applies-to: version-updates
         patterns:
           - '*'
         update-types:
           - minor
           - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: '09:00'
+      timezone: America/New_York
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
- harden Dependabot version-update policy for DEBT-393 Tier 2
- add `@types/node` semver-major ignore, `cooldown.default-days: 7`, npm `versioning-strategy: increase-if-necessary`, and a standalone Biome group
- add separate default-branch security-update grouping entries for npm and GitHub Actions without cooldown

## Verification
- Verified key names against GitHub's Dependabot options reference: https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference
- `yq` is not installed locally, so YAML parse was verified with Ruby `YAML.safe_load` plus structural assertions for all expected policy keys.
- Full local gate under Node 24.16.0: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- E2E env present: `pnpm test:e2e` passed 35/35
- `pnpm audit --json`: 3 moderate / 0 high / 0 critical

## Out of scope
- no pnpm supply-chain hardening settings; that remains DEBT-394
- no code changes
- no direct changes to Dependabot-owned PR branches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to improve update handling for npm packages and GitHub Actions. Changes include refined grouping strategies, security-focused update procedures, and adjusted cooldown periods to optimize the update workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->