### PR TITLE
chore: migrate to pnpm 11.3 for DEBT-394

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.8
         with:
-          version: 10.33.4
+          version: 11.3.0
           run_install: false
 
       - name: Setup Node

--- a/docs/dev/supply-chain-overrides.md
+++ b/docs/dev/supply-chain-overrides.md
@@ -1,0 +1,300 @@
+# Supply-Chain Policy Overrides - On-Call Playbook
+
+This is the documented escape hatch for the supply-chain hardening policy
+introduced by DEBT-394.
+
+Use this playbook when a dependency update needs one of these deliberate,
+reviewable exceptions:
+
+- a security fix is newer than the 7-day maturity window;
+- a new dependency needs an install script;
+- a dependency needs to be tested against the policy before a real PR;
+- pnpm audit needs a documented advisory exception.
+
+The active debt record is
+`docs/debt/debt-394-supply-chain-hardening.md`. After archival, the same
+record lives at `docs/_archive/debt/debt-394-supply-chain-hardening.md`.
+
+The policy is intentionally strict:
+
+```yaml
+minimumReleaseAge: 10080
+minimumReleaseAgeStrict: true
+minimumReleaseAgeIgnoreMissingTime: false
+minimumReleaseAgeExclude:
+  - '<exact already-shipped package@version>' # temporary bootstrap exception; see pnpm-workspace.yaml.
+blockExoticSubdeps: true
+trustPolicy: no-downgrade
+strictDepBuilds: true
+trustPolicyExclude:
+  - semver@6.3.1
+  - tinyexec@1.2.2
+allowBuilds:
+  '@clerk/shared': false
+  '@sentry/cli': true
+  bufferutil: false
+  core-js: false
+  esbuild: true
+  sharp: true
+  utf-8-validate: false
+```
+
+Do not weaken these settings casually. Every exception must be small,
+named in the PR body, and removed when it is no longer needed.
+
+## Urgent CVE patches before the 7-day cooldown
+
+`minimumReleaseAge: 10080` means pnpm refuses package versions published
+less than 10,080 minutes ago, which is 7 days.
+
+For ordinary updates, wait for the version to mature. For urgent security
+fixes, use `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`.
+
+Package-wide exception:
+
+```yaml
+minimumReleaseAgeExclude:
+  - '@clerk/nextjs' # urgent advisory GHSA-xxxx-yyyy-zzzz; remove after 2026-06-02.
+```
+
+Exact-version exception:
+
+```yaml
+minimumReleaseAgeExclude:
+  - 'some-pkg@1.2.3' # urgent advisory GHSA-xxxx-yyyy-zzzz; remove after 2026-06-02.
+```
+
+Prefer exact-version exceptions when the advisory fix is known. A
+package-wide exception also allows later versions of that package during
+the exception window, so it has a wider trust surface.
+
+Workflow:
+
+1. Confirm the advisory source and the fixed version.
+2. Add the smallest `minimumReleaseAgeExclude` entry that unlocks the fix.
+3. Add a rationale comment with the advisory ID and removal date.
+4. Land the security update through the normal PR path.
+5. Name the exception in the PR body.
+6. Remove the exception after the version is older than 7 days.
+
+Never leave a maturity exception in place as cleanup debt. It is a
+temporary override, not a standing policy.
+
+Temporary bootstrap exceptions are allowed only when enabling the policy
+over package versions that already shipped to `dev` before the policy was
+active. Scope them to exact versions, give each line a removal date, and
+remove them as soon as the versions are older than the configured 7-day
+window. Do not use package-wide bootstrap exceptions.
+
+The only current package-wide bootstrap exception is `ws`, because the
+rejected `ws@8.21.0` lockfile entry is peer-suffixed in the lockfile. Keep
+that exception temporary and remove it with the other bootstrap entries.
+
+## Adding a new native-build package to allowBuilds
+
+`strictDepBuilds: true` means dependencies with install or postinstall
+scripts must be explicitly allowed or denied. `allowBuilds: true` means
+we trust that package to execute code at install time.
+
+When pnpm reports a new package that wants a build script:
+
+```sh
+rm -rf node_modules
+pnpm install --frozen-lockfile
+```
+
+Read the pnpm error and inspect the package's script before deciding:
+
+```sh
+node -e "const p=require('./node_modules/<pkg>/package.json'); console.log(p.scripts)"
+```
+
+If the script is required for the package to function, add an allow entry:
+
+```yaml
+allowBuilds:
+  esbuild: true # validates/prepares platform esbuild binaries used by Vite, tsx, and Drizzle tooling.
+```
+
+If the script is telemetry, a funding banner, an optional accelerator, or
+otherwise unnecessary, deny it:
+
+```yaml
+allowBuilds:
+  core-js: false # postinstall prints support/funding banner with temp-file dedupe; no build artifact.
+```
+
+After editing, verify from a clean install:
+
+```sh
+rm -rf node_modules
+pnpm install --frozen-lockfile
+pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build
+```
+
+If the local authenticated billing E2E environment is present, also run:
+
+```sh
+lsof -ti:3000 | xargs kill -9 2>/dev/null
+pnpm test:e2e
+```
+
+The committed `allowBuilds` entry must include a one-line rationale
+comment. A bare `true` is not acceptable because reviewers cannot tell
+what install-time code they are trusting.
+
+## Why Dependabot cooldown and pnpm minimumReleaseAge MUST match
+
+Dependabot and pnpm enforce two different parts of the same policy.
+
+- `.github/dependabot.yml:14-15` sets `cooldown.default-days: 7` for npm
+  version updates.
+- `.github/dependabot.yml:65-66` sets `cooldown.default-days: 7` for
+  GitHub Actions version updates.
+- `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080`, which is the same
+  7-day window expressed in minutes.
+
+Keep these values coupled. If Dependabot cooldown is shorter than pnpm's
+minimum release age, Dependabot opens PRs that `pnpm install` refuses. If
+pnpm's minimum release age is shorter than Dependabot cooldown, pnpm
+accepts fresh versions that the Dependabot policy is trying to delay.
+
+Change one only when the same PR changes the other and explains the new
+window.
+
+## Testing a candidate dep against the policy
+
+Use a scratch branch for policy experiments. Do not test fresh packages on
+a branch that already contains unrelated work.
+
+```sh
+git switch -c scratch/test-supply-chain-policy
+pnpm add --save-dev <candidate-package>
+```
+
+Expected outcomes:
+
+- fresh package accepted only if it is older than the 7-day threshold or
+  explicitly excluded;
+- fresh package rejected with a minimum-release-age error when no mature
+  version satisfies the requested range;
+- package with a build script rejected until `allowBuilds` names it.
+
+Roll back the experiment before returning to real work:
+
+```sh
+git restore package.json pnpm-lock.yaml
+rm -rf node_modules
+pnpm install --frozen-lockfile
+git switch -
+git branch -D scratch/test-supply-chain-policy
+```
+
+Only delete the scratch branch after confirming it has no useful changes.
+Never use this rollback flow on a branch with uncommitted work from
+another session.
+
+## Trust review for new install scripts
+
+Install scripts are a supply-chain execution boundary. A malicious install
+script can read workspace files, environment variables, SSH agent sockets,
+GitHub tokens on CI, and build-time secrets on hosting providers.
+
+Default to `false` unless you can explain why the script must run.
+
+Current denied examples:
+
+- `@clerk/shared: false` - postinstall prints a telemetry notice and writes
+  `telemetryNoticeVersion` to local Clerk config; no build artifact is
+  required.
+- `bufferutil: false` - optional `ws` native performance addon built by
+  `node-gyp-build`; `ws` can fall back without it.
+- `core-js: false` - postinstall prints support/funding text with temp-file
+  dedupe; no build artifact is required.
+- `utf-8-validate: false` - optional `ws` legacy UTF-8 native addon built
+  by `node-gyp-build`; Node 24 and `ws` can fall back without it.
+
+Current allowed examples:
+
+- `@sentry/cli: true` - installs or verifies the platform `sentry-cli`
+  binary used by Sentry tooling.
+- `esbuild: true` - validates or prepares platform binaries used by Vite,
+  tsx, and Drizzle tooling.
+- `sharp: true` - verifies or builds the native image-processing addon used
+  by Next's image pipeline.
+
+Use these comments as templates. The rationale should name the artifact or
+runtime behavior that would break without the script.
+
+## Trust-policy downgrade exceptions
+
+`trustPolicy: no-downgrade` fails when a package version has weaker trust
+evidence than an earlier-published version of the same package. That can
+be a real supply-chain warning, so do not bypass it automatically.
+
+The only current exception is exact-version scoped:
+
+```yaml
+trustPolicyExclude:
+  - semver@6.3.1 # legacy Babel dependency published in 2023; exact exception for no-downgrade provenance gap.
+  - tinyexec@1.2.2 # already-shipped Vite/Vitest utility; exact exception for no-downgrade provenance gap.
+```
+
+Why this is allowed:
+
+- Babel requires `semver@^6.3.1` through `@babel/core`.
+- `semver@6.3.1` is a 2023 package and not a fresh-publish event.
+- `tinyexec@1.2.2` is already present in the shipped lockfile through the
+  Vite/Vitest toolchain.
+- The exceptions are exact-version scoped, not package-wide.
+- The policy still protects every other package and every future `semver`
+  or `tinyexec` release.
+
+Workflow for any future trust-policy exception:
+
+1. Confirm the dependency chain that requires the flagged package.
+2. Confirm the package version, publish date, and registry integrity.
+3. Prefer changing the dependency graph to a trusted version when that is
+   compatible.
+4. If no compatible trusted version exists, add an exact-version
+   `trustPolicyExclude` entry with a rationale comment.
+5. Name the exception in the PR body and remove it when the upstream chain
+   no longer needs it.
+
+## Audit hygiene under pnpm 11
+
+pnpm 11 reports and filters audit advisories by GHSA identifier. If this
+repo ever needs to ignore a specific advisory, use
+`auditConfig.ignoreGhsas`, not the deprecated CVE-based ignore key.
+
+Example:
+
+```yaml
+auditConfig:
+  ignoreGhsas:
+    - GHSA-xxxx-yyyy-zzzz # accepted until 2026-06-02; reason and owner in PR body.
+```
+
+Do not add audit ignores proactively. An ignore is allowed only after a
+review concludes that the advisory is not reachable, is mitigated by other
+controls, or cannot be fixed without a larger migration.
+
+## Vercel deploy notes
+
+At the pnpm 11 migration, Vercel's package-manager documentation listed
+pnpm 6-10 as supported package-manager versions. This repo still pins
+`packageManager: "pnpm@11.3.0"` in `package.json`, and Node 24 includes
+Corepack, which is the mechanism expected to activate the pinned pnpm
+version.
+
+For every pnpm major migration, the Vercel preview is load-bearing
+evidence. Before merging, confirm the Vercel build log shows:
+
+- Corepack or pnpm activation for the pinned pnpm 11.x version;
+- `pnpm install` running under pnpm 11.x;
+- install completion without falling back to pnpm 10.x or npm.
+
+If Vercel falls back to pnpm 10.x or fails before installing, stop and
+root-cause before merge. Possible fixes include an explicit install command
+or Corepack activation in Vercel configuration, but do not add those until
+the preview log proves they are necessary.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "private": true,
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.3.0",
   "engines": {
     "node": "24.x",
-    "pnpm": ">=10.0.0"
+    "pnpm": ">=11.0.0"
   },
   "scripts": {
     "dev": "next dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,73 @@
 minimumReleaseAge: 10080
+minimumReleaseAgeStrict: true # v11-only: fail when no version satisfies the 7-day age threshold.
+minimumReleaseAgeIgnoreMissingTime: false # v11-only: fail when registry metadata lacks package publish time.
+minimumReleaseAgeExclude:
+  - '@clerk/backend@3.4.13' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@clerk/localizations@4.6.8' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@clerk/nextjs@7.4.1' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@clerk/react@6.7.1' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@clerk/shared@4.13.1' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@clerk/testing@2.0.33' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@clerk/ui@1.13.1' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@vitest/browser-playwright@4.1.7' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@vitest/browser@4.1.7' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@vitest/coverage-v8@4.1.7' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@vitest/expect@4.1.7' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@vitest/mocker@4.1.7' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@vitest/pretty-format@4.1.7' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@vitest/runner@4.1.7' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@vitest/snapshot@4.1.7' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@vitest/spy@4.1.7' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@vitest/utils@4.1.7' # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - vitest@4.1.7 # temporary bootstrap exception for already-shipped version; remove after 2026-05-30.
+  - '@babel/code-frame@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/compat-data@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/core@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/generator@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/helper-compilation-targets@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/helper-globals@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/helper-module-imports@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/helper-module-transforms@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/helper-plugin-utils@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/helper-string-parser@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/helper-validator-identifier@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/helper-validator-option@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/helpers@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/parser@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/plugin-syntax-import-attributes@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/runtime@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/template@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/traverse@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@babel/types@7.29.7' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@exodus/bytes@1.15.1' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@sentry/cli-darwin@2.58.6' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@sentry/cli-linux-arm@2.58.6' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@sentry/cli-linux-arm64@2.58.6' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@sentry/cli-linux-i686@2.58.6' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@sentry/cli-linux-x64@2.58.6' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@sentry/cli-win32-arm64@2.58.6' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@sentry/cli-win32-i686@2.58.6' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@sentry/cli-win32-x64@2.58.6' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@sentry/cli@2.58.6' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - '@tanstack/query-core@5.100.14' # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - baseline-browser-mapping@2.10.32 # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - electron-to-chromium@1.5.361 # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - enhanced-resolve@5.22.0 # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - lru-cache@11.5.0 # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - node-releases@2.0.46 # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - semver@7.8.1 # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - shell-quote@1.8.4 # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - terser@5.48.0 # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - tinyexec@1.2.2 # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - tldts-core@7.1.2 # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - tldts@7.1.2 # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - webpack-sources@3.5.0 # temporary bootstrap exception for already-shipped lockfile entry; remove after 2026-06-02.
+  - ws # temporary bootstrap exception for peer-suffixed already-shipped lockfile entries; remove after 2026-06-02.
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+trustPolicyExclude:
+  - semver@6.3.1 # legacy Babel dependency published in 2023; exact exception for no-downgrade provenance gap.
+  - tinyexec@1.2.2 # already-shipped Vite/Vitest utility; exact exception for no-downgrade provenance gap.
 strictDepBuilds: true
 allowBuilds:
   '@clerk/shared': false # postinstall prints telemetry notice and persists telemetryNoticeVersion to local Clerk config.


### PR DESCRIPTION
## Summary

DEBT-394 PR 3 migrates the package-manager runtime from `pnpm@10.33.4` to `pnpm@11.3.0` without changing application dependencies.

- `package.json`: `packageManager` now pins `pnpm@11.3.0`; `engines.pnpm` is now `>=11.0.0`; `engines.node` remains `24.x`.
- `.github/workflows/ci.yml`: `pnpm/action-setup@v6.0.8` now uses `version: 11.3.0`, matching `packageManager` exactly.
- `pnpm-workspace.yaml`: adds v11-only strictness with `minimumReleaseAgeStrict: true` and `minimumReleaseAgeIgnoreMissingTime: false`.
- `pnpm-workspace.yaml`: adds exact temporary bootstrap `minimumReleaseAgeExclude` entries for already-shipped lockfile entries that are younger than 7 days, plus exact `trustPolicyExclude` entries for `semver@6.3.1` and `tinyexec@1.2.2`.
- `docs/dev/supply-chain-overrides.md`: adds the on-call playbook for maturity exceptions, native-build allowlist changes, cooldown matching, scratch policy tests, trust-policy exceptions, audit ignores, and Vercel pnpm 11 verification.

Resolved pnpm version source: `npm view pnpm dist-tags --json` returned `latest-11: 11.3.0`. Release notes: https://github.com/pnpm/pnpm/releases/tag/v11.3.0.

## Migration notes

`pnpm install` under pnpm 11.3.0 validated the existing `pnpm-lock.yaml` without rewriting it. I intentionally kept the existing lock graph instead of running `pnpm clean --lockfile`, because the clean re-resolution walked caret ranges and introduced unrelated dependency/lint churn. This PR is the package-manager migration, not a dependency update PR.

The temporary bootstrap `minimumReleaseAgeExclude` entries exist because the current `dev` lockfile already contains versions published inside the new 7-day window. They are exact-version scoped except `ws`, which needs package-name scope because the rejected lockfile entry is peer-suffixed. Each entry has a removal date comment.

## Proof of life

Fresh-package rejection using this PR's `pnpm-workspace.yaml` in a temp project:

```text
[ERR_PNPM_NO_MATURE_MATCHING_VERSION] 1 version does not meet the minimumReleaseAge constraint:
  pnpm@11.3.0 was published at 2026-05-24T08:43:45.834Z, within the minimumReleaseAge cutoff (2026-05-19T17:48:56.010Z)
PROOF_EXIT=1
```

## Verification

- [x] `pnpm install --frozen-lockfile` passed under pnpm 11.3.0.
- [x] `pnpm typecheck` passed.
- [x] `pnpm lint` passed with existing excessive-file warnings only.
- [x] `pnpm test --run` passed: 311 files / 2519 tests.
- [x] `pnpm test:browser` passed: 50 files / 271 tests.
- [x] `pnpm test:integration` passed: 18 files / 104 tests.
- [x] `pnpm build` passed.
- [x] `pnpm test:e2e` passed: 35/35.
- [x] `pnpm audit --json | jq '.metadata.vulnerabilities'` remained `3 moderate / 0 high / 0 critical`.
- [x] Pre-push hook passed: `pnpm typecheck && pnpm test --run`.

## Out of scope

- No application dependency updates.
- No Node runtime change.
- No DEBT-394 archive changes; archive is the next PR after this lands.
- No Vercel config changes unless the preview proves pnpm 11 is not being used.

## Required before merge

- [ ] GitHub Actions green.
- [ ] Vercel preview green.
- [ ] Confirm Vercel build log used pnpm 11.3.0 for install.
- [ ] CodeRabbit substantive review on latest head with no actionable comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded pnpm to version 11.3.0 across CI workflow and project configuration
  * Updated minimum required pnpm engine version to 11.0.0

* **Documentation**
  * Added guide for supply-chain policy overrides and implementation procedures

* **Configuration**
  * Enhanced workspace policies with stricter release-age enforcement and exemption management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->