### PR TITLE
Add pnpm maturity policy (DEBT-394 PR 1)

### DIFF
--- a/.husky/check-node-version.sh
+++ b/.husky/check-node-version.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=sh
 # Enforce Node version per .nvmrc - defends against stale global
 # ~/.config/husky/init.sh that loads nvm but never calls `nvm use`.
 # Without this, GUI-triggered hooks or shells that do not pick up

--- a/.husky/check-node-version.sh
+++ b/.husky/check-node-version.sh
@@ -6,7 +6,7 @@
 hook_name="${hook_name:-hook}"
 
 if [ -f .nvmrc ]; then
-  raw_required="$(tr -d 'v[:space:]' < .nvmrc)"
+  raw_required="$(sed 's/^[vV]//;s/[[:space:]]//g' < .nvmrc)"
   required_major="$(printf '%s' "$raw_required" | cut -d. -f1)"
 
   case "$required_major" in

--- a/.husky/check-node-version.sh
+++ b/.husky/check-node-version.sh
@@ -1,0 +1,37 @@
+# Enforce Node version per .nvmrc - defends against stale global
+# ~/.config/husky/init.sh that loads nvm but never calls `nvm use`.
+# Without this, GUI-triggered hooks or shells that do not pick up
+# .nvmrc automatically can run pnpm under the wrong Node.
+
+hook_name="${hook_name:-hook}"
+
+if [ -f .nvmrc ]; then
+  raw_required="$(tr -d 'v[:space:]' < .nvmrc)"
+  required_major="$(printf '%s' "$raw_required" | cut -d. -f1)"
+
+  case "$required_major" in
+    '' | *[!0-9]*)
+      echo "ERROR: ${hook_name} cannot parse .nvmrc" >&2
+      echo "  Expected a plain Node major or semver value such as '24' or '24.16.0'." >&2
+      echo "  Actual .nvmrc: ${raw_required:-<empty>}" >&2
+      exit 1
+      ;;
+  esac
+
+  actual_major="$(node -v 2>/dev/null | sed 's/^v//' | cut -d. -f1)"
+  if [ -z "$actual_major" ] || [ "$actual_major" != "$required_major" ]; then
+    echo "ERROR: ${hook_name} hook running on the wrong Node version" >&2
+    echo "  .nvmrc requires: Node ${required_major}.x" >&2
+    if [ -n "$actual_major" ]; then
+      echo "  Currently active: v${actual_major}.x" >&2
+    else
+      echo "  Currently active: <node not on PATH>" >&2
+    fi
+    echo "" >&2
+    echo "Fix one of:" >&2
+    echo "  - In your terminal: 'nvm use' (or 'fnm use', 'asdf shell nodejs', etc.) before 'git ${hook_name#pre-}'." >&2
+    echo "  - One-time: add '[ -f \"\$PWD/.nvmrc\" ] && nvm use --silent 2>/dev/null'" >&2
+    echo "    after the nvm load in ~/.config/husky/init.sh so all repos auto-respect .nvmrc." >&2
+    exit 1
+  fi
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,25 @@
+# Enforce Node version per .nvmrc - defends against stale global
+# ~/.config/husky/init.sh that loads nvm but never calls `nvm use`.
+# Without this, GUI-triggered hooks or shells that do not pick up
+# .nvmrc automatically can run pnpm under the wrong Node.
+if [ -f .nvmrc ]; then
+  required_major="$(tr -d 'v[:space:]' < .nvmrc | cut -d. -f1)"
+  actual_major="$(node -v 2>/dev/null | sed 's/^v//' | cut -d. -f1)"
+  if [ -z "$actual_major" ] || [ "$actual_major" != "$required_major" ]; then
+    echo "ERROR: pre-commit hook running on the wrong Node version" >&2
+    echo "  .nvmrc requires: Node ${required_major}.x" >&2
+    if [ -n "$actual_major" ]; then
+      echo "  Currently active: v${actual_major}.x" >&2
+    else
+      echo "  Currently active: <node not on PATH>" >&2
+    fi
+    echo "" >&2
+    echo "Fix one of:" >&2
+    echo "  - In your terminal: 'nvm use' (or 'fnm use', 'asdf shell nodejs', etc.) before 'git commit'." >&2
+    echo "  - One-time: add '[ -f \"\$PWD/.nvmrc\" ] && nvm use --silent 2>/dev/null'" >&2
+    echo "    after the nvm load in ~/.config/husky/init.sh so all repos auto-respect .nvmrc." >&2
+    exit 1
+  fi
+fi
+
 pnpm exec lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,25 +1,3 @@
-# Enforce Node version per .nvmrc - defends against stale global
-# ~/.config/husky/init.sh that loads nvm but never calls `nvm use`.
-# Without this, GUI-triggered hooks or shells that do not pick up
-# .nvmrc automatically can run pnpm under the wrong Node.
-if [ -f .nvmrc ]; then
-  required_major="$(tr -d 'v[:space:]' < .nvmrc | cut -d. -f1)"
-  actual_major="$(node -v 2>/dev/null | sed 's/^v//' | cut -d. -f1)"
-  if [ -z "$actual_major" ] || [ "$actual_major" != "$required_major" ]; then
-    echo "ERROR: pre-commit hook running on the wrong Node version" >&2
-    echo "  .nvmrc requires: Node ${required_major}.x" >&2
-    if [ -n "$actual_major" ]; then
-      echo "  Currently active: v${actual_major}.x" >&2
-    else
-      echo "  Currently active: <node not on PATH>" >&2
-    fi
-    echo "" >&2
-    echo "Fix one of:" >&2
-    echo "  - In your terminal: 'nvm use' (or 'fnm use', 'asdf shell nodejs', etc.) before 'git commit'." >&2
-    echo "  - One-time: add '[ -f \"\$PWD/.nvmrc\" ] && nvm use --silent 2>/dev/null'" >&2
-    echo "    after the nvm load in ~/.config/husky/init.sh so all repos auto-respect .nvmrc." >&2
-    exit 1
-  fi
-fi
-
+hook_name=pre-commit
+. "$(dirname "$0")/check-node-version.sh"
 pnpm exec lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,25 +1,3 @@
-# Enforce Node version per .nvmrc - defends against stale global
-# ~/.config/husky/init.sh that loads nvm but never calls `nvm use`.
-# Without this, GUI-triggered hooks or shells that do not pick up
-# .nvmrc automatically can run pnpm under the wrong Node.
-if [ -f .nvmrc ]; then
-  required_major="$(tr -d 'v[:space:]' < .nvmrc | cut -d. -f1)"
-  actual_major="$(node -v 2>/dev/null | sed 's/^v//' | cut -d. -f1)"
-  if [ -z "$actual_major" ] || [ "$actual_major" != "$required_major" ]; then
-    echo "ERROR: pre-push hook running on the wrong Node version" >&2
-    echo "  .nvmrc requires: Node ${required_major}.x" >&2
-    if [ -n "$actual_major" ]; then
-      echo "  Currently active: v${actual_major}.x" >&2
-    else
-      echo "  Currently active: <node not on PATH>" >&2
-    fi
-    echo "" >&2
-    echo "Fix one of:" >&2
-    echo "  - In your terminal: 'nvm use' (or 'fnm use', 'asdf shell nodejs', etc.) before 'git push'." >&2
-    echo "  - One-time: add '[ -f \"\$PWD/.nvmrc\" ] && nvm use --silent 2>/dev/null'" >&2
-    echo "    after the nvm load in ~/.config/husky/init.sh so all repos auto-respect .nvmrc." >&2
-    exit 1
-  fi
-fi
-
+hook_name=pre-push
+. "$(dirname "$0")/check-node-version.sh"
 pnpm typecheck && pnpm test --run

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,25 @@
+# Enforce Node version per .nvmrc - defends against stale global
+# ~/.config/husky/init.sh that loads nvm but never calls `nvm use`.
+# Without this, GUI-triggered hooks or shells that do not pick up
+# .nvmrc automatically can run pnpm under the wrong Node.
+if [ -f .nvmrc ]; then
+  required_major="$(tr -d 'v[:space:]' < .nvmrc | cut -d. -f1)"
+  actual_major="$(node -v 2>/dev/null | sed 's/^v//' | cut -d. -f1)"
+  if [ -z "$actual_major" ] || [ "$actual_major" != "$required_major" ]; then
+    echo "ERROR: pre-push hook running on the wrong Node version" >&2
+    echo "  .nvmrc requires: Node ${required_major}.x" >&2
+    if [ -n "$actual_major" ]; then
+      echo "  Currently active: v${actual_major}.x" >&2
+    else
+      echo "  Currently active: <node not on PATH>" >&2
+    fi
+    echo "" >&2
+    echo "Fix one of:" >&2
+    echo "  - In your terminal: 'nvm use' (or 'fnm use', 'asdf shell nodejs', etc.) before 'git push'." >&2
+    echo "  - One-time: add '[ -f \"\$PWD/.nvmrc\" ] && nvm use --silent 2>/dev/null'" >&2
+    echo "    after the nvm load in ~/.config/husky/init.sh so all repos auto-respect .nvmrc." >&2
+    exit 1
+  fi
+fi
+
 pnpm typecheck && pnpm test --run

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+minimumReleaseAge: 10080
+blockExoticSubdeps: true
+trustPolicy: no-downgrade


### PR DESCRIPTION
## Summary
- DEBT-394 PR 1: add root `pnpm-workspace.yaml` with pnpm 10-compatible supply-chain policy.
- Sets `minimumReleaseAge: 10080` (7 days), `blockExoticSubdeps: true`, and `trustPolicy: no-downgrade`.
- Deliberate user-authorized addendum: add repo-side Node major guards to `.husky/pre-commit` and `.husky/pre-push`, backed by shared `.husky/check-node-version.sh`.
- Leaves package versions, lockfile, app code, and Dependabot config unchanged.

## Why the Husky addendum is included
- While pushing the first #348 head, the global `~/.config/husky/init.sh` loaded nvm but did not run `nvm use`, so the pre-push hook ran pnpm under the wrong Node and produced misleading engine-warning JSON failures.
- DEBT-394 PR 2 and PR 3 will exercise the same hooks repeatedly; failing loudly before pnpm starts avoids repeat workarounds and gives future contributors a clear fix path.
- The new guard would have stopped the original problem with `ERROR: pre-push hook running on the wrong Node version` instead of letting pnpm continue under Node 22/25.
- CodeRabbit feedback on the duplicate guard was addressed by extracting the logic to `.husky/check-node-version.sh`; unsupported `.nvmrc` contents now fail loudly instead of silently bypassing enforcement.

## Upstream verification
- pnpm 10 settings reference: https://pnpm.io/10.x/settings
- Verified `minimumReleaseAge` is a number of minutes and was added in pnpm v10.16.0.
- Verified `trustPolicy` accepts `no-downgrade` and checks decreased trust evidence, not semver downgrades.
- Verified `blockExoticSubdeps` is a boolean setting available on pnpm 10.

## Repository verification
- Confirmed `.github/dependabot.yml` already has `cooldown.default-days: 7` on both routine `npm` and `github-actions` update entries, matching `minimumReleaseAge: 10080`.
- `pnpm install --frozen-lockfile` passed under Node 24 / pnpm 10.33.4; the current lockfile is not rejected by the 7-day gate.
- Hook syntax check passed: `sh -n .husky/check-node-version.sh && sh -n .husky/pre-commit && sh -n .husky/pre-push`.
- Wrong-Node sanity check passed: `PATH=/Users/ray/.nvm/versions/node/v22.22.1/bin:/usr/bin:/bin sh .husky/pre-push` exits 1 before pnpm starts.
- Missing-Node sanity check passed: `PATH=/usr/bin:/bin sh .husky/pre-push` exits 1 before pnpm starts.
- `pnpm audit --json | jq '.metadata.vulnerabilities'` remains `0 low / 3 moderate / 0 high / 0 critical`.

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- [x] `pnpm test:e2e` (35/35; local authenticated E2E env present)
- [x] pre-push hook (`pnpm typecheck && pnpm test --run`) on Node 24 after the guard was added
- [x] wrong-Node hook sanity check exits 1 with explicit error
- [x] `pnpm audit --json | jq '.metadata.vulnerabilities'`

## Out of scope
- PR 2 will enumerate `allowBuilds` from pnpm's strict build-policy output.
- PR 3 will migrate to pnpm 11 and add v11-only strictness.
- PR 4 will archive DEBT-394 after all implementation PRs land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enforced Node.js version consistency across development environments.
  * Implemented automated code quality checks before commits.
  * Configured automated type checking and testing validation before push operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->