### PR TITLE
Extract focus-ring as Tailwind utility (DEBT-399 PR 1)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -80,6 +80,18 @@
 }
 
 @layer utilities {
+  /* Canonical focus-ring primitives per docs/frontend/standards.md § 3.
+     DEBT-399 PR 1 extracts these so the 26 focus-visible + 1 focus-within
+     inline copies have a single shared source. DEBT-399 PR 2 migrates
+     every site to use these utilities. */
+  .ring-focus {
+    @apply focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px];
+  }
+
+  .ring-focus-within {
+    @apply focus-within:outline-none focus-within:ring-ring/50 focus-within:ring-[3px];
+  }
+
   body {
     font-family: "Manrope", Arial, Helvetica, sans-serif;
   }

--- a/docs/debt/debt-399-component-system-bypass-cleanup.md
+++ b/docs/debt/debt-399-component-system-bypass-cleanup.md
@@ -147,20 +147,25 @@ Add to `app/globals.css`:
   .ring-focus {
     @apply focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px];
   }
+
+  .ring-focus-within {
+    @apply focus-within:outline-none focus-within:ring-ring/50 focus-within:ring-[3px];
+  }
 }
 ```
 
 Then PR 2 can migrate existing call sites to `className="... ring-focus ..."` mechanically.
 
-This PR ONLY adds the `.ring-focus` utility. It does NOT migrate existing sites and does NOT edit `components/theme-token-regression-source-scan.ts` or `components/theme-token-regression.test.tsx`; the DEBT-398 PR 3 enforcement gate covers raw-button and opacity drift, not focus-ring extraction. Existing-site migrations happen in PR 2.
+This PR ONLY adds the `.ring-focus` and `.ring-focus-within` utilities. It does NOT migrate existing sites and does NOT edit `components/theme-token-regression-source-scan.ts` or `components/theme-token-regression.test.tsx`; the DEBT-398 PR 3 enforcement gate covers raw-button and opacity drift, not focus-ring extraction. Existing-site migrations happen in PR 2.
 
-### PR 2 — Migrate the 26 exact inline focus-ring occurrences to the shared utility
+### PR 2 — Migrate the 26 exact focus-visible occurrences plus the 1 focus-within occurrence to shared utilities
 
 Branch: `refactor/debt-399-focus-ring-migration`
 
-Mechanical sweep. For each of the 26 sites across 19 files (run the grep from Finding B for the authoritative list):
+Mechanical sweep. For each of the 26 focus-visible sites across 19 files and the 1 focus-within site in `components/question/choice-button.tsx` (run the grep from Finding B for the authoritative list):
 
 - Replace the literal `focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]` with `ring-focus`.
+- Replace the literal `focus-within:outline-none focus-within:ring-ring/50 focus-within:ring-[3px]` with `ring-focus-within`.
 - Delete the local `focusVisibleRing` const in `components/app-desktop-nav.tsx` once the local usages are migrated.
 
 After the sweep:
@@ -170,6 +175,8 @@ rg -c "focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-
 ```
 
 Should return ZERO (or only the chosen single canonical source).
+
+A grep for the focus-within literal should also return ZERO after `components/question/choice-button.tsx` migrates to `ring-focus-within`.
 
 Full local gate including browser tests. The visual output must be byte-identical — this is pure refactor.
 
@@ -218,7 +225,7 @@ This PR is lower priority — visual divergence is small, but the discipline mat
 
 PR 1 done when:
 
-- A Tailwind utility `.ring-focus` exists in `app/globals.css` and applies the exact canonical focus-ring pattern: `focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]`.
+- Tailwind utilities `.ring-focus` and `.ring-focus-within` exist in `app/globals.css` and apply the exact canonical focus-ring patterns: `focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]` and `focus-within:outline-none focus-within:ring-ring/50 focus-within:ring-[3px]`.
 - The existing `.claude/rules/frontend.md` focus-ring mandate still names the canonical pattern; no rule-file update is required until PR 2 starts migrating usage to `.ring-focus`.
 - The unit / browser tests pass with the utility in place but not yet adopted.
 

--- a/docs/debt/debt-399-component-system-bypass-cleanup.md
+++ b/docs/debt/debt-399-component-system-bypass-cleanup.md
@@ -131,13 +131,16 @@ Ship in four single-concern PRs. Order matters: extract the shared utility FIRST
 
 ### PR 1 — Extract the canonical focus-ring as a shared utility
 
-Branch: `feat/debt-399-focus-ring-utility`
+Branch: `feat/debt-399-pr-1-focus-ring-utility`
 
-Two options for the extraction location; pick one based on the repo's existing pattern:
+Use **Option A: Tailwind layer utility**. The pre-execution audit for this PR verified all of:
 
-**Option A: Tailwind layer utility (feasible in this repo because `app/globals.css` already uses `@layer utilities`; verify with the local gate)**
+- `tailwindcss` and `@tailwindcss/postcss` are pinned to `4.3.0`.
+- `app/globals.css` already uses the Tailwind v4 CSS-first entrypoint (`@import "tailwindcss";`) and an existing `@layer utilities` block.
+- The local Tailwind 4.3 compiler accepts `@apply focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]` inside a custom `.ring-focus` utility.
+- `lib/shared-styles.ts` is also a valid constant-export home, but using a CSS utility is the better fit for a visual design-system primitive and keeps PR 2's migration mechanical (`className="... ring-focus ..."`).
 
-Add to `app/globals.css` (or wherever the Tailwind layers are defined):
+Add to `app/globals.css`:
 
 ```css
 @layer utilities {
@@ -147,26 +150,9 @@ Add to `app/globals.css` (or wherever the Tailwind layers are defined):
 }
 ```
 
-Then `className="... ring-focus ..."` everywhere.
+Then PR 2 can migrate existing call sites to `className="... ring-focus ..."` mechanically.
 
-**Option B: Shared constant in `lib/shared-styles.ts`**
-
-If `lib/shared-styles.ts` is the established home (verify against `lib/shared-styles.ts` and `components/app-desktop-nav.tsx:10-11` precedent):
-
-```typescript
-export const focusVisibleRing =
-  'focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]';
-
-// Variant for focus-within (rare; used by choice-button)
-export const focusWithinRing =
-  'focus-within:outline-none focus-within:ring-ring/50 focus-within:ring-[3px]';
-```
-
-Then `className={cn(focusVisibleRing, ...)}`.
-
-Pick ONE option (recommend Option A if the local Tailwind v4/PostCSS pipeline accepts the custom utility cleanly, otherwise Option B). Document the chosen approach in the PR body.
-
-This PR ONLY adds the utility / constant. Does NOT migrate existing sites. Migrations happen in PR 2.
+This PR ONLY adds the `.ring-focus` utility. It does NOT migrate existing sites and does NOT edit `components/theme-token-regression-source-scan.ts` or `components/theme-token-regression.test.tsx`; the DEBT-398 PR 3 enforcement gate covers raw-button and opacity drift, not focus-ring extraction. Existing-site migrations happen in PR 2.
 
 ### PR 2 — Migrate the 26 exact inline focus-ring occurrences to the shared utility
 
@@ -174,8 +160,8 @@ Branch: `refactor/debt-399-focus-ring-migration`
 
 Mechanical sweep. For each of the 26 sites across 19 files (run the grep from Finding B for the authoritative list):
 
-- Replace the literal `focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]` with `ring-focus` (Option A) or `cn(focusVisibleRing, ...)` (Option B).
-- Delete the local `focusVisibleRing` const in `components/app-desktop-nav.tsx` and replace with imports.
+- Replace the literal `focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]` with `ring-focus`.
+- Delete the local `focusVisibleRing` const in `components/app-desktop-nav.tsx` once the local usages are migrated.
 
 After the sweep:
 
@@ -232,7 +218,8 @@ This PR is lower priority — visual divergence is small, but the discipline mat
 
 PR 1 done when:
 
-- Either a Tailwind utility `.ring-focus` exists OR a `focusVisibleRing` constant exists in `lib/shared-styles.ts` (chosen approach documented).
+- A Tailwind utility `.ring-focus` exists in `app/globals.css` and applies the exact canonical focus-ring pattern: `focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]`.
+- The existing `.claude/rules/frontend.md` focus-ring mandate still names the canonical pattern; no rule-file update is required until PR 2 starts migrating usage to `.ring-focus`.
 - The unit / browser tests pass with the utility in place but not yet adopted.
 
 PR 2 done when:


### PR DESCRIPTION
## Summary

DEBT-399 PR 1 of 4. Adds canonical focus-ring as Tailwind `@layer utilities` primitives in `app/globals.css`:

- `.ring-focus` — for focus-visible interactive elements (26 sites across 19 files use the inline pattern today)
- `.ring-focus-within` — for focus-within container elements (1 site in `components/question/choice-button.tsx` uses the inline pattern today)

This PR ONLY adds the utilities. The 27 existing inline copies are NOT migrated in this PR — that's DEBT-399 PR 2's mechanical sweep.

## Source

Implementation follows the pre-execution audited DEBT-399 § "PR 1 — Extract the canonical focus-ring as a shared utility" (audit commit `63d27dc2`). The audit committed Option A (Tailwind utility) over Option B (shared constant) because focus-rings are design-system primitives that belong in the CSS layer, not in JS.

Small audit-extension: the audit explicitly committed `.ring-focus` (focus-visible only). Execution adds `.ring-focus-within` as the sibling because the codebase has 1 focus-within consumer and shipping the pair together makes PR 2's migration complete instead of leaving 1 orphan.

## Verification

- [x] Tailwind v4 compiler accepts the `@apply` snippet for both utilities (`pnpm build` passes).
- [x] `rg "\\bring-focus\\b|ring-focus-within" app/ components/ --glob '*.tsx' --glob '*.ts' --glob '*.css'` returns only the `app/globals.css` definitions (zero consumer usage — PR 1 scope preserved).
- [x] DEBT-398 PR 3 regression test still passes (no consumer code changed).
- [x] Full local gate green.
- [x] E2E green: 35/35 passed.

## Out of scope

- Migration of the 27 inline sites → DEBT-399 PR 2.
- Raw `<button>` → `<Button>` migrations → DEBT-399 PR 3.
- Dark-mode opacity alignment → DEBT-399 PR 4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added globally available CSS utilities for consistent focus-state styling, including focus-visible and focus-within ring behavior with unified color and thickness.

* **Documentation**
  * Clarified design/implementation approach, PR sequencing, and acceptance criteria for the component-system focus-ring rollout, tightening guardrails for incremental changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->