### PR TITLE
Align dark-mode opacity divergences to Pattern Registry (DEBT-399 PR 4 / final)

### DIFF
--- a/app/(app)/app/history/components/history-sessions-tab.test.tsx
+++ b/app/(app)/app/history/components/history-sessions-tab.test.tsx
@@ -483,8 +483,8 @@ describe('HistorySessionsTab', () => {
     expect(panelClassTokens.has('mt-3')).toBe(true);
     expect(panelClassTokens.has('pt-3')).toBe(true);
     expect(panelClassTokens.has('border-t')).toBe(true);
-    expect(panelClassTokens.has('border-border/30')).toBe(true);
-    expect(panelClassTokens.has('dark:border-foreground/10')).toBe(true);
+    expect(panelClassTokens.has('border-border/40')).toBe(true);
+    expect(panelClassTokens.has('dark:border-foreground/40')).toBe(true);
     expect(panelClassTokens.has('bg-background')).toBe(false);
     expect(panelClassTokens.has('rounded-lg')).toBe(false);
     expect(toggle?.getAttribute('aria-expanded')).toBe('true');

--- a/app/(app)/app/history/components/history-sessions-tab.tsx
+++ b/app/(app)/app/history/components/history-sessions-tab.tsx
@@ -257,7 +257,7 @@ export function HistorySessionsTab({
                   role="region"
                   aria-label="Question breakdown"
                   data-session-breakdown-region="true"
-                  className="mt-3 border-t border-border/30 pt-3 dark:border-foreground/10"
+                  className="mt-3 border-t border-border/40 pt-3 dark:border-foreground/40"
                 >
                   {historySessions.reviewLoadState.status === 'loading' ? (
                     <output

--- a/app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx
@@ -35,10 +35,10 @@ type NavigatorReview =
   | GetPracticeSessionReviewOutput
   | GetCompletedSessionQuestionsWithFeedbackOutput;
 
-// Transitional DEBT-399 PR 3 card-row styling. PR 4 owns the /20
-// hover-opacity alignment before this can promote into a Button variant.
+// Keep the card-row surface pinned while using the in-card muted hover
+// from Pattern Registry section 1.2.
 const examReviewRowButtonClasses =
-  'block h-auto w-full shrink whitespace-normal rounded-2xl border bg-card p-4 text-left font-normal text-card-foreground shadow-sm hover:bg-muted/20 hover:text-card-foreground';
+  'block h-auto w-full shrink whitespace-normal rounded-2xl border bg-card p-4 text-left font-normal text-card-foreground shadow-sm hover:bg-muted/40 hover:text-card-foreground';
 
 export function QuestionNavigator({
   review,

--- a/app/(app)/app/shared/components/session-breakdown-list.test.tsx
+++ b/app/(app)/app/shared/components/session-breakdown-list.test.tsx
@@ -248,7 +248,7 @@ describe('SessionBreakdownList', () => {
     expect(link).not.toBeNull();
     const linkTokens = getClassTokens(link?.getAttribute('class') ?? '');
 
-    expect(linkTokens.has('hover:bg-muted/20')).toBe(true);
+    expect(linkTokens.has('hover:bg-muted/50')).toBe(true);
     expect(linkTokens.has('hover:underline')).toBe(false);
   });
 
@@ -269,7 +269,7 @@ describe('SessionBreakdownList', () => {
     const listTokens = getClassTokens(list?.getAttribute('class') ?? '');
 
     expect(listTokens.has('divide-y')).toBe(true);
-    expect(listTokens.has('divide-border/20')).toBe(true);
-    expect(listTokens.has('dark:divide-foreground/20')).toBe(true);
+    expect(listTokens.has('divide-border/40')).toBe(true);
+    expect(listTokens.has('dark:divide-foreground/40')).toBe(true);
   });
 });

--- a/app/(app)/app/shared/components/session-breakdown-list.tsx
+++ b/app/(app)/app/shared/components/session-breakdown-list.tsx
@@ -6,10 +6,10 @@ import type { PracticeSessionReviewRow } from '@/src/application/use-cases';
 
 const STEM_PREVIEW_LENGTH = 80;
 
-// Transitional DEBT-399 PR 3 row styling. PR 4 owns the /20 hover-opacity
-// alignment before this can promote into a semantic Button variant.
+// Keep the row transparent at rest while using the page-context muted hover
+// from Pattern Registry section 1.2.
 const questionActionButtonClasses =
-  '-mx-2 flex h-auto min-w-0 flex-1 shrink items-center justify-start gap-2 rounded-md bg-transparent px-2 py-0 text-left font-medium text-foreground shadow-none whitespace-normal hover:bg-muted/20 hover:text-foreground';
+  '-mx-2 flex h-auto min-w-0 flex-1 shrink items-center justify-start gap-2 rounded-md bg-transparent px-2 py-0 text-left font-medium text-foreground shadow-none whitespace-normal hover:bg-muted/50 hover:text-foreground';
 
 export function SessionBreakdownList({
   rows,
@@ -35,7 +35,7 @@ export function SessionBreakdownList({
   }
 
   return (
-    <ul className="divide-y divide-border/20 dark:divide-foreground/20">
+    <ul className="divide-y divide-border/40 dark:divide-foreground/40">
       {rows.map((row) => (
         <li
           key={row.questionId}
@@ -62,7 +62,7 @@ export function SessionBreakdownList({
                 sessionId,
                 historyHref,
               })}
-              className="-mx-2 flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 font-medium text-foreground transition-colors hover:bg-muted/20 ring-focus"
+              className="-mx-2 flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 font-medium text-foreground transition-colors hover:bg-muted/50 ring-focus"
             >
               <span className="shrink-0">{row.order}.</span>
               <span className="truncate">

--- a/components/theme-token-regression-source-scan.ts
+++ b/components/theme-token-regression-source-scan.ts
@@ -50,7 +50,7 @@ export const RAW_BUTTON_EXEMPTIONS: readonly CountedExemption[] = [
 ];
 
 // Add new source-scan allowlist entries only when the Pattern Registry
-// documents the pattern; TODO(DEBT-399) exemptions are temporary and must shrink.
+// documents the pattern; temporary exemptions must shrink over time.
 export const DOCUMENTED_OPACITY_TOKENS = new Set([
   'bg-muted/20',
   'hover:bg-muted/40',
@@ -80,52 +80,11 @@ export const DOCUMENTED_OPACITY_TOKENS = new Set([
   'dark:hover:border-foreground/70',
   'border-border/40',
   'border-border/60',
+  'divide-border/40',
+  'dark:divide-foreground/40',
 ]);
 
-export const TEMPORARY_OPACITY_EXEMPTIONS: readonly OpacityExemption[] = [
-  // TODO(DEBT-399): align session breakdown row hovers to Pattern Registry.
-  [
-    'app/(app)/app/shared/components/session-breakdown-list.tsx',
-    'hover:bg-muted/20',
-    2,
-    'Temporary DEBT-399 hover opacity divergence.',
-  ],
-  // TODO(DEBT-399): align exam review row hover to Pattern Registry.
-  [
-    'app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx',
-    'hover:bg-muted/20',
-    1,
-    'Temporary DEBT-399 hover opacity divergence.',
-  ],
-  // TODO(DEBT-399): align session breakdown divider to Pattern Registry.
-  [
-    'app/(app)/app/shared/components/session-breakdown-list.tsx',
-    'divide-border/20',
-    1,
-    'Temporary DEBT-399 divider opacity divergence.',
-  ],
-  // TODO(DEBT-399): align session breakdown dark divider to Pattern Registry.
-  [
-    'app/(app)/app/shared/components/session-breakdown-list.tsx',
-    'dark:divide-foreground/20',
-    1,
-    'Temporary DEBT-399 dark divider opacity divergence.',
-  ],
-  // TODO(DEBT-399): align history session panel border to Pattern Registry.
-  [
-    'app/(app)/app/history/components/history-sessions-tab.tsx',
-    'border-border/30',
-    1,
-    'Temporary DEBT-399 border opacity divergence.',
-  ],
-  // TODO(DEBT-399): align history session dark panel border to Pattern Registry.
-  [
-    'app/(app)/app/history/components/history-sessions-tab.tsx',
-    'dark:border-foreground/10',
-    1,
-    'Temporary DEBT-399 dark border opacity divergence.',
-  ],
-];
+export const TEMPORARY_OPACITY_EXEMPTIONS: readonly OpacityExemption[] = [];
 
 export function readProductionUiSources(): SourceFile[] {
   return fg

--- a/docs/debt/debt-399-component-system-bypass-cleanup.md
+++ b/docs/debt/debt-399-component-system-bypass-cleanup.md
@@ -86,19 +86,15 @@ Each original occurrence was CORRECT (matched the documented pattern), but each 
 
 ### C. Hover-opacity divergence from `pattern-registry.md` § 1.2
 
-`app/(app)/app/shared/components/session-breakdown-list.tsx:58` uses `hover:bg-muted/20`. The pattern registry says non-card page-context rows should use `hover:bg-muted/50` or, for tonal rows, `hover:bg-foreground/[0.12]`. The `/20` choice is lighter than the documented scale and was not added to the registry as a new pattern with rationale.
+`app/(app)/app/shared/components/session-breakdown-list.tsx:12` and `:65` use `hover:bg-muted/20`. The pattern registry says non-card page-context rows should use `hover:bg-muted/50` or, for tonal rows, `hover:bg-foreground/[0.12]`. The same shared component also renders inside the session-summary card, but the history expanded-row use is directly on the page-background tonal row, and the current class is a muted-scale hover with no foreground-ramp rest fill. PR 4 therefore aligns both session-breakdown hover sites to `hover:bg-muted/50`; do not register `/20`.
 
-PR 3 deliberately preserves this token while migrating the raw `<button>` to `<Button>` so the Button migration stays visually bounded. PR 4 resolves the opacity divergence for both this button branch and the adjacent `Link` branch by choosing one of:
-- Adopt the registry pattern (`/50`)
-- Or formally add the `/20` variant to `pattern-registry.md` § 1.2 with rationale (e.g., "list-row inside dashboard breakdown surface uses lighter hover to avoid competing with row content")
-
-Don't ship a divergence without one of these two actions.
+`app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx:41` also uses `hover:bg-muted/20`. That row is inside a `<Card>` (`QuestionNavigator` card at line 58), so PR 4 aligns it to the documented in-card muted-scale hover `hover:bg-muted/40`; do not register `/20`.
 
 ### D. Custom dark-mode opacities scattered without registry entry
 
-`app/(app)/app/shared/components/session-breakdown-list.tsx:32` uses `dark:divide-foreground/20`. `app/(app)/app/history/components/history-sessions-tab.tsx:253` uses `dark:border-foreground/10`. Neither opacity (`/20`, `/10`) is in the nearest documented separator/border contracts: `pattern-registry.md` § 1.3 specifies `border-border`, `border-border/60`, `border-border/40`, and `dark:border-foreground/40`, while M-2 specifies `border-t border-border`, `/60`, or `/40` for content separators.
+`app/(app)/app/shared/components/session-breakdown-list.tsx:38` uses `divide-border/20 dark:divide-foreground/20`. `app/(app)/app/history/components/history-sessions-tab.tsx:260` uses `border-border/30 dark:border-foreground/10`. None of `/20`, `/30`, or `/10` is in the nearest documented separator/border contracts: `pattern-registry.md` § 1.3 specifies `border-border`, `border-border/60`, `border-border/40`, and `dark:border-foreground/40`, while M-2 specifies `border-t border-border`, `/60`, or `/40` for content separators.
 
-These are MEDIUM severity divergences. Either align to the documented scale or formally add the variants to the registry.
+PR 4 aligns these separators to the documented light separator / required dark boundary tier: `divide-border/40 dark:divide-foreground/40` for the list divider, and `border-border/40 dark:border-foreground/40` for the history breakdown panel. Because the regression scan currently allowlists `border-border/40` but not the equivalent `divide-*` utility form, PR 4 must add `divide-border/40` and `dark:divide-foreground/40` to `DOCUMENTED_OPACITY_TOKENS` when deleting the temporary exemptions. Do not register the old `/20`, `/30`, or `/10` values.
 
 ### E. Component file bloat
 
@@ -286,20 +282,26 @@ Capture before/after screenshots or document manual parity notes in the PR body.
 
 ### PR 4 — Fix opacity divergences (Findings C / D)
 
-Branch: `style/debt-399-dark-mode-opacity-alignment`
+Branch: `feat/debt-399-pr-4-dark-mode-opacity-alignment`
 
 Six temporary opacity exemption entries remain after PR 3 removes the raw-button exemptions:
 
-- `session-breakdown-list.tsx` button branch plus adjacent `Link` branch — `hover:bg-muted/20` (expected count 2)
-- `exam-review-view.tsx` row button — `hover:bg-muted/20`
-- `session-breakdown-list.tsx:32` — `divide-border/20`
-- `session-breakdown-list.tsx:32` — `dark:divide-foreground/20`
-- `history-sessions-tab.tsx:253` — `border-border/30`
-- `history-sessions-tab.tsx:253` — `dark:border-foreground/10`
+- `session-breakdown-list.tsx:12` button branch and `:65` adjacent `Link` branch — `hover:bg-muted/20` (expected count 2). ALIGN to `hover:bg-muted/50` per `pattern-registry.md` § 1.2 page-background muted-scale hover guidance.
+- `exam-review-view.tsx:41` row button — `hover:bg-muted/20` (expected count 1). ALIGN to `hover:bg-muted/40` per `pattern-registry.md` § 1.2 in-card muted-scale hover guidance.
+- `session-breakdown-list.tsx:38` — `divide-border/20` (expected count 1). ALIGN to `divide-border/40`, the `divide-y` utility form of the M-2 Light internal separator (`border-border/40`).
+- `session-breakdown-list.tsx:38` — `dark:divide-foreground/20` (expected count 1). ALIGN to `dark:divide-foreground/40`, matching the required dark boundary tier from `pattern-registry.md` § 1.3.
+- `history-sessions-tab.tsx:260` — `border-border/30` (expected count 1). ALIGN to `border-border/40`, the M-2 Light internal separator.
+- `history-sessions-tab.tsx:260` — `dark:border-foreground/10` (expected count 1). ALIGN to `dark:border-foreground/40`, matching the required dark boundary tier from `pattern-registry.md` § 1.3.
 
-For each: choose to align with `pattern-registry.md` § 1.2 / § 1.3 (`hover:bg-muted/40`, `hover:bg-muted/50`, `/40`, `/60`, or full as applicable) OR add the variant to the registry with rationale. Ship the choice and delete the matching `TEMPORARY_OPACITY_EXEMPTIONS` entries from `components/theme-token-regression-source-scan.ts`.
+Execution recipe:
 
-This PR is lower priority — visual divergence is small, but the discipline matters. If scope pressure, defer this PR and document the divergence in DEBT-399 archive resolution as "left as-is, registry exception accepted."
+1. Apply the six ALIGN replacements above. No Pattern Registry edit is needed because the target values come from existing § 1.2 / § 1.3 / M-2 rules.
+2. Update source tests that assert the old tokens:
+   - `app/(app)/app/shared/components/session-breakdown-list.test.tsx` currently expects `hover:bg-muted/20`, `divide-border/20`, and `dark:divide-foreground/20`.
+   - `app/(app)/app/history/components/history-sessions-tab.test.tsx` currently expects `border-border/30` and `dark:border-foreground/10`.
+3. In `components/theme-token-regression-source-scan.ts`, add `divide-border/40` and `dark:divide-foreground/40` to `DOCUMENTED_OPACITY_TOKENS`, then delete all six `TEMPORARY_OPACITY_EXEMPTIONS` entries. `hover:bg-muted/40`, `hover:bg-muted/50`, `border-border/40`, and `dark:border-foreground/40` are already allowlisted.
+4. Run `pnpm test --run components/theme-token-regression.test.tsx`; it should remain 16/16 passing with zero `TODO(DEBT-399)` markers.
+5. Visually verify light + dark and desktop + mobile for session-breakdown rows, the exam-review question list, and the history-sessions expanded panel border. Expected visual change: slightly stronger hover/divider/border contrast, intentionally matching the registry.
 
 ---
 
@@ -337,7 +339,11 @@ PR 3 done when:
 PR 4 done when:
 
 - The six temporary opacity exemptions are deleted from `components/theme-token-regression-source-scan.ts`.
-- Each former opacity divergence is either aligned to registry or the registry is extended with rationale.
+- `rg 'TODO\(DEBT-399\)' components/theme-token-regression-source-scan.ts` returns zero matches.
+- Each former opacity divergence is aligned to the target value documented in PR 4 above; no `/20`, `/30`, or `/10` opacity exception is registered.
+- `DOCUMENTED_OPACITY_TOKENS` includes the `divide-border/40` and `dark:divide-foreground/40` separator utility forms needed by the aligned list divider.
+- `pnpm test --run components/theme-token-regression.test.tsx` passes 16/16.
+- Full local gate green, with visual verification captured for the three affected surfaces in light + dark and desktop + mobile.
 
 ---
 


### PR DESCRIPTION
## Summary

DEBT-399 PR 4 of 4 — **the final PR**. Aligns 6 dark-mode opacity divergences to Pattern Registry-documented values and removes the last 6 `TODO(DEBT-399)` markers from the regression scan. After this lands, **DEBT-399 is fully closed**.

Alignments (per audited DEBT-399 PR 4, audit commit 649ca319):

| Site | File:Line | Before | After | Context |
|---|---|---|---|---|
| A | session-breakdown-list.tsx:12, :65 | `hover:bg-muted/20` | `hover:bg-muted/50` | page-context muted hover |
| B | exam-review-view.tsx:41 | `hover:bg-muted/20` | `hover:bg-muted/40` | in-card muted hover |
| C | session-breakdown-list.tsx:38 | `divide-border/20` | `divide-border/40` | divider |
| D | session-breakdown-list.tsx:38 | `dark:divide-foreground/20` | `dark:divide-foreground/40` | dark divider |
| E | history-sessions-tab.tsx:260 | `border-border/30` | `border-border/40` | panel border |
| F | history-sessions-tab.tsx:260 | `dark:border-foreground/10` | `dark:border-foreground/40` | dark panel border |

No REGISTER decisions — the old `/10`, `/20`, `/30` values do NOT become canonical. Every alignment uses a Pattern Registry-documented target.

## Regression scan updates

- Removed 6 `TODO(DEBT-399)` opacity exemptions from `components/theme-token-regression-source-scan.ts` (lines 86-127 pre-edit).
- Added `divide-border/40` and `dark:divide-foreground/40` to `DOCUMENTED_OPACITY_TOKENS`. Other aligned values were already on the allowlist.
- Updated source tests asserting old tokens.

## Source

Implementation follows pre-execution audited DEBT-399 PR 4 (audit commit 649ca319). The audit verified:
- Each site's context (page-background vs in-card) drives the `/50` vs `/40` choice per Pattern Registry I-2.
- Dark-mode alignments target `/40` per Pattern Registry § 1.3 (which specifies `/40`, `/60`, or full as canonical).
- Visual-change risk bounded to subtle contrast increases.

## Verification

- [x] `rg 'TODO\(DEBT-399\)' components/theme-token-regression-source-scan.ts` returns ZERO matches (DEBT-399 fully closed).
- [x] `rg 'TODO\(DEBT-399\)' components/` returns ZERO matches.
- [x] DEBT-398 PR 3 regression test passes 16/16 with the aligned values + updated allowlist.
- [x] Visual parity verified per protocol (light/dark, desktop/mobile, session breakdown rows + dividers, exam review list, history expanded panel border). Local evidence saved under `/tmp/debt399-pr4-visual/`:
  - `session-breakdown-desktop-light.png`
  - `session-breakdown-mobile-dark.png`
  - `history-expanded-panel-desktop-light.png`
  - `history-expanded-panel-mobile-dark.png`
  - `exam-review-list-desktop-light.png`
  - `exam-review-list-mobile-dark.png`
- [x] Full local gate green: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`.
- [x] E2E green: `pnpm test:e2e` passed 35/35.

## DEBT-399 closure

After this merges:
- Zero `TODO(DEBT-399)` markers anywhere in the codebase.
- Single permanent exemption remains: `components/mobile-nav.tsx` (Pattern Registry I-6 app-shell disclosure toggle — documented design-system rule, not a workaround).
- DEBT-399 doc gets archived to `docs/_archive/debt/` in a follow-up small PR per the established archive ritual.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined opacity levels for interactive hover states and component border/divider styling to enhance visual hierarchy and improve overall design consistency.

* **Tests**
  * Updated test expectations to reflect styling refinements and verify design system compliance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->