### PR TITLE
Add strictDepBuilds and curated allowBuilds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,12 @@
 minimumReleaseAge: 10080
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+strictDepBuilds: true
+allowBuilds:
+  '@clerk/shared': false # postinstall only records Clerk telemetry notice state; no runtime build artifact.
+  '@sentry/cli': true # installs/verifies the platform sentry-cli binary used by Sentry tooling.
+  bufferutil: false # optional ws native performance addon; ws has a JavaScript fallback.
+  core-js: false # postinstall only prints a funding banner; no runtime build artifact.
+  esbuild: true # validates/prepares platform esbuild binaries used by Vite, tsx, and Drizzle tooling.
+  sharp: true # verifies/builds the native image-processing addon used by Next's image pipeline.
+  utf-8-validate: false # optional ws legacy UTF-8 native addon; Node 24/ws can fall back.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,10 +3,10 @@ blockExoticSubdeps: true
 trustPolicy: no-downgrade
 strictDepBuilds: true
 allowBuilds:
-  '@clerk/shared': false # postinstall only records Clerk telemetry notice state; no runtime build artifact.
+  '@clerk/shared': false # postinstall prints telemetry notice and persists telemetryNoticeVersion to local Clerk config.
   '@sentry/cli': true # installs/verifies the platform sentry-cli binary used by Sentry tooling.
-  bufferutil: false # optional ws native performance addon; ws has a JavaScript fallback.
-  core-js: false # postinstall only prints a funding banner; no runtime build artifact.
+  bufferutil: false # optional ws peer/native performance addon built by node-gyp-build; ws can fall back.
+  core-js: false # postinstall prints support/funding banner with temp-file dedupe; no build artifact.
   esbuild: true # validates/prepares platform esbuild binaries used by Vite, tsx, and Drizzle tooling.
   sharp: true # verifies/builds the native image-processing addon used by Next's image pipeline.
-  utf-8-validate: false # optional ws legacy UTF-8 native addon; Node 24/ws can fall back.
+  utf-8-validate: false # optional ws peer/legacy UTF-8 native addon built by node-gyp-build; Node 24/ws can fall back.


### PR DESCRIPTION
## Summary

DEBT-394 PR 2 adds pnpm strict dependency-build enforcement and a curated `allowBuilds` map derived from this repository's actual clean-install output under `pnpm@10.33.4`.

This PR is intentionally limited to `pnpm-workspace.yaml`:

- keeps the existing PR 1 policy keys unchanged: `minimumReleaseAge: 10080`, `blockExoticSubdeps: true`, `trustPolicy: no-downgrade`
- adds `strictDepBuilds: true`
- adds a reviewed `allowBuilds` map with a one-line rationale comment per entry

## Discovery

Baseline:

- `node -v`: `v24.16.0`
- `pnpm --version`: `10.33.4`
- `pnpm install --frozen-lockfile`: clean before policy expansion

Clean discovery run with `strictDepBuilds: true` and `allowBuilds: {}` after `rm -rf node_modules` failed with:

```text
ERR_PNPM_IGNORED_BUILDS Ignored build scripts: @clerk/shared@4.13.1, @sentry/cli@2.58.6, bufferutil@4.1.0, core-js@3.47.0, esbuild@0.18.20, esbuild@0.25.12, esbuild@0.27.2, esbuild@0.28.0, sharp@0.34.5, utf-8-validate@6.0.6
```

`pnpm approve-builds` agreed on the package-name surface and collapsed the versioned list to:

```text
@clerk/shared
@sentry/cli
bufferutil
core-js
esbuild
sharp
utf-8-validate
```

After curating the map, `pnpm approve-builds` reports:

```text
There are no packages awaiting approval
```

## Trust Decisions

Allowed:

- `@sentry/cli: true` — installs/verifies the platform `sentry-cli` binary used by Sentry tooling.
- `esbuild: true` — validates/prepares platform esbuild binaries used by Vite, tsx, and Drizzle tooling.
- `sharp: true` — verifies/builds the native image-processing addon used by Next's image pipeline.

Denied:

- `@clerk/shared: false` — postinstall only records Clerk telemetry notice state; no runtime build artifact.
- `bufferutil: false` — optional `ws` native performance addon; `ws` has a JavaScript fallback.
- `core-js: false` — postinstall only prints a funding banner; no runtime build artifact.
- `utf-8-validate: false` — optional `ws` legacy UTF-8 native addon; Node 24 / `ws` can fall back.

## Proof of Life

The prompt's suggested `true -> false` flip was validated and rejected: `false` is an explicit deny policy, so install exits 0 and skips that package's script. The actual enforcement check is removing a reviewed entry entirely.

Removing the `esbuild` entry from `allowBuilds`, then running `rm -rf node_modules && pnpm install --frozen-lockfile`, failed as expected:

```text
ERR_PNPM_IGNORED_BUILDS Ignored build scripts: esbuild@0.18.20, esbuild@0.25.12, esbuild@0.27.2, esbuild@0.28.0

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.

INSTALL_EXIT=1
```

That proves `strictDepBuilds` is active and not hidden by pnpm's build cache.

## Out of Scope

- No pnpm 11 migration in this PR.
- No `minimumReleaseAgeStrict` or `minimumReleaseAgeIgnoreMissingTime` yet; those are DEBT-394 PR 3.
- No dependency version bumps.
- No app code or test changes.

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm approve-builds` (no packages awaiting approval)
- [x] `pnpm typecheck`
- [x] `pnpm lint` (passes with existing 19 noExcessiveLinesPerFile warnings)
- [x] `pnpm test --run` (311 files, 2519 tests)
- [x] `pnpm test:browser` (50 files, 271 tests)
- [x] `pnpm test:integration` (18 files, 104 tests)
- [x] `pnpm build`
- [x] `pnpm test:e2e` (35/35; authenticated E2E env present)
- [x] `pnpm audit --json | jq '.metadata.vulnerabilities'` => 3 moderate / 0 high / 0 critical


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened build configuration to enforce stricter dependency build controls and introduced an allowlist mechanism to selectively permit safe dependency build steps while blocking others, improving build consistency, reliability, and predictable fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->