### PR TITLE
Document test environment isolation rule (DEBT-395 PR 2/3)

### DIFF
--- a/.claude/rules/test-isolation.md
+++ b/.claude/rules/test-isolation.md
@@ -1,0 +1,105 @@
+---
+paths:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "tests/**"
+---
+
+# Test Isolation Rules
+
+## Process.env isolation
+
+`process.env` is global within a Vitest worker. Tests that mutate it must restore it explicitly so later tests do not inherit hidden state.
+
+### Module-scope env defaults
+
+For module-scope `process.env.X = ...` or `process.env.X ??= ...`, capture the snapshot before any env writes, then restore after the suite.
+
+Use `afterAll` only for shared defaults that intentionally stay constant for every test in the file. Use `afterEach` when tests mutate env differently.
+
+```typescript
+import { afterAll } from 'vitest';
+import {
+  restoreProcessEnv,
+  snapshotProcessEnv,
+} from '@/tests/shared/process-env';
+
+const ORIGINAL_ENV = snapshotProcessEnv();
+
+process.env.DATABASE_URL ??=
+  'postgresql://user:pass@localhost:5432/addiction_boards_test';
+
+afterAll(() => {
+  restoreProcessEnv(ORIGINAL_ENV);
+});
+```
+
+### vi.stubEnv cleanup
+
+Pair all `vi.stubEnv()` calls with `vi.unstubAllEnvs()`, normally in suite-level `afterEach`.
+
+```typescript
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+```
+
+`restoreProcessEnv()` is not a replacement for `vi.unstubAllEnvs()`. Vitest tracks env stubs separately and `vi.unstubAllEnvs()` clears that registry.
+
+### Direct env mutation inside tests
+
+For direct `process.env.X = ...` or `delete process.env.X` inside tests, use `snapshotProcessEnv()` / `restoreProcessEnv()` in `afterEach`.
+
+```typescript
+import { afterEach } from 'vitest';
+import {
+  restoreProcessEnv,
+  snapshotProcessEnv,
+} from '@/tests/shared/process-env';
+
+const ORIGINAL_ENV = snapshotProcessEnv();
+
+afterEach(() => {
+  restoreProcessEnv(ORIGINAL_ENV);
+});
+```
+
+Avoid delete-only `finally` cleanup. It destroys pre-existing values instead of restoring them. A per-test `delete process.env.X` is acceptable as an arrange step when the test explicitly needs the variable absent.
+
+### Combined cleanup ordering
+
+When `vi.stubEnv()` and direct env snapshot cleanup appear in the same suite, `vi.unstubAllEnvs()` must run first, then `restoreProcessEnv(ORIGINAL_ENV)`. The snapshot is authoritative and must be the last env writer. `vi.resetModules()` comes after env restoration when modules read env at import time.
+
+```typescript
+afterEach(() => {
+  vi.unstubAllEnvs();
+  restoreProcessEnv(ORIGINAL_ENV);
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+```
+
+### Helper API
+
+The canonical helper lives at `tests/shared/process-env.ts`:
+
+```typescript
+export type ProcessEnvSnapshot = Record<string, string | undefined>;
+export function snapshotProcessEnv(): ProcessEnvSnapshot;
+export function restoreProcessEnv(snapshot: ProcessEnvSnapshot): void;
+```
+
+`restoreProcessEnv()` deletes keys added after the snapshot and restores keys that existed before the snapshot. Newly set variables such as `TEST_ENV_LOADED` or `DATABASE_URL` are truly cleaned instead of merely overwritten.
+
+### Canonical examples
+
+- `components/get-started-cta.test.tsx` is the PR #342 direct-env reference pattern.
+- `lib/container.test.ts` shows shared module-scope defaults protected by snapshot/restore.
+- `proxy.test.ts` shows `vi.stubEnv()` cleanup combined with process-env snapshot restoration.
+- `tests/shared/load-dotenv-file.test.ts` shows direct env mutation restored without delete-only cleanup.
+
+### Do not churn clean files
+
+Many existing env-mutation sites are already correctly restored. Apply this rule to new or changed tests; do not rewrite known-clean files only to make style uniform.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -31,6 +31,10 @@ Use existing fakes from `src/application/test-helpers/fakes/`. NEVER use `vi.moc
 - External SDKs: `@clerk/nextjs`, `next/link`, `server-only`
 - Browser Mode sealed ESM: `vi.mock(path, { spy: true })` for controller modules
 
+## Test Environment Isolation
+
+Tests that mutate `process.env` (module-scope defaults, `vi.stubEnv()`, or direct assignment) MUST snapshot/restore via `tests/shared/process-env.ts`. See **`.claude/rules/test-isolation.md`** for the full rule, cleanup ordering, and examples.
+
 ## Test Quality
 
 1. Test behavior, not implementation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Claude Code loads additional context from `.claude/rules/` based on which files 
 | `testing.md` | Any file | Vitest, TDD, fakes-over-mocks, test locations |
 | `testing-react19.md` | `**/*.test.tsx` | `renderToStaticMarkup`, jsdom directive, deprecated APIs |
 | `testing-browser.md` | `**/*.browser.spec.tsx` | `vitest-browser-react`, controller mocking, stability tips |
+| `test-isolation.md` | `**/*.test.ts(x)`, `**/*.spec.ts(x)`, `tests/**` | process.env snapshot/restore, vi.stubEnv cleanup, combined ordering |
 | `architecture.md` | `src/**` | Clean Architecture layers, SOLID, dependency inversion |
 | `domain-layer.md` | `src/domain/**` | Zero-import purity rules |
 | `frontend.md` | `app/**`, `components/**` | Route constants, shadcn, error state patterns, and the shipped design-system gateway. **For design-system rules (tokens, focus rings, opacity scale, dark mode, Button mandate) see `docs/frontend/` — listed under Quick Reference → Design System below.** |

--- a/docs/debt/debt-395-test-environment-isolation-hardening.md
+++ b/docs/debt/debt-395-test-environment-isolation-hardening.md
@@ -187,6 +187,8 @@ The PR 1 proof-of-fix was the full local gate plus shuffled full-suite seeds `1`
 
 Branch: `feat/debt-395-test-isolation-docs`
 
+Status: **implemented on this branch; PR number to be filled during stop-and-grade.**
+
 Decision: **Option A — single source of truth in `.claude/rules/test-isolation.md`, with a pointer from `.claude/rules/testing.md`.**
 
 Rationale:
@@ -317,13 +319,13 @@ Status: **complete in PR #363 at `47b7d376`**.
 
 Consolidated PR 2/3 done when:
 
-- `.claude/rules/test-isolation.md` exists with the frontmatter and rule contract above.
-- `.claude/rules/testing.md` cross-references `test-isolation.md` with a pointer only.
-- `CLAUDE.md` table is updated to list the new rule and its activation scope.
-- No source files or test files change.
-- `pnpm test --run components/theme-token-regression.test.tsx` remains 16/16 green for DEBT-398 PR 3.
-- Full local gate is green before push, even though the PR is doc-only.
-- The DEBT-395 doc marks the consolidated documentation PR complete.
+- [x] `.claude/rules/test-isolation.md` exists with the frontmatter and rule contract above.
+- [x] `.claude/rules/testing.md` cross-references `test-isolation.md` with a pointer only.
+- [x] `CLAUDE.md` table is updated to list the new rule and its activation scope.
+- [x] No source files or test files change.
+- [x] `pnpm test --run components/theme-token-regression.test.tsx` remains 16/16 green for DEBT-398 PR 3.
+- [x] Full local gate is green before push, even though the PR is doc-only.
+- [x] The DEBT-395 doc marks the consolidated documentation PR complete.
 
 Archive PR done when:
 

--- a/docs/debt/debt-395-test-environment-isolation-hardening.md
+++ b/docs/debt/debt-395-test-environment-isolation-hardening.md
@@ -1,9 +1,9 @@
 # DEBT-395: Test Environment Isolation Hardening
 
-**Priority:** P2 (active bug class — same shape as PR #342's pre-existing test-isolation leak. The current high-confidence misses are the module-scope env defaults in `lib/container.test.ts`, the `vi.stubEnv()` cleanup gap in `proxy.test.ts`, and the direct env cleanup gap in `tests/shared/load-dotenv-file.test.ts`; a repo-wide grep shows many additional env-mutation sites that are already correctly restored and should not be churned. The fix is mechanical and the rule is already partially implemented in `tests/shared/process-env.ts` but undocumented.)
+**Priority:** P2 (active documentation hardening. PR 1 fixed the high-confidence `process.env` isolation leaks in `lib/container.test.ts`, `proxy.test.ts`, and `tests/shared/load-dotenv-file.test.ts`; the remaining work is to document the pattern in the Claude test-rule system without duplicating rule bodies. A repo-wide grep shows many additional env-mutation sites that are already correctly restored and should not be churned.)
 **Created:** 2026-05-26
 **Source:** Deep adversarial test-suite audit conducted alongside DEBT-394 archival. The proximate trigger is PR #342 (`Fix GetStartedCta test env isolation`) where `components/get-started-cta.test.tsx` was leaking `NEXT_PUBLIC_SKIP_CLERK=true` env state into the "entitled user → /app/dashboard" assertion — a pre-existing bug that fired only when Dependabot's secret-less CI ran and exposed the latent ordering dependency. The audit found the same bug class still alive in other test files.
-**Related:** [.claude/rules/testing.md](../../.claude/rules/testing.md) (testing rules; currently silent on env isolation), [docs/dev/testing-infrastructure.md](../dev/testing-infrastructure.md), [DEBT-394 (archived)](../_archive/debt/debt-394-supply-chain-hardening.md)
+**Related:** [.claude/rules/testing.md](../../.claude/rules/testing.md) (testing rules; consolidated PR 2/3 will add a pointer to the canonical isolation rule), [docs/dev/testing-infrastructure.md](../dev/testing-infrastructure.md), [DEBT-394 (archived)](../_archive/debt/debt-394-supply-chain-hardening.md)
 
 **Status:** Active
 
@@ -21,7 +21,7 @@ export function snapshotProcessEnv(): ProcessEnvSnapshot;
 export function restoreProcessEnv(snapshot: ProcessEnvSnapshot): void;
 ```
 
-The canonical pattern remains the one shipped in `components/get-started-cta.test.tsx`: capture `const ORIGINAL_ENV = snapshotProcessEnv()` at module scope, mutate env inside hooks/tests, then call `restoreProcessEnv(ORIGINAL_ENV)` in cleanup before `vi.resetModules()` when modules read env at import time.
+The canonical direct-env pattern remains the one shipped in `components/get-started-cta.test.tsx`: capture `const ORIGINAL_ENV = snapshotProcessEnv()` at module scope, mutate env inside hooks/tests, then call `restoreProcessEnv(ORIGINAL_ENV)` in cleanup before `vi.resetModules()` when modules read env at import time. If a suite also uses `vi.stubEnv()`, `vi.unstubAllEnvs()` must run first and `restoreProcessEnv(ORIGINAL_ENV)` second so the snapshot remains the authoritative final state.
 
 Current sweep commands used for this audit:
 
@@ -43,15 +43,15 @@ The required shuffled verification also exposed a separate module-cache/mock-ord
 2. **Silent contamination of unrelated suites** — a stripe webhook test mutates `process.env.STRIPE_WEBHOOK_SECRET` and the practice-controller tests three files later read the wrong value.
 3. **Bugs that only surface in specific CI configurations** — PR #342 was invisible until Dependabot's `NEXT_PUBLIC_SKIP_CLERK=true` fallback hit a test that assumed the variable was unset.
 
-The repo already has a helper that solves this: `tests/shared/process-env.ts` exports `snapshotProcessEnv()` and `restoreProcessEnv()`. PR #342 wired those into `components/get-started-cta.test.tsx`. But **the pattern is not documented anywhere** (`.claude/rules/testing.md` does not mention it, `AGENTS.md` does not mention it), so test files that mutate `process.env` use a mix of good snapshot/restore, local ad-hoc cleanup, and missing `vi.stubEnv` cleanup.
+The repo already has a helper that solves this: `tests/shared/process-env.ts` exports `snapshotProcessEnv()` and `restoreProcessEnv()`. PR #342 wired those into `components/get-started-cta.test.tsx`. At creation, **the pattern was not documented anywhere** (`.claude/rules/testing.md` did not mention it, `AGENTS.md` did not mention it), so test files that mutated `process.env` used a mix of good snapshot/restore, local ad-hoc cleanup, and missing `vi.stubEnv` cleanup.
 
 ---
 
 ## Findings
 
-Three high-confidence bug clusters surfaced during the audit. Each is HIGH-severity because each can fire intermittently under any of: random test ordering, parallel worker assignment, or future test additions to the same file.
+Three high-confidence bug clusters surfaced during the original audit. PR #363 fixed them in DEBT-395 PR 1; they remain here as provenance and as concrete examples for the documentation rule. Each was HIGH-severity because each could fire intermittently under any of: random test ordering, parallel worker assignment, or future test additions to the same file.
 
-### A. `lib/container.test.ts:49-57` — module-scope `process.env.X ??= ...` without cleanup
+### A. `lib/container.test.ts:49-57` — module-scope `process.env.X ??= ...` without cleanup before PR 1
 
 ```typescript
 process.env.DATABASE_URL ??=
@@ -65,17 +65,17 @@ process.env.NEXT_PUBLIC_APP_URL ??= 'http://localhost:3000';
 process.env.NEXT_PUBLIC_SKIP_CLERK ??= 'true';
 ```
 
-Eight environment variables get mutated at module scope. The eighth line (`NEXT_PUBLIC_SKIP_CLERK`) currently sits on line 57, so the old `49-56` citation under-counted the block by one line. The file does not call `snapshotProcessEnv()` or restore in `afterAll`. Every subsequent test in the worker observes whatever this file left behind. Verify with:
+Before PR 1, eight environment variables were mutated at module scope with no cleanup. The eighth line (`NEXT_PUBLIC_SKIP_CLERK`) sat on line 57, so the old `49-56` citation under-counted the block by one line. Current `main` at `47b7d376` captures `const ORIGINAL_ENV = snapshotProcessEnv()` immediately before the shared defaults, then restores it in `afterAll`; the env-default writes currently sit at lines 55-63 and the restore is at lines 76-78. Verify with:
 
 ```sh
 rg -n 'process\.env\.' lib/container.test.ts
 ```
 
-The `??=` operator only sets if the variable is undefined, which masks the leak under most local conditions but means CI worker scheduling order can produce different observed state across runs.
+The `??=` operator only sets if the variable is undefined, which masked the leak under most local conditions but meant CI worker scheduling order could produce different observed state across runs. Capturing the snapshot before the default writes and restoring it after the suite closes the cross-file leak while preserving the intentionally shared defaults inside this file.
 
-### B. `proxy.test.ts:119-121, 585-587, 633-635, 663/667, 686-692, 710` — `vi.stubEnv()` calls without top-level `vi.unstubAllEnvs()` cleanup
+### B. `proxy.test.ts:119-122, 585-588, 633-636, 664/668, 686-693, 711` — `vi.stubEnv()` calls without top-level `vi.unstubAllEnvs()` cleanup before PR 1
 
-Six distinct test blocks call `vi.stubEnv()` for `NEXT_PUBLIC_SKIP_CLERK`, `VERCEL_ENV`, `NODE_ENV`, or `NEXT_PUBLIC_SENTRY_DSN` and the suite-level `afterEach` never calls `vi.unstubAllEnvs()` to clear Vitest's env-stub registry. Example from line 119:
+Before PR 1, six distinct test blocks called `vi.stubEnv()` for `NEXT_PUBLIC_SKIP_CLERK`, `VERCEL_ENV`, `NODE_ENV`, or `NEXT_PUBLIC_SENTRY_DSN` and the suite-level `afterEach` never called `vi.unstubAllEnvs()` to clear Vitest's env-stub registry. Current `main` at `47b7d376` fixes this with a suite-level `afterEach` at lines 72-77 that calls `vi.unstubAllEnvs()` before `restoreProcessEnv(ORIGINAL_ENV)`, then `vi.resetModules()` and `vi.restoreAllMocks()`. Example from the first stub block:
 
 ```typescript
 it('ignores NEXT_PUBLIC_SKIP_CLERK=true in production...', () => {
@@ -83,11 +83,11 @@ it('ignores NEXT_PUBLIC_SKIP_CLERK=true in production...', () => {
   vi.stubEnv('VERCEL_ENV', 'production');
   vi.stubEnv('NODE_ENV', 'development');
   // ... assertions ...
-  // No cleanup: stubs survive to the next test
+  // Suite-level afterEach now clears the stubs.
 });
 ```
 
-The file's `afterEach` at line 72-76 calls `restoreProcessEnv()` and `vi.resetModules()`, but `restoreProcessEnv()` only rewrites `process.env` from the captured snapshot. It does not clear Vitest's internal `_stubsEnv` registry; `node_modules/vitest/dist/chunks/test.DNmyFkvJ.js` shows `stubEnv()` records originals in `_stubsEnv` and `unstubAllEnvs()` both restores those originals and clears that map. The two patterns are related but not interchangeable.
+`restoreProcessEnv()` only rewrites `process.env` from the captured snapshot. It does not clear Vitest's internal `_stubsEnv` registry; `node_modules/vitest/dist/chunks/test.DNmyFkvJ.js` shows `stubEnv()` records originals in `_stubsEnv` and `unstubAllEnvs()` both restores those originals and clears that map. The two patterns are related but not interchangeable.
 
 ### C. `proxy.test.ts:663-667` — Mixed `vi.stubEnv` + direct `process.env` manipulation
 
@@ -99,19 +99,19 @@ delete process.env.VERCEL_ENV;
 vi.stubEnv('NODE_ENV', 'production');
 ```
 
-The unstub at line 664 clears the stub set at line 663, then direct-mutates `process.env` at lines 665-666 and re-stubs `NODE_ENV` at line 667. This is not an async race in the current test, but it is confusing intent and masks the larger problem: cleanup is happening locally inside one test instead of uniformly in suite-level `afterEach`.
+The local unstub now sits at line 665. It clears the stub set at line 664, then direct-mutates `process.env` at lines 666-667 and re-stubs `NODE_ENV` at line 668. This is not an async race in the current test, and the PR 1 suite-level cleanup makes it harmless redundancy. Leave it alone unless a future focused cleanup rewrites the mixed-pattern test for clarity.
 
 ### D. Pattern across the suite — undocumented and inconsistent
 
-A grep of `vi\.stubEnv` across all test files surfaces additional sites. Many already include cleanup (`app/(app)/app/request-boundary.test.ts`, `lib/logger.test.ts`, `lib/request-ip.test.ts`, `lib/report-client-error.test.ts`, and `tests/e2e/helpers/seed-test-user.test.ts` all call `vi.unstubAllEnvs()` in `beforeEach` or `afterEach`), while `app/pricing/*-action.test.ts` performs local cleanup in individual tests. A full sweep should catalog every site and either:
+A grep of `vi\.stubEnv` across all test files surfaced additional sites. Many already included cleanup (`app/(app)/app/request-boundary.test.ts`, `lib/logger.test.ts`, `lib/request-ip.test.ts`, `lib/report-client-error.test.ts`, and `tests/e2e/helpers/seed-test-user.test.ts` all call `vi.unstubAllEnvs()` in `beforeEach` or `afterEach`), while `app/pricing/*-action.test.ts` performs local cleanup in individual tests. The documentation rule should teach future changes to either:
 - Add `vi.unstubAllEnvs()` to `afterEach` in the same file, OR
 - Migrate to the `snapshotProcessEnv` / `restoreProcessEnv` pattern from `tests/shared/process-env.ts`.
 
 Either is acceptable; the choice depends on whether the test uses Vitest's stub API (use `vi.unstubAllEnvs`) or direct `process.env` assignment (use snapshot/restore).
 
-### E. `tests/shared/load-dotenv-file.test.ts:17, 23, 33, 39` — direct env mutation with delete-only cleanup
+### E. `tests/shared/load-dotenv-file.test.ts:17, 23, 33, 39` — direct env mutation with delete-only cleanup before PR 1
 
-The 2026-05-28 sweep found one additional PR 1 scope item:
+The 2026-05-28 sweep found one additional PR 1 scope item. Before PR 1, the shape was:
 
 ```typescript
 delete process.env.TEST_ENV_LOADED;
@@ -121,17 +121,17 @@ process.env.TEST_ENV_LOADED = '2';
 delete process.env.TEST_ENV_LOADED;
 ```
 
-The local `finally` blocks delete `TEST_ENV_LOADED`, but they do not restore a pre-existing value. If a developer, CI worker, or previous suite has `TEST_ENV_LOADED` set before this file runs, this test permanently removes it for the rest of the worker. Fix this with the canonical `snapshotProcessEnv()` / `restoreProcessEnv()` helper and keep the per-test `delete process.env.TEST_ENV_LOADED` only where the arrange step requires the variable to start unset.
+The local `finally` blocks deleted `TEST_ENV_LOADED`, but they did not restore a pre-existing value. If a developer, CI worker, or previous suite had `TEST_ENV_LOADED` set before this file ran, this test permanently removed it for the rest of the worker. Current `main` at `47b7d376` captures `const ORIGINAL_ENV = snapshotProcessEnv()` at line 8, restores it in `afterEach` at lines 11-13, and keeps `delete process.env.TEST_ENV_LOADED` only as an arrange step where the test requires the variable to start unset.
 
 ### F. 2026-05-28 sweep catalog
 
-PR 1 must fix these HIGH sites:
+PR 1 fixed these HIGH sites in PR #363:
 
-| File | Current evidence | Required PR 1 action |
+| File | Pre-PR1 evidence | Shipped PR 1 action |
 | --- | --- | --- |
-| `lib/container.test.ts` | Lines 49-57 mutate eight env vars at module scope with no `snapshotProcessEnv` / `restoreProcessEnv` cleanup. | Move mutations behind a hook that runs after the snapshot is captured and restore in `afterAll`. |
-| `proxy.test.ts` | `vi.stubEnv()` at lines 119-121, 585-587, 633-635, 663, 667, 686-692, and 710. Suite `afterEach` at lines 72-76 calls `restoreProcessEnv()`, `vi.resetModules()`, and `vi.restoreAllMocks()`, but not `vi.unstubAllEnvs()`. | Add `vi.unstubAllEnvs()` to the existing suite `afterEach`. |
-| `tests/shared/load-dotenv-file.test.ts` | Lines 17, 23, 33, and 39 delete/set `TEST_ENV_LOADED`; cleanup deletes instead of restoring any original value. | Add module-scope snapshot + `afterEach` restore. |
+| `lib/container.test.ts` | Lines 49-57 mutated eight env vars at module scope with no `snapshotProcessEnv` / `restoreProcessEnv` cleanup. | Added module-scope snapshot before the shared defaults and `afterAll` restore. |
+| `proxy.test.ts` | `vi.stubEnv()` at lines 119-121, 585-587, 633-635, 663, 667, 686-692, and 710. Suite `afterEach` called `restoreProcessEnv()`, `vi.resetModules()`, and `vi.restoreAllMocks()`, but not `vi.unstubAllEnvs()`. | Added `vi.unstubAllEnvs()` before `restoreProcessEnv(ORIGINAL_ENV)` in the existing suite `afterEach`. |
+| `tests/shared/load-dotenv-file.test.ts` | Lines 17, 23, 33, and 39 deleted/set `TEST_ENV_LOADED`; cleanup deleted instead of restoring any original value. | Added module-scope snapshot + `afterEach` restore, and removed delete-only cleanup from `finally` blocks. |
 
 Known-OK reference patterns from the sweep:
 
@@ -154,12 +154,12 @@ Known-OK reference patterns from the sweep:
 
 ## Why Existing Docs Were Not Enough
 
-`AGENTS.md` and `.claude/rules/testing.md` cover Vitest, fakes, TDD, and test quality, but neither mentions:
+At creation, `AGENTS.md` and `.claude/rules/testing.md` covered Vitest, fakes, TDD, and test quality, but neither mentioned:
 
 - That `process.env` mutations leak across tests by default.
 - That `vi.stubEnv()` needs explicit `vi.unstubAllEnvs()` cleanup.
 - That `snapshotProcessEnv` / `restoreProcessEnv` helpers exist in `tests/shared/process-env.ts` and are the canonical pattern.
-- The interaction with `vi.resetModules()` (must come AFTER env restoration when the module reads env at import time).
+- The interaction with `vi.stubEnv()` cleanup ordering (`vi.unstubAllEnvs()` before `restoreProcessEnv(ORIGINAL_ENV)`) and `vi.resetModules()` (must come AFTER env restoration when the module reads env at import time).
 
 The helper file at `tests/shared/process-env.ts` is the existing solution. The gap is documentation + adoption.
 
@@ -167,42 +167,103 @@ The helper file at `tests/shared/process-env.ts` is the existing solution. The g
 
 ## Required Remediation
 
-Ship in three single-concern PRs.
+PR 1 is complete. The remaining DEBT-395 implementation is one consolidated documentation PR, followed by a small archive PR after the documentation lands.
 
 ### PR 1 — Fix the high-confidence env-isolation misses
 
-Branch: `feat/debt-395-pr-1-process-env-isolation-leaks`
+Status: **shipped in PR #363 at `47b7d376`**.
 
-Edits, with explicit matching cleanup:
+Branch used: `feat/debt-395-pr-1-process-env-isolation-leaks`
 
-1. **`lib/container.test.ts`** — import `snapshotProcessEnv()` / `restoreProcessEnv()` from `@/tests/shared/process-env`; capture `const ORIGINAL_ENV = snapshotProcessEnv()` at module scope; move the eight env-default writes into a helper called from `beforeAll` before `loadContainer()` imports `./container`; restore in `afterAll`.
+Shipped cleanup:
 
-   Concrete shape:
+1. **`lib/container.test.ts`** — imports `snapshotProcessEnv()` / `restoreProcessEnv()` from `@/tests/shared/process-env`, captures `const ORIGINAL_ENV = snapshotProcessEnv()` before the shared module-scope env defaults, and restores in `afterAll`.
+2. **`proxy.test.ts`** — adds `vi.unstubAllEnvs()` to the suite-level `afterEach`, before `restoreProcessEnv(ORIGINAL_ENV)`, so Vitest env stubs are cleared and the snapshot is the final visible env state.
+3. **`tests/shared/load-dotenv-file.test.ts`** — captures the original env once and restores it in `afterEach`; temp directory cleanup stays in `finally`, while delete-only env cleanup no longer owns restoration.
+
+The PR 1 proof-of-fix was the full local gate plus shuffled full-suite seeds `1`, `42`, `9999`, `1779972928761`, and `7777777` all passing.
+
+### Consolidated PR 2/3 — Document test environment isolation
+
+Branch: `feat/debt-395-test-isolation-docs`
+
+Decision: **Option A — single source of truth in `.claude/rules/test-isolation.md`, with a pointer from `.claude/rules/testing.md`.**
+
+Rationale:
+
+- `.claude/rules/testing.md` is listed in `CLAUDE.md` as activating on any file, so a scoped `test-isolation.md` does not expand auto-load reach by itself.
+- The separate file still has real value: it matches the existing scoped-rule-file pattern used by `testing-react19.md` and `testing-browser.md`, keeps `testing.md` concise, and gives future agents a discoverable, focused isolation rule.
+- Duplicating the full body in both files is rejected. It would create a documentation drift trap and was the main defect in the original PR 2/PR 3 plan.
+- Option B is acceptable in principle but weaker here because test isolation is a focused subtopic with enough detail and examples to justify a dedicated file.
+
+Exact execution file list:
+
+1. **`.claude/rules/test-isolation.md`** — new canonical rule file with the full process-env isolation rule.
+2. **`.claude/rules/testing.md`** — add only a short "Test Environment Isolation" pointer after "Fakes Over Mocks"; do not duplicate the full rule body.
+3. **`CLAUDE.md`** — add `test-isolation.md` to the Path-Scoped Rules table.
+4. **`docs/debt/debt-395-test-environment-isolation-hardening.md`** — mark the consolidated documentation PR complete after execution.
+
+Do not edit test/source files in the consolidated docs PR. Do not reproduce the full rule body in `AGENTS.md` or `testing.md`; if universal-agent guidance is later desired, use a pointer-only follow-up so `.claude/rules/test-isolation.md` remains the canonical home.
+
+The new rule file should use the existing frontmatter convention:
+
+```markdown
+---
+paths:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "tests/**"
+---
+```
+
+Rule content contract:
+
+1. **Module-scope `process.env.X = ...` / `process.env.X ??= ...`** — capture the snapshot at module scope before any env writes, then restore after the suite. Use `afterAll` only for shared defaults that intentionally stay constant for every test in the file; use `afterEach` when tests mutate env differently.
 
    ```typescript
+   import { afterAll } from 'vitest';
+   import {
+     restoreProcessEnv,
+     snapshotProcessEnv,
+   } from '@/tests/shared/process-env';
+
    const ORIGINAL_ENV = snapshotProcessEnv();
 
-   function setSharedTestEnv() {
-     process.env.DATABASE_URL ??=
-       'postgresql://user:pass@localhost:5432/addiction_boards_test';
-     // ... seven more current defaults ...
-   }
-
-   beforeAll(async () => {
-     setSharedTestEnv();
-     createContainer = await loadContainer();
-   });
+   process.env.DATABASE_URL ??=
+     'postgresql://user:pass@localhost:5432/addiction_boards_test';
 
    afterAll(() => {
      restoreProcessEnv(ORIGINAL_ENV);
    });
    ```
 
-   Verify with `pnpm test --run lib/container.test.ts` then with `pnpm test --run --sequence.shuffle` to confirm no order dependency.
+2. **`vi.stubEnv()`** — pair all stubs with `vi.unstubAllEnvs()`, normally in suite-level `afterEach`.
 
-2. **`proxy.test.ts`** — add `vi.unstubAllEnvs()` to the top-level `afterEach` so every `vi.stubEnv()` call in the file (not just the documented ones) gets cleared. Keep the existing `restoreProcessEnv()` call for direct `process.env` mutations and call `vi.unstubAllEnvs()` before restoring the snapshot so the final visible env state comes from `ORIGINAL_ENV`.
+   ```typescript
+   afterEach(() => {
+     vi.unstubAllEnvs();
+   });
+   ```
 
-   Concrete shape:
+3. **Direct `process.env.X = ...` / `delete process.env.X` inside tests** — use `snapshotProcessEnv()` / `restoreProcessEnv()` in `afterEach`. Avoid delete-only `finally` cleanup because it destroys pre-existing values instead of restoring them. A per-test `delete process.env.X` is acceptable as an arrange step when the test explicitly needs the variable absent.
+
+   ```typescript
+   import { afterEach } from 'vitest';
+   import {
+     restoreProcessEnv,
+     snapshotProcessEnv,
+   } from '@/tests/shared/process-env';
+
+   const ORIGINAL_ENV = snapshotProcessEnv();
+
+   afterEach(() => {
+     restoreProcessEnv(ORIGINAL_ENV);
+   });
+   ```
+
+4. **Combined cleanup ordering** — when `vi.stubEnv()` and direct env snapshot cleanup appear in the same suite, `vi.unstubAllEnvs()` must run first, then `restoreProcessEnv(ORIGINAL_ENV)`. The snapshot is authoritative and must be the last env writer. `vi.resetModules()` comes after env restoration when modules read env at import time.
 
    ```typescript
    afterEach(() => {
@@ -213,137 +274,29 @@ Edits, with explicit matching cleanup:
    });
    ```
 
-   This one-line cleanup addition covers the cited `vi.stubEnv()` blocks at current lines 119-121, 585-587, 633-635, 663/667, 686-692, and 710. The local `vi.unstubAllEnvs()` at line 664 becomes redundant after the global cleanup exists, but it is harmless. Leave it in PR 1 unless the execution agent chooses to simplify the mixed-pattern test in the same focused edit.
-
-3. **`tests/shared/load-dotenv-file.test.ts`** — add `snapshotProcessEnv()` / `restoreProcessEnv()` from `./process-env`; capture `const ORIGINAL_ENV = snapshotProcessEnv()` at module scope; restore in `afterEach`. Keep temp directory cleanup in each `finally`; remove delete-only cleanup for `TEST_ENV_LOADED` from `finally` once `afterEach` owns env restoration.
-
-   Concrete shape:
+5. **Helper semantics** — document the exact helper API from `tests/shared/process-env.ts`:
 
    ```typescript
-   import { afterEach, describe, expect, it } from 'vitest';
-   import { restoreProcessEnv, snapshotProcessEnv } from './process-env';
-
-   const ORIGINAL_ENV = snapshotProcessEnv();
-
-   afterEach(() => {
-     restoreProcessEnv(ORIGINAL_ENV);
-   });
+   export type ProcessEnvSnapshot = Record<string, string | undefined>;
+   export function snapshotProcessEnv(): ProcessEnvSnapshot;
+   export function restoreProcessEnv(snapshot: ProcessEnvSnapshot): void;
    ```
 
-4. **Audit-sweep**: re-run the three `rg` commands from the pre-execution audit section across the full repo root, not only `app/ src/ components/ lib/ tests/`, because root-level test files such as `proxy.test.ts` and `sentry-config.test.ts` are otherwise missed. For every file with mutation calls, verify the `afterEach`, `afterAll`, or local `finally` has matching cleanup. Add cleanup where missing.
+   `restoreProcessEnv()` deletes keys added after the snapshot and restores keys that existed before the snapshot, so newly set variables such as `TEST_ENV_LOADED` or `DATABASE_URL` are truly cleaned instead of merely overwritten.
 
-Full local gate after fixes:
+6. **Canonical examples** — cite `components/get-started-cta.test.tsx` as the PR #342 direct-env reference pattern, plus the PR 1 examples: `lib/container.test.ts`, `proxy.test.ts`, and `tests/shared/load-dotenv-file.test.ts`.
 
-```sh
-pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build
-```
+7. **Do-not-churn guidance** — many env-mutation sites are already clean. The rule governs new or changed tests; do not rewrite known-OK files only to make style uniform.
 
-Then run unit tests in random order to catch any remaining leaks:
+Do not carry forward the old PR 3 outline's unverified broad claims about module-cache ordering, database isolation, or generic mutable state. DEBT-395 is specifically about process-env isolation. Broader test-isolation topics can get their own debt if a concrete bug or rule gap is found.
 
-```sh
-pnpm test --run --sequence.shuffle
-```
+### Follow-up archive PR
 
-If a shuffled run reveals a new failure, that's a hidden order dependency — surface it as an additional fix in the same PR.
+After the consolidated documentation PR merges, close DEBT-395 with a separate archive PR:
 
-Also keep the DEBT-398 PR 3 regression scan green:
-
-```sh
-pnpm test --run components/theme-token-regression.test.tsx
-```
-
-Expected current signal: 16 tests pass in `components/theme-token-regression.test.tsx`.
-
-### PR 2 — Document the pattern (no code changes)
-
-Branch: `docs/debt-395-test-env-isolation-rule`
-
-Edit `.claude/rules/testing.md` — add a section after "Fakes Over Mocks":
-
-```markdown
-## Test Environment Isolation
-
-`process.env` mutations are global and persist across tests unless explicitly reset. Any test that modifies `process.env` MUST follow this pattern.
-
-### For `vi.stubEnv()` calls
-
-Add to the suite's `afterEach`:
-
-```typescript
-afterEach(() => {
-  vi.unstubAllEnvs();
-});
-```
-
-`vi.unstubAllEnvs()` clears all stubs set via `vi.stubEnv()` in the current test. Without it, stubs leak to the next test in the same file.
-
-### For direct `process.env.X = ...` assignments
-
-Use the snapshot helpers from `tests/shared/process-env.ts`:
-
-```typescript
-import { snapshotProcessEnv, restoreProcessEnv } from '../../tests/shared/process-env';
-
-const ORIGINAL_ENV = snapshotProcessEnv();
-
-afterEach(() => {
-  restoreProcessEnv(ORIGINAL_ENV);
-  vi.resetModules();  // purge cached imports that read env at module load
-});
-```
-
-Snapshot at suite level (not in `beforeEach` — that's too late if module-scope setup runs first). Restore in `afterEach` (not `afterAll` — sibling tests need a clean slate between each test).
-
-### Ordering matters
-
-`vi.resetModules()` MUST come AFTER env restoration when modules read env at import time, because re-importing the module after reset captures the current env.
-
-### Why this matters
-
-Process env leaks cause order-dependent test failures that:
-- Pass locally but fail in CI (different worker scheduling)
-- Pass in isolation but fail in suite (and vice versa)
-- Mask production bugs by accidentally setting the "right" value
-
-See PR #342 for the precedent incident: `components/get-started-cta.test.tsx` was leaking `NEXT_PUBLIC_SKIP_CLERK=true` and the bug only surfaced when Dependabot CI ran without repo secrets.
-```
-
-Also add a small section to `AGENTS.md` under the Testing rules pointing at this new section, so universal-context agents see it.
-
-### PR 3 — New rule file `.claude/rules/test-isolation.md`
-
-Branch: `docs/debt-395-test-isolation-rule-file`
-
-Create a dedicated rule file at `.claude/rules/test-isolation.md` so agents working on `**/*.test.ts` / `**/*.test.tsx` auto-load isolation guidance separately from general testing rules. Outline:
-
-```markdown
-# Test Isolation Rules
-
-Activates for: `**/*.test.ts`, `**/*.test.tsx`, `tests/**`
-
-## Process.env Isolation
-
-[reproduce the pattern from testing.md update above]
-
-## Module Caching
-
-- `vi.resetModules()` in afterEach when dynamic imports read env at module scope.
-- `vi.restoreAllMocks()` / `vi.resetMocks()` in afterEach when mocks were created in the test.
-- Order: restore mocks BEFORE resetting modules.
-
-## Database Isolation (Integration Tests)
-
-- Each integration test gets isolated state via transaction rollback or per-test temp schema.
-- Never rely on suite-level cleanup that other tests' setup might invalidate.
-
-## Cross-test State Contamination
-
-- Avoid module-scope `let counter = 0`-style mutable state.
-- Shared factories (`createX()` from `src/domain/test-helpers/`) are OK ONLY if they return fresh instances per call.
-- Shared mock instances MUST be `mockReset()`-ed in `afterEach`.
-```
-
-Add `test-isolation.md` to the table in `CLAUDE.md` under Path-Scoped Rules so it's discoverable.
+1. Move this file to `docs/_archive/debt/`.
+2. Update the active and archived debt indexes consistently with recent DEBT-398/DEBT-399 archival style.
+3. Add a resolution paragraph naming PR #363 and the consolidated documentation PR.
 
 ---
 
@@ -360,32 +313,38 @@ PR 1 done when:
 - `pnpm test --run components/theme-token-regression.test.tsx` remains 16/16 green for DEBT-398 PR 3.
 - Pre-push hook green.
 
-PR 2 done when:
+Status: **complete in PR #363 at `47b7d376`**.
 
-- `.claude/rules/testing.md` has the "Test Environment Isolation" section.
-- `AGENTS.md` references the new section.
-- A future agent editing a test file will see the rule loaded.
+Consolidated PR 2/3 done when:
 
-PR 3 done when:
+- `.claude/rules/test-isolation.md` exists with the frontmatter and rule contract above.
+- `.claude/rules/testing.md` cross-references `test-isolation.md` with a pointer only.
+- `CLAUDE.md` table is updated to list the new rule and its activation scope.
+- No source files or test files change.
+- `pnpm test --run components/theme-token-regression.test.tsx` remains 16/16 green for DEBT-398 PR 3.
+- Full local gate is green before push, even though the PR is doc-only.
+- The DEBT-395 doc marks the consolidated documentation PR complete.
 
-- `.claude/rules/test-isolation.md` exists with the documented sections.
-- `CLAUDE.md` table is updated to list the new rule.
-- Existing `.claude/rules/testing.md` cross-references it.
+Archive PR done when:
+
+- This debt doc is moved to `docs/_archive/debt/`.
+- Debt indexes are updated.
+- The archive text names PR #363 and the consolidated documentation PR as the completed resolution chain.
 
 ---
 
 ## Risk and Reversibility
 
-- **PR 1 (test fixes)** — low risk. Failure mode is "test that previously passed now fails because the leak is gone." That's a discovery, not a regression — fix the now-exposed dependency.
-- **PR 2 (testing.md update)** — zero risk. Doc-only.
-- **PR 3 (new rule file)** — zero risk. Doc-only. The rule auto-loads on test files; if it's wrong, edit it.
+- **PR 1 (test fixes)** — shipped. Low risk; failure mode was "test that previously passed now fails because the leak is gone." That is a discovery, not a regression.
+- **Consolidated PR 2/3 (rule docs)** — zero production risk. Doc-only. If the rule is wrong, edit the single canonical rule file.
+- **Archive PR** — zero production risk. Doc-only bookkeeping.
 
-All three PRs are independently revertable.
+All remaining PRs are independently revertable.
 
 ---
 
 ## Done When
 
-All three PRs merged to `dev` and synced to `main`. `pnpm test --run --sequence.shuffle` is green on the final state. The `vi.stubEnv` and module-scope `process.env` audit returns clean. DEBT-395 doc moved to `docs/_archive/debt/` with resolution paragraph naming all three PRs.
+PR #363, the consolidated documentation PR, and the archive PR have merged to `dev` and synced to `main`. `pnpm test --run --sequence.shuffle` is green on the final state. The `vi.stubEnv` and module-scope `process.env` audit returns clean. DEBT-395 doc is moved to `docs/_archive/debt/` with a resolution paragraph naming the completed PR chain.
 
 A future agent who triggers `vi.stubEnv` in a new test will be reminded (via the auto-loaded rule) to add the matching cleanup, and the bug class behind PR #342 stops recurring.


### PR DESCRIPTION
## Summary

Implements DEBT-395 PR 2/3 as one consolidated documentation PR using the audited Option A structure from commit 838c4708.

- Adds `.claude/rules/test-isolation.md` as the single source of truth for process-env test isolation.
- Adds a pointer-only section in `.claude/rules/testing.md` after Fakes Over Mocks; no duplicated rule body.
- Adds `test-isolation.md` to the `CLAUDE.md` Path-Scoped Rules table.
- Marks the consolidated documentation criteria complete in the DEBT-395 doc.

## Source

- Scope audited in 838c4708: `Pre-execution audit DEBT-395 PR 2/3 scope`.
- DEBT-395 PR 1 shipped the underlying bug fixes in PR #363.
- The separate DEBT-395 archive PR follows after this documentation PR lands.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- [x] `pnpm test --run components/theme-token-regression.test.tsx` (16/16)
- [x] Pre-push hook: `tsc --noEmit` + `vitest --run` (2524/2524)
- [x] E2E skipped: pure doc/rule-only PR per execution prompt.

## Notes

The new rule intentionally overlaps existing scoped test rules in activation, but not in responsibility: `testing-react19.md` covers React 19 jsdom mechanics, `testing-browser.md` covers browser specs, and `test-isolation.md` covers process-env isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive testing guidelines for environment variable isolation to ensure stable and reliable test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->