### PR TITLE
Migrate inline focus-ring sites to .ring-focus utility (DEBT-399 PR 2)

### DIFF
--- a/app/(app)/app/bookmarks/page.test.tsx
+++ b/app/(app)/app/bookmarks/page.test.tsx
@@ -301,9 +301,7 @@ describe('app/(app)/app/bookmarks', () => {
     expect(bookmarkRowTokens.has('dark:border-foreground/40')).toBe(false);
     expect(reviewLink).not.toBeUndefined();
     expect(reviewLinkTokens.has('hover:underline')).toBe(false);
-    expect(reviewLinkTokens.has('focus-visible:outline-none')).toBe(true);
-    expect(reviewLinkTokens.has('focus-visible:ring-ring/50')).toBe(true);
-    expect(reviewLinkTokens.has('focus-visible:ring-[3px]')).toBe(true);
+    expect(reviewLinkTokens.has('ring-focus')).toBe(true);
     expect(removeButtonTokens.has('rounded-full')).toBe(true);
   });
 

--- a/app/(app)/app/bookmarks/page.tsx
+++ b/app/(app)/app/bookmarks/page.tsx
@@ -147,7 +147,7 @@ export function BookmarksView({ rows }: { rows: GetBookmarksOutput['rows'] }) {
                         <div className="text-sm font-medium text-foreground">
                           <Link
                             href={reviewHref}
-                            className="rounded-sm focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+                            className="rounded-sm ring-focus"
                           >
                             {getStemPreview(row.stemMd, 80)}
                           </Link>

--- a/app/(app)/app/dashboard/page.tsx
+++ b/app/(app)/app/dashboard/page.tsx
@@ -152,7 +152,7 @@ export function DashboardView({
                   <li key={row.sessionId}>
                     <Link
                       href={sessionReviewHref}
-                      className="block rounded-xl bg-foreground/5 p-3 transition-colors hover:bg-foreground/[0.08] focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+                      className="block rounded-xl bg-foreground/5 p-3 transition-colors hover:bg-foreground/[0.08] ring-focus"
                     >
                       <div className="flex items-center justify-between gap-2">
                         <span className="inline-flex items-center rounded-full border-0 bg-foreground/[0.06] px-2 py-0.5 text-xs font-medium text-foreground/60">
@@ -230,7 +230,7 @@ export function DashboardView({
                         mode: 'review',
                         attemptId: row.attemptId,
                       })}
-                      className="block rounded-xl bg-foreground/5 p-3 transition-colors hover:bg-foreground/[0.08] focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+                      className="block rounded-xl bg-foreground/5 p-3 transition-colors hover:bg-foreground/[0.08] ring-focus"
                     >
                       <div className="flex items-start justify-between gap-3">
                         <span className="min-w-0 flex-1 text-sm font-medium text-foreground">

--- a/app/(app)/app/history/components/history-questions-tab.test.tsx
+++ b/app/(app)/app/history/components/history-questions-tab.test.tsx
@@ -166,7 +166,7 @@ describe('HistoryQuestionsTab', () => {
       expect(classTokens).toContain('transition-colors');
       expect(classTokens).toContain('hover:bg-foreground/[0.12]');
       expect(classTokens).not.toContain('hover:bg-foreground/[0.08]');
-      expect(classTokens).toContain('focus-visible:ring-[3px]');
+      expect(classTokens).toContain('ring-focus');
       expect(classTokens).not.toContain('border');
       expect(classTokens).not.toContain('border-border');
       expect(classTokens).not.toContain('shadow-sm');

--- a/app/(app)/app/history/components/history-questions-tab.tsx
+++ b/app/(app)/app/history/components/history-questions-tab.tsx
@@ -499,7 +499,7 @@ export function HistoryQuestionsTab({
                 <li key={row.questionId}>
                   <Link
                     href={href}
-                    className="block rounded-2xl bg-foreground/[0.08] p-4 transition-colors hover:bg-foreground/[0.12] focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+                    className="block rounded-2xl bg-foreground/[0.08] p-4 transition-colors hover:bg-foreground/[0.12] ring-focus"
                   >
                     <div className="space-y-2">
                       <span className="text-sm font-medium text-foreground">

--- a/app/(app)/app/history/components/history-sessions-tab.test.tsx
+++ b/app/(app)/app/history/components/history-sessions-tab.test.tsx
@@ -265,8 +265,7 @@ describe('HistorySessionsTab', () => {
     expect(reviewLinkClassTokens.has('rounded-md')).toBe(true);
     expect(reviewLinkClassTokens.has('text-sm')).toBe(true);
     expect(reviewLinkClassTokens.has('text-foreground')).toBe(true);
-    expect(reviewLinkClassTokens.has('focus-visible:ring-[3px]')).toBe(true);
-    expect(reviewLinkClassTokens.has('focus-visible:ring-ring/50')).toBe(true);
+    expect(reviewLinkClassTokens.has('ring-focus')).toBe(true);
     expect(reviewLinkClassTokens.has('hover:underline')).toBe(false);
     expect(reviewLinkClassTokens.has('transition-colors')).toBe(false);
     expect(html).toContain('data-session-summary-content="true"');
@@ -394,8 +393,7 @@ describe('HistorySessionsTab', () => {
     expect(toggle?.textContent).toBe('');
     expect(toggleClassTokens.has('rounded-full')).toBe(false);
     expect(toggleClassTokens.has('border')).toBe(false);
-    expect(toggleClassTokens.has('focus-visible:ring-[3px]')).toBe(true);
-    expect(toggleClassTokens.has('focus-visible:ring-ring/50')).toBe(true);
+    expect(toggleClassTokens.has('ring-focus')).toBe(true);
     expect(icon).not.toBeNull();
     expect(iconClassTokens.has('size-4')).toBe(true);
     expect(iconClassTokens.has('text-foreground/60')).toBe(true);

--- a/app/(app)/app/history/components/history-sessions-tab.tsx
+++ b/app/(app)/app/history/components/history-sessions-tab.tsx
@@ -202,7 +202,7 @@ export function HistorySessionsTab({
                 {sessionReviewHref ? (
                   <Link
                     href={sessionReviewHref}
-                    className="rounded-md text-sm text-foreground focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+                    className="rounded-md text-sm text-foreground ring-focus"
                   >
                     <SessionSummaryContent
                       mode={row.mode}
@@ -225,7 +225,7 @@ export function HistorySessionsTab({
                 )}
                 <button
                   type="button"
-                  className="shrink-0 rounded-md p-1 focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+                  className="shrink-0 rounded-md p-1 ring-focus"
                   aria-label={`${isSelected ? 'Hide' : 'View'} breakdown for ${sessionSummary}`}
                   aria-expanded={isSelected}
                   aria-controls={`breakdown-${row.sessionId}`}

--- a/app/(app)/app/layout.tsx
+++ b/app/(app)/app/layout.tsx
@@ -67,7 +67,7 @@ export function AppLayoutShell({
           <div className="flex items-center gap-6">
             <Link
               href={ROUTES.APP_DASHBOARD}
-              className="rounded-md text-base font-bold font-heading whitespace-nowrap text-foreground transition-colors hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+              className="rounded-md text-base font-bold font-heading whitespace-nowrap text-foreground transition-colors hover:text-foreground/80 ring-focus"
             >
               Addiction Boards
             </Link>

--- a/app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx
@@ -215,7 +215,7 @@ export function ExamReviewView({
                   type="button"
                   className={cn(
                     'bg-card text-card-foreground block w-full rounded-2xl border p-4 text-left shadow-sm transition-colors',
-                    'hover:bg-muted/20 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+                    'hover:bg-muted/20 focus-visible:border-ring ring-focus',
                   )}
                   onClick={() => onOpenQuestion(row.questionId)}
                 >

--- a/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx
@@ -94,13 +94,12 @@ describe('PostExamReviewView', () => {
     expect(panel?.tagName).toBe('SECTION');
   });
 
-  it('applies the repo-standard focus-visible ring classes to the review panel', () => {
+  it('applies the repo-standard focus-ring utility to the review panel', () => {
     const doc = renderView();
     const panel = doc.querySelector('#practice-question-panel');
     const className = panel?.getAttribute('class') ?? '';
 
-    expect(className).toContain('focus-visible:ring-ring/50');
-    expect(className).toContain('focus-visible:ring-[3px]');
+    expect(className).toContain('ring-focus');
   });
 
   it('keeps the review panel programmatically focusable with tabIndex -1', () => {

--- a/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx
@@ -107,7 +107,7 @@ export function PostExamReviewView({
           ref={panelRef}
           id={controlledPanelId}
           aria-label={`Question ${currentRow.order} of ${review.totalCount}`}
-          className="space-y-6 outline-none focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+          className="space-y-6 outline-none ring-focus"
           tabIndex={-1}
         >
           <p className="text-sm text-muted-foreground">

--- a/app/(app)/app/practice/components/practice-view.tsx
+++ b/app/(app)/app/practice/components/practice-view.tsx
@@ -425,7 +425,7 @@ export function PracticeView(props: PracticeViewProps) {
         data-testid="active-question-panel"
         aria-labelledby={questionPanelLabelledBy}
         tabIndex={-1}
-        className="space-y-6 outline-none focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+        className="space-y-6 outline-none ring-focus"
       >
         {props.loadState.status === 'error' ? (
           <ErrorCard>

--- a/app/(app)/app/questions/[slug]/question-page-client.tsx
+++ b/app/(app)/app/questions/[slug]/question-page-client.tsx
@@ -260,7 +260,7 @@ export function QuestionView(props: QuestionViewProps) {
         {shouldShowTopBackLink ? (
           <Link
             href={originUi.backHref}
-            className="rounded-md text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+            className="rounded-md text-sm font-medium text-muted-foreground transition-colors hover:text-foreground ring-focus"
           >
             {originUi.backLabel}
           </Link>

--- a/app/(app)/app/shared/components/session-breakdown-list.tsx
+++ b/app/(app)/app/shared/components/session-breakdown-list.tsx
@@ -38,7 +38,7 @@ export function SessionBreakdownList({
           {row.isAvailable && onOpenQuestion ? (
             <button
               type="button"
-              className="-mx-2 flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 text-left font-medium text-foreground transition-colors hover:bg-muted/20 focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50"
+              className="-mx-2 flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 text-left font-medium text-foreground transition-colors hover:bg-muted/20 ring-focus disabled:pointer-events-none disabled:opacity-50"
               disabled={isQuestionActionPending}
               onClick={() => onOpenQuestion(row.questionId)}
             >
@@ -55,7 +55,7 @@ export function SessionBreakdownList({
                 sessionId,
                 historyHref,
               })}
-              className="-mx-2 flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 font-medium text-foreground transition-colors hover:bg-muted/20 focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+              className="-mx-2 flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 font-medium text-foreground transition-colors hover:bg-muted/20 ring-focus"
             >
               <span className="shrink-0">{row.order}.</span>
               <span className="truncate">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -47,10 +47,7 @@ export function RootProvidersShell({
 function RootContentShell({ children }: { children: React.ReactNode }) {
   return (
     <>
-      <a
-        href="#main-content"
-        className="sr-only focus:not-sr-only focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
-      >
+      <a href="#main-content" className="sr-only focus:not-sr-only ring-focus">
         Skip to content
       </a>
       {children}

--- a/app/pricing/pricing-view-skeleton.tsx
+++ b/app/pricing/pricing-view-skeleton.tsx
@@ -76,7 +76,7 @@ export async function PricingViewSkeleton() {
         <div className="mt-8 text-center">
           <Link
             href={ROUTES.HOME}
-            className="rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+            className="rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground ring-focus"
           >
             Back to Home
           </Link>

--- a/app/pricing/pricing-view.tsx
+++ b/app/pricing/pricing-view.tsx
@@ -71,7 +71,7 @@ export function PricingView({
               ) : null}
               <Link
                 href={ROUTES.PRICING}
-                className="ml-4 rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+                className="ml-4 rounded-md text-muted-foreground transition-colors hover:text-foreground ring-focus"
                 aria-label="Dismiss"
               >
                 ×
@@ -183,7 +183,7 @@ export function PricingView({
         <div className="mt-8 text-center">
           <Link
             href={ROUTES.HOME}
-            className="rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+            className="rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground ring-focus"
           >
             Back to Home
           </Link>

--- a/components/app-desktop-nav.tsx
+++ b/components/app-desktop-nav.tsx
@@ -7,9 +7,6 @@ import {
   getActiveAppNavItemHref,
 } from '@/components/app-nav-items';
 
-const focusVisibleRing =
-  'focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]';
-
 export function AppDesktopNav() {
   const activeHref = getActiveAppNavItemHref(usePathname());
 
@@ -27,8 +24,8 @@ export function AppDesktopNav() {
             aria-current={isActive ? 'page' : undefined}
             className={
               isActive
-                ? `rounded-md whitespace-nowrap text-foreground font-medium ${focusVisibleRing}`
-                : `rounded-md whitespace-nowrap text-muted-foreground transition-colors hover:text-foreground ${focusVisibleRing}`
+                ? 'rounded-md whitespace-nowrap text-foreground font-medium ring-focus'
+                : 'rounded-md whitespace-nowrap text-muted-foreground transition-colors hover:text-foreground ring-focus'
             }
           >
             {item.label}

--- a/components/auth-nav.tsx
+++ b/components/auth-nav.tsx
@@ -66,7 +66,7 @@ export async function AuthNav({
       {primaryLink ? (
         <Link
           href={primaryLink.href}
-          className="rounded-md text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+          className="rounded-md text-sm font-medium text-muted-foreground transition-colors hover:text-foreground ring-focus"
         >
           {primaryLink.label}
         </Link>

--- a/components/marketing/marketing-layout.tsx
+++ b/components/marketing/marketing-layout.tsx
@@ -12,7 +12,7 @@ export type MarketingLayoutProps = {
 };
 
 const marketingNavLinkClass =
-  'rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]';
+  'rounded-md text-muted-foreground transition-colors hover:text-foreground ring-focus';
 
 async function DeferredAuthNav() {
   return <AuthNav />;
@@ -26,7 +26,7 @@ async function MarketingHeaderPrimaryNav({
   'use cache';
 
   const brandLinkClass =
-    'rounded-md text-base font-bold font-heading whitespace-nowrap text-foreground transition-colors hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]';
+    'rounded-md text-base font-bold font-heading whitespace-nowrap text-foreground transition-colors hover:text-foreground/80 ring-focus';
 
   return (
     <div className="flex items-center gap-6">

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -71,8 +71,8 @@ function MobileNavLinks({
             aria-current={isActive ? 'page' : undefined}
             className={
               isActive
-                ? 'block rounded-md bg-muted px-3 py-3 text-sm font-medium text-foreground focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]'
-                : 'block rounded-md px-3 py-3 text-sm text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]'
+                ? 'block rounded-md bg-muted px-3 py-3 text-sm font-medium text-foreground ring-focus'
+                : 'block rounded-md px-3 py-3 text-sm text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground ring-focus'
             }
             onClick={onClose}
           >
@@ -108,7 +108,7 @@ export function MobileNav() {
         ref={buttonRef}
         type="button"
         onClick={onToggleOpen}
-        className="p-2.5 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+        className="p-2.5 text-muted-foreground transition-colors hover:text-foreground ring-focus"
         aria-label={isOpen ? 'Close navigation menu' : 'Open navigation menu'}
         aria-expanded={isOpen}
         aria-controls={navId}

--- a/components/question/choice-button.tsx
+++ b/components/question/choice-button.tsx
@@ -29,7 +29,7 @@ export function ChoiceButton({
   return (
     <label
       className={cn(
-        'block w-full rounded-xl border border-foreground/50 bg-background/50 p-4 text-left shadow-sm transition-colors focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]',
+        'block w-full rounded-xl border border-foreground/50 bg-background/50 p-4 text-left shadow-sm transition-colors focus-within:border-ring ring-focus-within',
         !hasVerdict &&
           !selected &&
           'dark:border-foreground/40 dark:bg-background/50',

--- a/components/ui/filter-chip.test.tsx
+++ b/components/ui/filter-chip.test.tsx
@@ -44,7 +44,7 @@ describe('FilterChip', () => {
     expect(classTokens.has('rounded-full')).toBe(false);
     expect(classTokens.has('border')).toBe(false);
     expect(classTokens.has('focus-visible:border-ring')).toBe(false);
-    expect(classTokens.has('focus-visible:outline-none')).toBe(true);
+    expect(classTokens.has('ring-focus')).toBe(true);
     expect(classTokens.has('outline-none')).toBe(false);
     expect(classTokens.has('border-primary')).toBe(false);
     expect(classTokens.has('text-sm')).toBe(true);
@@ -66,10 +66,8 @@ describe('FilterChip', () => {
     expect(classTokens.has('rounded-full')).toBe(false);
     expect(classTokens.has('border')).toBe(false);
     expect(classTokens.has('focus-visible:border-ring')).toBe(false);
-    expect(classTokens.has('focus-visible:outline-none')).toBe(true);
+    expect(classTokens.has('ring-focus')).toBe(true);
     expect(classTokens.has('outline-none')).toBe(false);
-    expect(classTokens.has('focus-visible:ring-ring/50')).toBe(true);
-    expect(classTokens.has('focus-visible:ring-[3px]')).toBe(true);
     expect(classTokens.has('text-sm')).toBe(true);
     expect(classTokens.has('font-medium')).toBe(true);
     expect(classTokens.has('bg-primary')).toBe(false);

--- a/components/ui/filter-chip.tsx
+++ b/components/ui/filter-chip.tsx
@@ -21,7 +21,7 @@ export function FilterChip({
       onClick={onClick}
       className={cn(
         'inline-flex cursor-pointer items-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
-        'focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'ring-focus',
         'disabled:pointer-events-none disabled:opacity-50',
         selected
           ? 'bg-primary text-primary-foreground'

--- a/components/ui/tab-switch-styles.test.ts
+++ b/components/ui/tab-switch-styles.test.ts
@@ -33,7 +33,7 @@ describe('tab-switch-styles', () => {
 
   it('defines the canonical base classes', () => {
     expect(tabSwitchItemBaseClasses).toContain('rounded-md');
-    expect(tabSwitchItemBaseClasses).toContain('focus-visible');
+    expect(tabSwitchItemBaseClasses).toContain('ring-focus');
     expect(tabSwitchItemBaseClasses).toContain('py-2');
   });
 

--- a/components/ui/tab-switch-styles.ts
+++ b/components/ui/tab-switch-styles.ts
@@ -13,7 +13,7 @@ export const tabSwitchContainerClasses = compactControlShellClasses;
 
 /** Base classes for each tab item (active or inactive). */
 export const tabSwitchItemBaseClasses =
-  'rounded-md px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]';
+  'rounded-md px-4 py-2 text-sm font-medium transition-colors ring-focus';
 
 /** Additional classes for the active/selected tab item. */
 export const tabSwitchItemActiveClasses =

--- a/docs/debt/debt-399-component-system-bypass-cleanup.md
+++ b/docs/debt/debt-399-component-system-bypass-cleanup.md
@@ -203,7 +203,7 @@ rg -c "focus-within:ring-ring/50 focus-within:ring-\[3px\]" app/ components/ -g 
 rg -n "focusVisibleRing" app/ components/
 ```
 
-Each command should return ZERO. An unscoped grep over `app/` and `components/` will still find `app/globals.css`, because PR 1 intentionally made that the canonical `@apply` source.
+Each command should return ZERO. A grep without file-type filters over `app/` and `components/` will still find `app/globals.css`, because PR 1 intentionally made that the canonical `@apply` source.
 
 Full local gate including browser tests. The visual output must be equivalent to pre-PR — this is pure refactor. Confirm with `pnpm build`; if Tailwind emits unexpected CSS differences beyond using the already-defined `.ring-focus` / `.ring-focus-within` utilities, stop and investigate before pushing.
 
@@ -258,7 +258,7 @@ PR 1 done when:
 
 PR 2 done when:
 
-- A `.tsx` / `.ts` grep of `app/` and `components/` for the literal canonical focus-ring string returns ZERO sites; an unscoped grep may still find the single canonical source in `app/globals.css`.
+- A `.tsx` / `.ts` grep of `app/` and `components/` for the literal canonical focus-ring string returns ZERO sites; a grep without file-type filters may still find the single canonical source in `app/globals.css`.
 - A `.tsx` / `.ts` grep for `focus-within:ring-ring/50 focus-within:ring-[3px]` returns ZERO sites after `components/question/choice-button.tsx` migrates to `focus-within:border-ring ring-focus-within`.
 - `rg -n "focusVisibleRing" app/ components/` returns ZERO after the local `components/app-desktop-nav.tsx` constant is deleted.
 - The visual output is equivalent to pre-PR (no design regressions).

--- a/docs/debt/debt-399-component-system-bypass-cleanup.md
+++ b/docs/debt/debt-399-component-system-bypass-cleanup.md
@@ -289,6 +289,6 @@ All four PRs independently revertable.
 
 ## Done When
 
-All four PRs merged to `dev` and synced to `main`. The grep for `focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-\[3px\]` returns one canonical source (or zero if the Tailwind utility approach). Raw `<button>` count outside `components/ui/` and registry-documented exceptions is zero. Dark-mode opacities align with `pattern-registry.md` § 1.3 or are documented as new registry entries. DEBT-399 doc archived to `docs/_archive/debt/` with resolution paragraph naming all four PRs.
+All four PRs merged to `dev` and synced to `main`. The grep for `focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-\[3px\]` returns one canonical source in `app/globals.css`, and a `.tsx` / `.ts` grep of `app/` and `components/` returns zero usage sites. Raw `<button>` count outside `components/ui/` and registry-documented exceptions is zero. Dark-mode opacities align with `pattern-registry.md` § 1.3 or are documented as new registry entries. DEBT-399 doc archived to `docs/_archive/debt/` with resolution paragraph naming all four PRs.
 
 Combined with DEBT-398's enforcement layer, the design system is now both documented AND enforced — future drift gets caught at lint / CI time rather than accumulating until the next manual audit.

--- a/docs/debt/debt-399-component-system-bypass-cleanup.md
+++ b/docs/debt/debt-399-component-system-bypass-cleanup.md
@@ -160,25 +160,52 @@ This PR ONLY adds the `.ring-focus` and `.ring-focus-within` utilities. It does 
 
 ### PR 2 — Migrate the 26 exact focus-visible occurrences plus the 1 focus-within occurrence to shared utilities
 
-Branch: `refactor/debt-399-focus-ring-migration`
+Branch: `feat/debt-399-pr-2-focus-ring-migration`
 
-Mechanical sweep. For each of the 26 focus-visible sites across 19 files and the 1 focus-within site in `components/question/choice-button.tsx` (run the grep from Finding B for the authoritative list):
+Mechanical sweep. The pre-execution audit for this PR re-verified the current ledger after PR 1 landed:
+
+- 26 exact `focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]` code occurrences across 19 `.tsx` / `.ts` files.
+- 1 `focus-within` ring-pair occurrence in `components/question/choice-button.tsx`; it is not the exact `.ring-focus-within` source string because it currently preserves `focus-within:border-ring`.
+- 1 local `focusVisibleRing` constant declaration plus 2 local usages in `components/app-desktop-nav.tsx`.
+
+For the 26 focus-visible sites across 19 files (run the grep from Finding B with `--glob "*.tsx" --glob "*.ts"` for the authoritative list):
 
 - Replace the literal `focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]` with `ring-focus`.
-- Replace the literal `focus-within:outline-none focus-within:ring-ring/50 focus-within:ring-[3px]` with `ring-focus-within`.
-- Delete the local `focusVisibleRing` const in `components/app-desktop-nav.tsx` once the local usages are migrated.
+- In `components/question/choice-button.tsx`, replace only the literal `focus-within:ring-ring/50 focus-within:ring-[3px]` pair with `ring-focus-within` and keep the existing `focus-within:border-ring` token.
+- In `components/app-desktop-nav.tsx`, replace the two `${focusVisibleRing}` template interpolations with the literal `ring-focus` class and delete the local `focusVisibleRing` constant declaration.
+
+Suggested mechanical commands after reviewing the diff target list:
+
+```sh
+rg -l 'focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-\[3px\]' app/ components/ --glob '*.tsx' --glob '*.ts' |
+  while IFS= read -r file; do
+    perl -0pi -e 's|focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-\[3px\]|ring-focus|g' "$file"
+  done
+perl -0pi -e 's|focus-within:ring-ring/50 focus-within:ring-\[3px\]|ring-focus-within|g' components/question/choice-button.tsx
+```
+
+Then manually clean up `components/app-desktop-nav.tsx` so the active and inactive `Link` className strings contain `ring-focus` directly and the now-unused `focusVisibleRing` constant is gone.
+
+Do **not** migrate the broader-but-not-exact focus-ring family in this PR. Those sites are intentionally out of scope because they are shadcn primitives, current-selection rings, or alternate focus treatments rather than the exact canonical copy-paste:
+
+- `components/ui/button.tsx`
+- `components/ui/input.tsx`
+- `components/ui/select.tsx`
+- `app/(app)/app/questions/[slug]/components/review-question-navigator.tsx`
+- `app/(app)/app/practice/components/practice-session-starter.tsx`
+- `app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx:94`
 
 After the sweep:
 
 ```sh
 rg -c "focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-\[3px\]" app/ components/ -g "*.tsx" -g "*.ts"
+rg -c "focus-within:ring-ring/50 focus-within:ring-\[3px\]" app/ components/ -g "*.tsx" -g "*.ts"
+rg -n "focusVisibleRing" app/ components/
 ```
 
-Should return ZERO (or only the chosen single canonical source).
+Each command should return ZERO. An unscoped grep over `app/` and `components/` will still find `app/globals.css`, because PR 1 intentionally made that the canonical `@apply` source.
 
-A grep for the focus-within literal should also return ZERO after `components/question/choice-button.tsx` migrates to `ring-focus-within`.
-
-Full local gate including browser tests. The visual output must be byte-identical — this is pure refactor.
+Full local gate including browser tests. The visual output must be equivalent to pre-PR — this is pure refactor. Confirm with `pnpm build`; if Tailwind emits unexpected CSS differences beyond using the already-defined `.ring-focus` / `.ring-focus-within` utilities, stop and investigate before pushing.
 
 ### PR 3 — Refactor the raw `<button>` bypasses and resolve the history disclosure toggle
 
@@ -231,8 +258,10 @@ PR 1 done when:
 
 PR 2 done when:
 
-- A grep of `app/` and `components/` for the literal canonical focus-ring string returns ZERO sites (or only the single canonical source).
-- The visual output is byte-identical to pre-PR (no design regressions).
+- A `.tsx` / `.ts` grep of `app/` and `components/` for the literal canonical focus-ring string returns ZERO sites; an unscoped grep may still find the single canonical source in `app/globals.css`.
+- A `.tsx` / `.ts` grep for `focus-within:ring-ring/50 focus-within:ring-[3px]` returns ZERO sites after `components/question/choice-button.tsx` migrates to `focus-within:border-ring ring-focus-within`.
+- `rg -n "focusVisibleRing" app/ components/` returns ZERO after the local `components/app-desktop-nav.tsx` constant is deleted.
+- The visual output is equivalent to pre-PR (no design regressions).
 - Full local gate green including `pnpm test:browser`.
 
 PR 3 done when:


### PR DESCRIPTION
Summary

DEBT-399 PR 2 of 4. Mechanical migration sweep that converts all inline canonical focus-ring copies to use the .ring-focus and .ring-focus-within utilities shipped in PR 1 (#357, commit 90608878).

Three migrations bundled in one PR (all mechanical, all co-dependent on the PR 1 utilities):

1. 26 focus-visible inline copies -> .ring-focus across 19 files.
2. 1 focus-within ring-pair site -> .ring-focus-within in components/question/choice-button.tsx. Note: applying the utility adds focus-within:outline-none (canonical per standards.md § 3); the prior inline form omitted that directive.
3. focusVisibleRing constant deletion in components/app-desktop-nav.tsx:10-11 + 2 in-file usages replaced with .ring-focus.

Source

Implementation follows the pre-execution audited DEBT-399 PR 2 recipe (audit commit 0a838640). The audit verified:
- Site count (26 focus-visible / 1 focus-within / 3 focusVisibleRing matches = 1 declaration + 2 usages).
- Sed/perl replacement verified clean on representative sites.
- Out-of-scope broader-but-not-exact variant family (6 sites) is intentionally not touched.

Verification

- [x] rg returns ZERO matches for the canonical inline focus-ring string in app/ and components/ TSX/TS source; only app/globals.css retains the literal as the utility definition.
- [x] rg returns ZERO matches for focusVisibleRing anywhere.
- [x] Tailwind pnpm build succeeds (utility compiles cleanly).
- [x] DEBT-398 PR 3 regression test still passes 16/16.
- [x] Full local gate green.
- [x] E2E green: 35/35 passed.

Out of scope

Per the audit, the broader 33-instance variant family is NOT migrated in this PR:

- components/ui/button.tsx
- components/ui/input.tsx
- components/ui/select.tsx
- app/(app)/app/questions/[slug]/components/review-question-navigator.tsx
- app/(app)/app/practice/components/practice-session-starter.tsx
- app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx:94 (alternate ordering)

These either belong to shadcn primitives (which manage their own focus styles) or use alternate orderings that don't match the canonical exact pattern. A separate small follow-up could address them if desired; not blocking DEBT-399.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized keyboard and focus-within indicators across interactive elements to use a single shared CSS utility, unifying focus visuals throughout the app.

* **Tests**
  * Updated tests to assert the new shared focus styling.

* **Documentation**
  * Expanded the migration guide with step-by-step migration, validation checks, and updated completion criteria for the focus-styling consolidation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->