### PR TITLE
Add For AI Agents preamble to standards.md (DEBT-398 PR 2)

### DIFF
--- a/docs/debt/debt-398-design-system-enforcement-gap.md
+++ b/docs/debt/debt-398-design-system-enforcement-gap.md
@@ -211,16 +211,21 @@ This is the single highest-leverage edit in this debt cycle. With it, every futu
 
 ### PR 2 — `docs/frontend/standards.md` "For AI Agents" preamble
 
-Branch: `docs/debt-398-standards-agent-preamble`
+Branch: `feat/debt-398-pr-2-standards-md-agent-preamble`
 
-Add at the top of `docs/frontend/standards.md` (before § 1):
+Add near the top of `docs/frontend/standards.md`, after the existing
+introductory "See also" list and before the horizontal rule / table of
+contents. The preamble must stay before § 1 so agents see the binding
+context before the token rules:
 
 ```markdown
 ## For AI Agents (Claude Code, Cursor, Codex, etc.)
 
-This document is **authoritative** and is loaded into your context via
-`.claude/rules/frontend.md` whenever you edit files in `app/**` or
-`components/**`. Do NOT skip it. Do NOT invent patterns.
+This document is **authoritative**. Claude Code loads the matching
+gateway summary from `.claude/rules/frontend.md` whenever it edits
+files in `app/**` or `components/**`; general agent guidance in
+`AGENTS.md` also points AI coding agents here. Do NOT skip it. Do NOT
+invent patterns.
 
 When making a UI change:
 
@@ -234,9 +239,10 @@ When making a UI change:
    `pattern-registry.md` first** (with rationale and design review),
    THEN implement in code.
 
-Violations are caught at code review and CI. Merging without
-conformance means rework. See `.claude/rules/frontend.md` for the
-mandatory pattern enforcement summary.
+Violations should be caught at code review. DEBT-398 PR 3 ships the
+regression-test enforcement that will make CI catch new violations
+automatically. See `.claude/rules/frontend.md` for the mandatory
+pattern enforcement summary.
 ```
 
 Pure doc edit. No code changes. The point is to signal to any agent that does find the doc (even without the `.claude/rules/frontend.md` gateway) that it is binding.
@@ -272,7 +278,8 @@ PR 2 done when:
 
 - `docs/frontend/standards.md` has the "For AI Agents" preamble at the top.
 - The preamble is explicit that the doc is authoritative.
-- The preamble references `.claude/rules/frontend.md` as the enforcement layer.
+- The preamble references `.claude/rules/frontend.md` as the shipped path-scoped gateway summary.
+- The preamble accurately states that CI enforcement lands in PR 3, not in PR 2.
 
 PR 3 done when:
 

--- a/docs/frontend/standards.md
+++ b/docs/frontend/standards.md
@@ -10,6 +10,31 @@ Canonical reference for all frontend patterns, component usage, accessibility, a
 - [Contrast Policy](./contrast-policy.md) — Canonical WCAG AA contrast targets and rules
 - [Bookmark Surface Policy](./bookmark-surface-policy.md) — Where bookmark appears/doesn't and why (decision tree for new surfaces)
 
+## For AI Agents (Claude Code, Cursor, Codex, etc.)
+
+This document is **authoritative**. Claude Code loads the matching
+gateway summary from `.claude/rules/frontend.md` whenever it edits
+files in `app/**` or `components/**`; general agent guidance in
+`AGENTS.md` also points AI coding agents here. Do NOT skip it. Do NOT
+invent patterns.
+
+When making a UI change:
+
+1. **Read this document first.** It is the source of truth for tokens,
+   focus rings, spacing, typography, and component-system mandates.
+2. **Check `pattern-registry.md`** for opacity scales, foreground ramps,
+   dark-mode rules.
+3. **Check `contrast-policy.md`** if your change involves foreground or
+   background pair choices.
+4. **If the pattern you need does not exist here, add it to
+   `pattern-registry.md` first** (with rationale and design review),
+   THEN implement in code.
+
+Violations should be caught at code review. DEBT-398 PR 3 ships the
+regression-test enforcement that will make CI catch new violations
+automatically. See `.claude/rules/frontend.md` for the mandatory
+pattern enforcement summary.
+
 ---
 
 ## Table of Contents


### PR DESCRIPTION
## Summary

DEBT-398 PR 2 of 3. Adds a "For AI Agents (Claude Code, Cursor, Codex, etc.)" preamble near the top of `docs/frontend/standards.md` so any agent that opens the doc directly, without going through the `.claude/rules/frontend.md` gateway, sees an immediate signal that the doc is authoritative and binding.

The preamble references the now-shipped `.claude/rules/frontend.md` gateway (DEBT-398 PR 1, merged in #354) and accurately notes that CI enforcement is still pending (lands in DEBT-398 PR 3).

## Content source

The inserted preamble is taken verbatim from `docs/debt/debt-398-design-system-enforcement-gap.md` section "PR 2 — `docs/frontend/standards.md` 'For AI Agents' preamble". The pre-execution audit (commit 35a9a8eb) verified:
- The `.claude/rules/frontend.md` reference matches the now-shipped gateway from PR 1.
- The "Cursor, Codex, etc." reference is scoped correctly (Claude Code is the only agent that loads `.claude/rules/`; AGENTS.md points general agents to standards.md).
- The "violations caught at CI" claim is correctly aspirational (defers to PR 3).
- The insertion point (after See also list, before horizontal rule) matches the current top-of-file structure.

## Test plan

- [x] Local full gate (typecheck / lint / unit / browser / integration / build) — green.
- [x] E2E green: 35/35.
- [x] `grep` confirms preamble headers and DEBT-398 PR 3 reference present in standards.md.
- [x] Existing "See also" list and Table of Contents intact.

## Out of scope

- Enforcement layer (regression test) → DEBT-398 PR 3.
- Other design docs already self-identify as canonical and do not need parallel preambles — verified during PR 2 pre-execution audit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design system standards documentation with enhanced guidelines for AI-assisted development tools.
  * Clarified design system enforcement procedures and validation timeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->