### PR TITLE
DEBT-400 PR 2a — controller/job/gateway app-UUID boundary fixtures

### DIFF
--- a/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
+++ b/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
@@ -382,7 +382,7 @@ PR 2 proof method:
   ```
 - Acceptance is not "zero placeholder-looking strings in adapters." Provider and invalid buckets above are expected to remain.
 
-Split recommendation: keep PR 2 as **one adapter-layer PR** on `feat/debt-400-pr-2-adapter-boundary-fixtures`, but execute and review it in sub-area commits (`controllers/shared`, `repositories`, `gateways/jobs`). The change has one reason to change, is test-only, and the table above provides enough do-not-churn guardrails; splitting into more PRs would mostly add coordination overhead unless execution discovers unexpectedly large non-mechanical fallout.
+Split decision: PR 2 ships as **two PRs** on adapter-layer boundaries. PR 2a uses `feat/debt-400-pr-2-adapter-boundary-fixtures` and covers controllers, `src/adapters/shared/with-idempotency.test.ts`, jobs, and gateways. PR 2b follows on a fresh branch for `src/adapters/repositories/**/*.test.ts`. The table above remains the SSOT for both PRs; PR 2a must not touch repository tests.
 
 ### PR 3 — App, browser, and application fixture sweep
 

--- a/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
+++ b/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
@@ -375,11 +375,13 @@ PR 2 proof method:
 - Convert valid-path app UUID placeholders to semantic generated IDs, then assert against those variables instead of old literals.
 - Repository tests must keep Drizzle row typing intact; do not use `as any`, widen row types, or relax expectations to hide invalid UUID fixtures.
 - Run the adapter PR 2 slice directly, then the full local gate:
+
   ```sh
   pnpm test --run src/adapters/controllers src/adapters/repositories src/adapters/shared/with-idempotency.test.ts src/adapters/jobs src/adapters/gateways
   pnpm test --run tests/shared/fixture-uuid-integrity.test.ts
   pnpm test --run components/theme-token-regression.test.tsx
   ```
+
 - Acceptance is not "zero placeholder-looking strings in adapters." Provider and invalid buckets above are expected to remain.
 
 Split decision: PR 2 ships as **two PRs** on adapter-layer boundaries. PR 2a uses `feat/debt-400-pr-2-adapter-boundary-fixtures` and covers controllers, `src/adapters/shared/with-idempotency.test.ts`, jobs, and gateways. PR 2b follows on a fresh branch for `src/adapters/repositories/**/*.test.ts`. The table above remains the SSOT for both PRs; PR 2a must not touch repository tests.

--- a/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
+++ b/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
@@ -1,8 +1,8 @@
 # DEBT-400: Test Fixture Integrity (Zod Boundary Class)
 
-**Priority:** P2 (latent bug class. The current canonical candidate grep finds 2,447 placeholder-ID assignments across 163 test files. This is a candidate set, not a mandate to replace every string: the execution scope is only IDs that cross `zUuid = z.guid()` controller schemas or model Drizzle `uuid()` columns.)
+**Priority:** P2 (latent bug class. After PR 1, the current canonical candidate grep finds 2,438 placeholder-ID assignments across 162 test files. This is a candidate set, not a mandate to replace every string: the execution scope is only IDs that cross `zUuid = z.guid()` controller schemas or model Drizzle `uuid()` columns.)
 **Created:** 2026-05-26
-**Source:** Deep schema/boundary integrity audit conducted alongside DEBT-394 archival; re-audited on 2026-05-28 from `dev` at `f2dc0793`. Direct precedent is PR #330, which bumped Zod from 3 to 4 and deliberately kept historical UUID/GUID behavior by replacing the shared controller ID schema with Zod 4 `z.guid()`.
+**Source:** Deep schema/boundary integrity audit conducted alongside DEBT-394 archival; re-audited on 2026-05-28 from `dev` at `f2dc0793`, then PR 2 scope re-audited on 2026-05-28 from `dev` at `e7f1029a` after PR 1 merged. Direct precedent is PR #330, which bumped Zod from 3 to 4 and deliberately kept historical UUID/GUID behavior by replacing the shared controller ID schema with Zod 4 `z.guid()`.
 **Related:** [src/adapters/shared/zod-schemas.ts](../../src/adapters/shared/zod-schemas.ts), [db/schema.ts](../../db/schema.ts), [src/domain/test-helpers/](../../src/domain/test-helpers/), [src/application/test-helpers/fakes/](../../src/application/test-helpers/fakes/), [docs/dev/dependency-update-protocol.md](../dev/dependency-update-protocol.md), [DEBT-397](./debt-397-datetime-boundary-type-normalization.md), [DEBT-394 (archived)](../_archive/debt/debt-394-supply-chain-hardening.md), PR #330
 
 **Status:** Active
@@ -89,11 +89,11 @@ rg -n "\b(questionId|sessionId|attemptId|choiceId|selectedChoiceId|correctChoice
   --glob '!**/_archive/**'
 ```
 
-Current result on `f2dc0793`: **2,447 lines across 163 files**.
+Current result on `e7f1029a` after PR 1: **2,438 lines across 162 files**. The pre-PR1 audit result on `f2dc0793` was **2,447 lines across 163 files**.
 
 This replaces the old narrower `604 / 64` count. The old grep only searched `app/ src/ components/`, only camel-case object properties, only five field names, and only underscore-prefixed values. It missed hyphenated placeholders (`session-1`), choice/tag/subscription fields, snake_case SQL-row fixtures (`user_id`), and `tests/**` helper fixtures.
 
-High-count files from the current sweep:
+High-count files from the original `f2dc0793` sweep, kept as directional context:
 
 | File | Hits | Why it matters |
 |---|---:|---|
@@ -121,7 +121,7 @@ The execution agent should regenerate the full line list from the command above 
 
 ### A. Placeholder IDs are broad, but the cleanup boundary is narrower than the raw count
 
-The broad candidate set is now 2,447 lines across 163 files. Many are real boundary-crossing problems, but some are intentionally harmless:
+The broad candidate set is now 2,438 lines across 162 files. Many are real boundary-crossing problems, but some are intentionally harmless:
 
 - a component-only selected-choice token that never leaves the component;
 - a provider-owned external ID such as `cus_123`, `sub_123`, `evt_1`, or a Clerk `user_...` id;
@@ -142,20 +142,15 @@ const sessionId = crypto.randomUUID();
 
 Do not replace a readable placeholder with an opaque hardcoded UUID literal unless the test specifically needs a stable literal for a snapshot or fixture file.
 
-### C. Domain factories and fakes still generate non-UUID IDs
+### C. Domain factories and fakes were fixed by PR 1
 
-Confirmed current drift:
+PR 1 merged as #368 at `e7f1029a`. Current code now has the intended foundation:
 
-- `src/domain/test-helpers/factories.ts:28` returns `id: 'user-1'`.
-- `src/domain/test-helpers/factories.ts:49-55` defaults attempt `id`, `userId`, `questionId`, and selected choice values to non-UUID strings.
-- `src/domain/test-helpers/factories.ts:73-74` defaults bookmark `userId` / `questionId` to non-UUID strings.
-- `src/domain/test-helpers/factories.ts:82`, `92-93`, `106`, `131-132`, `161`, and `187-188` default tag, choice, question, subscription, and practice-session IDs to non-UUID strings.
-- `src/application/test-helpers/fakes/fake-attempt-repository.ts:29, 40-44, 82-83` tracks numeric `nextId` and emits `attempt-${n}`.
-- `src/application/test-helpers/fakes/fake-practice-session-repository.ts:192` emits `session-${this.sessions.length + 1}`.
-- `src/application/test-helpers/fakes/fake-user-repository.ts:13, 98` tracks numeric `nextId` and emits `user-${n}`.
-- `src/application/test-helpers/fakes/fake-subscription-repository.ts:63` emits `subscription-${this.byUserId.size + 1}`.
+- `src/domain/test-helpers/factories.ts` uses `crypto.randomUUID()` for generated app-owned IDs while preserving explicit overrides.
+- `src/application/test-helpers/fakes/fake-attempt-repository.ts`, `fake-practice-session-repository.ts`, `fake-user-repository.ts`, and `fake-subscription-repository.ts` generate UUID-valid app IDs internally.
+- `tests/shared/fixture-uuid-integrity.test.ts` proves those generated factory/fake IDs pass the real `zUuid.safeParse()` contract.
 
-These are high-leverage fixes because many tests receive IDs indirectly from the shared factory/fake layer.
+The remaining DEBT-400 work is explicit fixture overrides and adapter/app DTO rows that still provide placeholder IDs directly.
 
 ### D. Fakes are shape-permissive
 
@@ -246,7 +241,7 @@ No separate DEBT-402 is filed from this audit. A new debt file would be speculat
 
 ## Required Remediation
 
-Ship as split, reviewable PRs. The original four-PR plan is replaced because a 2,447-hit candidate set is too large for one "fixture sweep" PR, and duplicating rule text across `testing.md` and a new rule file would recreate the DEBT-395 documentation drift trap.
+Ship as split, reviewable PRs. The original four-PR plan is replaced because a 2,438-hit candidate set is too large for one "fixture sweep" PR, and duplicating rule text across `testing.md` and a new rule file would recreate the DEBT-395 documentation drift trap.
 
 ### PR 1 — Foundation: factories/fakes plus proof harness
 
@@ -271,6 +266,8 @@ Rules:
 - Do not make all fakes import controller schemas or validate every input in this PR.
 - Capture returned IDs in assertions instead of expecting `attempt-1`, `session-1`, etc.
 
+Status: shipped in PR #368 at `e7f1029a`.
+
 ### PR 2 — Adapter boundary fixture sweep
 
 Branch: `feat/debt-400-pr-2-adapter-boundary-fixtures`
@@ -294,6 +291,98 @@ Proof:
 - Existing controller validation tests still reject invalid UUIDs.
 - Valid-path controller tests pass with generated UUIDs.
 - Repository tests still pass without widening type assertions.
+
+#### PR 2 pre-execution audit: adapter target list
+
+Re-audited on 2026-05-28 from `dev` at `e7f1029a` after PR 1 merged. The `zUuid` controller-field list and Drizzle `uuid()` column list above remain current. The PR 2 file globs resolve to real files:
+
+- `src/adapters/controllers/**/*.test.ts`
+- `src/adapters/repositories/**/*.test.ts`
+- `src/adapters/shared/with-idempotency.test.ts`
+- `src/adapters/jobs/**/*.test.ts`
+- `src/adapters/gateways/**/*.test.ts`
+
+The classification below is the execution target list. Counts are candidate string-literal occurrences from an AST-assisted audit of ID-shaped test literals; final edit count may be lower when one semantic `const userId = crypto.randomUUID()` replaces several repeated literals. Do not treat provider/invalid counts as failures.
+
+| File | FIX app-UUID | LEAVE provider | LEAVE invalid | Execution note |
+|---|---:|---:|---:|---|
+| `src/adapters/controllers/billing-controller.test.ts` | 5 | 2 | 0 | Fix app `user.id` / `userId`; leave `clerkUserId`. |
+| `src/adapters/controllers/bookmark-controller.test.ts` | 4 | 0 | 1 | Fix auth/user fixtures; keep `not-a-uuid` rejection case. |
+| `src/adapters/controllers/clerk-webhook-controller.test.ts` | 0 | 103 | 0 | Provider-only Clerk/Svix/email/customer sentinels; do not churn. |
+| `src/adapters/controllers/create-action.test.ts` | 0 | 0 | 1 | Keep direct invalid schema test. |
+| `src/adapters/controllers/practice-controller-exam-draft.test.ts` | 2 | 0 | 3 | Fix auth `userId`; keep invalid session/question/choice case. |
+| `src/adapters/controllers/practice-controller-mark-and-count.test.ts` | 3 | 0 | 2 | Fix auth `userId`; keep invalid session/question case. |
+| `src/adapters/controllers/practice-controller-session-lifecycle.test.ts` | 6 | 0 | 2 | Fix auth `userId` and valid-path `sessionId` output placeholders; keep invalid `bad` inputs. |
+| `src/adapters/controllers/practice-controller-session-reads.test.ts` | 9 | 0 | 3 | Fix auth `userId` placeholders; keep invalid `sessionId` cases. |
+| `src/adapters/controllers/question-controller-exam-timer.test.ts` | 3 | 0 | 0 | Fix valid-path question/choice/user IDs. |
+| `src/adapters/controllers/question-controller.test.ts` | 14 | 0 | 3 | Fix auth, input, and output UUID placeholders; keep invalid input cases. |
+| `src/adapters/controllers/question-view-controller.test.ts` | 40 | 0 | 1 | Fix question/choice/attempt/user fixtures; keep invalid question-id case. |
+| `src/adapters/controllers/require-entitled-user-id.test.ts` | 2 | 0 | 0 | Fix app `users.id` fixtures. |
+| `src/adapters/controllers/review-controller.test.ts` | 6 | 0 | 0 | Fix app `users.id` / use-case `userId` fixtures. |
+| `src/adapters/controllers/shared/execute-idempotent.test.ts` | 6 | 0 | 0 | Fix `idempotency_keys.userId` fixtures. |
+| `src/adapters/controllers/stats-controller.test.ts` | 3 | 0 | 0 | Fix app `users.id` / use-case `userId` fixtures. |
+| `src/adapters/controllers/stripe-webhook-controller.test.ts` | 10 | 46 | 0 | Fix subscription/customer repo `userId`; leave Stripe event/customer/subscription IDs. |
+| `src/adapters/controllers/tag-controller.test.ts` | 6 | 0 | 0 | Fix app user and tag UUID fixtures. |
+| `src/adapters/gateways/clerk-auth-gateway.test.ts` | 0 | 20 | 0 | Provider-only Clerk/email IDs; PR 1 fake user defaults already cover generated app IDs. |
+| `src/adapters/gateways/stripe-payment-gateway.test.ts` | 23 | 138 | 0 | Fix app `userId` / metadata `user_id`; leave Stripe/Clerk IDs and price IDs. |
+| `src/adapters/gateways/stripe-subscription-canceler.test.ts` | 0 | 17 | 0 | Provider-only Stripe subscription IDs. |
+| `src/adapters/gateways/stripe/stripe-checkout-sessions.test.ts` | 1 | 43 | 0 | Fix app `userId`; leave Stripe checkout/customer/price IDs. |
+| `src/adapters/gateways/stripe/stripe-customers.test.ts` | 7 | 20 | 0 | Fix app `userId`, including malformed valid-path `user_`; leave Stripe/Clerk IDs. |
+| `src/adapters/gateways/stripe/stripe-portal.test.ts` | 0 | 3 | 0 | Provider-only Stripe customer IDs. |
+| `src/adapters/gateways/stripe/stripe-subscription-normalizer.test.ts` | 4 | 29 | 0 | Fix app metadata/user IDs; leave Stripe subscription/customer/price IDs. |
+| `src/adapters/gateways/stripe/stripe-webhook-processor.test.ts` | 5 | 46 | 0 | Fix app metadata/user IDs; leave Stripe event/subscription/customer/price IDs. |
+| `src/adapters/gateways/stripe/stripe-webhook-schemas.test.ts` | 0 | 7 | 0 | Provider-only Stripe webhook schema sentinel IDs. |
+| `src/adapters/jobs/reconcile-stripe-subscriptions.test.ts` | 40 | 118 | 0 | Fix app `userId` values in local subscription/customer mappings; leave Stripe customer/subscription/price IDs. |
+| `src/adapters/repositories/attempt-row-mappers.test.ts` | 4 | 0 | 0 | Fix attempt row UUID fields. |
+| `src/adapters/repositories/drizzle-attempt-repository.test.ts` | 128 | 0 | 0 | Fix all attempt/question/session/choice/user row and query UUID fixtures. |
+| `src/adapters/repositories/drizzle-bookmark-repository.test.ts` | 27 | 0 | 0 | Fix bookmark `userId` / `questionId` fixtures. |
+| `src/adapters/repositories/drizzle-clerk-event-repository.test.ts` | 0 | 12 | 0 | Provider event IDs; do not churn. |
+| `src/adapters/repositories/drizzle-deleted-clerk-user-repository.test.ts` | 0 | 8 | 0 | Clerk user IDs are varchar provider IDs; do not churn. |
+| `src/adapters/repositories/drizzle-pending-stripe-cancellation-repository.test.ts` | 0 | 10 | 0 | Stripe event/customer IDs; do not churn. |
+| `src/adapters/repositories/drizzle-practice-session-repository-question-state.test.ts` | 45 | 0 | 0 | Fix session/user/question/choice state UUID fixtures. |
+| `src/adapters/repositories/drizzle-practice-session-repository-reads.test.ts` | 29 | 0 | 0 | Fix session/user/question UUID fixtures. |
+| `src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts` | 23 | 0 | 0 | Fix session/user/question/choice UUID fixtures. |
+| `src/adapters/repositories/drizzle-question-repository.test.ts` | 13 | 0 | 0 | Fix question/choice/tag/user UUID fixtures; slugs remain unchanged. |
+| `src/adapters/repositories/drizzle-stripe-customer-repository.test.ts` | 9 | 12 | 0 | Fix app `userId`; leave Stripe customer IDs. |
+| `src/adapters/repositories/drizzle-stripe-event-repository.test.ts` | 0 | 22 | 0 | Provider event IDs; do not churn. |
+| `src/adapters/repositories/drizzle-subscription-repository.test.ts` | 19 | 35 | 0 | Fix `stripe_subscriptions.id` and `userId`; leave `stripeSubscriptionId` / `priceId`. |
+| `src/adapters/repositories/drizzle-tag-repository.test.ts` | 6 | 0 | 0 | Fix tag UUID fixtures. |
+| `src/adapters/repositories/drizzle-user-repository.test.ts` | 7 | 19 | 0 | Fix app `users.id`; leave `clerkUserId`. |
+| `src/adapters/repositories/practice-session-params.test.ts` | 7 | 0 | 0 | Fix question/choice IDs embedded in practice-session params JSON. |
+| `src/adapters/shared/with-idempotency.test.ts` | 31 | 0 | 0 | Fix `idempotency_keys.userId` fixtures; existing idempotency keys are already UUID-shaped where controller-like. |
+
+Totals from the PR 2 audit table: **547 FIX**, **710 LEAVE-provider**, **16 LEAVE-invalid** candidate literal occurrences.
+
+Controller validation exercise notes:
+
+| Controller test file | Real validation exercised? | Note |
+|---|---|---|
+| `billing-controller.test.ts` | Yes, via `createAction` | Input only validates `plan` / optional `idempotencyKey`; app user placeholders are auth/use-case fixtures. |
+| `bookmark-controller.test.ts` | Yes, via `createAction` | `questionId` negative test proves `zUuid` rejection. |
+| `clerk-webhook-controller.test.ts` | No `zUuid` boundary | Tests provider webhook payload validation; provider IDs stay provider-shaped. |
+| `create-action.test.ts` | Yes, direct schema | Keep invalid UUID test as the shared action validation proof. |
+| `practice-controller-*.test.ts` | Yes, via `createAction` and exported practice schemas | Valid-path UUID placeholders should be UUID-valid; invalid tests stay invalid. |
+| `question-controller*.test.ts` | Yes, via `createAction`; `submitAnswer` also parses idempotent output schema | Fix input/output/user placeholders that model `zUuid` or app UUIDs. |
+| `question-view-controller.test.ts` | Yes for `getPreviousAttempt`; `getQuestionBySlug` has slug input but returns DB UUID-shaped question/choice data | Fix returned question/choice/attempt/user placeholders. |
+| `require-entitled-user-id.test.ts` | Bypasses controller schema | Still fixes app `users.id` fixtures because they model the auth/domain user row. |
+| `review-controller.test.ts`, `stats-controller.test.ts`, `tag-controller.test.ts` | Yes, but no `zUuid` input fields | Fix app auth/user/tag fixtures that model UUID columns. |
+| `stripe-webhook-controller.test.ts` | No `zUuid` input boundary | Fix app `userId` in subscription/customer fake state; leave Stripe event/customer/subscription IDs. |
+
+PR 2 proof method:
+
+- Do not export private controller schemas just to add a standalone `safeParse()` harness. The controller tests already exercise real input schemas through `createAction`; adding exports would widen production/test API surface for little value.
+- Keep existing negative tests (`not-a-uuid`, `bad`, `still-bad`, `also-bad`) invalid and assert `VALIDATION_ERROR` / rejection.
+- Convert valid-path app UUID placeholders to semantic generated IDs, then assert against those variables instead of old literals.
+- Repository tests must keep Drizzle row typing intact; do not use `as any`, widen row types, or relax expectations to hide invalid UUID fixtures.
+- Run the adapter PR 2 slice directly, then the full local gate:
+  ```sh
+  pnpm test --run src/adapters/controllers src/adapters/repositories src/adapters/shared/with-idempotency.test.ts src/adapters/jobs src/adapters/gateways
+  pnpm test --run tests/shared/fixture-uuid-integrity.test.ts
+  pnpm test --run components/theme-token-regression.test.tsx
+  ```
+- Acceptance is not "zero placeholder-looking strings in adapters." Provider and invalid buckets above are expected to remain.
+
+Split recommendation: keep PR 2 as **one adapter-layer PR** on `feat/debt-400-pr-2-adapter-boundary-fixtures`, but execute and review it in sub-area commits (`controllers/shared`, `repositories`, `gateways/jobs`). The change has one reason to change, is test-only, and the table above provides enough do-not-churn guardrails; splitting into more PRs would mostly add coordination overhead unless execution discovers unexpectedly large non-mechanical fallout.
 
 ### PR 3 — App, browser, and application fixture sweep
 
@@ -369,9 +458,12 @@ PR 1 done when:
 
 PR 2 done when:
 
-- Valid-path adapter/controller tests use UUID-valid values for every `zUuid` field.
-- Adapter repository row fixtures use UUID-valid values for every Drizzle `uuid()` column they model.
+- Valid-path adapter/controller tests use UUID-valid values for every `zUuid` field and app `users.id` auth fixture they model.
+- Adapter repository row fixtures use UUID-valid values for every Drizzle `uuid()` column they model, including IDs embedded in practice-session params JSON.
+- Gateway/job tests fix only app UUID fields such as `userId` / metadata `user_id`; provider IDs (`cus_`, `sub_`, `evt_`, `price_`, Clerk IDs) remain provider-shaped.
 - Invalid UUID negative tests remain explicit and intentional.
+- `tests/shared/fixture-uuid-integrity.test.ts` from PR 1 remains green.
+- `pnpm test --run components/theme-token-regression.test.tsx` remains 16/16.
 - Full local gate green.
 
 PR 3 done when:

--- a/src/adapters/controllers/billing-controller.test.ts
+++ b/src/adapters/controllers/billing-controller.test.ts
@@ -28,6 +28,9 @@ type BillingControllerTestDeps = BillingControllerDeps & {
   _calls: {
     clerkCalls: Array<undefined>;
   };
+  _fixtures: {
+    userId: string;
+  };
 };
 
 function createDeps(overrides?: {
@@ -44,12 +47,12 @@ function createDeps(overrides?: {
   const user =
     overrides?.user === undefined
       ? createUser({
-          id: 'user_1',
           email: 'user@example.com',
           createdAt: new Date('2026-02-01T00:00:00Z'),
           updatedAt: new Date('2026-02-01T00:00:00Z'),
         })
       : overrides.user;
+  const userId = user?.id ?? crypto.randomUUID();
 
   const appUrl = overrides?.appUrl ?? 'https://app.example.com';
   const clerkUserId =
@@ -89,6 +92,9 @@ function createDeps(overrides?: {
     now,
     _calls: {
       clerkCalls,
+    },
+    _fixtures: {
+      userId,
     },
   };
 }
@@ -152,7 +158,7 @@ describe('billing-controller', () => {
       });
       expect(deps.createCheckoutSessionUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           clerkUserId: 'clerk_1',
           email: 'user@example.com',
           plan: 'annual',
@@ -255,7 +261,10 @@ describe('billing-controller', () => {
         data: { url: 'https://stripe/portal' },
       });
       expect(deps.createPortalSessionUseCase.inputs).toEqual([
-        { userId: 'user_1', returnUrl: 'https://app.example.com/app/billing' },
+        {
+          userId: deps._fixtures.userId,
+          returnUrl: 'https://app.example.com/app/billing',
+        },
       ]);
     });
 
@@ -274,7 +283,10 @@ describe('billing-controller', () => {
         },
       });
       expect(deps.createPortalSessionUseCase.inputs).toEqual([
-        { userId: 'user_1', returnUrl: 'https://app.example.com/app/billing' },
+        {
+          userId: deps._fixtures.userId,
+          returnUrl: 'https://app.example.com/app/billing',
+        },
       ]);
     });
 
@@ -296,7 +308,7 @@ describe('billing-controller', () => {
       expect(deps.createPortalSessionUseCase.inputs).toHaveLength(1);
       expect(deps.createPortalSessionUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           returnUrl: 'https://app.example.com/app/billing',
           idempotencyKey: '11111111-1111-1111-1111-111111111111',
         },

--- a/src/adapters/controllers/bookmark-controller.test.ts
+++ b/src/adapters/controllers/bookmark-controller.test.ts
@@ -25,6 +25,9 @@ type BookmarkControllerTestDeps = BookmarkControllerDeps & {
   toggleBookmarkUseCase: FakeToggleBookmarkUseCase;
   getBookmarksUseCase: FakeGetBookmarksUseCase;
   rateLimiter: FakeRateLimiter;
+  _fixtures: {
+    userId: string;
+  };
 };
 
 function createDeps(overrides?: {
@@ -39,12 +42,12 @@ function createDeps(overrides?: {
   const user =
     overrides?.user === undefined
       ? createUser({
-          id: 'user_1',
           email: 'user@example.com',
           createdAt: new Date('2026-02-01T00:00:00Z'),
           updatedAt: new Date('2026-02-01T00:00:00Z'),
         })
       : overrides.user;
+  const userId = user?.id ?? crypto.randomUUID();
 
   const now = new Date('2026-02-01T00:00:00Z');
 
@@ -55,7 +58,7 @@ function createDeps(overrides?: {
       ? []
       : [
           createSubscription({
-            userId: user?.id ?? 'user_1',
+            userId,
             status: 'active',
             currentPeriodEnd: new Date('2026-12-31T00:00:00Z'),
           }),
@@ -88,6 +91,9 @@ function createDeps(overrides?: {
     toggleBookmarkUseCase,
     getBookmarksUseCase,
     now: () => now,
+    _fixtures: {
+      userId,
+    },
   };
 }
 
@@ -149,7 +155,7 @@ describe('bookmark-controller', () => {
       expect(result).toEqual({ ok: true, data: { bookmarked: false } });
       expect(deps.toggleBookmarkUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           questionId: '11111111-1111-1111-1111-111111111111',
         },
       ]);
@@ -192,7 +198,7 @@ describe('bookmark-controller', () => {
       expect(deps.toggleBookmarkUseCase.inputs).toEqual([]);
       expect(deps.rateLimiter.inputs).toEqual([
         {
-          key: 'bookmark:toggleBookmark:user_1',
+          key: `bookmark:toggleBookmark:${deps._fixtures.userId}`,
           limit: 60,
           windowMs: 60_000,
         },
@@ -258,12 +264,13 @@ describe('bookmark-controller', () => {
     });
 
     it('returns ok when use case returns bookmarks', async () => {
+      const questionId = crypto.randomUUID();
       const deps = createDeps({
         getBookmarksOutput: {
           rows: [
             {
               isAvailable: true,
-              questionId: 'q1',
+              questionId,
               slug: 'q-1',
               stemMd: 'Stem for q1',
               difficulty: 'easy',
@@ -276,7 +283,9 @@ describe('bookmark-controller', () => {
       const result = await getBookmarks({}, deps);
 
       expect(result.ok).toBe(true);
-      expect(deps.getBookmarksUseCase.inputs).toEqual([{ userId: 'user_1' }]);
+      expect(deps.getBookmarksUseCase.inputs).toEqual([
+        { userId: deps._fixtures.userId },
+      ]);
     });
 
     it('returns error when use case throws ApplicationError', async () => {

--- a/src/adapters/controllers/practice-controller-exam-draft.test.ts
+++ b/src/adapters/controllers/practice-controller-exam-draft.test.ts
@@ -85,7 +85,7 @@ describe('practice-controller', () => {
       expect(result).toEqual({ ok: true, data: saveDraftOutput });
       expect(deps.saveExamDraftAnswerUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           sessionId: '11111111-1111-1111-1111-111111111111',
           questionId: '22222222-2222-2222-2222-222222222222',
           selectedChoiceId: '33333333-3333-3333-3333-333333333333',
@@ -161,7 +161,7 @@ describe('practice-controller', () => {
       expect(result).toEqual({ ok: true, data: saveDraftOutput });
       expect(deps.saveExamDraftAnswerUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           sessionId: '11111111-1111-1111-1111-111111111111',
           questionId: '22222222-2222-2222-2222-222222222222',
           selectedChoiceId: '33333333-3333-3333-3333-333333333333',

--- a/src/adapters/controllers/practice-controller-mark-and-count.test.ts
+++ b/src/adapters/controllers/practice-controller-mark-and-count.test.ts
@@ -119,7 +119,7 @@ describe('practice-controller', () => {
       });
       expect(deps.setPracticeSessionQuestionMarkUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           sessionId: input.sessionId,
           questionId: input.questionId,
           markedForReview: false,
@@ -219,7 +219,7 @@ describe('practice-controller', () => {
       });
       expect(deps.countAvailableQuestionsUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           tagSlugs: [],
           difficulties: [],
           statuses: [],
@@ -238,7 +238,7 @@ describe('practice-controller', () => {
       expect(result).toEqual({ ok: true, data: { count: 42 } });
       expect(deps.countAvailableQuestionsUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           tagSlugs: [],
           difficulties: [],
           statuses: ['unanswered'],

--- a/src/adapters/controllers/practice-controller-session-lifecycle.test.ts
+++ b/src/adapters/controllers/practice-controller-session-lifecycle.test.ts
@@ -131,7 +131,7 @@ describe('practice-controller', () => {
       });
       expect(deps.startPracticeSessionUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           mode: 'exam',
           count: 2,
           tagSlugs: ['opioids'],
@@ -171,7 +171,7 @@ describe('practice-controller', () => {
       });
       expect(deps.startPracticeSessionUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           mode: 'tutor',
           count: 1,
           tagSlugs: [],
@@ -278,7 +278,7 @@ describe('practice-controller', () => {
 
     it('returns session summary when use case succeeds', async () => {
       const endOutput = {
-        sessionId: 'session_123',
+        sessionId: '22222222-2222-2222-2222-222222222222',
         endedAt: '2026-02-01T00:00:00.000Z',
         mode: 'tutor',
         questionCount: 2,
@@ -299,7 +299,10 @@ describe('practice-controller', () => {
 
       expect(result).toEqual({ ok: true, data: endOutput });
       expect(deps.endPracticeSessionUseCase.inputs).toEqual([
-        { userId: 'user_1', sessionId: '11111111-1111-1111-1111-111111111111' },
+        {
+          userId: deps._fixtures.userId,
+          sessionId: '11111111-1111-1111-1111-111111111111',
+        },
       ]);
     });
 
@@ -405,7 +408,10 @@ describe('practice-controller', () => {
 
       expect(result).toEqual({ ok: true, data: finalizeOutput });
       expect(deps.finalizeExamAnswersUseCase.inputs).toEqual([
-        { userId: 'user_1', sessionId: '11111111-1111-1111-1111-111111111111' },
+        {
+          userId: deps._fixtures.userId,
+          sessionId: '11111111-1111-1111-1111-111111111111',
+        },
       ]);
     });
 
@@ -485,7 +491,7 @@ describe('practice-controller', () => {
     it('returns VALIDATION_ERROR when finalize output is invalid without idempotency', async () => {
       const deps = createDeps({
         finalizeOutput: {
-          sessionId: 'session_123',
+          sessionId: '22222222-2222-2222-2222-222222222222',
           endedAt: '2026-02-01T00:00:00.000Z',
           mode: 'exam',
           questionCount: -1,

--- a/src/adapters/controllers/practice-controller-session-reads.test.ts
+++ b/src/adapters/controllers/practice-controller-session-reads.test.ts
@@ -43,7 +43,7 @@ describe('practice-controller', () => {
 
       expect(result).toEqual({ ok: true, data: null });
       expect(deps.getIncompletePracticeSessionUseCase.inputs).toEqual([
-        { userId: 'user_1' },
+        { userId: deps._fixtures.userId },
       ]);
     });
 
@@ -71,7 +71,7 @@ describe('practice-controller', () => {
         },
       });
       expect(deps.getIncompletePracticeSessionUseCase.inputs).toEqual([
-        { userId: 'user_1' },
+        { userId: deps._fixtures.userId },
       ]);
     });
 
@@ -190,7 +190,7 @@ describe('practice-controller', () => {
         data: { sessionId, markedCount: 1 },
       });
       expect(deps.getPracticeSessionReviewUseCase.inputs).toEqual([
-        { userId: 'user_1', sessionId },
+        { userId: deps._fixtures.userId, sessionId },
       ]);
     });
   });
@@ -270,7 +270,7 @@ describe('practice-controller', () => {
       });
       expect(
         deps.getCompletedSessionQuestionsWithFeedbackUseCase.inputs,
-      ).toEqual([{ userId: 'user_1', sessionId }]);
+      ).toEqual([{ userId: deps._fixtures.userId, sessionId }]);
     });
 
     it('returns completed feedback rows when the use case succeeds', async () => {
@@ -322,7 +322,7 @@ describe('practice-controller', () => {
       });
       expect(
         deps.getCompletedSessionQuestionsWithFeedbackUseCase.inputs,
-      ).toEqual([{ userId: 'user_1', sessionId }]);
+      ).toEqual([{ userId: deps._fixtures.userId, sessionId }]);
     });
   });
 
@@ -410,7 +410,7 @@ describe('practice-controller', () => {
         error: { code: 'NOT_FOUND', message: 'Practice session not found' },
       });
       expect(deps.getPracticeSessionSummaryUseCase.inputs).toEqual([
-        { userId: 'user_1', sessionId },
+        { userId: deps._fixtures.userId, sessionId },
       ]);
     });
 
@@ -433,7 +433,7 @@ describe('practice-controller', () => {
         data: { sessionId, questionCount: 0 },
       });
       expect(deps.getPracticeSessionSummaryUseCase.inputs).toEqual([
-        { userId: 'user_1', sessionId },
+        { userId: deps._fixtures.userId, sessionId },
       ]);
     });
   });
@@ -514,7 +514,7 @@ describe('practice-controller', () => {
         },
       });
       expect(deps.getSessionHistoryUseCase.inputs).toEqual([
-        { userId: 'user_1', limit: 20, offset: 0, mode: null },
+        { userId: deps._fixtures.userId, limit: 20, offset: 0, mode: null },
       ]);
     });
 
@@ -528,7 +528,7 @@ describe('practice-controller', () => {
 
       expect(result).toMatchObject({ ok: true });
       expect(deps.getSessionHistoryUseCase.inputs).toEqual([
-        { userId: 'user_1', limit: 20, offset: 0, mode: 'tutor' },
+        { userId: deps._fixtures.userId, limit: 20, offset: 0, mode: 'tutor' },
       ]);
     });
   });

--- a/src/adapters/controllers/practice-controller-test-helpers.ts
+++ b/src/adapters/controllers/practice-controller-test-helpers.ts
@@ -45,6 +45,9 @@ export type PracticeControllerTestDeps = PracticeControllerDeps & {
   getPracticeSessionSummaryUseCase: FakeGetPracticeSessionSummaryUseCase;
   getSessionHistoryUseCase: FakeGetSessionHistoryUseCase;
   setPracticeSessionQuestionMarkUseCase: FakeSetPracticeSessionQuestionMarkUseCase;
+  _fixtures: {
+    userId: string;
+  };
 };
 
 export function createDeps(overrides?: {
@@ -84,12 +87,12 @@ export function createDeps(overrides?: {
   const user =
     overrides?.user === undefined
       ? createUser({
-          id: 'user_1',
           email: 'user@example.com',
           createdAt: new Date('2026-02-01T00:00:00Z'),
           updatedAt: new Date('2026-02-01T00:00:00Z'),
         })
       : overrides.user;
+  const userId = user?.id ?? crypto.randomUUID();
 
   const now = overrides?.now ?? (() => new Date('2026-02-01T00:00:00Z'));
 
@@ -100,7 +103,7 @@ export function createDeps(overrides?: {
       ? []
       : [
           createSubscription({
-            userId: user?.id ?? 'user_1',
+            userId,
             status: 'active',
             currentPeriodEnd: new Date('2026-12-31T00:00:00Z'),
           }),
@@ -246,5 +249,8 @@ export function createDeps(overrides?: {
     getSessionHistoryUseCase,
     setPracticeSessionQuestionMarkUseCase,
     now,
+    _fixtures: {
+      userId,
+    },
   };
 }

--- a/src/adapters/controllers/question-controller-exam-timer.test.ts
+++ b/src/adapters/controllers/question-controller-exam-timer.test.ts
@@ -18,14 +18,17 @@ const sessionId = '11111111-1111-1111-1111-111111111111';
 function createActiveQuestion(
   deadlineAt: string | null,
 ): GetNextQuestionOutput {
+  const questionId = crypto.randomUUID();
+  const choiceId = crypto.randomUUID();
+
   return {
-    questionId: 'q_1',
+    questionId,
     slug: 'q-1',
     stemMd: 'Stem',
     difficulty: 'easy',
     choices: [
       {
-        id: 'choice_1',
+        id: choiceId,
         label: 'A',
         textMd: 'Choice',
         sortOrder: 1,
@@ -50,7 +53,7 @@ function createDeps(
   getNextQuestionOutput: GetNextQuestionOutput,
 ): QuestionControllerDeps {
   return {
-    authGateway: new FakeAuthGateway(createUser({ id: 'user_1' })),
+    authGateway: new FakeAuthGateway(createUser()),
     logger: new FakeLogger(),
     rateLimiter: new FakeRateLimiter(),
     idempotencyKeyRepository: new FakeIdempotencyKeyRepository(),

--- a/src/adapters/controllers/question-controller.test.ts
+++ b/src/adapters/controllers/question-controller.test.ts
@@ -41,6 +41,9 @@ import {
 type QuestionControllerTestDeps = QuestionControllerDeps & {
   getNextQuestionUseCase: FakeGetNextQuestionUseCase;
   submitAnswerUseCase: FakeSubmitAnswerUseCase;
+  _fixtures: {
+    userId: string;
+  };
 };
 
 function passthroughSubmitTransaction(
@@ -62,13 +65,14 @@ function createDeps(overrides?: {
   submitAnswerThrows?: unknown;
 }): QuestionControllerTestDeps {
   const user =
-    overrides?.user ??
-    createUser({
-      id: 'user_1',
-      email: 'user@example.com',
-      createdAt: new Date('2026-02-01T00:00:00Z'),
-      updatedAt: new Date('2026-02-01T00:00:00Z'),
-    });
+    overrides?.user === undefined
+      ? createUser({
+          email: 'user@example.com',
+          createdAt: new Date('2026-02-01T00:00:00Z'),
+          updatedAt: new Date('2026-02-01T00:00:00Z'),
+        })
+      : overrides.user;
+  const userId = user?.id ?? crypto.randomUUID();
 
   const now = overrides?.now ?? new Date('2026-02-01T00:00:00Z');
 
@@ -80,7 +84,7 @@ function createDeps(overrides?: {
       ? []
       : [
           createSubscription({
-            userId: user?.id ?? 'user_1',
+            userId,
             status: 'active',
             currentPeriodEnd: new Date('2026-12-31T00:00:00Z'),
           }),
@@ -123,6 +127,9 @@ function createDeps(overrides?: {
     checkEntitlementUseCase,
     getNextQuestionUseCase,
     submitAnswerUseCase,
+    _fixtures: {
+      userId,
+    },
   };
 }
 
@@ -184,7 +191,7 @@ describe('question-controller', () => {
       expect(result).toEqual({ ok: true, data: null });
       expect(deps.getNextQuestionUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           filters: { tagSlugs: [], difficulties: [], statuses: [] },
         },
       ]);
@@ -207,7 +214,7 @@ describe('question-controller', () => {
       expect(result).toEqual({ ok: true, data: null });
       expect(deps.getNextQuestionUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           filters: { tagSlugs: [], difficulties: [], statuses: ['bookmarked'] },
         },
       ]);
@@ -235,15 +242,17 @@ describe('question-controller', () => {
     });
 
     it('returns ok result when sessionId is provided', async () => {
+      const questionId = crypto.randomUUID();
+      const choiceId = crypto.randomUUID();
       const deps = createDeps({
         getNextQuestionOutput: {
-          questionId: 'q_1',
+          questionId,
           slug: 'q-1',
           stemMd: 'Stem',
           difficulty: 'easy',
           choices: [
             {
-              id: 'choice_1',
+              id: choiceId,
               label: 'A',
               textMd: 'Choice',
               sortOrder: 1,
@@ -256,9 +265,9 @@ describe('question-controller', () => {
       const sessionId = '11111111-1111-1111-1111-111111111111';
       const result = await getNextQuestion({ sessionId }, deps);
 
-      expect(result).toMatchObject({ ok: true, data: { questionId: 'q_1' } });
+      expect(result).toMatchObject({ ok: true, data: { questionId } });
       expect(deps.getNextQuestionUseCase.inputs).toEqual([
-        { userId: 'user_1', sessionId },
+        { userId: deps._fixtures.userId, sessionId },
       ]);
     });
 
@@ -271,7 +280,7 @@ describe('question-controller', () => {
 
       expect(result).toEqual({ ok: true, data: null });
       expect(deps.getNextQuestionUseCase.inputs).toEqual([
-        { userId: 'user_1', sessionId, questionId },
+        { userId: deps._fixtures.userId, sessionId, questionId },
       ]);
     });
 
@@ -457,7 +466,7 @@ describe('question-controller', () => {
       });
       expect(deps.submitAnswerUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           questionId: input.questionId,
           choiceId: input.choiceId,
           sessionId: input.sessionId,
@@ -526,16 +535,17 @@ describe('question-controller', () => {
         ],
       });
       const attempts = new FakeAttemptRepository();
+      const baseDeps = createDeps();
+      const userId = baseDeps._fixtures.userId;
       const sessions = new FakePracticeSessionRepository([
         createPracticeSession({
           id: sessionId,
-          userId: 'user_1',
+          userId,
           mode: 'exam',
           endedAt: null,
           questionIds: [questionId],
         }),
       ]);
-      const baseDeps = createDeps();
       const deps: QuestionControllerDeps = {
         ...baseDeps,
         submitAnswerUseCase: new SubmitAnswerUseCase(
@@ -575,7 +585,7 @@ describe('question-controller', () => {
 
       expect(result).toMatchObject({ ok: true });
       expect(deps.submitAnswerUseCase.inputs[0]).toMatchObject({
-        userId: 'user_1',
+        userId: deps._fixtures.userId,
         questionId: input.questionId,
         choiceId: input.choiceId,
         retryOfAttemptId: input.retryOfAttemptId,
@@ -595,7 +605,7 @@ describe('question-controller', () => {
       await submitAnswer(input, deps);
 
       expect(deps.submitAnswerUseCase.inputs[0]).toMatchObject({
-        userId: 'user_1',
+        userId: deps._fixtures.userId,
         questionId: input.questionId,
         choiceId: input.choiceId,
         timeSpentSeconds: 15,
@@ -680,7 +690,7 @@ describe('question-controller', () => {
       );
 
       const record = await deps.idempotencyKeyRepository.find(
-        'user_1',
+        deps._fixtures.userId,
         'question:submitAnswer',
         idempotencyKey,
       );

--- a/src/adapters/controllers/question-view-controller.test.ts
+++ b/src/adapters/controllers/question-view-controller.test.ts
@@ -51,7 +51,7 @@ function findUserIdWithNonCanonicalShuffle(
   // To ensure the tests would fail if the controller returned canonical order, probe
   // multiple userIds until we find one whose shuffle differs from the canonical mapping.
   for (let i = 0; i < 50; i++) {
-    const userId = `user_${i + 1}`;
+    const userId = crypto.randomUUID();
     const shuffledChoices = mapChoicesForOutput(question, userId);
     if (JSON.stringify(shuffledChoices) !== JSON.stringify(canonicalChoices)) {
       return userId;
@@ -95,12 +95,12 @@ function createDeps(overrides?: {
   const user =
     overrides?.user === undefined
       ? createUser({
-          id: 'user_1',
           email: 'user@example.com',
           createdAt: new Date('2026-02-01T00:00:00Z'),
           updatedAt: new Date('2026-02-01T00:00:00Z'),
         })
       : overrides.user;
+  const userId = user?.id ?? crypto.randomUUID();
 
   const authGateway = new FakeAuthGateway(user);
 
@@ -109,7 +109,7 @@ function createDeps(overrides?: {
       ? []
       : [
           createSubscription({
-            userId: user?.id ?? 'user_1',
+            userId,
             status: 'active',
             currentPeriodEnd: new Date('2026-12-31T00:00:00Z'),
           }),
@@ -146,6 +146,9 @@ function createDeps(overrides?: {
     logger,
     questionRepository,
     getPreviousAttemptUseCase,
+    _fixtures: {
+      userId,
+    },
   };
 }
 
@@ -201,23 +204,26 @@ describe('question-view-controller', () => {
     });
 
     it('returns the question with choices when found', async () => {
+      const questionId = crypto.randomUUID();
+      const firstChoiceId = crypto.randomUUID();
+      const secondChoiceId = crypto.randomUUID();
       const question = createQuestion({
-        id: 'question-1',
+        id: questionId,
         slug: 'q-1',
         stemMd: 'Stem for q1',
         difficulty: 'medium',
         choices: [
           createChoice({
-            id: 'choice-1',
-            questionId: 'question-1',
+            id: firstChoiceId,
+            questionId,
             label: 'A',
             textMd: 'Choice A',
             isCorrect: false,
             sortOrder: 1,
           }),
           createChoice({
-            id: 'choice-2',
-            questionId: 'question-1',
+            id: secondChoiceId,
+            questionId,
             label: 'B',
             textMd: 'Choice B',
             isCorrect: true,
@@ -234,7 +240,7 @@ describe('question-view-controller', () => {
       expect(result).toEqual({
         ok: true,
         data: {
-          questionId: 'question-1',
+          questionId,
           slug: 'q-1',
           stemMd: 'Stem for q1',
           difficulty: 'medium',
@@ -244,39 +250,44 @@ describe('question-view-controller', () => {
     });
 
     it('returns shuffled labels consistent with buildShuffledChoiceViews', async () => {
+      const questionId = crypto.randomUUID();
+      const firstChoiceId = crypto.randomUUID();
+      const secondChoiceId = crypto.randomUUID();
+      const thirdChoiceId = crypto.randomUUID();
+      const fourthChoiceId = crypto.randomUUID();
       const question = createQuestion({
-        id: 'question-2',
+        id: questionId,
         slug: 'q-2',
         stemMd: 'Stem for q2',
         difficulty: 'hard',
         choices: [
           createChoice({
-            id: 'choice-a',
-            questionId: 'question-2',
+            id: firstChoiceId,
+            questionId,
             label: 'A',
             textMd: 'Choice A',
             isCorrect: false,
             sortOrder: 1,
           }),
           createChoice({
-            id: 'choice-b',
-            questionId: 'question-2',
+            id: secondChoiceId,
+            questionId,
             label: 'B',
             textMd: 'Choice B',
             isCorrect: false,
             sortOrder: 2,
           }),
           createChoice({
-            id: 'choice-c',
-            questionId: 'question-2',
+            id: thirdChoiceId,
+            questionId,
             label: 'C',
             textMd: 'Choice C',
             isCorrect: true,
             sortOrder: 3,
           }),
           createChoice({
-            id: 'choice-d',
-            questionId: 'question-2',
+            id: fourthChoiceId,
+            questionId,
             label: 'D',
             textMd: 'Choice D',
             isCorrect: false,
@@ -293,7 +304,7 @@ describe('question-view-controller', () => {
       expect(result).toEqual({
         ok: true,
         data: {
-          questionId: 'question-2',
+          questionId,
           slug: 'q-2',
           stemMd: 'Stem for q2',
           difficulty: 'hard',
@@ -403,7 +414,7 @@ describe('question-view-controller', () => {
     });
 
     it('passes attemptId to use case when provided', async () => {
-      const userId = 'user_1';
+      const userId = crypto.randomUUID();
       const questionId = validPreviousAttemptQuestionId;
       const attemptId = '00000000-0000-4000-8000-000000000001';
 
@@ -432,7 +443,7 @@ describe('question-view-controller', () => {
     });
 
     it('passes sessionId to use case when provided', async () => {
-      const userId = 'user_1';
+      const userId = crypto.randomUUID();
       const questionId = validPreviousAttemptQuestionId;
       const sessionId = '00000000-0000-4000-8000-000000000002';
 
@@ -461,8 +472,10 @@ describe('question-view-controller', () => {
     });
 
     it('returns the previous attempt when found', async () => {
-      const userId = 'user_1';
+      const userId = crypto.randomUUID();
       const questionId = validPreviousAttemptQuestionId;
+      const attemptId = crypto.randomUUID();
+      const choiceId = crypto.randomUUID();
       const logger = new FakeLogger();
 
       let receivedInput: {
@@ -477,10 +490,10 @@ describe('question-view-controller', () => {
             receivedInput = input;
             return {
               kind: 'attempt',
-              attemptId: 'attempt_1',
-              selectedChoiceId: 'choice_1',
+              attemptId,
+              selectedChoiceId: choiceId,
               isCorrect: true,
-              correctChoiceId: 'choice_1',
+              correctChoiceId: choiceId,
               explanationMd: 'Explanation',
               choiceExplanations: [],
               answeredAt: '2026-02-01T00:00:00.000Z',
@@ -497,10 +510,10 @@ describe('question-view-controller', () => {
         ok: true,
         data: {
           kind: 'attempt',
-          attemptId: 'attempt_1',
-          selectedChoiceId: 'choice_1',
+          attemptId,
+          selectedChoiceId: choiceId,
           isCorrect: true,
-          correctChoiceId: 'choice_1',
+          correctChoiceId: choiceId,
           explanationMd: 'Explanation',
           choiceExplanations: [],
           answeredAt: '2026-02-01T00:00:00.000Z',
@@ -514,15 +527,17 @@ describe('question-view-controller', () => {
           hasAttemptId: false,
           hasSessionId: false,
           questionId,
-          userId: 'user_1',
+          userId,
         },
         msg: 'Review hydration outcome',
       });
     });
 
     it('returns the previous attempt when hydration telemetry info logging throws', async () => {
-      const userId = 'user_1';
+      const userId = crypto.randomUUID();
       const questionId = validPreviousAttemptQuestionId;
+      const attemptId = crypto.randomUUID();
+      const choiceId = crypto.randomUUID();
       const logger = new ThrowingInfoLogger();
 
       const deps = createDeps({
@@ -530,10 +545,10 @@ describe('question-view-controller', () => {
         getPreviousAttemptUseCase: {
           execute: async () => ({
             kind: 'attempt',
-            attemptId: 'attempt_1',
-            selectedChoiceId: 'choice_1',
+            attemptId,
+            selectedChoiceId: choiceId,
             isCorrect: true,
-            correctChoiceId: 'choice_1',
+            correctChoiceId: choiceId,
             explanationMd: 'Explanation',
             choiceExplanations: [],
             answeredAt: '2026-02-01T00:00:00.000Z',
@@ -548,10 +563,10 @@ describe('question-view-controller', () => {
         ok: true,
         data: {
           kind: 'attempt',
-          attemptId: 'attempt_1',
-          selectedChoiceId: 'choice_1',
+          attemptId,
+          selectedChoiceId: choiceId,
           isCorrect: true,
-          correctChoiceId: 'choice_1',
+          correctChoiceId: choiceId,
           explanationMd: 'Explanation',
           choiceExplanations: [],
           answeredAt: '2026-02-01T00:00:00.000Z',
@@ -583,13 +598,14 @@ describe('question-view-controller', () => {
     });
 
     it('emits session_unanswered hydration telemetry when unanswered session reveal is returned', async () => {
+      const correctChoiceId = crypto.randomUUID();
       const logger = new FakeLogger();
       const deps = createDeps({
         logger,
         getPreviousAttemptUseCase: {
           execute: async () => ({
             kind: 'session_unanswered',
-            correctChoiceId: 'choice_2',
+            correctChoiceId,
             explanationMd: 'Explanation',
             referenceMd: null,
             choiceExplanations: [],
@@ -609,7 +625,7 @@ describe('question-view-controller', () => {
         ok: true,
         data: {
           kind: 'session_unanswered',
-          correctChoiceId: 'choice_2',
+          correctChoiceId,
           explanationMd: 'Explanation',
           referenceMd: null,
           choiceExplanations: [],
@@ -623,7 +639,7 @@ describe('question-view-controller', () => {
           hasAttemptId: false,
           hasSessionId: true,
           questionId: validPreviousAttemptQuestionId,
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
         },
         msg: 'Review hydration outcome',
       });
@@ -652,7 +668,7 @@ describe('question-view-controller', () => {
           hasAttemptId: false,
           hasSessionId: false,
           questionId: validPreviousAttemptQuestionId,
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
         },
         msg: 'Review hydration outcome',
       });
@@ -686,7 +702,7 @@ describe('question-view-controller', () => {
           hasAttemptId: false,
           hasSessionId: false,
           questionId: validPreviousAttemptQuestionId,
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           errorCode: 'INTERNAL_ERROR',
         },
         msg: 'Review hydration outcome',

--- a/src/adapters/controllers/require-entitled-user-id.test.ts
+++ b/src/adapters/controllers/require-entitled-user-id.test.ts
@@ -10,7 +10,7 @@ import { requireEntitledUserId } from './require-entitled-user-id';
 
 describe('requireEntitledUserId', () => {
   it('returns the user id when the user is entitled', async () => {
-    const user = createUser({ id: 'user_1' });
+    const user = createUser();
 
     const authGateway = new FakeAuthGateway(user);
     const subscriptionRepository = new FakeSubscriptionRepository([
@@ -31,7 +31,7 @@ describe('requireEntitledUserId', () => {
   });
 
   it('throws UNSUBSCRIBED when the user is not entitled', async () => {
-    const user = createUser({ id: 'user_1' });
+    const user = createUser();
 
     const authGateway = new FakeAuthGateway(user);
     const subscriptionRepository = new FakeSubscriptionRepository([]);

--- a/src/adapters/controllers/review-controller.test.ts
+++ b/src/adapters/controllers/review-controller.test.ts
@@ -18,6 +18,9 @@ import {
 
 type ReviewControllerTestDeps = ReviewControllerDeps & {
   getAttemptedQuestionsUseCase: FakeGetAttemptedQuestionsUseCase;
+  _fixtures: {
+    userId: string;
+  };
 };
 
 function createDeps(overrides?: {
@@ -26,10 +29,8 @@ function createDeps(overrides?: {
   useCaseOutput?: GetAttemptedQuestionsOutput;
   useCaseThrows?: unknown;
 }): ReviewControllerTestDeps {
-  const user =
-    overrides?.user === undefined
-      ? createUser({ id: 'user_1' })
-      : overrides.user;
+  const user = overrides?.user === undefined ? createUser() : overrides.user;
+  const userId = user?.id ?? crypto.randomUUID();
 
   const authGateway = new FakeAuthGateway(user);
 
@@ -38,7 +39,7 @@ function createDeps(overrides?: {
       ? []
       : [
           createSubscription({
-            userId: user?.id ?? 'user_1',
+            userId,
             status: 'active',
             currentPeriodEnd: new Date('2026-12-31T00:00:00Z'),
           }),
@@ -63,6 +64,9 @@ function createDeps(overrides?: {
     authGateway,
     checkEntitlementUseCase,
     getAttemptedQuestionsUseCase,
+    _fixtures: {
+      userId,
+    },
   };
 }
 
@@ -158,7 +162,7 @@ describe('review-controller', () => {
       });
       expect(deps.getAttemptedQuestionsUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           limit: 10,
           offset: 0,
           result: null,
@@ -181,7 +185,7 @@ describe('review-controller', () => {
       expect(result.ok).toBe(true);
       expect(deps.getAttemptedQuestionsUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           limit: 10,
           offset: 0,
           result: 'correct',
@@ -209,7 +213,7 @@ describe('review-controller', () => {
       expect(result.ok).toBe(true);
       expect(deps.getAttemptedQuestionsUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           limit: 10,
           offset: 0,
           result: null,
@@ -232,7 +236,7 @@ describe('review-controller', () => {
       expect(result.ok).toBe(true);
       expect(deps.getAttemptedQuestionsUseCase.inputs).toEqual([
         {
-          userId: 'user_1',
+          userId: deps._fixtures.userId,
           limit: 10,
           offset: 0,
           result: null,

--- a/src/adapters/controllers/shared/execute-idempotent.test.ts
+++ b/src/adapters/controllers/shared/execute-idempotent.test.ts
@@ -59,10 +59,11 @@ describe('executeIdempotent', () => {
     const deps = createDeps();
     const execute = vi.fn().mockResolvedValue({ value: 1 });
     const schema = z.object({ value: z.number() });
+    const userId = crypto.randomUUID();
 
     const result = await executeIdempotent({
       d: deps,
-      userId: 'user-1',
+      userId,
       idempotencyKey: null,
       action: 'practice:test',
       outputSchema: schema,
@@ -78,10 +79,11 @@ describe('executeIdempotent', () => {
     const deps = createDeps();
     const execute = vi.fn().mockResolvedValue({ value: 2 });
     const schema = z.object({ value: z.number() });
+    const userId = crypto.randomUUID();
 
     const result = await executeIdempotent({
       d: deps,
-      userId: 'user-1',
+      userId,
       idempotencyKey: undefined,
       action: 'practice:test',
       outputSchema: schema,
@@ -97,11 +99,12 @@ describe('executeIdempotent', () => {
     const deps = createDeps();
     const execute = vi.fn().mockResolvedValue({ value: 'not-a-number' });
     const schema = z.object({ value: z.number() });
+    const userId = crypto.randomUUID();
 
     await expect(
       executeIdempotent({
         d: deps,
-        userId: 'user-1',
+        userId,
         idempotencyKey: null,
         action: 'practice:test',
         outputSchema: schema,
@@ -117,10 +120,11 @@ describe('executeIdempotent', () => {
     const deps = createDeps();
     const execute = vi.fn().mockResolvedValue({ value: 42 });
     const schema = z.object({ value: z.number() });
+    const userId = crypto.randomUUID();
 
     const result = await executeIdempotent({
       d: deps,
-      userId: 'user-1',
+      userId,
       idempotencyKey: '11111111-1111-1111-1111-111111111111',
       action: 'practice:test',
       outputSchema: schema,
@@ -140,9 +144,10 @@ describe('executeIdempotent', () => {
     const deps = createDeps();
     const execute = vi.fn().mockResolvedValue({ value: 100 });
     const schema = z.object({ value: z.number() });
+    const userId = crypto.randomUUID();
     const args = {
       d: deps,
-      userId: 'user-1',
+      userId,
       idempotencyKey: '22222222-2222-2222-2222-222222222222',
       action: 'practice:test',
       outputSchema: schema,
@@ -164,9 +169,10 @@ describe('executeIdempotent', () => {
       .mockResolvedValueOnce({ value: 100 })
       .mockResolvedValueOnce({ value: 200 });
     const schema = z.object({ value: z.number() });
+    const userId = crypto.randomUUID();
     const args = {
       d: deps,
-      userId: 'user-1',
+      userId,
       idempotencyKey: '33333333-3333-3333-3333-333333333333',
       action: 'practice:test',
       outputSchema: schema,

--- a/src/adapters/controllers/stats-controller.test.ts
+++ b/src/adapters/controllers/stats-controller.test.ts
@@ -14,6 +14,9 @@ import { getUserStats, type StatsControllerDeps } from './stats-controller';
 
 type StatsControllerTestDeps = StatsControllerDeps & {
   getUserStatsUseCase: FakeGetUserStatsUseCase;
+  _fixtures: {
+    userId: string;
+  };
 };
 
 function createDeps(overrides?: {
@@ -22,10 +25,8 @@ function createDeps(overrides?: {
   useCaseOutput?: UserStatsOutput;
   useCaseThrows?: unknown;
 }): StatsControllerTestDeps {
-  const user =
-    overrides?.user === undefined
-      ? createUser({ id: 'user_1' })
-      : overrides.user;
+  const user = overrides?.user === undefined ? createUser() : overrides.user;
+  const userId = user?.id ?? crypto.randomUUID();
 
   const authGateway = new FakeAuthGateway(user);
   const now = () => new Date('2026-02-01T00:00:00Z');
@@ -35,7 +36,7 @@ function createDeps(overrides?: {
       ? []
       : [
           createSubscription({
-            userId: user?.id ?? 'user_1',
+            userId,
             status: 'active',
             currentPeriodEnd: new Date('2026-12-31T00:00:00Z'),
           }),
@@ -63,6 +64,9 @@ function createDeps(overrides?: {
     authGateway,
     checkEntitlementUseCase,
     getUserStatsUseCase,
+    _fixtures: {
+      userId,
+    },
   };
 }
 
@@ -110,7 +114,9 @@ describe('stats-controller', () => {
       const result = await getUserStats({}, deps);
 
       expect(result).toMatchObject({ ok: true });
-      expect(deps.getUserStatsUseCase.inputs).toEqual([{ userId: 'user_1' }]);
+      expect(deps.getUserStatsUseCase.inputs).toEqual([
+        { userId: deps._fixtures.userId },
+      ]);
     });
 
     it('returns INTERNAL_ERROR when use case throws ApplicationError', async () => {

--- a/src/adapters/controllers/stripe-webhook-controller.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.test.ts
@@ -213,6 +213,7 @@ describe('processStripeWebhook', () => {
   });
 
   it('claims, processes, and marks subscription events idempotently', async () => {
+    const userId = crypto.randomUUID();
     const paymentGateway = new FakePaymentGateway({
       externalCustomerId: 'cus_test',
       checkoutUrl: 'https://stripe/checkout',
@@ -221,7 +222,7 @@ describe('processStripeWebhook', () => {
         eventId: 'evt_1',
         type: 'customer.subscription.updated',
         subscriptionUpdate: {
-          userId: 'user_1',
+          userId,
           externalCustomerId: 'cus_123',
           externalSubscriptionId: 'sub_123',
           plan: 'monthly',
@@ -239,15 +240,15 @@ describe('processStripeWebhook', () => {
 
     await processStripeWebhook(deps, { rawBody: 'raw', signature: 'sig' });
 
-    await expect(subscriptions.findByUserId('user_1')).resolves.toMatchObject({
-      userId: 'user_1',
+    await expect(subscriptions.findByUserId(userId)).resolves.toMatchObject({
+      userId,
       plan: 'monthly',
       status: 'active',
     });
     await expect(
       subscriptions.findByExternalSubscriptionId('sub_123'),
     ).resolves.toMatchObject({
-      userId: 'user_1',
+      userId,
     });
     expect(insertSpy).toHaveBeenCalledTimes(1);
 
@@ -279,6 +280,7 @@ describe('processStripeWebhook', () => {
   });
 
   it('updates stale stripe customer mappings in webhook context instead of failing', async () => {
+    const userId = crypto.randomUUID();
     const paymentGateway = new FakePaymentGateway({
       externalCustomerId: 'cus_test',
       checkoutUrl: 'https://stripe/checkout',
@@ -287,7 +289,7 @@ describe('processStripeWebhook', () => {
         eventId: 'evt_customer_remap',
         type: 'customer.subscription.updated',
         subscriptionUpdate: {
-          userId: 'user_1',
+          userId,
           externalCustomerId: 'cus_new',
           externalSubscriptionId: 'sub_123',
           plan: 'monthly',
@@ -299,13 +301,13 @@ describe('processStripeWebhook', () => {
     });
 
     const { deps, stripeCustomers } = createDeps({ paymentGateway });
-    await stripeCustomers.insert('user_1', 'cus_old');
+    await stripeCustomers.insert(userId, 'cus_old');
 
     await expect(
       processStripeWebhook(deps, { rawBody: 'raw', signature: 'sig' }),
     ).resolves.toBeUndefined();
 
-    await expect(stripeCustomers.findByUserId('user_1')).resolves.toEqual({
+    await expect(stripeCustomers.findByUserId(userId)).resolves.toEqual({
       stripeCustomerId: 'cus_new',
     });
   });
@@ -417,6 +419,7 @@ describe('processStripeWebhook', () => {
   });
 
   it('returns early when the event was already processed', async () => {
+    const userId = crypto.randomUUID();
     const paymentGateway = new FakePaymentGateway({
       externalCustomerId: 'cus_test',
       checkoutUrl: 'https://stripe/checkout',
@@ -425,7 +428,7 @@ describe('processStripeWebhook', () => {
         eventId: 'evt_3',
         type: 'customer.subscription.updated',
         subscriptionUpdate: {
-          userId: 'user_1',
+          userId,
           externalCustomerId: 'cus_123',
           externalSubscriptionId: 'sub_123',
           plan: 'monthly',
@@ -492,6 +495,7 @@ describe('processStripeWebhook', () => {
   });
 
   it('persists failure state even when the transaction would rollback on throw', async () => {
+    const userId = crypto.randomUUID();
     const paymentGateway = new FakePaymentGateway({
       externalCustomerId: 'cus_test',
       checkoutUrl: 'https://stripe/checkout',
@@ -500,7 +504,7 @@ describe('processStripeWebhook', () => {
         eventId: 'evt_rollback_failure_state',
         type: 'customer.subscription.updated',
         subscriptionUpdate: {
-          userId: 'user_1',
+          userId,
           externalCustomerId: 'cus_123',
           externalSubscriptionId: 'sub_123',
           plan: 'monthly',
@@ -530,6 +534,7 @@ describe('processStripeWebhook', () => {
   });
 
   it('marks the event failed when processing throws', async () => {
+    const userId = crypto.randomUUID();
     const paymentGateway = new FakePaymentGateway({
       externalCustomerId: 'cus_test',
       checkoutUrl: 'https://stripe/checkout',
@@ -538,7 +543,7 @@ describe('processStripeWebhook', () => {
         eventId: 'evt_4',
         type: 'customer.subscription.updated',
         subscriptionUpdate: {
-          userId: 'user_1',
+          userId,
           externalCustomerId: 'cus_123',
           externalSubscriptionId: 'sub_123',
           plan: 'monthly',

--- a/src/adapters/controllers/tag-controller.test.ts
+++ b/src/adapters/controllers/tag-controller.test.ts
@@ -16,20 +16,26 @@ import {
   createUser,
 } from '@/src/domain/test-helpers';
 
+type TagControllerTestDeps = TagControllerDeps & {
+  _fixtures: {
+    userId: string;
+  };
+};
+
 function createDeps(overrides?: {
   user?: ReturnType<typeof createUser> | null;
   isEntitled?: boolean;
   tags?: Array<ReturnType<typeof createTag>>;
-}): TagControllerDeps {
+}): TagControllerTestDeps {
   const user =
     overrides?.user === undefined
       ? createUser({
-          id: 'user_1',
           email: 'user@example.com',
           createdAt: new Date('2026-02-01T00:00:00Z'),
           updatedAt: new Date('2026-02-01T00:00:00Z'),
         })
       : overrides.user;
+  const userId = user?.id ?? crypto.randomUUID();
 
   const authGateway = new FakeAuthGateway(user);
 
@@ -38,7 +44,7 @@ function createDeps(overrides?: {
       ? []
       : [
           createSubscription({
-            userId: user?.id ?? 'user_1',
+            userId,
             status: 'active',
             currentPeriodEnd: new Date('2026-12-31T00:00:00Z'),
           }),
@@ -58,6 +64,9 @@ function createDeps(overrides?: {
     checkEntitlementUseCase,
     tagRepository,
     logger: new FakeLogger(),
+    _fixtures: {
+      userId,
+    },
   };
 }
 
@@ -97,16 +106,18 @@ describe('tag-controller', () => {
     });
 
     it('returns tags when entitled', async () => {
+      const opioidTagId = crypto.randomUUID();
+      const alcoholTagId = crypto.randomUUID();
       const deps = createDeps({
         tags: [
           createTag({
-            id: 'tag_1',
+            id: opioidTagId,
             slug: 'opioids',
             name: 'Opioids',
             kind: 'substance',
           }),
           createTag({
-            id: 'tag_2',
+            id: alcoholTagId,
             slug: 'alcohol',
             name: 'Alcohol',
             kind: 'substance',
@@ -121,13 +132,13 @@ describe('tag-controller', () => {
         data: {
           rows: [
             {
-              id: 'tag_1',
+              id: opioidTagId,
               slug: 'opioids',
               name: 'Opioids',
               kind: 'substance',
             },
             {
-              id: 'tag_2',
+              id: alcoholTagId,
               slug: 'alcohol',
               name: 'Alcohol',
               kind: 'substance',

--- a/src/adapters/gateways/stripe-payment-gateway.test.ts
+++ b/src/adapters/gateways/stripe-payment-gateway.test.ts
@@ -17,6 +17,7 @@ import { StripePaymentGateway } from './stripe-payment-gateway';
 
 const TEST_WEBHOOK_SECRET = 'whsec_1';
 const TEST_PRICE_IDS = { monthly: 'price_m', annual: 'price_a' } as const;
+const appUserId = crypto.randomUUID();
 
 type StripeWebhookEventFixture<TObject> = {
   id: string;
@@ -24,6 +25,24 @@ type StripeWebhookEventFixture<TObject> = {
   data: { object: TObject };
   [key: string]: unknown;
 };
+
+type StripeSubscriptionFixtureObject = {
+  metadata?: Record<string, string>;
+  [key: string]: unknown;
+};
+
+function withSubscriptionUserId<T extends StripeSubscriptionFixtureObject>(
+  subscription: T,
+  userId = appUserId,
+): T {
+  return {
+    ...subscription,
+    metadata: {
+      ...(subscription.metadata ?? {}),
+      user_id: userId,
+    },
+  };
+}
 
 function createGateway(
   stripe: StripeClient,
@@ -156,7 +175,7 @@ describe('StripePaymentGateway', () => {
 
     await expect(
       gateway.createCustomer({
-        userId: 'user_1',
+        userId: appUserId,
         clerkUserId: 'clerk_1',
         email: 'user@example.com',
       }),
@@ -165,14 +184,14 @@ describe('StripePaymentGateway', () => {
     expect(customersCreate).toHaveBeenCalledWith(
       {
         email: 'user@example.com',
-        metadata: { user_id: 'user_1', clerk_user_id: 'clerk_1' },
+        metadata: { user_id: appUserId, clerk_user_id: 'clerk_1' },
       },
       {
-        idempotencyKey: 'create_stripe_customer:user_1',
+        idempotencyKey: `create_stripe_customer:${appUserId}`,
       },
     );
     expect(customersSearch).toHaveBeenCalledWith({
-      query: "metadata['user_id']:'user_1'",
+      query: `metadata['user_id']:'${appUserId}'`,
       limit: 2,
     });
   });
@@ -185,14 +204,14 @@ describe('StripePaymentGateway', () => {
 
     await expect(
       gateway.createCustomer({
-        userId: 'user_1',
+        userId: appUserId,
         clerkUserId: 'clerk_1',
         email: 'user@example.com',
       }),
     ).resolves.toEqual({ externalCustomerId: 'cus_123' });
 
     expect(customersSearch).toHaveBeenCalledWith({
-      query: "metadata['user_id']:'user_1'",
+      query: `metadata['user_id']:'${appUserId}'`,
       limit: 2,
     });
     expect(customersCreate).toHaveBeenCalledTimes(0);
@@ -210,7 +229,7 @@ describe('StripePaymentGateway', () => {
     await expect(
       gateway.createCustomer(
         {
-          userId: 'user_1',
+          userId: appUserId,
           clerkUserId: 'clerk_1',
           email: 'user@example.com',
         },
@@ -228,7 +247,7 @@ describe('StripePaymentGateway', () => {
 
     await expect(
       gateway.createCustomer({
-        userId: 'user_1',
+        userId: appUserId,
         clerkUserId: 'clerk_1',
         email: 'user@example.com',
       }),
@@ -241,7 +260,7 @@ describe('StripePaymentGateway', () => {
 
     await expect(
       gateway.createCheckoutSession({
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         plan: 'monthly',
         successUrl: 'https://app/success',
@@ -258,13 +277,15 @@ describe('StripePaymentGateway', () => {
         billing_address_collection: 'auto',
         success_url: 'https://app/success',
         cancel_url: 'https://app/cancel',
-        client_reference_id: 'user_1',
+        client_reference_id: appUserId,
         subscription_data: {
-          metadata: { user_id: 'user_1' },
+          metadata: { user_id: appUserId },
         },
       }),
       expect.objectContaining({
-        idempotencyKey: expect.stringMatching(/^checkout_session:user_1:/),
+        idempotencyKey: expect.stringMatching(
+          new RegExp(`^checkout_session:${appUserId}:`),
+        ),
       }),
     );
   });
@@ -287,7 +308,7 @@ describe('StripePaymentGateway', () => {
 
     await expect(
       gateway.createCheckoutSession({
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         plan: 'monthly',
         successUrl: 'https://app/success',
@@ -317,7 +338,7 @@ describe('StripePaymentGateway', () => {
 
     await expect(
       gateway.createCheckoutSession({
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         plan: 'monthly',
         successUrl: 'https://app/success',
@@ -353,7 +374,7 @@ describe('StripePaymentGateway', () => {
 
     await expect(
       gateway.createCheckoutSession({
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         plan: 'annual',
         successUrl: 'https://app/success',
@@ -397,7 +418,7 @@ describe('StripePaymentGateway', () => {
 
     await expect(
       gateway.createCheckoutSession({
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         plan: 'monthly',
         successUrl: 'https://app/success',
@@ -416,7 +437,9 @@ describe('StripePaymentGateway', () => {
         line_items: [{ price: 'price_m', quantity: 1 }],
       }),
       expect.objectContaining({
-        idempotencyKey: expect.stringMatching(/^checkout_session:user_1:/),
+        idempotencyKey: expect.stringMatching(
+          new RegExp(`^checkout_session:${appUserId}:`),
+        ),
       }),
     );
   });
@@ -441,7 +464,7 @@ describe('StripePaymentGateway', () => {
     const gateway = createGateway(stripe, { logger });
 
     const result = await gateway.createCheckoutSession({
-      userId: 'user_1',
+      userId: appUserId,
       externalCustomerId: 'cus_123',
       plan: 'monthly',
       successUrl: 'https://app/success',
@@ -494,7 +517,7 @@ describe('StripePaymentGateway', () => {
 
     await expect(
       gateway.createCheckoutSession({
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         plan: 'monthly',
         successUrl: 'https://app/success',
@@ -513,7 +536,7 @@ describe('StripePaymentGateway', () => {
 
     await expect(
       gateway.createCheckoutSession({
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         plan: 'monthly',
         successUrl: 'https://app/success',
@@ -543,7 +566,7 @@ describe('StripePaymentGateway', () => {
     const event = loadJsonFixture<
       StripeWebhookEventFixture<{ id: string; [key: string]: unknown }>
     >('stripe/customer.subscription.updated.json');
-    const subscription = event.data.object;
+    const subscription = withSubscriptionUserId(event.data.object);
     const { stripe, constructEvent, subscriptionsRetrieve } = createStripeMock({
       withSubscriptions: true,
     });
@@ -557,7 +580,7 @@ describe('StripePaymentGateway', () => {
       eventId: 'evt_1',
       type: 'customer.subscription.updated',
       subscriptionUpdate: {
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         externalSubscriptionId: 'sub_123',
         plan: 'monthly',
@@ -575,7 +598,7 @@ describe('StripePaymentGateway', () => {
     const event = loadJsonFixture<
       StripeWebhookEventFixture<{ id: string; [key: string]: unknown }>
     >('stripe/customer.subscription.updated.json');
-    const subscription = event.data.object;
+    const subscription = withSubscriptionUserId(event.data.object);
     const constructedEvent = {
       ...event,
       id: 'evt_trial_will_end_1',
@@ -585,7 +608,9 @@ describe('StripePaymentGateway', () => {
       withSubscriptions: true,
     });
     constructEvent.mockReturnValue(constructedEvent);
-    subscriptionsRetrieve.mockResolvedValue(event.data.object);
+    subscriptionsRetrieve.mockResolvedValue(
+      withSubscriptionUserId(event.data.object),
+    );
     const gateway = createGateway(stripe);
 
     await expect(
@@ -594,7 +619,7 @@ describe('StripePaymentGateway', () => {
       eventId: 'evt_trial_will_end_1',
       type: 'customer.subscription.trial_will_end',
       subscriptionUpdate: {
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         externalSubscriptionId: 'sub_123',
         plan: 'monthly',
@@ -612,10 +637,10 @@ describe('StripePaymentGateway', () => {
       data: { object: { id: string; status: string; [key: string]: unknown } };
     }>('stripe/customer.subscription.updated.json');
 
-    const subscription = {
+    const subscription = withSubscriptionUserId({
       ...subscriptionEvent.data.object,
       status: 'canceled',
-    };
+    });
 
     const constructedEvent = {
       ...subscriptionEvent,
@@ -638,7 +663,7 @@ describe('StripePaymentGateway', () => {
       eventId: 'evt_deleted_1',
       type: 'customer.subscription.deleted',
       subscriptionUpdate: expect.objectContaining({
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         externalSubscriptionId: 'sub_123',
         plan: 'monthly',
@@ -660,7 +685,7 @@ describe('StripePaymentGateway', () => {
     const subscriptionEvent = loadJsonFixture<{
       data: { object: { id: string } };
     }>('stripe/customer.subscription.updated.json');
-    const subscription = subscriptionEvent.data.object;
+    const subscription = withSubscriptionUserId(subscriptionEvent.data.object);
 
     const constructedEvent = {
       id: eventId,
@@ -684,7 +709,7 @@ describe('StripePaymentGateway', () => {
       eventId,
       type,
       subscriptionUpdate: {
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         externalSubscriptionId: 'sub_123',
         plan: 'monthly',
@@ -701,7 +726,7 @@ describe('StripePaymentGateway', () => {
     const subscriptionEvent = loadJsonFixture<{
       data: { object: { id: string } };
     }>('stripe/customer.subscription.updated.json');
-    const subscription = subscriptionEvent.data.object;
+    const subscription = withSubscriptionUserId(subscriptionEvent.data.object);
 
     const constructedEvent = {
       id: 'evt_invoice_success_nested_1',
@@ -733,7 +758,7 @@ describe('StripePaymentGateway', () => {
       eventId: 'evt_invoice_success_nested_1',
       type: 'invoice.payment_succeeded',
       subscriptionUpdate: {
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         externalSubscriptionId: 'sub_123',
         plan: 'monthly',
@@ -908,7 +933,9 @@ describe('StripePaymentGateway', () => {
       withSubscriptions: true,
     });
     constructEvent.mockReturnValue(event);
-    subscriptionsRetrieve.mockResolvedValue(event.data.object);
+    subscriptionsRetrieve.mockResolvedValue(
+      withSubscriptionUserId(event.data.object),
+    );
     const gateway = createGateway(stripe);
 
     await expect(
@@ -917,7 +944,7 @@ describe('StripePaymentGateway', () => {
       eventId: 'evt_2',
       type: 'customer.subscription.paused',
       subscriptionUpdate: {
-        userId: 'user_2',
+        userId: appUserId,
         externalCustomerId: 'cus_456',
         externalSubscriptionId: 'sub_456',
         plan: 'annual',
@@ -938,7 +965,9 @@ describe('StripePaymentGateway', () => {
       withSubscriptions: true,
     });
     constructEvent.mockReturnValue(event);
-    subscriptionsRetrieve.mockResolvedValue(event.data.object);
+    subscriptionsRetrieve.mockResolvedValue(
+      withSubscriptionUserId(event.data.object),
+    );
     const gateway = createGateway(stripe);
 
     await expect(
@@ -947,7 +976,7 @@ describe('StripePaymentGateway', () => {
       eventId: 'evt_3',
       type: 'customer.subscription.resumed',
       subscriptionUpdate: {
-        userId: 'user_3',
+        userId: appUserId,
         externalCustomerId: 'cus_789',
         externalSubscriptionId: 'sub_789',
         plan: 'monthly',
@@ -968,7 +997,9 @@ describe('StripePaymentGateway', () => {
       withSubscriptions: true,
     });
     constructEvent.mockReturnValue(event);
-    subscriptionsRetrieve.mockResolvedValue(event.data.object);
+    subscriptionsRetrieve.mockResolvedValue(
+      withSubscriptionUserId(event.data.object),
+    );
     const gateway = createGateway(stripe);
 
     await expect(
@@ -977,7 +1008,7 @@ describe('StripePaymentGateway', () => {
       eventId: 'evt_4',
       type: 'customer.subscription.pending_update_applied',
       subscriptionUpdate: {
-        userId: 'user_4',
+        userId: appUserId,
         externalCustomerId: 'cus_901',
         externalSubscriptionId: 'sub_901',
         plan: 'annual',
@@ -998,7 +1029,9 @@ describe('StripePaymentGateway', () => {
       withSubscriptions: true,
     });
     constructEvent.mockReturnValue(event);
-    subscriptionsRetrieve.mockResolvedValue(event.data.object);
+    subscriptionsRetrieve.mockResolvedValue(
+      withSubscriptionUserId(event.data.object),
+    );
     const gateway = createGateway(stripe);
 
     await expect(
@@ -1007,7 +1040,7 @@ describe('StripePaymentGateway', () => {
       eventId: 'evt_5',
       type: 'customer.subscription.pending_update_expired',
       subscriptionUpdate: {
-        userId: 'user_5',
+        userId: appUserId,
         externalCustomerId: 'cus_902',
         externalSubscriptionId: 'sub_902',
         plan: 'monthly',

--- a/src/adapters/gateways/stripe-payment-gateway.test.ts
+++ b/src/adapters/gateways/stripe-payment-gateway.test.ts
@@ -283,9 +283,7 @@ describe('StripePaymentGateway', () => {
         },
       }),
       expect.objectContaining({
-        idempotencyKey: expect.stringMatching(
-          new RegExp(`^checkout_session:${appUserId}:`),
-        ),
+        idempotencyKey: `checkout_session:${appUserId}:monthly`,
       }),
     );
   });
@@ -437,9 +435,7 @@ describe('StripePaymentGateway', () => {
         line_items: [{ price: 'price_m', quantity: 1 }],
       }),
       expect.objectContaining({
-        idempotencyKey: expect.stringMatching(
-          new RegExp(`^checkout_session:${appUserId}:`),
-        ),
+        idempotencyKey: `checkout_session:${appUserId}:monthly`,
       }),
     );
   });

--- a/src/adapters/gateways/stripe/stripe-checkout-sessions.test.ts
+++ b/src/adapters/gateways/stripe/stripe-checkout-sessions.test.ts
@@ -111,8 +111,9 @@ function createStripeMock(overrides?: {
 }
 
 describe('createStripeCheckoutSession', () => {
+  const appUserId = crypto.randomUUID();
   const input = {
-    userId: 'user_1',
+    userId: appUserId,
     externalCustomerId: 'cus_123',
     plan: 'monthly' as const,
     successUrl: 'https://app/success',
@@ -145,7 +146,7 @@ describe('createStripeCheckoutSession', () => {
     expect(sessionsCreate).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({
-        idempotencyKey: 'checkout_session:user_1:monthly',
+        idempotencyKey: `checkout_session:${appUserId}:monthly`,
       }),
     );
   });
@@ -208,14 +209,14 @@ describe('createStripeCheckoutSession', () => {
       1,
       expect.any(Object),
       expect.objectContaining({
-        idempotencyKey: 'checkout_session:user_1:monthly',
+        idempotencyKey: `checkout_session:${appUserId}:monthly`,
       }),
     );
     expect(sessionsCreate).toHaveBeenNthCalledWith(
       2,
       expect.any(Object),
       expect.objectContaining({
-        idempotencyKey: 'checkout_session_recovery:user_1:monthly:cs_expired',
+        idempotencyKey: `checkout_session_recovery:${appUserId}:monthly:cs_expired`,
       }),
     );
   });
@@ -475,7 +476,7 @@ describe('createStripeCheckoutSession', () => {
     expect(sessionsCreate).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({
-        idempotencyKey: 'checkout_session:user_1:monthly',
+        idempotencyKey: `checkout_session:${appUserId}:monthly`,
       }),
     );
   });

--- a/src/adapters/gateways/stripe/stripe-customers.test.ts
+++ b/src/adapters/gateways/stripe/stripe-customers.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FakeLogger } from '@/src/application/test-helpers/fakes';
 import { createStripeCustomer } from './stripe-customers';
 
+const appUserId = crypto.randomUUID();
+
 describe('createStripeCustomer', () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -31,7 +33,7 @@ describe('createStripeCustomer', () => {
       createStripeCustomer({
         stripe,
         input: {
-          userId: 'user_1',
+          userId: appUserId,
           clerkUserId: 'clerk_1',
           email: 'user@example.com',
         },
@@ -40,7 +42,7 @@ describe('createStripeCustomer', () => {
     ).resolves.toEqual({ externalCustomerId: 'cus_123' });
 
     expect(makeRequest).toHaveBeenCalledWith({
-      query: "metadata['user_id']:'user_1'",
+      query: `metadata['user_id']:'${appUserId}'`,
       limit: 2,
     });
     expect(customers.create).not.toHaveBeenCalled();
@@ -86,7 +88,7 @@ describe('createStripeCustomer', () => {
       createStripeCustomer({
         stripe,
         input: {
-          userId: 'user_1',
+          userId: appUserId,
           clerkUserId: 'clerk_1',
           email: 'user@example.com',
         },
@@ -112,7 +114,7 @@ describe('createStripeCustomer', () => {
       createStripeCustomer({
         stripe,
         input: {
-          userId: 'user_1',
+          userId: appUserId,
           clerkUserId: 'clerk_1',
           email: 'user@example.com',
         },
@@ -140,7 +142,7 @@ describe('createStripeCustomer', () => {
       createStripeCustomer({
         stripe,
         input: {
-          userId: 'user_1',
+          userId: appUserId,
           clerkUserId: 'clerk_1',
           email: 'user@example.com',
         },
@@ -166,7 +168,7 @@ describe('createStripeCustomer', () => {
       createStripeCustomer({
         stripe,
         input: {
-          userId: 'user_1',
+          userId: appUserId,
           clerkUserId: 'clerk_1',
           email: 'user@example.com',
         },
@@ -209,7 +211,7 @@ describe('createStripeCustomer', () => {
     const promise = createStripeCustomer({
       stripe,
       input: {
-        userId: 'user_1',
+        userId: appUserId,
         clerkUserId: 'clerk_1',
         email: 'user@example.com',
       },
@@ -231,7 +233,7 @@ describe('createStripeCustomer', () => {
       | undefined;
 
     expect(firstOptions).toMatchObject({
-      idempotencyKey: 'create_stripe_customer:user_1',
+      idempotencyKey: `create_stripe_customer:${appUserId}`,
     });
     expect(secondOptions).toEqual(firstOptions);
   });

--- a/src/adapters/gateways/stripe/stripe-subscription-normalizer.test.ts
+++ b/src/adapters/gateways/stripe/stripe-subscription-normalizer.test.ts
@@ -13,6 +13,8 @@ const priceIds: StripePriceIds = {
   annual: 'price_annual',
 };
 
+const appUserId = crypto.randomUUID();
+
 function createSubscriptionFixture(overrides?: {
   status?: string;
   userId?: string | null;
@@ -23,7 +25,7 @@ function createSubscriptionFixture(overrides?: {
     overrides?.userId === null
       ? undefined
       : {
-          user_id: overrides?.userId ?? 'user_1',
+          user_id: overrides?.userId ?? appUserId,
           ...(overrides?.e2eOwner ? { e2e_owner: overrides.e2eOwner } : {}),
         };
 
@@ -58,7 +60,7 @@ describe('normalizeStripeSubscriptionUpdate', () => {
     });
 
     expect(result).toEqual({
-      userId: 'user_1',
+      userId: appUserId,
       externalCustomerId: 'cus_123',
       externalSubscriptionId: 'sub_123',
       plan: 'monthly',
@@ -150,7 +152,7 @@ describe('normalizeStripeSubscriptionUpdate', () => {
       webhookE2EOwner: 'vercel-dev-preview',
     });
 
-    expect(result.userId).toBe('user_1');
+    expect(result.userId).toBe(appUserId);
   });
 
   it('does not throw when webhook owner is configured but event has no e2e_owner metadata', () => {
@@ -226,7 +228,7 @@ describe('retrieveAndNormalizeStripeSubscription', () => {
           customer: 'cus_123',
           status: 'active',
           cancel_at_period_end: false,
-          metadata: { user_id: 'user_1' },
+          metadata: { user_id: appUserId },
           items: { data: [] },
         })),
       },
@@ -266,7 +268,7 @@ describe('retrieveAndNormalizeStripeSubscription', () => {
     });
 
     expect(result).toMatchObject({
-      userId: 'user_1',
+      userId: appUserId,
       externalCustomerId: 'cus_123',
       externalSubscriptionId: 'sub_123',
       plan: 'monthly',

--- a/src/adapters/gateways/stripe/stripe-webhook-processor.test.ts
+++ b/src/adapters/gateways/stripe/stripe-webhook-processor.test.ts
@@ -9,13 +9,15 @@ const priceIds: StripePriceIds = {
   annual: 'price_annual',
 };
 
+const appUserId = crypto.randomUUID();
+
 function createSubscriptionFixture() {
   return {
     id: 'sub_123',
     customer: 'cus_123',
     status: 'active',
     cancel_at_period_end: false,
-    metadata: { user_id: 'user_1' },
+    metadata: { user_id: appUserId },
     items: {
       data: [
         {
@@ -187,7 +189,7 @@ describe('processStripeWebhookEvent', () => {
       eventId: 'evt_checkout',
       type: 'checkout.session.completed',
       subscriptionUpdate: {
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         externalSubscriptionId: 'sub_123',
         plan: 'monthly',
@@ -234,7 +236,7 @@ describe('processStripeWebhookEvent', () => {
       eventId: 'evt_invoice_success_nested',
       type: 'invoice.payment_succeeded',
       subscriptionUpdate: {
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         externalSubscriptionId: 'sub_123',
         plan: 'monthly',
@@ -283,7 +285,7 @@ describe('processStripeWebhookEvent', () => {
       eventId: 'evt_invoice_failed_nested',
       type: 'invoice.payment_failed',
       subscriptionUpdate: {
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         externalSubscriptionId: 'sub_123',
         plan: 'monthly',
@@ -397,7 +399,7 @@ describe('processStripeWebhookEvent', () => {
       eventId: 'evt_sub_updated',
       type: 'customer.subscription.updated',
       subscriptionUpdate: {
-        userId: 'user_1',
+        userId: appUserId,
         externalCustomerId: 'cus_123',
         externalSubscriptionId: 'sub_123',
         plan: 'monthly',

--- a/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
@@ -25,6 +25,11 @@ type StripeSubscriptionFixture = {
 
 type LocalSubscriptionRow = { userId: string; stripeSubscriptionId: string };
 
+const primaryUserId = crypto.randomUUID();
+const secondaryUserId = crypto.randomUUID();
+const tertiaryUserId = crypto.randomUUID();
+const otherUserId = crypto.randomUUID();
+
 type ReconciliationInput = Parameters<typeof reconcileStripeSubscriptions>[0];
 type ReconciliationDeps = Parameters<typeof reconcileStripeSubscriptions>[1];
 type StripeStub = {
@@ -99,7 +104,7 @@ function createUserSubscriptionFixture(
 ): StripeSubscriptionFixture {
   return createSubscriptionFixture({
     id,
-    userId: input.userId ?? 'user_1',
+    userId: input.userId ?? primaryUserId,
     customerId: input.customerId,
     status: input.status,
     currentPeriodEnd: input.currentPeriodEnd,
@@ -240,7 +245,9 @@ function createSingleRowScenario(input: {
   return createReconciliationTestScenario({
     stripe: input.stripe,
     stripeCustomers: input.stripeCustomers,
-    localSubscriptions: [row(input.userId ?? 'user_1', input.subscriptionId)],
+    localSubscriptions: [
+      row(input.userId ?? primaryUserId, input.subscriptionId),
+    ],
   });
 }
 
@@ -280,7 +287,7 @@ describe('reconcileStripeSubscriptions', () => {
     }
 
     const rows = Array.from({ length: 12 }, (_, i) => ({
-      userId: `user_${i + 1}`,
+      userId: crypto.randomUUID(),
       stripeSubscriptionId: `sub_${i + 1}`,
     }));
 
@@ -376,11 +383,11 @@ describe('reconcileStripeSubscriptions', () => {
       customerId: 'cus_1',
     });
     const goodSub3 = createUserSubscriptionFixture('sub_3', {
-      userId: 'user_3',
+      userId: tertiaryUserId,
       customerId: 'cus_3',
     });
     const badSub = createUserSubscriptionFixture('sub_2', {
-      userId: 'user_other',
+      userId: otherUserId,
       customerId: 'cus_2',
     });
 
@@ -413,9 +420,9 @@ describe('reconcileStripeSubscriptions', () => {
     const scenario = createReconciliationTestScenario({
       stripe,
       localSubscriptions: [
-        row('user_1', 'sub_1'),
-        row('user_2', 'sub_2'),
-        row('user_3', 'sub_3'),
+        row(primaryUserId, 'sub_1'),
+        row(secondaryUserId, 'sub_2'),
+        row(tertiaryUserId, 'sub_3'),
       ],
     });
 
@@ -430,13 +437,13 @@ describe('reconcileStripeSubscriptions', () => {
     });
 
     await expect(
-      scenario.subscriptions.findByUserId('user_1'),
+      scenario.subscriptions.findByUserId(primaryUserId),
     ).resolves.not.toBeNull();
     await expect(
-      scenario.subscriptions.findByUserId('user_3'),
+      scenario.subscriptions.findByUserId(tertiaryUserId),
     ).resolves.not.toBeNull();
     await expect(
-      scenario.subscriptions.findByUserId('user_2'),
+      scenario.subscriptions.findByUserId(secondaryUserId),
     ).resolves.toBeNull();
     expect(scenario.logger.errorCalls.length).toBeGreaterThan(0);
   });
@@ -499,7 +506,7 @@ describe('reconcileStripeSubscriptions', () => {
     });
     const scenario = createReconciliationTestScenario({
       stripe,
-      localSubscriptions: [row('user_1', 'sub_owner_mismatch')],
+      localSubscriptions: [row(primaryUserId, 'sub_owner_mismatch')],
       webhookE2EOwner: 'vercel-dev-preview',
     });
 
@@ -624,7 +631,7 @@ describe('reconcileStripeSubscriptions', () => {
     await expectDryRunSuccess(scenario);
 
     await expect(
-      scenario.subscriptions.findByUserId('user_1'),
+      scenario.subscriptions.findByUserId(primaryUserId),
     ).resolves.toMatchObject({
       status: 'canceled',
     });
@@ -636,7 +643,7 @@ describe('reconcileStripeSubscriptions', () => {
       status: 'active',
     });
     const blockingMismatch = createUserSubscriptionFixture('sub_blocking', {
-      userId: 'user_other',
+      userId: otherUserId,
       customerId: 'cus_1',
       status: 'active',
     });
@@ -658,10 +665,10 @@ describe('reconcileStripeSubscriptions', () => {
     });
 
     await expect(
-      scenario.subscriptions.findByUserId('user_1'),
+      scenario.subscriptions.findByUserId(primaryUserId),
     ).resolves.toBeNull();
     await expect(
-      scenario.stripeCustomers.findByUserId('user_1'),
+      scenario.stripeCustomers.findByUserId(primaryUserId),
     ).resolves.toBeNull();
   });
 
@@ -725,14 +732,14 @@ describe('reconcileStripeSubscriptions', () => {
     });
 
     await expect(
-      scenario.subscriptions.findByUserId('user_1'),
+      scenario.subscriptions.findByUserId(primaryUserId),
     ).resolves.toMatchObject({
-      userId: 'user_1',
+      userId: primaryUserId,
       status: 'active',
       plan: 'monthly',
     });
     await expect(
-      scenario.stripeCustomers.findByUserId('user_1'),
+      scenario.stripeCustomers.findByUserId(primaryUserId),
     ).resolves.toEqual({
       stripeCustomerId: 'cus_123',
     });
@@ -792,7 +799,7 @@ describe('reconcileStripeSubscriptions', () => {
       { idempotencyKey: 'reconcile_duplicate_subscription:sub_dup_1' },
     );
     await expect(
-      scenario.subscriptions.findByUserId('user_1'),
+      scenario.subscriptions.findByUserId(primaryUserId),
     ).resolves.toMatchObject({
       status: 'pastDue',
       currentPeriodEnd: new Date(1_700_000_200 * 1000),
@@ -800,7 +807,7 @@ describe('reconcileStripeSubscriptions', () => {
     await expect(
       scenario.subscriptions.findByExternalSubscriptionId('sub_dup_2'),
     ).resolves.toMatchObject({
-      userId: 'user_1',
+      userId: primaryUserId,
       status: 'pastDue',
       currentPeriodEnd: new Date(1_700_000_200 * 1000),
     });
@@ -926,7 +933,7 @@ describe('reconcileStripeSubscriptions', () => {
     expect(scenario.logger.warnCalls).toEqual([
       {
         context: {
-          userId: 'user_1',
+          userId: primaryUserId,
           stripeCustomerId: 'cus_123',
           keptSubscriptionId: 'sub_dup_2',
           duplicateSubscriptionIds: ['sub_keep', 'sub_dup_1'],
@@ -983,7 +990,7 @@ describe('reconcileStripeSubscriptions', () => {
     expect(scenario.logger.warnCalls).toEqual([
       {
         context: {
-          userId: 'user_1',
+          userId: primaryUserId,
           stripeCustomerId: 'cus_123',
           keptSubscriptionId: 'sub_dup_2',
           duplicateSubscriptionIds: ['sub_keep', 'sub_dup_1'],
@@ -1050,14 +1057,14 @@ describe('reconcileStripeSubscriptions', () => {
     await expectDryRunSuccess(scenario);
 
     await expect(
-      scenario.subscriptions.findByUserId('user_1'),
+      scenario.subscriptions.findByUserId(primaryUserId),
     ).resolves.toMatchObject({
       status: 'active',
     });
     await expect(
       scenario.subscriptions.findByExternalSubscriptionId(active.id),
     ).resolves.toMatchObject({
-      userId: 'user_1',
+      userId: primaryUserId,
       status: 'active',
     });
     await expect(
@@ -1105,7 +1112,7 @@ describe('reconcileStripeSubscriptions', () => {
       },
     );
     await expect(
-      scenario.subscriptions.findByUserId('user_1'),
+      scenario.subscriptions.findByUserId(primaryUserId),
     ).resolves.toMatchObject({
       status: 'active',
       currentPeriodEnd: new Date(1_800_000_000 * 1000),
@@ -1113,7 +1120,7 @@ describe('reconcileStripeSubscriptions', () => {
     await expect(
       scenario.subscriptions.findByExternalSubscriptionId('sub_better'),
     ).resolves.toMatchObject({
-      userId: 'user_1',
+      userId: primaryUserId,
       status: 'active',
       currentPeriodEnd: new Date(1_800_000_000 * 1000),
     });
@@ -1160,7 +1167,7 @@ describe('reconcileStripeSubscriptions', () => {
     await expect(
       scenario.subscriptions.findByExternalSubscriptionId('sub_a'),
     ).resolves.toMatchObject({
-      userId: 'user_1',
+      userId: primaryUserId,
       status: 'active',
       currentPeriodEnd: new Date(1_800_000_000 * 1000),
     });
@@ -1221,7 +1228,7 @@ describe('reconcileStripeSubscriptions', () => {
 
     const subscriptions = new FakeSubscriptionRepository();
     await subscriptions.upsert({
-      userId: 'user_1',
+      userId: primaryUserId,
       externalSubscriptionId: local.id,
       plan: 'monthly',
       status: 'active',
@@ -1232,7 +1239,7 @@ describe('reconcileStripeSubscriptions', () => {
     const scenario = createReconciliationTestScenario({
       stripe,
       subscriptions,
-      localSubscriptions: [row('user_1', local.id)],
+      localSubscriptions: [row(primaryUserId, local.id)],
     });
 
     const result = await scenario.run({ dryRun: false });
@@ -1251,7 +1258,7 @@ describe('reconcileStripeSubscriptions', () => {
     await expect(
       scenario.subscriptions.findByExternalSubscriptionId('sub_better'),
     ).resolves.toMatchObject({
-      userId: 'user_1',
+      userId: primaryUserId,
       status: 'active',
       currentPeriodEnd: new Date(1_800_000_000 * 1000),
     });
@@ -1276,7 +1283,7 @@ describe('reconcileStripeSubscriptions', () => {
 
     const subscriptions = new FakeSubscriptionRepository();
     await subscriptions.upsert({
-      userId: 'user_1',
+      userId: primaryUserId,
       externalSubscriptionId: local.id,
       plan: 'monthly',
       status: 'active',
@@ -1287,7 +1294,7 @@ describe('reconcileStripeSubscriptions', () => {
     const scenario = createReconciliationTestScenario({
       stripe,
       subscriptions,
-      localSubscriptions: [row('user_1', local.id)],
+      localSubscriptions: [row(primaryUserId, local.id)],
       transaction: async () => {
         throw new Error('db failed');
       },
@@ -1303,7 +1310,7 @@ describe('reconcileStripeSubscriptions', () => {
     await expect(
       scenario.subscriptions.findByExternalSubscriptionId('sub_local'),
     ).resolves.toMatchObject({
-      userId: 'user_1',
+      userId: primaryUserId,
       status: 'active',
       currentPeriodEnd: new Date(1_700_000_000 * 1000),
     });
@@ -1343,7 +1350,7 @@ describe('reconcileStripeSubscriptions', () => {
     await expect(
       scenario.subscriptions.findByExternalSubscriptionId('sub_a'),
     ).resolves.toMatchObject({
-      userId: 'user_1',
+      userId: primaryUserId,
       status: 'active',
     });
     await expect(
@@ -1353,7 +1360,7 @@ describe('reconcileStripeSubscriptions', () => {
 
   it('reports a failure when Stripe subscription metadata user id mismatches', async () => {
     const mismatch = createUserSubscriptionFixture('sub_123', {
-      userId: 'user_other',
+      userId: otherUserId,
     });
     const stripe = createStripeFromFixtures({
       fixtures: [{ fixture: mismatch }],
@@ -1372,10 +1379,10 @@ describe('reconcileStripeSubscriptions', () => {
     });
 
     await expect(
-      scenario.subscriptions.findByUserId('user_1'),
+      scenario.subscriptions.findByUserId(primaryUserId),
     ).resolves.toBeNull();
     await expect(
-      scenario.stripeCustomers.findByUserId('user_1'),
+      scenario.stripeCustomers.findByUserId(primaryUserId),
     ).resolves.toBeNull();
     expect(scenario.logger.errorCalls.length).toBeGreaterThan(0);
   });
@@ -1389,7 +1396,7 @@ describe('reconcileStripeSubscriptions', () => {
     });
 
     const stripeCustomers = new FakeStripeCustomerRepository();
-    await stripeCustomers.insert('user_1', 'cus_old');
+    await stripeCustomers.insert(primaryUserId, 'cus_old');
 
     const scenario = createSingleRowScenario({
       stripe,
@@ -1399,13 +1406,13 @@ describe('reconcileStripeSubscriptions', () => {
     await expectDryRunSuccess(scenario);
 
     await expect(
-      scenario.stripeCustomers.findByUserId('user_1'),
+      scenario.stripeCustomers.findByUserId(primaryUserId),
     ).resolves.toEqual({
       stripeCustomerId: 'cus_new',
     });
 
     await expect(
-      scenario.stripeCustomers.insert('user_2', 'cus_old'),
+      scenario.stripeCustomers.insert(secondaryUserId, 'cus_old'),
     ).resolves.toBeUndefined();
   });
 });

--- a/src/adapters/shared/with-idempotency.test.ts
+++ b/src/adapters/shared/with-idempotency.test.ts
@@ -6,6 +6,8 @@ import {
 } from '@/src/application/test-helpers/fakes';
 import { withIdempotency } from './with-idempotency';
 
+const appUserId = crypto.randomUUID();
+
 describe('withIdempotency', () => {
   it('executes once and returns cached result for subsequent calls', async () => {
     const now = () => new Date();
@@ -15,7 +17,7 @@ describe('withIdempotency', () => {
 
     const input = {
       repo,
-      userId: 'user_1',
+      userId: appUserId,
       action: 'billing:createCheckoutSession',
       key: '11111111-1111-1111-1111-111111111111',
       now,
@@ -48,7 +50,7 @@ describe('withIdempotency', () => {
 
     const input = {
       repo,
-      userId: 'user_1',
+      userId: appUserId,
       action: 'billing:createCheckoutSession',
       key: '11111111-1111-1111-1111-111111111111',
       now,
@@ -79,7 +81,7 @@ describe('withIdempotency', () => {
 
     const input = {
       repo,
-      userId: 'user_1',
+      userId: appUserId,
       action: 'billing:createCheckoutSession',
       key: '11111111-1111-1111-1111-111111111112',
       now,
@@ -120,7 +122,7 @@ describe('withIdempotency', () => {
 
     const base = {
       repo,
-      userId: 'user_1',
+      userId: appUserId,
       action: 'question:submitAnswer',
       key: '22222222-2222-2222-2222-222222222222',
       now,
@@ -149,14 +151,14 @@ describe('withIdempotency', () => {
     const key = '22222222-2222-2222-2222-222222222223';
 
     await repo.claim({
-      userId: 'user_1',
+      userId: appUserId,
       action: 'question:submitAnswer',
       key,
       expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
     });
 
     await repo.storeResult({
-      userId: 'user_1',
+      userId: appUserId,
       action: 'question:submitAnswer',
       key,
       resultJson: null,
@@ -166,7 +168,7 @@ describe('withIdempotency', () => {
     await expect(
       withIdempotency({
         repo,
-        userId: 'user_1',
+        userId: appUserId,
         action: 'question:submitAnswer',
         key,
         now,
@@ -185,13 +187,13 @@ describe('withIdempotency', () => {
     const key = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 
     await repo.claim({
-      userId: 'user_1',
+      userId: appUserId,
       action: 'question:submitAnswer',
       key,
       expiresAt: new Date('2026-02-08T00:00:00.000Z'),
     });
     await repo.storeResult({
-      userId: 'user_1',
+      userId: appUserId,
       action: 'question:submitAnswer',
       key,
       resultJson: null,
@@ -203,7 +205,7 @@ describe('withIdempotency', () => {
     await expect(
       withIdempotency({
         repo,
-        userId: 'user_1',
+        userId: appUserId,
         action: 'question:submitAnswer',
         key,
         now,
@@ -224,13 +226,13 @@ describe('withIdempotency', () => {
     const key = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
 
     await repo.claim({
-      userId: 'user_1',
+      userId: appUserId,
       action: 'question:submitAnswer',
       key,
       expiresAt: new Date('2026-02-08T00:00:00.000Z'),
     });
     await repo.storeResult({
-      userId: 'user_1',
+      userId: appUserId,
       action: 'question:submitAnswer',
       key,
       resultJson: null,
@@ -244,7 +246,7 @@ describe('withIdempotency', () => {
 
     const promise = withIdempotency({
       repo,
-      userId: 'user_1',
+      userId: appUserId,
       action: 'question:submitAnswer',
       key,
       now,
@@ -277,7 +279,7 @@ describe('withIdempotency', () => {
 
     const input = {
       repo,
-      userId: 'user_1',
+      userId: appUserId,
       action: 'practice:startPracticeSession',
       key,
       now,
@@ -308,7 +310,7 @@ describe('withIdempotency', () => {
 
     const repo = new FakeIdempotencyKeyRepository(now);
     await repo.claim({
-      userId: 'user_1',
+      userId: appUserId,
       action: 'billing:createCheckoutSession',
       key: '44444444-4444-4444-4444-444444444444',
       expiresAt: new Date('2026-02-08T00:00:00.000Z'),
@@ -320,7 +322,7 @@ describe('withIdempotency', () => {
     await expect(
       withIdempotency({
         repo,
-        userId: 'user_1',
+        userId: appUserId,
         action: 'billing:createCheckoutSession',
         key: '44444444-4444-4444-4444-444444444444',
         now,
@@ -352,7 +354,7 @@ describe('withIdempotency', () => {
     const key = '44444444-4444-4444-4444-444444444446';
 
     await repo.claim({
-      userId: 'user_1',
+      userId: appUserId,
       action: 'billing:createCheckoutSession',
       key,
       expiresAt: new Date('2026-02-08T00:00:00.000Z'),
@@ -365,7 +367,7 @@ describe('withIdempotency', () => {
     await expect(
       withIdempotency({
         repo,
-        userId: 'user_1',
+        userId: appUserId,
         action: 'billing:createCheckoutSession',
         key,
         now,
@@ -382,7 +384,7 @@ describe('withIdempotency', () => {
     await expect(
       withIdempotency({
         repo,
-        userId: 'user_1',
+        userId: appUserId,
         action: 'billing:createCheckoutSession',
         key,
         now,
@@ -407,7 +409,7 @@ describe('withIdempotency', () => {
     const key = '44444444-4444-4444-4444-444444444445';
 
     await repo.claim({
-      userId: 'user_1',
+      userId: appUserId,
       action: 'billing:createCheckoutSession',
       key,
       expiresAt: new Date('2026-02-08T00:00:00.000Z'),
@@ -418,7 +420,7 @@ describe('withIdempotency', () => {
     await expect(
       withIdempotency({
         repo,
-        userId: 'user_1',
+        userId: appUserId,
         action: 'billing:createCheckoutSession',
         key,
         now,
@@ -446,7 +448,7 @@ describe('withIdempotency', () => {
     await expect(
       withIdempotency({
         repo,
-        userId: 'user_1',
+        userId: appUserId,
         action: 'billing:createCheckoutSession',
         key: '55555555-5555-5555-5555-555555555555',
         now,
@@ -473,7 +475,7 @@ describe('withIdempotency', () => {
     await expect(
       withIdempotency({
         repo,
-        userId: 'user_1',
+        userId: appUserId,
         action: 'billing:createCheckoutSession',
         key: '66666666-6666-6666-6666-666666666666',
         now,
@@ -499,7 +501,7 @@ describe('withIdempotency', () => {
     await expect(
       withIdempotency({
         repo,
-        userId: 'user_1',
+        userId: appUserId,
         action: 'billing:createCheckoutSession',
         key: '77777777-7777-7777-7777-777777777777',
         now,
@@ -512,7 +514,7 @@ describe('withIdempotency', () => {
     expect(logger.warnCalls[0]).toMatchObject({
       msg: 'Idempotency prune failed',
       context: {
-        userId: 'user_1',
+        userId: appUserId,
         action: 'billing:createCheckoutSession',
         key: '77777777-7777-7777-7777-777777777777',
         error: 'prune failed',
@@ -529,7 +531,7 @@ describe('withIdempotency', () => {
     await expect(
       withIdempotency({
         repo,
-        userId: 'user_1',
+        userId: appUserId,
         action: 'billing:createCheckoutSession',
         key: '88888888-8888-8888-8888-888888888888',
         now,
@@ -541,7 +543,7 @@ describe('withIdempotency', () => {
     const parseError = new Error('invalid cached result');
     const promise = withIdempotency({
       repo,
-      userId: 'user_1',
+      userId: appUserId,
       action: 'billing:createCheckoutSession',
       key: '88888888-8888-8888-8888-888888888888',
       now,
@@ -581,7 +583,7 @@ describe('withIdempotency', () => {
 
     const input = {
       repo,
-      userId: 'user_1',
+      userId: appUserId,
       action: 'billing:createCheckoutSession',
       key,
       now,
@@ -618,7 +620,7 @@ describe('withIdempotency', () => {
     await expect(
       withIdempotency({
         repo,
-        userId: 'user_1',
+        userId: appUserId,
         action: 'billing:createCheckoutSession',
         key: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
         now,
@@ -631,7 +633,7 @@ describe('withIdempotency', () => {
     expect(logger.errorCalls[0]).toMatchObject({
       msg: 'Failed to persist idempotency error record',
       context: {
-        userId: 'user_1',
+        userId: appUserId,
         action: 'billing:createCheckoutSession',
         key: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
       },
@@ -665,7 +667,7 @@ describe('withIdempotency', () => {
     await expect(
       withIdempotency({
         repo,
-        userId: 'user_1',
+        userId: appUserId,
         action: 'billing:createCheckoutSession',
         key: 'ffffffff-1111-2222-3333-444444444444',
         now,


### PR DESCRIPTION
## Summary

DEBT-400 PR 2a (of the split PR 2). Migrates only the app-UUID FIX sites in the **controller / shared / job / gateway** adapter test files to valid UUIDs, per the audited 44-row classification table (`14f3ab91`). Repositories are PR 2b; app/application/browser fixtures are PR 3.

## What changed (FIX = app-UUID boundary only)

- Controllers: valid-path `zUuid` input/output fields now use generated or factory-provided valid UUIDs; negative-validation tests keep their invalid inputs.
- `src/adapters/shared/with-idempotency.test.ts`: app UUID `userId` fixtures fixed.
- Jobs/gateways: surgical app `userId` / Stripe metadata `user_id` fixes only. Stripe, Clerk, price, event, customer, subscription, and Svix provider IDs remain provider-shaped.
- `docs/debt/debt-400-test-fixture-integrity-zod-boundary.md`: records the 2a/2b split for PR 2 execution.

## Do-not-churn (preserved)

- Provider IDs (`cus_`/`sub_`/`evt_`/`price_`/Clerk/Svix).
- Negative-validation invalid fixtures, including the unsupported Stripe search-character case.
- `clerk-webhook-controller.test.ts` and `clerk-auth-gateway.test.ts` provider-only rows.
- All repository tests (`src/adapters/repositories/**`) deferred to PR 2b.

## Verification

- [x] `pnpm test --run src/adapters/controllers src/adapters/shared/with-idempotency.test.ts` — 20 files / 238 tests passed.
- [x] `pnpm test --run src/adapters/jobs src/adapters/gateways` — 14 files / 166 tests passed.
- [x] `pnpm test --run tests/shared/fixture-uuid-integrity.test.ts` — 2/2 passed.
- [x] `pnpm test --run components/theme-token-regression.test.tsx` — 16/16 passed.
- [x] Full local gate green: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`.
- [x] Authenticated billing E2E green: `pnpm test:e2e` — 35/35 passed.
- [x] `git diff --stat`: only controller/shared/job/gateway files + DEBT-400 doc; no repositories, app, application, or browser files.
- [x] No `as any` / widened type assertions introduced.

## Follow-ups

- PR 2b: repository row fixtures.
- PR 3: app/application/browser fixtures.
- PR 4: fixture-integrity docs SSOT.
- Archive PR after DEBT-400 completes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now derive and share dynamic UUIDs for users, sessions, questions, and related fixtures instead of hardcoded IDs.
  * Idempotency, caching, and webhook/gateway test scenarios updated to use those dynamic identifiers for more reliable assertions.
* **Documentation**
  * Updated DEBT-400 test-fixture guidance: provenance, candidate counts, scope clarifications, and tightened acceptance criteria for UUID fixture remediation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->