### PR TITLE
Fix auth-nav test module-cache order dependency (DEBT-401)

### DIFF
--- a/components/auth-nav.test.tsx
+++ b/components/auth-nav.test.tsx
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
 import type { ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { MarketingLayout } from '@/components/marketing/marketing-layout';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FakeAuthGateway } from '@/src/application/test-helpers/fakes/fake-gateways';
 import { FakeCheckEntitlementUseCase } from '@/src/application/test-helpers/fakes/fake-use-cases';
 import { createUser } from '@/src/domain/test-helpers/factories';
@@ -39,6 +38,9 @@ function getLinksByHrefAndLabel(
 }
 
 async function renderMarketingLayout(authNavSlot: ReactNode) {
+  const { MarketingLayout } = await import(
+    '@/components/marketing/marketing-layout'
+  );
   const element = await MarketingLayout({
     authNavSlot,
     featuresHref: '#features',
@@ -49,6 +51,12 @@ async function renderMarketingLayout(authNavSlot: ReactNode) {
 }
 
 describe('AuthNav', () => {
+  beforeEach(() => {
+    restoreProcessEnv(ORIGINAL_ENV);
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
   afterEach(() => {
     restoreProcessEnv(ORIGINAL_ENV);
     vi.resetModules();


### PR DESCRIPTION
## Summary

Fixes DEBT-401 — a hidden module-cache/mock-order dependency in `components/auth-nav.test.tsx` exposed by the DEBT-395 PR 1 pre-execution audit (commit fbd9d012).

Root cause: file imported `MarketingLayout` at module scope, which transitively cached `AuthUserButton` BEFORE per-test `vi.doMock()` calls could intercept the import. Under seed `1779972928761`, scenario 4 ran first and failed because `[data-testid="user-button"]` wasn't present.

Fix per the audited DEBT-401 recipe:
- Removed module-scope `MarketingLayout` import.
- Dynamic-import `MarketingLayout` inside `renderMarketingLayout()` so per-test mocks take effect.
- Added `beforeEach` symmetric with existing `afterEach` (restore env + reset modules + restore mocks).

## Proof of fix

| Seed | Before | After |
|---|---|---|
| 1 | pass 9/9 | pass 9/9 |
| 42 | pass 9/9 | pass 9/9 |
| 9999 | pass 9/9 | pass 9/9 |
| 1779972928761 | **FAIL** scenario 4 | pass 9/9 |
| 7777777 | pass 9/9 | pass 9/9 |

Full-suite `pnpm test --run --sequence.shuffle --sequence.seed=1779972928761`:
- Before: 1 fail (auth-nav scenario 4)
- After: 2524/2524 pass

## Zero production impact

This is a test-suite-only ordering bug. Production code (`AuthNav`, `MarketingLayout`, `AuthUserButton`) is unchanged. The fix only restructures how the test imports + sets up its mocks.

## Why this matters

Unblocks DEBT-395 PR 1's acceptance criterion (`pnpm test --run --sequence.shuffle` passes). DEBT-395 PR 1 ships the `process.env` isolation fixes; without DEBT-401 fixed first, the shuffle-suite signal is corrupted by a different bug class.

## Test plan

- [x] Pre-fix reproduction: seed 1779972928761 fails scenario 4.
- [x] Post-fix: 5 seeds all pass 9/9 on the test file.
- [x] Post-fix: full suite shuffle-seed-1779972928761 passes 2524/2524.
- [x] Declaration-order test still passes 9/9.
- [x] Full local gate green: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`.
- [x] E2E green: `pnpm test:e2e` passed 35/35.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and isolation for authentication navigation tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->