### PR TITLE
DEBT-400 PR 2b — repository row-fixture boundary sweep

### DIFF
--- a/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
+++ b/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
@@ -1,8 +1,8 @@
 # DEBT-400: Test Fixture Integrity (Zod Boundary Class)
 
-**Priority:** P2 (latent bug class. After PR 1, the current canonical candidate grep finds 2,438 placeholder-ID assignments across 162 test files. This is a candidate set, not a mandate to replace every string: the execution scope is only IDs that cross `zUuid = z.guid()` controller schemas or model Drizzle `uuid()` columns.)
+**Priority:** P2 (latent bug class. After PR 2a, the current canonical candidate grep finds 2,244 placeholder-ID assignments across 140 test files. This is a candidate set, not a mandate to replace every string: the execution scope is only IDs that cross `zUuid = z.guid()` controller schemas or model Drizzle `uuid()` columns.)
 **Created:** 2026-05-26
-**Source:** Deep schema/boundary integrity audit conducted alongside DEBT-394 archival; re-audited on 2026-05-28 from `dev` at `f2dc0793`, then PR 2 scope re-audited on 2026-05-28 from `dev` at `e7f1029a` after PR 1 merged. Direct precedent is PR #330, which bumped Zod from 3 to 4 and deliberately kept historical UUID/GUID behavior by replacing the shared controller ID schema with Zod 4 `z.guid()`.
+**Source:** Deep schema/boundary integrity audit conducted alongside DEBT-394 archival; re-audited on 2026-05-28 from `dev` at `f2dc0793`, PR 2 scope re-audited on 2026-05-28 from `dev` at `e7f1029a` after PR 1 merged, then repository-slice PR 2b scope re-audited on 2026-05-29 from `dev` at `a98b5922` after PR 2a merged. Direct precedent is PR #330, which bumped Zod from 3 to 4 and deliberately kept historical UUID/GUID behavior by replacing the shared controller ID schema with Zod 4 `z.guid()`.
 **Related:** [src/adapters/shared/zod-schemas.ts](../../src/adapters/shared/zod-schemas.ts), [db/schema.ts](../../db/schema.ts), [src/domain/test-helpers/](../../src/domain/test-helpers/), [src/application/test-helpers/fakes/](../../src/application/test-helpers/fakes/), [docs/dev/dependency-update-protocol.md](../dev/dependency-update-protocol.md), [DEBT-397](./debt-397-datetime-boundary-type-normalization.md), [DEBT-394 (archived)](../_archive/debt/debt-394-supply-chain-hardening.md), PR #330
 
 **Status:** Active
@@ -70,6 +70,21 @@ Confirmed current Drizzle `uuid()` columns in `db/schema.ts`:
 | `attempts` | `id`, `userId`, `questionId`, `practiceSessionId`, `selectedChoiceId`, `retryOfAttemptId`, `retrySessionId` |
 | `bookmarks` | `userId`, `questionId` |
 
+Confirmed current provider/text identifier columns in `db/schema.ts` that are explicitly **not** app UUIDs:
+
+| Table | Provider/text columns |
+|---|---|
+| `users` | `clerkUserId` |
+| `stripe_customers` | `stripeCustomerId` |
+| `stripe_subscriptions` | `stripeSubscriptionId`, `priceId` |
+| `stripe_events` | `id` (Stripe event id), `type`, `error` |
+| `clerk_events` | `id` (Svix delivery id), `type`, `error` |
+| `deleted_clerk_users` | `clerkUserId` |
+| `pending_stripe_cancellations` | `eventId`, `stripeCustomerId` |
+| `rate_limits` | `key` |
+| `idempotency_keys` | `action`, `key`, `errorCode`, `errorMessage` |
+| `questions` / `tags` | `slug`; tag `name` / `kind`; choice `label` |
+
 Explicit non-targets:
 
 - `stripe_events.id`, `clerk_events.id`, `deleted_clerk_users.clerkUserId`, `pending_stripe_cancellations.eventId`, Stripe `cus_` / `sub_` / `evt_` values, Clerk `user_...` values, and Svix delivery IDs are external-provider string IDs, not Drizzle UUID columns.
@@ -89,7 +104,7 @@ rg -n "\b(questionId|sessionId|attemptId|choiceId|selectedChoiceId|correctChoice
   --glob '!**/_archive/**'
 ```
 
-Current result on `e7f1029a` after PR 1: **2,438 lines across 162 files**. The pre-PR1 audit result on `f2dc0793` was **2,447 lines across 163 files**.
+Current result on `a98b5922` after PR 2a: **2,244 lines across 140 files**. The result on `e7f1029a` after PR 1 was **2,438 lines across 162 files**. The pre-PR1 audit result on `f2dc0793` was **2,447 lines across 163 files**.
 
 This replaces the old narrower `604 / 64` count. The old grep only searched `app/ src/ components/`, only camel-case object properties, only five field names, and only underscore-prefixed values. It missed hyphenated placeholders (`session-1`), choice/tag/subscription fields, snake_case SQL-row fixtures (`user_id`), and `tests/**` helper fixtures.
 
@@ -270,7 +285,10 @@ Status: shipped in PR #368 at `e7f1029a`.
 
 ### PR 2 — Adapter boundary fixture sweep
 
-Branch: `feat/debt-400-pr-2-adapter-boundary-fixtures`
+Branches:
+
+- PR 2a: `feat/debt-400-pr-2-adapter-boundary-fixtures` (controllers/shared/jobs/gateways; shipped in PR #369 at `a98b5922`)
+- PR 2b: `feat/debt-400-pr-2b-repository-fixtures` (repository row fixtures)
 
 Scope:
 
@@ -384,7 +402,59 @@ PR 2 proof method:
 
 - Acceptance is not "zero placeholder-looking strings in adapters." Provider and invalid buckets above are expected to remain.
 
-Split decision: PR 2 ships as **two PRs** on adapter-layer boundaries. PR 2a uses `feat/debt-400-pr-2-adapter-boundary-fixtures` and covers controllers, `src/adapters/shared/with-idempotency.test.ts`, jobs, and gateways. PR 2b follows on a fresh branch for `src/adapters/repositories/**/*.test.ts`. The table above remains the SSOT for both PRs; PR 2a must not touch repository tests.
+Split decision: PR 2 ships as **two PRs** on adapter-layer boundaries. PR 2a used `feat/debt-400-pr-2-adapter-boundary-fixtures` and shipped in PR #369 at `a98b5922`, covering controllers, `src/adapters/shared/with-idempotency.test.ts`, jobs, and gateways. PR 2b uses `feat/debt-400-pr-2b-repository-fixtures` for `src/adapters/repositories/**/*.test.ts`. The 2026-05-29 PR 2b table below supersedes the repository rows in the historical 44-row adapter table above.
+
+#### PR 2b pre-execution audit: repository row-fixture target list
+
+Re-audited on 2026-05-29 from `dev` at `a98b5922` after PR 2a merged. The authoritative schema path is `db/schema.ts`; no `src/adapters/db` schema exists. The repository slice resolves to these test files:
+
+- `src/adapters/repositories/attempt-row-mappers.test.ts`
+- `src/adapters/repositories/drizzle-*-repository.test.ts`
+- `src/adapters/repositories/practice-session-params.test.ts`
+- plus non-target repository tests with no fixture IDs: `index.test.ts`, `postgres-errors.test.ts`
+
+Counts below are current candidate occurrences from a repository-slice AST/text audit. They are **not** expected edit counts: one named value such as `const userId = crypto.randomUUID()` may replace multiple repeated literals. The execution target is the `FIX uuid-column` column only.
+
+| File | FIX uuid-column | LEAVE provider/text | LEAVE other / already valid | Execution note |
+|---|---:|---:|---:|---|
+| `src/adapters/repositories/attempt-row-mappers.test.ts` | 4 | 0 | 0 | Base attempt row models `attempts.id`, `userId`, `questionId`, `selectedChoiceId`; update error-message expectations by capturing `baseRow.id`, not by hardcoding the old literal. |
+| `src/adapters/repositories/drizzle-attempt-repository.test.ts` | 136 | 0 | 0 | Near-pure FIX. Replace attempt/user/question/session/choice row mocks, query args, `answeredOutcome(...)` choice IDs, aggregate query result rows, and expected returned IDs with semantic UUID variables. |
+| `src/adapters/repositories/drizzle-bookmark-repository.test.ts` | 27 | 0 | 0 | Near-pure FIX. `bookmarks.userId` / `questionId` appear in query args, insert/delete values, returned rows, and list assertions; capture shared `userId` / `questionId`. |
+| `src/adapters/repositories/drizzle-clerk-event-repository.test.ts` | 0 | 12 | 0 | Provider/Svix event IDs only (`clerk_events.id` is varchar); do not churn. |
+| `src/adapters/repositories/drizzle-deleted-clerk-user-repository.test.ts` | 0 | 8 | 0 | Clerk user IDs populate `deleted_clerk_users.clerkUserId` varchar; do not churn. |
+| `src/adapters/repositories/drizzle-idempotency-key-repository.test.ts` | 0 | 0 | 13 already-valid `userId` UUID literals; idempotency `action` / `key` strings remain text | Corrected from the earlier directional "drizzle-idempotency ~32" concern: current app `userId` fixtures already use UUID-shaped values. PR 2b should not churn this file unless a test fails from nearby changes. |
+| `src/adapters/repositories/drizzle-pending-stripe-cancellation-repository.test.ts` | 0 | 10 | 0 | Stripe/Svix event/customer text columns only; do not churn. |
+| `src/adapters/repositories/drizzle-practice-session-repository-question-state.test.ts` | 102 | 0 | 0 | Near-pure FIX. Includes `practice_sessions.id` / `userId` row mocks, command inputs, `paramsJson.questionIds`, question-state `questionId`, `latestSelectedChoiceId`, `draftSelectedChoiceId`, and selected-choice values. |
+| `src/adapters/repositories/drizzle-practice-session-repository-reads.test.ts` | 53 | 0 | 0 | Near-pure FIX. Includes read query args, returned session rows, `paramsJson.questionIds`, question-state rows, and orphan `questionId` fixtures; tag slugs remain ordinary slugs. |
+| `src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts` | 39 | 0 | 0 | Near-pure FIX. Includes create/end query args, returned rows, `paramsJson.questionIds`, question-state `questionId`, and latest choice IDs. |
+| `src/adapters/repositories/drizzle-question-repository.test.ts` | 16 | 0 | slugs unchanged | Fix question/choice/tag UUID row fields, `findPublishedByIds` placeholder IDs, and app `userId` status-filter fixtures. Keep `slug` values, tag names/kinds, and invalid status sentinels unchanged. |
+| `src/adapters/repositories/drizzle-stripe-customer-repository.test.ts` | 9 | 12 | 0 | Surgical mixed file. Fix only app `userId` query/insert args; leave `cus_*` Stripe customer IDs provider-shaped. |
+| `src/adapters/repositories/drizzle-stripe-event-repository.test.ts` | 0 | 22 | 0 | Stripe event IDs only (`stripe_events.id` is varchar); do not churn. |
+| `src/adapters/repositories/drizzle-subscription-repository.test.ts` | 19 | 35 | 0 | Surgical mixed file. Fix `stripe_subscriptions.id` row IDs (`sub_row_1`) and app `userId`; leave `stripeSubscriptionId` (`sub_*`) and `priceId` (`price_*`) as provider/text values. |
+| `src/adapters/repositories/drizzle-tag-repository.test.ts` | 6 | 0 | 0 | Near-pure FIX for `tags.id`; slugs/names/kinds remain text. |
+| `src/adapters/repositories/drizzle-user-repository.test.ts` | 7 | 19 | 0 | Surgical mixed file. Fix app `users.id`; leave `clerkUserId` args/rows (`clerk_*`) provider-shaped. |
+| `src/adapters/repositories/index.test.ts` | 0 | 0 | 0 | Barrel export test; no ID fixtures. |
+| `src/adapters/repositories/postgres-errors.test.ts` | 0 | 0 | 0 | Error-shape test; no ID fixtures. |
+| `src/adapters/repositories/practice-session-params.test.ts` | 10 | 0 | 0 | Fix `questionIds`, question-state `questionId`, and draft choice IDs embedded in practice-session params JSON. |
+
+Repository PR 2b totals: **428 FIX uuid-column candidate occurrences**, **118 LEAVE provider/text occurrences**, and **13 already-valid app UUID literals** in `drizzle-idempotency-key-repository.test.ts`. `idempotency_keys.action` / `key`, slugs, labels, enum-ish status/action strings, and Postgres constraint names are expected text values, not debt.
+
+Row-fixture mechanics and execution rules:
+
+- Most repository tests use object-literal row mocks plus `db as unknown as RepoDb` to stand in for the injected Drizzle client. That DB seam cast is pre-existing and not the DEBT-400 target; PR 2b must not add `as any`, widen row object types, or relax expectations to make invalid fixtures compile.
+- App-entity repository files (`drizzle-attempt`, `drizzle-practice-session-*`, `drizzle-bookmark`, `drizzle-question`, `drizzle-tag`, `attempt-row-mappers`, `practice-session-params`) are near-pure FIX. Prefer small semantic constants per test (`userId`, `sessionId`, `questionId`, `selectedChoiceId`) or local row factories when a value repeats across query args, mocked rows, and assertions.
+- Stripe/Clerk repository files are column-level surgical edits. Fix app UUID columns (`users.id`, `stripe_customers.userId`, `stripe_subscriptions.id`, `stripe_subscriptions.userId`) and leave provider/text columns (`clerkUserId`, `stripeCustomerId`, `stripeSubscriptionId`, `priceId`, event IDs) unchanged.
+- Capture-the-id sites are common: insert-then-expect returned row, query-by-id then assert returned row id, `toThrow('Attempt attempt-1 ...')`, and `toMatchObject([{ questionId: 'q_correct' }])`. The fix is to capture the generated semantic UUID and assert against that variable, not to introduce opaque UUID literals.
+
+PR 2b proof method:
+
+- Run `pnpm test --run src/adapters/repositories` after migration; all repository tests must pass with valid UUIDs in UUID-column fixtures and no new `as any` / row-type widening.
+- Run `pnpm test --run tests/shared/fixture-uuid-integrity.test.ts` to keep PR 1's proof harness green.
+- Run `pnpm test --run components/theme-token-regression.test.tsx` and confirm 16/16 still passes.
+- Full local gate remains required before push. No extra production-schema export or standalone repository-row `safeParse()` harness is recommended; the repository tests already exercise the row mappers and Drizzle adapter behavior, and a harness would either duplicate the schema table manually or expose internals for test-only proof.
+- Acceptance is not "zero placeholder-looking strings in repositories." Provider/text values and the already-valid idempotency UUID literals above are expected to remain.
+
+PR 2b split decision: ship as **one repository PR** on `feat/debt-400-pr-2b-repository-fixtures`. Although the current repository FIX volume is about 428 candidate occurrences, the edits are mechanical, confined to `src/adapters/repositories/**/*.test.ts`, and reviewable with commits split by sub-area: attempt/practice-session bulk first, then question/bookmark/tag/user, then Stripe/Clerk surgical files. Splitting again would create more branch choreography without reducing conceptual scope.
 
 ### PR 3 — App, browser, and application fixture sweep
 

--- a/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
+++ b/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
@@ -288,7 +288,7 @@ Status: shipped in PR #368 at `e7f1029a`.
 Branches:
 
 - PR 2a: `feat/debt-400-pr-2-adapter-boundary-fixtures` (controllers/shared/jobs/gateways; shipped in PR #369 at `a98b5922`)
-- PR 2b: `feat/debt-400-pr-2b-repository-fixtures` (repository row fixtures)
+- PR 2b: `feat/debt-400-pr-2b-repository-fixtures` (repository row fixtures; implemented in the PR 2b branch, pending review/merge)
 
 Scope:
 
@@ -455,6 +455,8 @@ PR 2b proof method:
 - Acceptance is not "zero placeholder-looking strings in repositories." Provider/text values and the already-valid idempotency UUID literals above are expected to remain.
 
 PR 2b split decision: ship as **one repository PR** on `feat/debt-400-pr-2b-repository-fixtures`. Although the current repository FIX volume is about 428 candidate occurrences, the edits are mechanical, confined to `src/adapters/repositories/**/*.test.ts`, and reviewable with commits split by sub-area: attempt/practice-session bulk first, then question/bookmark/tag/user, then Stripe/Clerk surgical files. Splitting again would create more branch choreography without reducing conceptual scope.
+
+PR 2b execution status: implemented in the repository-slice PR. The branch migrates only `FIX uuid-column` repository fixtures to UUID-valid values, preserves provider/text identifiers and the already-valid `drizzle-idempotency-key-repository.test.ts`, and leaves PR 3 plus PR 4 as the remaining DEBT-400 work.
 
 ### PR 3 — App, browser, and application fixture sweep
 

--- a/src/adapters/repositories/attempt-row-mappers.test.ts
+++ b/src/adapters/repositories/attempt-row-mappers.test.ts
@@ -2,12 +2,17 @@ import { describe, expect, it } from 'vitest';
 import { ApplicationError } from '@/src/application/errors';
 import { toAttemptDomain } from './attempt-row-mappers';
 
+const attemptId = crypto.randomUUID();
+const userId = crypto.randomUUID();
+const questionId = crypto.randomUUID();
+const selectedChoiceId = crypto.randomUUID();
+
 const baseRow = {
-  id: 'attempt-1',
-  userId: 'user-1',
-  questionId: 'question-1',
+  id: attemptId,
+  userId,
+  questionId,
   practiceSessionId: null,
-  selectedChoiceId: 'choice-1',
+  selectedChoiceId,
   isCorrect: true,
   timeSpentSeconds: 12,
   answeredAt: new Date('2026-03-17T12:00:00.000Z'),
@@ -42,7 +47,7 @@ describe('attempt row mappers', () => {
         isOmitted: true,
         isCorrect: false,
       }),
-    ).toThrow('Attempt attempt-1 cannot be omitted with a selected choice');
+    ).toThrow(`Attempt ${attemptId} cannot be omitted with a selected choice`);
   });
 
   it('rejects answered rows without a selected choice', () => {
@@ -52,7 +57,7 @@ describe('attempt row mappers', () => {
         selectedChoiceId: null,
         isOmitted: false,
       }),
-    ).toThrow('Attempt attempt-1 selectedChoiceId must not be null');
+    ).toThrow(`Attempt ${attemptId} selectedChoiceId must not be null`);
   });
 
   it('rejects omitted rows marked correct', () => {
@@ -62,6 +67,6 @@ describe('attempt row mappers', () => {
         selectedChoiceId: null,
         isOmitted: true,
       }),
-    ).toThrow('Attempt attempt-1 cannot be omitted and correct');
+    ).toThrow(`Attempt ${attemptId} cannot be omitted and correct`);
   });
 });

--- a/src/adapters/repositories/drizzle-attempt-repository.test.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.test.ts
@@ -11,6 +11,20 @@ import { DrizzleAttemptRepository } from './drizzle-attempt-repository';
 
 type RepoDb = ConstructorParameters<typeof DrizzleAttemptRepository>[0];
 
+const attemptId = crypto.randomUUID();
+const userId = crypto.randomUUID();
+const questionId = crypto.randomUUID();
+const sessionId = crypto.randomUUID();
+const alternateSessionId = crypto.randomUUID();
+const selectedChoiceId = crypto.randomUUID();
+const firstQuestionId = crypto.randomUUID();
+const secondQuestionId = crypto.randomUUID();
+const correctQuestionId = crypto.randomUUID();
+const incorrectQuestionId = crypto.randomUUID();
+const adhocQuestionId = crypto.randomUUID();
+const tutorQuestionId = crypto.randomUUID();
+const examQuestionId = crypto.randomUUID();
+
 function createDbMock() {
   const insertReturning = vi.fn();
   const insertValues = vi.fn(() => ({ returning: insertReturning }));
@@ -258,11 +272,11 @@ describe('DrizzleAttemptRepository', () => {
       const answeredAt = new Date('2026-02-01T00:00:00Z');
       db._mocks.insertReturning.mockResolvedValue([
         {
-          id: 'attempt_1',
-          userId: 'user_1',
-          questionId: 'question_1',
-          practiceSessionId: 'session_1',
-          selectedChoiceId: 'choice_1',
+          id: attemptId,
+          userId: userId,
+          questionId: questionId,
+          practiceSessionId: sessionId,
+          selectedChoiceId: selectedChoiceId,
           isOmitted: false,
           isCorrect: true,
           timeSpentSeconds: 42,
@@ -274,21 +288,21 @@ describe('DrizzleAttemptRepository', () => {
 
       await expect(
         repo.insert({
-          userId: 'user_1',
-          questionId: 'question_1',
-          practiceSessionId: 'session_1',
-          outcome: answeredOutcome('choice_1'),
+          userId: userId,
+          questionId: questionId,
+          practiceSessionId: sessionId,
+          outcome: answeredOutcome(selectedChoiceId),
           isCorrect: true,
           timeSpentSeconds: 42,
         }),
       ).resolves.toEqual({
-        id: 'attempt_1',
-        userId: 'user_1',
-        questionId: 'question_1',
-        practiceSessionId: 'session_1',
+        id: attemptId,
+        userId: userId,
+        questionId: questionId,
+        practiceSessionId: sessionId,
         outcome: {
           kind: 'answered',
-          selectedChoiceId: 'choice_1',
+          selectedChoiceId: selectedChoiceId,
         },
         isCorrect: true,
         timeSpentSeconds: 42,
@@ -299,10 +313,10 @@ describe('DrizzleAttemptRepository', () => {
       });
 
       expect(db._mocks.insertValues).toHaveBeenCalledWith({
-        userId: 'user_1',
-        questionId: 'question_1',
-        practiceSessionId: 'session_1',
-        selectedChoiceId: 'choice_1',
+        userId: userId,
+        questionId: questionId,
+        practiceSessionId: sessionId,
+        selectedChoiceId: selectedChoiceId,
         isOmitted: false,
         isCorrect: true,
         timeSpentSeconds: 42,
@@ -317,10 +331,10 @@ describe('DrizzleAttemptRepository', () => {
       const answeredAt = new Date('2026-02-01T00:00:00Z');
       db._mocks.insertReturning.mockResolvedValue([
         {
-          id: 'attempt_1',
-          userId: 'user_1',
-          questionId: 'question_1',
-          practiceSessionId: 'session_1',
+          id: attemptId,
+          userId: userId,
+          questionId: questionId,
+          practiceSessionId: sessionId,
           selectedChoiceId: null,
           isOmitted: true,
           isCorrect: false,
@@ -333,9 +347,9 @@ describe('DrizzleAttemptRepository', () => {
 
       await expect(
         repo.insert({
-          userId: 'user_1',
-          questionId: 'question_1',
-          practiceSessionId: 'session_1',
+          userId: userId,
+          questionId: questionId,
+          practiceSessionId: sessionId,
           outcome: omittedOutcome(),
           isCorrect: false,
           timeSpentSeconds: 0,
@@ -346,9 +360,9 @@ describe('DrizzleAttemptRepository', () => {
       });
 
       expect(db._mocks.insertValues).toHaveBeenCalledWith({
-        userId: 'user_1',
-        questionId: 'question_1',
-        practiceSessionId: 'session_1',
+        userId: userId,
+        questionId: questionId,
+        practiceSessionId: sessionId,
         selectedChoiceId: null,
         isOmitted: true,
         isCorrect: false,
@@ -366,10 +380,10 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       const promise = repo.insert({
-        userId: 'user_1',
-        questionId: 'question_1',
+        userId: userId,
+        questionId: questionId,
         practiceSessionId: null,
-        outcome: answeredOutcome('choice_1'),
+        outcome: answeredOutcome(selectedChoiceId),
         isCorrect: true,
         timeSpentSeconds: 10,
       });
@@ -382,9 +396,9 @@ describe('DrizzleAttemptRepository', () => {
       const db = createDbMock();
       db._mocks.insertReturning.mockResolvedValue([
         {
-          id: 'attempt_1',
-          userId: 'user_1',
-          questionId: 'question_1',
+          id: attemptId,
+          userId: userId,
+          questionId: questionId,
           practiceSessionId: null,
           selectedChoiceId: null,
           isCorrect: false,
@@ -396,10 +410,10 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       const promise = repo.insert({
-        userId: 'user_1',
-        questionId: 'question_1',
+        userId: userId,
+        questionId: questionId,
         practiceSessionId: null,
-        outcome: answeredOutcome('choice_1'),
+        outcome: answeredOutcome(selectedChoiceId),
         isCorrect: false,
         timeSpentSeconds: 5,
       });
@@ -418,10 +432,10 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       const promise = repo.insert({
-        userId: 'user_1',
-        questionId: 'question_1',
-        practiceSessionId: 'session_1',
-        outcome: answeredOutcome('choice_1'),
+        userId: userId,
+        questionId: questionId,
+        practiceSessionId: sessionId,
+        outcome: answeredOutcome(selectedChoiceId),
         isCorrect: true,
         timeSpentSeconds: 12,
       });
@@ -445,10 +459,10 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       const promise = repo.insert({
-        userId: 'user_1',
-        questionId: 'question_1',
-        practiceSessionId: 'session_1',
-        outcome: answeredOutcome('choice_1'),
+        userId: userId,
+        questionId: questionId,
+        practiceSessionId: sessionId,
+        outcome: answeredOutcome(selectedChoiceId),
         isCorrect: true,
         timeSpentSeconds: 12,
       });
@@ -471,10 +485,10 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       const promise = repo.insert({
-        userId: 'user_1',
-        questionId: 'question_1',
+        userId: userId,
+        questionId: questionId,
         practiceSessionId: null,
-        outcome: answeredOutcome('choice_1'),
+        outcome: answeredOutcome(selectedChoiceId),
         isCorrect: true,
         timeSpentSeconds: 12,
       });
@@ -496,11 +510,11 @@ describe('DrizzleAttemptRepository', () => {
       const answeredAt = new Date('2026-02-01T00:00:00Z');
       db._mocks.queryFindMany.mockResolvedValue([
         {
-          id: 'attempt_1',
-          userId: 'user_1',
-          questionId: 'question_1',
+          id: attemptId,
+          userId: userId,
+          questionId: questionId,
           practiceSessionId: null,
-          selectedChoiceId: 'choice_1',
+          selectedChoiceId: selectedChoiceId,
           isOmitted: false,
           isCorrect: true,
           timeSpentSeconds: 12,
@@ -511,16 +525,16 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.findByUserId('user_1', { limit: 10, offset: 0 }),
+        repo.findByUserId(userId, { limit: 10, offset: 0 }),
       ).resolves.toEqual([
         {
-          id: 'attempt_1',
-          userId: 'user_1',
-          questionId: 'question_1',
+          id: attemptId,
+          userId: userId,
+          questionId: questionId,
           practiceSessionId: null,
           outcome: {
             kind: 'answered',
-            selectedChoiceId: 'choice_1',
+            selectedChoiceId: selectedChoiceId,
           },
           isCorrect: true,
           timeSpentSeconds: 12,
@@ -543,7 +557,7 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.findByUserId('user_1', { limit: 0, offset: 0 }),
+        repo.findByUserId(userId, { limit: 0, offset: 0 }),
       ).resolves.toEqual([]);
 
       expect(db._mocks.queryFindMany).not.toHaveBeenCalled();
@@ -554,7 +568,7 @@ describe('DrizzleAttemptRepository', () => {
       db._mocks.queryFindMany.mockResolvedValue([]);
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
-      await repo.findByUserId('user_1', { limit: 10, offset: -5 });
+      await repo.findByUserId(userId, { limit: 10, offset: -5 });
 
       expect(db._mocks.queryFindMany).toHaveBeenCalledWith(
         expect.objectContaining({ limit: 10, offset: 0 }),
@@ -565,10 +579,10 @@ describe('DrizzleAttemptRepository', () => {
       const db = createDbMock();
       db._mocks.queryFindMany.mockResolvedValue([
         {
-          id: 'attempt_1',
+          id: attemptId,
           selectedChoiceId: null,
-          userId: 'user_1',
-          questionId: 'question_1',
+          userId: userId,
+          questionId: questionId,
           practiceSessionId: null,
           isCorrect: false,
           timeSpentSeconds: 1,
@@ -578,7 +592,7 @@ describe('DrizzleAttemptRepository', () => {
 
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
-      const promise = repo.findByUserId('user_1', { limit: 10, offset: 0 });
+      const promise = repo.findByUserId(userId, { limit: 10, offset: 0 });
       await expect(promise).rejects.toBeInstanceOf(ApplicationError);
       await expect(promise).rejects.toMatchObject({ code: 'INTERNAL_ERROR' });
     });
@@ -590,11 +604,11 @@ describe('DrizzleAttemptRepository', () => {
       const answeredAt = new Date('2026-02-01T00:00:00Z');
       db._mocks.queryFindMany.mockResolvedValue([
         {
-          id: 'attempt_1',
-          userId: 'user_1',
-          questionId: 'question_1',
-          practiceSessionId: 'session_1',
-          selectedChoiceId: 'choice_1',
+          id: attemptId,
+          userId: userId,
+          questionId: questionId,
+          practiceSessionId: sessionId,
+          selectedChoiceId: selectedChoiceId,
           isOmitted: false,
           isCorrect: false,
           timeSpentSeconds: 9,
@@ -604,17 +618,15 @@ describe('DrizzleAttemptRepository', () => {
 
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
-      await expect(
-        repo.findBySessionId('session_1', 'user_1'),
-      ).resolves.toEqual([
+      await expect(repo.findBySessionId(sessionId, userId)).resolves.toEqual([
         {
-          id: 'attempt_1',
-          userId: 'user_1',
-          questionId: 'question_1',
-          practiceSessionId: 'session_1',
+          id: attemptId,
+          userId: userId,
+          questionId: questionId,
+          practiceSessionId: sessionId,
           outcome: {
             kind: 'answered',
-            selectedChoiceId: 'choice_1',
+            selectedChoiceId: selectedChoiceId,
           },
           isCorrect: false,
           timeSpentSeconds: 9,
@@ -643,7 +655,7 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.findMostRecentAnsweredAtByQuestionIds('user_1', []),
+        repo.findMostRecentAnsweredAtByQuestionIds(userId, []),
       ).resolves.toEqual([]);
 
       expect(db._mocks.select).not.toHaveBeenCalled();
@@ -653,29 +665,32 @@ describe('DrizzleAttemptRepository', () => {
       const db = createDbMock();
       const answeredAt = new Date('2026-02-01T00:00:00Z');
       db._mocks.groupByExecute.mockResolvedValue([
-        { questionId: 'q1', answeredAt },
-        { questionId: 'q2', answeredAt: null },
+        { questionId: firstQuestionId, answeredAt },
+        { questionId: secondQuestionId, answeredAt: null },
       ]);
 
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.findMostRecentAnsweredAtByQuestionIds('user_1', ['q1', 'q2']),
-      ).resolves.toEqual([{ questionId: 'q1', answeredAt }]);
+        repo.findMostRecentAnsweredAtByQuestionIds(userId, [
+          firstQuestionId,
+          secondQuestionId,
+        ]),
+      ).resolves.toEqual([{ questionId: firstQuestionId, answeredAt }]);
     });
 
     it('left-joins practice sessions before aggregating latest answeredAt values', async () => {
       const db = createDbMock();
       const answeredAt = new Date('2026-02-01T00:00:00Z');
       db._mocks.groupByExecute.mockResolvedValue([
-        { questionId: 'q1', answeredAt },
+        { questionId: firstQuestionId, answeredAt },
       ]);
 
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.findMostRecentAnsweredAtByQuestionIds('user_1', ['q1']),
-      ).resolves.toEqual([{ questionId: 'q1', answeredAt }]);
+        repo.findMostRecentAnsweredAtByQuestionIds(userId, [firstQuestionId]),
+      ).resolves.toEqual([{ questionId: firstQuestionId, answeredAt }]);
 
       expect(db._mocks.leftJoinFindMostRecent).toHaveBeenCalledTimes(1);
       expect(db._mocks.leftJoinFindMostRecent).toHaveBeenCalledWith(
@@ -690,11 +705,11 @@ describe('DrizzleAttemptRepository', () => {
       const db = createDbMock();
       const answeredAt = new Date('2026-02-01T00:00:00Z');
       const attemptRow = {
-        id: 'attempt_1',
-        userId: 'user_1',
-        questionId: 'question_1',
+        id: attemptId,
+        userId: userId,
+        questionId: questionId,
         practiceSessionId: null,
-        selectedChoiceId: 'choice_1',
+        selectedChoiceId: selectedChoiceId,
         isOmitted: false,
         isCorrect: true,
         timeSpentSeconds: 42,
@@ -712,11 +727,11 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.findLatestByUserAndQuestion('user_1', 'question_1'),
+        repo.findLatestByUserAndQuestion(userId, questionId),
       ).resolves.toMatchObject({
-        id: 'attempt_1',
-        userId: 'user_1',
-        questionId: 'question_1',
+        id: attemptId,
+        userId: userId,
+        questionId: questionId,
         answeredAt,
       });
 
@@ -739,14 +754,14 @@ describe('DrizzleAttemptRepository', () => {
         .mockResolvedValueOnce([{ count: 3 }])
         .mockResolvedValueOnce([{ count: 2 }]);
 
-      await expect(repo.countByUserId('user_1')).resolves.toBe(10);
-      await expect(repo.countCorrectByUserId('user_1')).resolves.toBe(7);
+      await expect(repo.countByUserId(userId)).resolves.toBe(10);
+      await expect(repo.countCorrectByUserId(userId)).resolves.toBe(7);
       await expect(
-        repo.countByUserIdSince('user_1', new Date('2026-02-01T00:00:00Z')),
+        repo.countByUserIdSince(userId, new Date('2026-02-01T00:00:00Z')),
       ).resolves.toBe(3);
       await expect(
         repo.countCorrectByUserIdSince(
-          'user_1',
+          userId,
           new Date('2026-02-01T00:00:00Z'),
         ),
       ).resolves.toBe(2);
@@ -757,7 +772,7 @@ describe('DrizzleAttemptRepository', () => {
       db._mocks.countWhere.mockResolvedValueOnce([{ count: 10 }]);
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
-      await expect(repo.countByUserId('user_1')).resolves.toBe(10);
+      await expect(repo.countByUserId(userId)).resolves.toBe(10);
 
       expect(db._mocks.countLeftJoin).toHaveBeenCalledTimes(1);
       expect(db._mocks.countWhere).toHaveBeenCalledTimes(1);
@@ -770,11 +785,11 @@ describe('DrizzleAttemptRepository', () => {
       const answeredAt = new Date('2026-02-02T00:00:00Z');
       db._mocks.recentQueryExecute.mockResolvedValue([
         {
-          id: 'attempt_1',
-          userId: 'user_1',
-          questionId: 'question_1',
+          id: attemptId,
+          userId: userId,
+          questionId: questionId,
           practiceSessionId: null,
-          selectedChoiceId: 'choice_1',
+          selectedChoiceId: selectedChoiceId,
           isOmitted: false,
           isCorrect: true,
           timeSpentSeconds: 12,
@@ -785,15 +800,15 @@ describe('DrizzleAttemptRepository', () => {
 
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
-      await expect(repo.listRecentByUserId('user_1', 5)).resolves.toEqual([
+      await expect(repo.listRecentByUserId(userId, 5)).resolves.toEqual([
         {
-          id: 'attempt_1',
-          userId: 'user_1',
-          questionId: 'question_1',
+          id: attemptId,
+          userId: userId,
+          questionId: questionId,
           practiceSessionId: null,
           outcome: {
             kind: 'answered',
-            selectedChoiceId: 'choice_1',
+            selectedChoiceId: selectedChoiceId,
           },
           isCorrect: true,
           timeSpentSeconds: 12,
@@ -811,7 +826,7 @@ describe('DrizzleAttemptRepository', () => {
       db._mocks.recentQueryExecute.mockResolvedValue([]);
 
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
-      await repo.listRecentByUserId('user_1', 20);
+      await repo.listRecentByUserId(userId, 20);
 
       expect(db._mocks.recentWhere).toHaveBeenCalledTimes(1);
     });
@@ -827,7 +842,7 @@ describe('DrizzleAttemptRepository', () => {
 
       await expect(
         repo.listAnsweredAtByUserIdSince(
-          'user_1',
+          userId,
           new Date('2026-02-01T00:00:00Z'),
         ),
       ).resolves.toEqual([answeredAt]);
@@ -843,14 +858,14 @@ describe('DrizzleAttemptRepository', () => {
 
       db._mocks.finalQueryExecute.mockResolvedValue([
         {
-          questionId: 'q1',
+          questionId: firstQuestionId,
           answeredAt,
           isCorrect: true,
-          sessionId: 'session-1',
+          sessionId: sessionId,
           sessionMode: 'exam',
         },
         {
-          questionId: 'q2',
+          questionId: secondQuestionId,
           answeredAt: null,
           isCorrect: false,
           sessionId: null,
@@ -861,13 +876,13 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.listAttemptedQuestionsByUserId('user_1', 10, 0),
+        repo.listAttemptedQuestionsByUserId(userId, 10, 0),
       ).resolves.toEqual([
         {
-          questionId: 'q1',
+          questionId: firstQuestionId,
           answeredAt,
           isCorrect: true,
-          sessionId: 'session-1',
+          sessionId: sessionId,
           sessionMode: 'exam',
         },
       ]);
@@ -879,7 +894,7 @@ describe('DrizzleAttemptRepository', () => {
 
       db._mocks.finalQueryExecute.mockResolvedValue([
         {
-          questionId: 'q_correct',
+          questionId: correctQuestionId,
           answeredAt,
           isCorrect: true,
           sessionId: null,
@@ -890,10 +905,12 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.listAttemptedQuestionsByUserId('user_1', 10, 0, {
+        repo.listAttemptedQuestionsByUserId(userId, 10, 0, {
           result: 'correct',
         }),
-      ).resolves.toMatchObject([{ questionId: 'q_correct', isCorrect: true }]);
+      ).resolves.toMatchObject([
+        { questionId: correctQuestionId, isCorrect: true },
+      ]);
     });
 
     it('supports result filter (incorrect)', async () => {
@@ -902,7 +919,7 @@ describe('DrizzleAttemptRepository', () => {
 
       db._mocks.finalQueryExecute.mockResolvedValue([
         {
-          questionId: 'q_incorrect',
+          questionId: incorrectQuestionId,
           answeredAt,
           isCorrect: false,
           sessionId: null,
@@ -913,11 +930,11 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.listAttemptedQuestionsByUserId('user_1', 10, 0, {
+        repo.listAttemptedQuestionsByUserId(userId, 10, 0, {
           result: 'incorrect',
         }),
       ).resolves.toMatchObject([
-        { questionId: 'q_incorrect', isCorrect: false },
+        { questionId: incorrectQuestionId, isCorrect: false },
       ]);
     });
 
@@ -927,7 +944,7 @@ describe('DrizzleAttemptRepository', () => {
 
       db._mocks.finalQueryExecute.mockResolvedValue([
         {
-          questionId: 'q_adhoc',
+          questionId: adhocQuestionId,
           answeredAt,
           isCorrect: true,
           sessionId: null,
@@ -938,10 +955,12 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.listAttemptedQuestionsByUserId('user_1', 10, 0, {
+        repo.listAttemptedQuestionsByUserId(userId, 10, 0, {
           source: 'adhoc',
         }),
-      ).resolves.toMatchObject([{ questionId: 'q_adhoc', sessionId: null }]);
+      ).resolves.toMatchObject([
+        { questionId: adhocQuestionId, sessionId: null },
+      ]);
     });
 
     it('supports source filter (tutor)', async () => {
@@ -950,10 +969,10 @@ describe('DrizzleAttemptRepository', () => {
 
       db._mocks.finalQueryExecute.mockResolvedValue([
         {
-          questionId: 'q_tutor',
+          questionId: tutorQuestionId,
           answeredAt,
           isCorrect: true,
-          sessionId: 'session-1',
+          sessionId: sessionId,
           sessionMode: 'tutor',
         },
       ]);
@@ -961,11 +980,11 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.listAttemptedQuestionsByUserId('user_1', 10, 0, {
+        repo.listAttemptedQuestionsByUserId(userId, 10, 0, {
           source: 'tutor',
         }),
       ).resolves.toMatchObject([
-        { questionId: 'q_tutor', sessionMode: 'tutor' },
+        { questionId: tutorQuestionId, sessionMode: 'tutor' },
       ]);
     });
 
@@ -975,10 +994,10 @@ describe('DrizzleAttemptRepository', () => {
 
       db._mocks.finalQueryExecute.mockResolvedValue([
         {
-          questionId: 'q_exam',
+          questionId: examQuestionId,
           answeredAt,
           isCorrect: true,
-          sessionId: 'session-2',
+          sessionId: alternateSessionId,
           sessionMode: 'exam',
         },
       ]);
@@ -986,10 +1005,12 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.listAttemptedQuestionsByUserId('user_1', 10, 0, {
+        repo.listAttemptedQuestionsByUserId(userId, 10, 0, {
           source: 'exam',
         }),
-      ).resolves.toMatchObject([{ questionId: 'q_exam', sessionMode: 'exam' }]);
+      ).resolves.toMatchObject([
+        { questionId: examQuestionId, sessionMode: 'exam' },
+      ]);
     });
 
     it('applies active-exam secrecy filtering to attempted-question list query', async () => {
@@ -997,7 +1018,7 @@ describe('DrizzleAttemptRepository', () => {
       db._mocks.finalQueryExecute.mockResolvedValue([]);
 
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
-      await repo.listAttemptedQuestionsByUserId('user_1', 20, 0);
+      await repo.listAttemptedQuestionsByUserId(userId, 20, 0);
 
       expect(db._mocks.leftJoinLatestAttemptRows).toHaveBeenCalledTimes(1);
       expect(db._mocks.whereGroupBy).toHaveBeenCalledTimes(1);
@@ -1012,9 +1033,9 @@ describe('DrizzleAttemptRepository', () => {
 
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
-      await expect(
-        repo.countAttemptedQuestionsByUserId('user_1'),
-      ).resolves.toBe(3);
+      await expect(repo.countAttemptedQuestionsByUserId(userId)).resolves.toBe(
+        3,
+      );
       expect(db._mocks.countLeftJoin).toHaveBeenCalledTimes(2);
     });
 
@@ -1025,7 +1046,7 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.countAttemptedQuestionsByUserId('user_1', { source: 'tutor' }),
+        repo.countAttemptedQuestionsByUserId(userId, { source: 'tutor' }),
       ).resolves.toBe(1);
       expect(db._mocks.countLeftJoin).toHaveBeenCalledTimes(2);
     });
@@ -1037,7 +1058,7 @@ describe('DrizzleAttemptRepository', () => {
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
 
       await expect(
-        repo.countAttemptedQuestionsByUserId('user_1', { source: 'exam' }),
+        repo.countAttemptedQuestionsByUserId(userId, { source: 'exam' }),
       ).resolves.toBe(2);
       expect(db._mocks.countLeftJoin).toHaveBeenCalledTimes(2);
     });
@@ -1047,9 +1068,9 @@ describe('DrizzleAttemptRepository', () => {
       db._mocks.countWhere.mockResolvedValueOnce([{ count: 3 }]);
 
       const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
-      await expect(
-        repo.countAttemptedQuestionsByUserId('user_1'),
-      ).resolves.toBe(3);
+      await expect(repo.countAttemptedQuestionsByUserId(userId)).resolves.toBe(
+        3,
+      );
 
       expect(db._mocks.leftJoinLatestAttemptRows).toHaveBeenCalledTimes(1);
       expect(db._mocks.whereGroupBy).toHaveBeenCalledTimes(1);

--- a/src/adapters/repositories/drizzle-bookmark-repository.test.ts
+++ b/src/adapters/repositories/drizzle-bookmark-repository.test.ts
@@ -6,6 +6,9 @@ import { DrizzleBookmarkRepository } from './drizzle-bookmark-repository';
 
 type RepoDb = ConstructorParameters<typeof DrizzleBookmarkRepository>[0];
 
+const userId = crypto.randomUUID();
+const questionId = crypto.randomUUID();
+
 function createDbMock() {
   const queryFindFirst = vi.fn();
   const queryFindMany = vi.fn();
@@ -53,19 +56,19 @@ describe('DrizzleBookmarkRepository', () => {
 
       const repo = new DrizzleBookmarkRepository(db as unknown as RepoDb);
 
-      await expect(repo.exists('user_1', 'question_1')).resolves.toBe(false);
+      await expect(repo.exists(userId, questionId)).resolves.toBe(false);
     });
 
     it('returns true when bookmark exists', async () => {
       const db = createDbMock();
       db._mocks.queryFindFirst.mockResolvedValue({
-        userId: 'user_1',
-        questionId: 'question_1',
+        userId: userId,
+        questionId: questionId,
       });
 
       const repo = new DrizzleBookmarkRepository(db as unknown as RepoDb);
 
-      await expect(repo.exists('user_1', 'question_1')).resolves.toBe(true);
+      await expect(repo.exists(userId, questionId)).resolves.toBe(true);
     });
   });
 
@@ -75,23 +78,23 @@ describe('DrizzleBookmarkRepository', () => {
       const createdAt = new Date('2026-02-01T00:00:00Z');
       db._mocks.insertReturning.mockResolvedValue([
         {
-          userId: 'user_1',
-          questionId: 'question_1',
+          userId: userId,
+          questionId: questionId,
           createdAt,
         },
       ]);
 
       const repo = new DrizzleBookmarkRepository(db as unknown as RepoDb);
 
-      await expect(repo.add('user_1', 'question_1')).resolves.toEqual({
-        userId: 'user_1',
-        questionId: 'question_1',
+      await expect(repo.add(userId, questionId)).resolves.toEqual({
+        userId: userId,
+        questionId: questionId,
         createdAt,
       });
 
       expect(db._mocks.insertValues).toHaveBeenCalledWith({
-        userId: 'user_1',
-        questionId: 'question_1',
+        userId: userId,
+        questionId: questionId,
       });
     });
 
@@ -101,7 +104,7 @@ describe('DrizzleBookmarkRepository', () => {
 
       const repo = new DrizzleBookmarkRepository(db as unknown as RepoDb);
 
-      const promise = repo.add('user_1', 'question_1');
+      const promise = repo.add(userId, questionId);
       await expect(promise).rejects.toBeInstanceOf(ApplicationError);
       await expect(promise).rejects.toMatchObject({ code: 'INTERNAL_ERROR' });
     });
@@ -111,11 +114,11 @@ describe('DrizzleBookmarkRepository', () => {
     it('returns true when a bookmark was removed', async () => {
       const db = createDbMock();
       db._mocks.deleteReturning.mockResolvedValue([
-        { userId: 'user_1', questionId: 'question_1' },
+        { userId: userId, questionId: questionId },
       ]);
       const repo = new DrizzleBookmarkRepository(db as unknown as RepoDb);
 
-      await expect(repo.remove('user_1', 'question_1')).resolves.toBe(true);
+      await expect(repo.remove(userId, questionId)).resolves.toBe(true);
       expect(db._mocks.deleteFn).toHaveBeenCalledTimes(1);
       expect(db._mocks.deleteWhere).toHaveBeenCalledTimes(1);
     });
@@ -125,7 +128,7 @@ describe('DrizzleBookmarkRepository', () => {
       db._mocks.deleteReturning.mockResolvedValue([]);
       const repo = new DrizzleBookmarkRepository(db as unknown as RepoDb);
 
-      await expect(repo.remove('user_1', 'question_1')).resolves.toBe(false);
+      await expect(repo.remove(userId, questionId)).resolves.toBe(false);
     });
   });
 
@@ -135,16 +138,16 @@ describe('DrizzleBookmarkRepository', () => {
       const createdAt = new Date('2026-02-01T00:00:00Z');
       db._mocks.queryFindMany.mockResolvedValue([
         {
-          userId: 'user_1',
-          questionId: 'question_1',
+          userId: userId,
+          questionId: questionId,
           createdAt,
         },
       ]);
 
       const repo = new DrizzleBookmarkRepository(db as unknown as RepoDb);
 
-      await expect(repo.listByUserId('user_1')).resolves.toEqual([
-        { userId: 'user_1', questionId: 'question_1', createdAt },
+      await expect(repo.listByUserId(userId)).resolves.toEqual([
+        { userId: userId, questionId: questionId, createdAt },
       ]);
 
       const queryArgs = db._mocks.queryFindMany.mock.calls[0]?.[0];

--- a/src/adapters/repositories/drizzle-practice-session-repository-question-state.test.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository-question-state.test.ts
@@ -3,25 +3,35 @@ import { answeredOutcome, omittedOutcome } from '@/src/domain/value-objects';
 import { DrizzlePracticeSessionRepository } from './drizzle-practice-session-repository';
 import { restoreDrizzlePracticeSessionRepositoryTestMocks } from './drizzle-practice-session-repository-test-helpers';
 
+const sessionId = crypto.randomUUID();
+const userId = crypto.randomUUID();
+const firstQuestionId = crypto.randomUUID();
+const secondQuestionId = crypto.randomUUID();
+const selectedChoiceId = crypto.randomUUID();
+const latestChoiceId = crypto.randomUUID();
+const draftChoiceId = crypto.randomUUID();
+const newerChoiceId = crypto.randomUUID();
+const olderChoiceId = crypto.randomUUID();
+
 describe('DrizzlePracticeSessionRepository question state', () => {
   afterEach(restoreDrizzlePracticeSessionRepositoryTestMocks);
 
   it('records the latest answer state for a session question', async () => {
     const row = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'exam',
       paramsJson: {
         count: 2,
         tagSlugs: [],
         difficulties: ['easy'],
-        questionIds: ['q1', 'q2'],
+        questionIds: [firstQuestionId, secondQuestionId],
       },
       startedAt: new Date('2026-02-01T00:00:00.000Z'),
       endedAt: null,
     } as const;
 
-    const updateReturning = vi.fn(async () => [{ id: 'session_1' }]);
+    const updateReturning = vi.fn(async () => [{ id: sessionId }]);
     const updateWhere = vi.fn(() => ({ returning: updateReturning }));
     const updateSet = vi.fn(() => ({ where: updateWhere }));
     const update = vi.fn(() => ({ set: updateSet }));
@@ -46,17 +56,17 @@ describe('DrizzlePracticeSessionRepository question state', () => {
     const answeredAt = new Date('2026-02-01T00:10:00.000Z');
     await expect(
       repo.recordQuestionAnswer({
-        sessionId: 'session_1',
-        userId: 'user_1',
-        questionId: 'q1',
-        selectedChoiceId: 'choice_1',
+        sessionId: sessionId,
+        userId: userId,
+        questionId: firstQuestionId,
+        selectedChoiceId: selectedChoiceId,
         isCorrect: true,
         answeredAt,
       }),
     ).resolves.toEqual({
-      questionId: 'q1',
+      questionId: firstQuestionId,
       markedForReview: false,
-      latestSelectedChoiceId: 'choice_1',
+      latestSelectedChoiceId: selectedChoiceId,
       latestIsCorrect: true,
       latestAnsweredAt: answeredAt,
       draftSelectedChoiceId: null,
@@ -68,9 +78,9 @@ describe('DrizzlePracticeSessionRepository question state', () => {
       paramsJson: expect.objectContaining({
         questionStates: [
           {
-            questionId: 'q1',
+            questionId: firstQuestionId,
             markedForReview: false,
-            latestSelectedChoiceId: 'choice_1',
+            latestSelectedChoiceId: selectedChoiceId,
             latestIsCorrect: true,
             latestAnsweredAt: answeredAt.toISOString(),
             draftSelectedChoiceId: null,
@@ -78,7 +88,7 @@ describe('DrizzlePracticeSessionRepository question state', () => {
             draftCumulativeMs: 0,
           },
           {
-            questionId: 'q2',
+            questionId: secondQuestionId,
             markedForReview: false,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,
@@ -94,19 +104,19 @@ describe('DrizzlePracticeSessionRepository question state', () => {
 
   it('saves a draft answer snapshot for a session question', async () => {
     const row = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'exam',
       paramsJson: {
         count: 2,
         tagSlugs: [],
         difficulties: ['easy'],
-        questionIds: ['q1', 'q2'],
+        questionIds: [firstQuestionId, secondQuestionId],
         questionStates: [
           {
-            questionId: 'q1',
+            questionId: firstQuestionId,
             markedForReview: false,
-            latestSelectedChoiceId: 'latest-choice',
+            latestSelectedChoiceId: latestChoiceId,
             latestIsCorrect: true,
             latestAnsweredAt: '2026-02-01T00:05:00.000Z',
             draftSelectedChoiceId: null,
@@ -114,7 +124,7 @@ describe('DrizzlePracticeSessionRepository question state', () => {
             draftCumulativeMs: 0,
           },
           {
-            questionId: 'q2',
+            questionId: secondQuestionId,
             markedForReview: false,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,
@@ -129,7 +139,7 @@ describe('DrizzlePracticeSessionRepository question state', () => {
       endedAt: null,
     } as const;
 
-    const updateReturning = vi.fn(async () => [{ id: 'session_1' }]);
+    const updateReturning = vi.fn(async () => [{ id: sessionId }]);
     const updateWhere = vi.fn(() => ({ returning: updateReturning }));
     const updateSet = vi.fn(() => ({ where: updateWhere }));
     const update = vi.fn(() => ({ set: updateSet }));
@@ -153,18 +163,18 @@ describe('DrizzlePracticeSessionRepository question state', () => {
 
     await expect(
       repo.saveDraftAnswer({
-        sessionId: 'session_1',
-        userId: 'user_1',
-        questionId: 'q1',
-        selectedChoiceId: 'draft-choice',
+        sessionId: sessionId,
+        userId: userId,
+        questionId: firstQuestionId,
+        selectedChoiceId: draftChoiceId,
         cumulativeMs: 45_000,
       }),
     ).resolves.toMatchObject({
-      questionId: 'q1',
-      latestSelectedChoiceId: 'latest-choice',
+      questionId: firstQuestionId,
+      latestSelectedChoiceId: latestChoiceId,
       latestIsCorrect: true,
       latestAnsweredAt: new Date('2026-02-01T00:05:00.000Z'),
-      draftSelectedChoiceId: 'draft-choice',
+      draftSelectedChoiceId: draftChoiceId,
       draftSavedAt: expect.any(Date),
       draftCumulativeMs: 45_000,
     });
@@ -173,17 +183,17 @@ describe('DrizzlePracticeSessionRepository question state', () => {
       paramsJson: expect.objectContaining({
         questionStates: [
           {
-            questionId: 'q1',
+            questionId: firstQuestionId,
             markedForReview: false,
-            latestSelectedChoiceId: 'latest-choice',
+            latestSelectedChoiceId: latestChoiceId,
             latestIsCorrect: true,
             latestAnsweredAt: '2026-02-01T00:05:00.000Z',
-            draftSelectedChoiceId: 'draft-choice',
+            draftSelectedChoiceId: draftChoiceId,
             draftSavedAt: expect.any(String),
             draftCumulativeMs: 45_000,
           },
           {
-            questionId: 'q2',
+            questionId: secondQuestionId,
             markedForReview: false,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,
@@ -199,27 +209,27 @@ describe('DrizzlePracticeSessionRepository question state', () => {
 
   it('finalizes a draft answer into latest fields and clears the draft snapshot', async () => {
     const row = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'exam',
       paramsJson: {
         count: 2,
         tagSlugs: [],
         difficulties: ['easy'],
-        questionIds: ['q1', 'q2'],
+        questionIds: [firstQuestionId, secondQuestionId],
         questionStates: [
           {
-            questionId: 'q1',
+            questionId: firstQuestionId,
             markedForReview: false,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,
             latestAnsweredAt: null,
-            draftSelectedChoiceId: 'draft-choice',
+            draftSelectedChoiceId: draftChoiceId,
             draftSavedAt: '2026-02-01T00:05:00.000Z',
             draftCumulativeMs: 45_000,
           },
           {
-            questionId: 'q2',
+            questionId: secondQuestionId,
             markedForReview: false,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,
@@ -234,7 +244,7 @@ describe('DrizzlePracticeSessionRepository question state', () => {
       endedAt: null,
     } as const;
 
-    const updateReturning = vi.fn(async () => [{ id: 'session_1' }]);
+    const updateReturning = vi.fn(async () => [{ id: sessionId }]);
     const updateWhere = vi.fn(() => ({ returning: updateReturning }));
     const updateSet = vi.fn(() => ({ where: updateWhere }));
     const update = vi.fn(() => ({ set: updateSet }));
@@ -259,17 +269,17 @@ describe('DrizzlePracticeSessionRepository question state', () => {
 
     await expect(
       repo.finalizeDraftAnswer({
-        sessionId: 'session_1',
-        userId: 'user_1',
-        questionId: 'q1',
-        outcome: answeredOutcome('draft-choice'),
+        sessionId: sessionId,
+        userId: userId,
+        questionId: firstQuestionId,
+        outcome: answeredOutcome(draftChoiceId),
         isCorrect: true,
         answeredAt,
       }),
     ).resolves.toEqual({
-      questionId: 'q1',
+      questionId: firstQuestionId,
       markedForReview: false,
-      latestSelectedChoiceId: 'draft-choice',
+      latestSelectedChoiceId: draftChoiceId,
       latestIsCorrect: true,
       latestAnsweredAt: answeredAt,
       draftSelectedChoiceId: null,
@@ -281,9 +291,9 @@ describe('DrizzlePracticeSessionRepository question state', () => {
       paramsJson: expect.objectContaining({
         questionStates: [
           {
-            questionId: 'q1',
+            questionId: firstQuestionId,
             markedForReview: false,
-            latestSelectedChoiceId: 'draft-choice',
+            latestSelectedChoiceId: draftChoiceId,
             latestIsCorrect: true,
             latestAnsweredAt: answeredAt.toISOString(),
             draftSelectedChoiceId: null,
@@ -291,7 +301,7 @@ describe('DrizzlePracticeSessionRepository question state', () => {
             draftCumulativeMs: 0,
           },
           {
-            questionId: 'q2',
+            questionId: secondQuestionId,
             markedForReview: false,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,
@@ -307,17 +317,17 @@ describe('DrizzlePracticeSessionRepository question state', () => {
 
   it('finalizes an omitted answer state for session review', async () => {
     const row = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'exam',
       paramsJson: {
         count: 1,
         tagSlugs: [],
         difficulties: ['easy'],
-        questionIds: ['q1'],
+        questionIds: [firstQuestionId],
         questionStates: [
           {
-            questionId: 'q1',
+            questionId: firstQuestionId,
             markedForReview: true,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,
@@ -332,7 +342,7 @@ describe('DrizzlePracticeSessionRepository question state', () => {
       endedAt: null,
     } as const;
 
-    const updateReturning = vi.fn(async () => [{ id: 'session_1' }]);
+    const updateReturning = vi.fn(async () => [{ id: sessionId }]);
     const updateWhere = vi.fn(() => ({ returning: updateReturning }));
     const updateSet = vi.fn(() => ({ where: updateWhere }));
     const update = vi.fn(() => ({ set: updateSet }));
@@ -357,15 +367,15 @@ describe('DrizzlePracticeSessionRepository question state', () => {
 
     await expect(
       repo.finalizeDraftAnswer({
-        sessionId: 'session_1',
-        userId: 'user_1',
-        questionId: 'q1',
+        sessionId: sessionId,
+        userId: userId,
+        questionId: firstQuestionId,
         outcome: omittedOutcome(),
         isCorrect: false,
         answeredAt,
       }),
     ).resolves.toEqual({
-      questionId: 'q1',
+      questionId: firstQuestionId,
       markedForReview: true,
       latestSelectedChoiceId: null,
       latestIsCorrect: false,
@@ -379,7 +389,7 @@ describe('DrizzlePracticeSessionRepository question state', () => {
       paramsJson: expect.objectContaining({
         questionStates: [
           {
-            questionId: 'q1',
+            questionId: firstQuestionId,
             markedForReview: true,
             latestSelectedChoiceId: null,
             latestIsCorrect: false,
@@ -395,22 +405,22 @@ describe('DrizzlePracticeSessionRepository question state', () => {
 
   it('ignores stale draft saves when the stored draft snapshot is newer', async () => {
     const row = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'exam',
       paramsJson: {
         count: 1,
         tagSlugs: [],
         difficulties: ['easy'],
-        questionIds: ['q1'],
+        questionIds: [firstQuestionId],
         questionStates: [
           {
-            questionId: 'q1',
+            questionId: firstQuestionId,
             markedForReview: false,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,
             latestAnsweredAt: null,
-            draftSelectedChoiceId: 'newer-choice',
+            draftSelectedChoiceId: newerChoiceId,
             draftSavedAt: '2026-02-01T00:05:00.000Z',
             draftCumulativeMs: 45_000,
           },
@@ -420,7 +430,7 @@ describe('DrizzlePracticeSessionRepository question state', () => {
       endedAt: null,
     } as const;
 
-    const updateReturning = vi.fn(async () => [{ id: 'session_1' }]);
+    const updateReturning = vi.fn(async () => [{ id: sessionId }]);
     const updateWhere = vi.fn(() => ({ returning: updateReturning }));
     const updateSet = vi.fn(() => ({ where: updateWhere }));
     const update = vi.fn(() => ({ set: updateSet }));
@@ -447,15 +457,15 @@ describe('DrizzlePracticeSessionRepository question state', () => {
 
     await expect(
       repo.saveDraftAnswer({
-        sessionId: 'session_1',
-        userId: 'user_1',
-        questionId: 'q1',
-        selectedChoiceId: 'older-choice',
+        sessionId: sessionId,
+        userId: userId,
+        questionId: firstQuestionId,
+        selectedChoiceId: olderChoiceId,
         cumulativeMs: 30_000,
       }),
     ).resolves.toMatchObject({
-      questionId: 'q1',
-      draftSelectedChoiceId: 'newer-choice',
+      questionId: firstQuestionId,
+      draftSelectedChoiceId: newerChoiceId,
       draftSavedAt: new Date('2026-02-01T00:05:00.000Z'),
       draftCumulativeMs: 45_000,
     });
@@ -463,14 +473,14 @@ describe('DrizzlePracticeSessionRepository question state', () => {
 
   it('retries question-state update when a concurrent write causes a stale write miss', async () => {
     const row = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'exam',
       paramsJson: {
         count: 2,
         tagSlugs: [],
         difficulties: ['easy'],
-        questionIds: ['q1', 'q2'],
+        questionIds: [firstQuestionId, secondQuestionId],
       },
       startedAt: new Date('2026-02-01T00:00:00.000Z'),
       endedAt: null,
@@ -480,7 +490,7 @@ describe('DrizzlePracticeSessionRepository question state', () => {
     const updateReturning = vi
       .fn()
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ id: 'session_1' }]);
+      .mockResolvedValueOnce([{ id: sessionId }]);
     const updateWhere = vi.fn(() => ({ returning: updateReturning }));
     const updateSet = vi.fn(() => ({ where: updateWhere }));
     const update = vi.fn(() => ({ set: updateSet }));
@@ -505,16 +515,16 @@ describe('DrizzlePracticeSessionRepository question state', () => {
     const answeredAt = new Date('2026-02-01T00:10:00.000Z');
     await expect(
       repo.recordQuestionAnswer({
-        sessionId: 'session_1',
-        userId: 'user_1',
-        questionId: 'q1',
-        selectedChoiceId: 'choice_1',
+        sessionId: sessionId,
+        userId: userId,
+        questionId: firstQuestionId,
+        selectedChoiceId: selectedChoiceId,
         isCorrect: true,
         answeredAt,
       }),
     ).resolves.toMatchObject({
-      questionId: 'q1',
-      latestSelectedChoiceId: 'choice_1',
+      questionId: firstQuestionId,
+      latestSelectedChoiceId: selectedChoiceId,
       latestIsCorrect: true,
       latestAnsweredAt: answeredAt,
     });
@@ -526,14 +536,14 @@ describe('DrizzlePracticeSessionRepository question state', () => {
 
   it('throws INTERNAL_ERROR when all CAS retries are exhausted', async () => {
     const row = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'exam',
       paramsJson: {
         count: 2,
         tagSlugs: [],
         difficulties: ['easy'],
-        questionIds: ['q1', 'q2'],
+        questionIds: [firstQuestionId, secondQuestionId],
       },
       startedAt: new Date('2026-02-01T00:00:00.000Z'),
       endedAt: null,
@@ -564,10 +574,10 @@ describe('DrizzlePracticeSessionRepository question state', () => {
 
     await expect(
       repo.recordQuestionAnswer({
-        sessionId: 'session_1',
-        userId: 'user_1',
-        questionId: 'q1',
-        selectedChoiceId: 'choice_1',
+        sessionId: sessionId,
+        userId: userId,
+        questionId: firstQuestionId,
+        selectedChoiceId: selectedChoiceId,
         isCorrect: true,
         answeredAt: new Date('2026-02-01T00:10:00.000Z'),
       }),
@@ -579,20 +589,20 @@ describe('DrizzlePracticeSessionRepository question state', () => {
 
   it('updates mark-for-review state for a session question', async () => {
     const row = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'exam',
       paramsJson: {
         count: 2,
         tagSlugs: [],
         difficulties: ['easy'],
-        questionIds: ['q1', 'q2'],
+        questionIds: [firstQuestionId, secondQuestionId],
       },
       startedAt: new Date('2026-02-01T00:00:00.000Z'),
       endedAt: null,
     } as const;
 
-    const updateReturning = vi.fn(async () => [{ id: 'session_1' }]);
+    const updateReturning = vi.fn(async () => [{ id: sessionId }]);
     const updateWhere = vi.fn(() => ({ returning: updateReturning }));
     const updateSet = vi.fn(() => ({ where: updateWhere }));
     const update = vi.fn(() => ({ set: updateSet }));
@@ -616,13 +626,13 @@ describe('DrizzlePracticeSessionRepository question state', () => {
 
     await expect(
       repo.setQuestionMarkedForReview({
-        sessionId: 'session_1',
-        userId: 'user_1',
-        questionId: 'q2',
+        sessionId: sessionId,
+        userId: userId,
+        questionId: secondQuestionId,
         markedForReview: true,
       }),
     ).resolves.toEqual({
-      questionId: 'q2',
+      questionId: secondQuestionId,
       markedForReview: true,
       latestSelectedChoiceId: null,
       latestIsCorrect: null,
@@ -636,7 +646,7 @@ describe('DrizzlePracticeSessionRepository question state', () => {
       paramsJson: expect.objectContaining({
         questionStates: [
           {
-            questionId: 'q1',
+            questionId: firstQuestionId,
             markedForReview: false,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,
@@ -646,7 +656,7 @@ describe('DrizzlePracticeSessionRepository question state', () => {
             draftCumulativeMs: 0,
           },
           {
-            questionId: 'q2',
+            questionId: secondQuestionId,
             markedForReview: true,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,

--- a/src/adapters/repositories/drizzle-practice-session-repository-reads.test.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository-reads.test.ts
@@ -2,6 +2,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DrizzlePracticeSessionRepository } from './drizzle-practice-session-repository';
 import { restoreDrizzlePracticeSessionRepositoryTestMocks } from './drizzle-practice-session-repository-test-helpers';
 
+const sessionId = crypto.randomUUID();
+const alternateSessionId = crypto.randomUUID();
+const userId = crypto.randomUUID();
+const firstQuestionId = crypto.randomUUID();
+const secondQuestionId = crypto.randomUUID();
+const thirdQuestionId = crypto.randomUUID();
+const orphanQuestionId = crypto.randomUUID();
+
 describe('DrizzlePracticeSessionRepository reads', () => {
   afterEach(restoreDrizzlePracticeSessionRepositoryTestMocks);
 
@@ -25,22 +33,20 @@ describe('DrizzlePracticeSessionRepository reads', () => {
     >[0];
     const repo = new DrizzlePracticeSessionRepository(db as unknown as RepoDb);
 
-    await expect(
-      repo.findByIdAndUserId('session_1', 'user_1'),
-    ).resolves.toBeNull();
+    await expect(repo.findByIdAndUserId(sessionId, userId)).resolves.toBeNull();
   });
 
   it('returns latest incomplete session for a user', async () => {
     const startedAt = new Date('2026-02-01T00:00:00.000Z');
     const queryFindFirst = vi.fn().mockResolvedValue({
-      id: 'session_2',
-      userId: 'user_1',
+      id: alternateSessionId,
+      userId: userId,
       mode: 'exam',
       paramsJson: {
         count: 3,
         tagSlugs: ['tag-1'],
         difficulties: ['easy'],
-        questionIds: ['q1', 'q2', 'q3'],
+        questionIds: [firstQuestionId, secondQuestionId, thirdQuestionId],
       },
       startedAt,
       endedAt: null,
@@ -65,14 +71,14 @@ describe('DrizzlePracticeSessionRepository reads', () => {
     >[0];
     const repo = new DrizzlePracticeSessionRepository(db as unknown as RepoDb);
 
-    await expect(repo.findLatestIncompleteByUserId('user_1')).resolves.toEqual({
-      id: 'session_2',
-      userId: 'user_1',
+    await expect(repo.findLatestIncompleteByUserId(userId)).resolves.toEqual({
+      id: alternateSessionId,
+      userId: userId,
       mode: 'exam',
-      questionIds: ['q1', 'q2', 'q3'],
+      questionIds: [firstQuestionId, secondQuestionId, thirdQuestionId],
       questionStates: [
         {
-          questionId: 'q1',
+          questionId: firstQuestionId,
           markedForReview: false,
           latestSelectedChoiceId: null,
           latestIsCorrect: null,
@@ -82,7 +88,7 @@ describe('DrizzlePracticeSessionRepository reads', () => {
           draftCumulativeMs: 0,
         },
         {
-          questionId: 'q2',
+          questionId: secondQuestionId,
           markedForReview: false,
           latestSelectedChoiceId: null,
           latestIsCorrect: null,
@@ -92,7 +98,7 @@ describe('DrizzlePracticeSessionRepository reads', () => {
           draftCumulativeMs: 0,
         },
         {
-          questionId: 'q3',
+          questionId: thirdQuestionId,
           markedForReview: false,
           latestSelectedChoiceId: null,
           latestIsCorrect: null,
@@ -116,14 +122,14 @@ describe('DrizzlePracticeSessionRepository reads', () => {
     const startedAt = new Date('2026-02-01T23:00:00.000Z');
     const findMany = vi.fn().mockResolvedValue([
       {
-        id: 'session_1',
-        userId: 'user_1',
+        id: sessionId,
+        userId: userId,
         mode: 'exam',
         paramsJson: {
           count: 2,
           tagSlugs: ['tag-1'],
           difficulties: ['easy'],
-          questionIds: ['q1', 'q2'],
+          questionIds: [firstQuestionId, secondQuestionId],
         },
         startedAt,
         endedAt,
@@ -176,16 +182,16 @@ describe('DrizzlePracticeSessionRepository reads', () => {
     >[0];
     const repo = new DrizzlePracticeSessionRepository(db as unknown as RepoDb);
 
-    await expect(repo.findCompletedByUserId('user_1', 10, 0)).resolves.toEqual({
+    await expect(repo.findCompletedByUserId(userId, 10, 0)).resolves.toEqual({
       rows: [
         {
-          id: 'session_1',
-          userId: 'user_1',
+          id: sessionId,
+          userId: userId,
           mode: 'exam',
-          questionIds: ['q1', 'q2'],
+          questionIds: [firstQuestionId, secondQuestionId],
           questionStates: [
             {
-              questionId: 'q1',
+              questionId: firstQuestionId,
               markedForReview: false,
               latestSelectedChoiceId: null,
               latestIsCorrect: null,
@@ -195,7 +201,7 @@ describe('DrizzlePracticeSessionRepository reads', () => {
               draftCumulativeMs: 0,
             },
             {
-              questionId: 'q2',
+              questionId: secondQuestionId,
               markedForReview: false,
               latestSelectedChoiceId: null,
               latestIsCorrect: null,
@@ -271,7 +277,7 @@ describe('DrizzlePracticeSessionRepository reads', () => {
     >[0];
     const repo = new DrizzlePracticeSessionRepository(db as unknown as RepoDb);
 
-    await expect(repo.findCompletedByUserId('user_1', 0, 0)).resolves.toEqual({
+    await expect(repo.findCompletedByUserId(userId, 0, 0)).resolves.toEqual({
       rows: [],
       total: 3,
     });
@@ -302,22 +308,20 @@ describe('DrizzlePracticeSessionRepository reads', () => {
     >[0];
     const repo = new DrizzlePracticeSessionRepository(db as unknown as RepoDb);
 
-    await expect(
-      repo.findLatestIncompleteByUserId('user_1'),
-    ).resolves.toBeNull();
+    await expect(repo.findLatestIncompleteByUserId(userId)).resolves.toBeNull();
   });
 
   it('parses paramsJson and maps the row to a domain PracticeSession', async () => {
     const startedAt = new Date('2026-02-01T00:00:00.000Z');
     const row = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'tutor',
       paramsJson: {
         count: 2,
         tagSlugs: ['tag-1'],
         difficulties: ['easy'],
-        questionIds: ['q1', 'q2'],
+        questionIds: [firstQuestionId, secondQuestionId],
       },
       startedAt,
       endedAt: null,
@@ -342,16 +346,14 @@ describe('DrizzlePracticeSessionRepository reads', () => {
     >[0];
     const repo = new DrizzlePracticeSessionRepository(db as unknown as RepoDb);
 
-    await expect(
-      repo.findByIdAndUserId('session_1', 'user_1'),
-    ).resolves.toEqual({
-      id: 'session_1',
-      userId: 'user_1',
+    await expect(repo.findByIdAndUserId(sessionId, userId)).resolves.toEqual({
+      id: sessionId,
+      userId: userId,
       mode: 'tutor',
-      questionIds: ['q1', 'q2'],
+      questionIds: [firstQuestionId, secondQuestionId],
       questionStates: [
         {
-          questionId: 'q1',
+          questionId: firstQuestionId,
           markedForReview: false,
           latestSelectedChoiceId: null,
           latestIsCorrect: null,
@@ -361,7 +363,7 @@ describe('DrizzlePracticeSessionRepository reads', () => {
           draftCumulativeMs: 0,
         },
         {
-          questionId: 'q2',
+          questionId: secondQuestionId,
           markedForReview: false,
           latestSelectedChoiceId: null,
           latestIsCorrect: null,
@@ -380,8 +382,8 @@ describe('DrizzlePracticeSessionRepository reads', () => {
 
   it('returns INTERNAL_ERROR when persisted paramsJson is invalid', async () => {
     const row = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'tutor',
       paramsJson: {
         count: 0,
@@ -413,30 +415,30 @@ describe('DrizzlePracticeSessionRepository reads', () => {
     const repo = new DrizzlePracticeSessionRepository(db as unknown as RepoDb);
 
     await expect(
-      repo.findByIdAndUserId('session_1', 'user_1'),
+      repo.findByIdAndUserId(sessionId, userId),
     ).rejects.toMatchObject({ code: 'INTERNAL_ERROR' });
   });
 
   it('drops orphaned questionStates without calling console.warn', async () => {
     const row = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'tutor',
       paramsJson: {
         count: 1,
         tagSlugs: [],
         difficulties: [],
-        questionIds: ['q1'],
+        questionIds: [firstQuestionId],
         questionStates: [
           {
-            questionId: 'q1',
+            questionId: firstQuestionId,
             markedForReview: false,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,
             latestAnsweredAt: null,
           },
           {
-            questionId: 'q-orphan',
+            questionId: orphanQuestionId,
             markedForReview: true,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,
@@ -471,10 +473,10 @@ describe('DrizzlePracticeSessionRepository reads', () => {
     >[0];
     const repo = new DrizzlePracticeSessionRepository(db as unknown as RepoDb);
 
-    const session = await repo.findByIdAndUserId('session_1', 'user_1');
+    const session = await repo.findByIdAndUserId(sessionId, userId);
     expect(session?.questionStates).toEqual([
       {
-        questionId: 'q1',
+        questionId: firstQuestionId,
         markedForReview: false,
         latestSelectedChoiceId: null,
         latestIsCorrect: null,

--- a/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
@@ -4,14 +4,20 @@ import { ApplicationError } from '@/src/application/errors';
 import { DrizzlePracticeSessionRepository } from './drizzle-practice-session-repository';
 import { restoreDrizzlePracticeSessionRepositoryTestMocks } from './drizzle-practice-session-repository-test-helpers';
 
+const sessionId = crypto.randomUUID();
+const userId = crypto.randomUUID();
+const firstQuestionId = crypto.randomUUID();
+const secondQuestionId = crypto.randomUUID();
+const selectedChoiceId = crypto.randomUUID();
+
 describe('DrizzlePracticeSessionRepository session writes', () => {
   afterEach(restoreDrizzlePracticeSessionRepositoryTestMocks);
 
   it('creates a practice session and returns a mapped PracticeSession', async () => {
     const startedAt = new Date('2026-02-01T00:00:00.000Z');
     const returningRow = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'exam',
       paramsJson: {},
       startedAt,
@@ -45,16 +51,16 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
       count: 2,
       tagSlugs: [],
       difficulties: ['easy', 'hard'],
-      questionIds: ['q1', 'q2'],
+      questionIds: [firstQuestionId, secondQuestionId],
     };
 
     await expect(
-      repo.create({ userId: 'user_1', mode: 'exam', paramsJson }),
+      repo.create({ userId: userId, mode: 'exam', paramsJson }),
     ).resolves.toMatchObject({
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'exam',
-      questionIds: ['q1', 'q2'],
+      questionIds: [firstQuestionId, secondQuestionId],
       tagFilters: [],
       difficultyFilters: ['easy', 'hard'],
       startedAt,
@@ -62,7 +68,7 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
     });
 
     expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: 'user_1', mode: 'exam' }),
+      expect.objectContaining({ userId: userId, mode: 'exam' }),
     );
   });
 
@@ -99,10 +105,10 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
       count: 2,
       tagSlugs: [],
       difficulties: ['easy'],
-      questionIds: ['q1', 'q2'],
+      questionIds: [firstQuestionId, secondQuestionId],
     };
 
-    const promise = repo.create({ userId: 'user_1', mode: 'exam', paramsJson });
+    const promise = repo.create({ userId: userId, mode: 'exam', paramsJson });
 
     await expect(promise).rejects.toEqual(
       new ApplicationError(
@@ -140,13 +146,13 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
     const repo = new DrizzlePracticeSessionRepository(db as unknown as RepoDb);
 
     const promise = repo.create({
-      userId: 'user_1',
+      userId: userId,
       mode: 'exam',
       paramsJson: {
         count: 2,
         tagSlugs: [],
         difficulties: ['easy'],
-        questionIds: ['q1', 'q2'],
+        questionIds: [firstQuestionId, secondQuestionId],
       },
     });
 
@@ -182,7 +188,7 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
 
     await expect(
       repo.create({
-        userId: 'user_1',
+        userId: userId,
         mode: 'tutor',
         paramsJson: {
           count: 0,
@@ -220,11 +226,11 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
       count: 2,
       tagSlugs: [],
       difficulties: ['easy'],
-      questionIds: ['q1', 'q2'],
+      questionIds: [firstQuestionId, secondQuestionId],
     };
 
     await expect(
-      repo.create({ userId: 'user_1', mode: 'tutor', paramsJson }),
+      repo.create({ userId: userId, mode: 'tutor', paramsJson }),
     ).rejects.toMatchObject({ code: 'INTERNAL_ERROR' });
   });
 
@@ -233,14 +239,14 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
     const nowFn = vi.fn(() => now);
 
     const row = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'tutor',
       paramsJson: {
         count: 2,
         tagSlugs: [],
         difficulties: [],
-        questionIds: ['q1', 'q2'],
+        questionIds: [firstQuestionId, secondQuestionId],
       },
       startedAt: new Date('2026-02-01T00:00:00.000Z'),
       endedAt: null,
@@ -254,9 +260,9 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
           ...row.paramsJson,
           questionStates: [
             {
-              questionId: 'q1',
+              questionId: firstQuestionId,
               markedForReview: false,
-              latestSelectedChoiceId: 'choice_1',
+              latestSelectedChoiceId: selectedChoiceId,
               latestIsCorrect: true,
               latestAnsweredAt: '2026-02-01T00:00:01.000Z',
             },
@@ -288,19 +294,21 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
       nowFn,
     );
 
-    const ended = await repo.end('session_1', 'user_1');
-    expect(ended).toMatchObject({ id: 'session_1', endedAt: now });
+    const ended = await repo.end(sessionId, userId);
+    expect(ended).toMatchObject({ id: sessionId, endedAt: now });
     expect(ended.questionStates).toHaveLength(2);
     expect(
-      ended.questionStates.find((state) => state.questionId === 'q1'),
+      ended.questionStates.find(
+        (state) => state.questionId === firstQuestionId,
+      ),
     ).toMatchObject({
-      questionId: 'q1',
+      questionId: firstQuestionId,
       markedForReview: false,
-      latestSelectedChoiceId: 'choice_1',
+      latestSelectedChoiceId: selectedChoiceId,
       latestIsCorrect: true,
     });
     expect(
-      ended.questionStates.find((state) => state.questionId === 'q1')
+      ended.questionStates.find((state) => state.questionId === firstQuestionId)
         ?.latestAnsweredAt,
     ).toEqual(new Date('2026-02-01T00:00:01.000Z'));
     expect(nowFn).toHaveBeenCalledTimes(1);
@@ -308,14 +316,14 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
 
   it('throws CONFLICT when the practice session is already ended', async () => {
     const row = {
-      id: 'session_1',
-      userId: 'user_1',
+      id: sessionId,
+      userId: userId,
       mode: 'tutor',
       paramsJson: {
         count: 2,
         tagSlugs: [],
         difficulties: [],
-        questionIds: ['q1', 'q2'],
+        questionIds: [firstQuestionId, secondQuestionId],
       },
       startedAt: new Date('2026-02-01T00:00:00.000Z'),
       endedAt: new Date('2026-02-01T00:01:00.000Z'),
@@ -340,10 +348,10 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
     >[0];
     const repo = new DrizzlePracticeSessionRepository(db as unknown as RepoDb);
 
-    await expect(repo.end('session_1', 'user_1')).rejects.toBeInstanceOf(
+    await expect(repo.end(sessionId, userId)).rejects.toBeInstanceOf(
       ApplicationError,
     );
-    await expect(repo.end('session_1', 'user_1')).rejects.toMatchObject({
+    await expect(repo.end(sessionId, userId)).rejects.toMatchObject({
       code: 'CONFLICT',
     });
   });

--- a/src/adapters/repositories/drizzle-question-repository.test.ts
+++ b/src/adapters/repositories/drizzle-question-repository.test.ts
@@ -6,6 +6,16 @@ import { DrizzleQuestionRepository } from './drizzle-question-repository';
 
 type RepoDb = ConstructorParameters<typeof DrizzleQuestionRepository>[0];
 
+const questionId = crypto.randomUUID();
+const firstChoiceId = crypto.randomUUID();
+const secondChoiceId = crypto.randomUUID();
+const invalidChoiceId = crypto.randomUUID();
+const tagId = crypto.randomUUID();
+const userId = crypto.randomUUID();
+const requestedFirstQuestionId = crypto.randomUUID();
+const missingQuestionId = crypto.randomUUID();
+const requestedThirdQuestionId = crypto.randomUUID();
+
 type QuestionRow = {
   id: string;
   slug: string;
@@ -19,7 +29,7 @@ type QuestionRow = {
 };
 
 const baseQuestionRow: QuestionRow = {
-  id: 'question_1',
+  id: questionId,
   slug: 'question-1',
   stemMd: 'stem',
   explanationMd: 'explanation',
@@ -66,7 +76,7 @@ function createQuestionRow(
   overrides: Partial<QuestionRow> = {},
   choices = [
     {
-      id: 'choice_1',
+      id: firstChoiceId,
       questionId: baseQuestionRow.id,
       label: 'A',
       textMd: 'Choice A',
@@ -75,7 +85,7 @@ function createQuestionRow(
       sortOrder: 2,
     },
     {
-      id: 'choice_2',
+      id: secondChoiceId,
       questionId: baseQuestionRow.id,
       label: 'B',
       textMd: 'Choice B',
@@ -87,9 +97,9 @@ function createQuestionRow(
   tags = [
     {
       questionId: baseQuestionRow.id,
-      tagId: 'tag_1',
+      tagId: tagId,
       tag: {
-        id: 'tag_1',
+        id: tagId,
         slug: 'addiction',
         name: 'Addiction',
         kind: 'topic',
@@ -136,8 +146,8 @@ describe('DrizzleQuestionRepository', () => {
       const result = await repo.findPublishedById(row.id);
 
       expect(result?.choices.map((c) => c.id)).toEqual([
-        'choice_2',
-        'choice_1',
+        secondChoiceId,
+        firstChoiceId,
       ]);
       expect(result?.choices.map((c) => c.explanationMd)).toEqual([
         'Because B is incorrect.',
@@ -145,7 +155,7 @@ describe('DrizzleQuestionRepository', () => {
       ]);
       expect(result?.tags).toEqual([
         {
-          id: 'tag_1',
+          id: tagId,
           slug: 'addiction',
           name: 'Addiction',
           kind: 'topic',
@@ -157,7 +167,7 @@ describe('DrizzleQuestionRepository', () => {
     it('throws INTERNAL_ERROR when a choice label is invalid', async () => {
       const row = createQuestionRow({}, [
         {
-          id: 'choice_bad',
+          id: invalidChoiceId,
           questionId: baseQuestionRow.id,
           label: 'Z',
           textMd: 'Invalid',
@@ -220,8 +230,14 @@ describe('DrizzleQuestionRepository', () => {
     });
 
     it('returns results ordered by requested ids and filters missing', async () => {
-      const row1 = createQuestionRow({ id: 'q1', slug: 'q1' });
-      const row3 = createQuestionRow({ id: 'q3', slug: 'q3' });
+      const row1 = createQuestionRow({
+        id: requestedFirstQuestionId,
+        slug: requestedFirstQuestionId,
+      });
+      const row3 = createQuestionRow({
+        id: requestedThirdQuestionId,
+        slug: requestedThirdQuestionId,
+      });
       const db = {
         query: {
           questions: {
@@ -232,9 +248,16 @@ describe('DrizzleQuestionRepository', () => {
 
       const repo = new DrizzleQuestionRepository(db as unknown as RepoDb);
 
-      const result = await repo.findPublishedByIds(['q3', 'q2', 'q1']);
+      const result = await repo.findPublishedByIds([
+        requestedThirdQuestionId,
+        missingQuestionId,
+        requestedFirstQuestionId,
+      ]);
 
-      expect(result.map((q) => q.id)).toEqual(['q3', 'q1']);
+      expect(result.map((q) => q.id)).toEqual([
+        requestedThirdQuestionId,
+        requestedFirstQuestionId,
+      ]);
     });
   });
 
@@ -262,7 +285,7 @@ describe('DrizzleQuestionRepository', () => {
         tagSlugs: [],
         difficulties: [],
         statuses: ['unknown' as unknown as QuestionProgressStatus],
-        userId: 'user_1',
+        userId: userId,
       });
 
       await expect(promise).rejects.toBeInstanceOf(ApplicationError);
@@ -297,7 +320,7 @@ describe('DrizzleQuestionRepository', () => {
         tagSlugs: [],
         difficulties: [],
         statuses: ['unknown' as unknown as QuestionProgressStatus],
-        userId: 'user_1',
+        userId: userId,
       });
 
       await expect(promise).rejects.toBeInstanceOf(ApplicationError);
@@ -343,7 +366,7 @@ describe('DrizzleQuestionRepository', () => {
           tagSlugs: [],
           difficulties: [],
           statuses: ['unanswered'],
-          userId: 'user_1',
+          userId: userId,
         }),
       ).resolves.toBe(5);
 
@@ -414,7 +437,7 @@ describe('DrizzleQuestionRepository', () => {
           tagSlugs: [],
           difficulties: [],
           statuses: ['incorrect'],
-          userId: 'user_1',
+          userId: userId,
         }),
       ).resolves.toBe(1);
 

--- a/src/adapters/repositories/drizzle-stripe-customer-repository.test.ts
+++ b/src/adapters/repositories/drizzle-stripe-customer-repository.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { ApplicationError } from '@/src/application/errors';
 import { DrizzleStripeCustomerRepository } from './drizzle-stripe-customer-repository';
 
+const userId = crypto.randomUUID();
+
 describe('DrizzleStripeCustomerRepository', () => {
   it('returns null from findByUserId when no mapping exists', async () => {
     const db = {
@@ -20,7 +22,7 @@ describe('DrizzleStripeCustomerRepository', () => {
     >[0];
     const repo = new DrizzleStripeCustomerRepository(db as unknown as RepoDb);
 
-    await expect(repo.findByUserId('user_1')).resolves.toBeNull();
+    await expect(repo.findByUserId(userId)).resolves.toBeNull();
   });
 
   it('returns stripeCustomerId from findByUserId when mapping exists', async () => {
@@ -40,7 +42,7 @@ describe('DrizzleStripeCustomerRepository', () => {
     >[0];
     const repo = new DrizzleStripeCustomerRepository(db as unknown as RepoDb);
 
-    await expect(repo.findByUserId('user_1')).resolves.toEqual({
+    await expect(repo.findByUserId(userId)).resolves.toEqual({
       stripeCustomerId: 'cus_123',
     });
   });
@@ -70,7 +72,7 @@ describe('DrizzleStripeCustomerRepository', () => {
     >[0];
     const repo = new DrizzleStripeCustomerRepository(db as unknown as RepoDb);
 
-    await expect(repo.insert('user_1', 'cus_123')).resolves.toBeUndefined();
+    await expect(repo.insert(userId, 'cus_123')).resolves.toBeUndefined();
     expect(queryFindFirst).not.toHaveBeenCalled();
   });
 
@@ -95,7 +97,7 @@ describe('DrizzleStripeCustomerRepository', () => {
     >[0];
     const repo = new DrizzleStripeCustomerRepository(db as unknown as RepoDb);
 
-    await expect(repo.insert('user_1', 'cus_new')).rejects.toMatchObject({
+    await expect(repo.insert(userId, 'cus_new')).rejects.toMatchObject({
       code: 'CONFLICT',
     });
   });
@@ -124,7 +126,7 @@ describe('DrizzleStripeCustomerRepository', () => {
     const repo = new DrizzleStripeCustomerRepository(db as unknown as RepoDb);
 
     await expect(
-      repo.insert('user_1', 'cus_new', { conflictStrategy: 'authoritative' }),
+      repo.insert(userId, 'cus_new', { conflictStrategy: 'authoritative' }),
     ).resolves.toBeUndefined();
   });
 
@@ -149,7 +151,7 @@ describe('DrizzleStripeCustomerRepository', () => {
     >[0];
     const repo = new DrizzleStripeCustomerRepository(db as unknown as RepoDb);
 
-    await expect(repo.insert('user_1', 'cus_123')).rejects.toMatchObject({
+    await expect(repo.insert(userId, 'cus_123')).rejects.toMatchObject({
       code: 'INTERNAL_ERROR',
     });
   });
@@ -177,10 +179,10 @@ describe('DrizzleStripeCustomerRepository', () => {
     >[0];
     const repo = new DrizzleStripeCustomerRepository(db as unknown as RepoDb);
 
-    await expect(repo.insert('user_1', 'cus_123')).rejects.toBeInstanceOf(
+    await expect(repo.insert(userId, 'cus_123')).rejects.toBeInstanceOf(
       ApplicationError,
     );
-    await expect(repo.insert('user_1', 'cus_123')).rejects.toMatchObject({
+    await expect(repo.insert(userId, 'cus_123')).rejects.toMatchObject({
       code: 'CONFLICT',
     });
   });
@@ -208,7 +210,7 @@ describe('DrizzleStripeCustomerRepository', () => {
     >[0];
     const repo = new DrizzleStripeCustomerRepository(db as unknown as RepoDb);
 
-    await expect(repo.insert('user_1', 'cus_123')).rejects.toMatchObject({
+    await expect(repo.insert(userId, 'cus_123')).rejects.toMatchObject({
       code: 'INTERNAL_ERROR',
     });
   });

--- a/src/adapters/repositories/drizzle-subscription-repository.test.ts
+++ b/src/adapters/repositories/drizzle-subscription-repository.test.ts
@@ -5,6 +5,9 @@ import { DrizzleSubscriptionRepository } from './drizzle-subscription-repository
 describe('DrizzleSubscriptionRepository', () => {
   type RepoDb = ConstructorParameters<typeof DrizzleSubscriptionRepository>[0];
 
+  const subscriptionRowId = crypto.randomUUID();
+  const userId = crypto.randomUUID();
+
   const createRepo = (
     db: unknown,
     priceIds: { monthly: string; annual: string },
@@ -31,7 +34,7 @@ describe('DrizzleSubscriptionRepository', () => {
 
     const repo = createRepo(db, priceIds);
 
-    await expect(repo.findByUserId('user_1')).resolves.toBeNull();
+    await expect(repo.findByUserId(userId)).resolves.toBeNull();
   });
 
   it('maps Stripe price ids to domain plan when loading subscriptions', async () => {
@@ -42,8 +45,8 @@ describe('DrizzleSubscriptionRepository', () => {
       query: {
         stripeSubscriptions: {
           findFirst: async () => ({
-            id: 'sub_row_1',
-            userId: 'user_1',
+            id: subscriptionRowId,
+            userId: userId,
             stripeSubscriptionId: 'sub_123',
             status: 'active',
             priceId: 'price_monthly',
@@ -66,9 +69,9 @@ describe('DrizzleSubscriptionRepository', () => {
 
     const repo = createRepo(db, priceIds);
 
-    await expect(repo.findByUserId('user_1')).resolves.toMatchObject({
-      id: 'sub_row_1',
-      userId: 'user_1',
+    await expect(repo.findByUserId(userId)).resolves.toMatchObject({
+      id: subscriptionRowId,
+      userId: userId,
       plan: 'monthly',
       status: 'active',
       currentPeriodEnd,
@@ -83,8 +86,8 @@ describe('DrizzleSubscriptionRepository', () => {
       query: {
         stripeSubscriptions: {
           findFirst: async () => ({
-            id: 'sub_row_1',
-            userId: 'user_1',
+            id: subscriptionRowId,
+            userId: userId,
             stripeSubscriptionId: 'sub_123',
             status: 'active',
             priceId: 'price_unknown',
@@ -107,10 +110,10 @@ describe('DrizzleSubscriptionRepository', () => {
 
     const repo = createRepo(db, priceIds);
 
-    await expect(repo.findByUserId('user_1')).rejects.toBeInstanceOf(
+    await expect(repo.findByUserId(userId)).rejects.toBeInstanceOf(
       ApplicationError,
     );
-    await expect(repo.findByUserId('user_1')).rejects.toMatchObject({
+    await expect(repo.findByUserId(userId)).rejects.toMatchObject({
       code: 'INTERNAL_ERROR',
     });
   });
@@ -122,7 +125,7 @@ describe('DrizzleSubscriptionRepository', () => {
     const values = (input: unknown) => ({
       onConflictDoUpdate: async (conflict: unknown) => {
         expect(input).toMatchObject({
-          userId: 'user_1',
+          userId: userId,
           stripeSubscriptionId: 'sub_123',
           status: 'active',
           priceId: 'price_monthly',
@@ -155,7 +158,7 @@ describe('DrizzleSubscriptionRepository', () => {
 
     await expect(
       repo.upsert({
-        userId: 'user_1',
+        userId: userId,
         externalSubscriptionId: 'sub_123',
         plan: 'monthly',
         status: 'active',
@@ -191,7 +194,7 @@ describe('DrizzleSubscriptionRepository', () => {
 
     await expect(
       repo.upsert({
-        userId: 'user_1',
+        userId: userId,
         externalSubscriptionId: 'sub_123',
         plan: 'monthly',
         status: 'active',
@@ -228,7 +231,7 @@ describe('DrizzleSubscriptionRepository', () => {
     let thrown: unknown;
     try {
       await repo.upsert({
-        userId: 'user_1',
+        userId: userId,
         externalSubscriptionId: 'sub_123',
         plan: 'monthly',
         status: 'active',
@@ -274,8 +277,8 @@ describe('DrizzleSubscriptionRepository', () => {
       query: {
         stripeSubscriptions: {
           findFirst: async () => ({
-            id: 'sub_row_1',
-            userId: 'user_1',
+            id: subscriptionRowId,
+            userId: userId,
             stripeSubscriptionId: 'sub_123',
             status: 'active',
             priceId: 'price_annual',
@@ -301,7 +304,7 @@ describe('DrizzleSubscriptionRepository', () => {
     await expect(
       repo.findByExternalSubscriptionId('sub_123'),
     ).resolves.toMatchObject({
-      userId: 'user_1',
+      userId: userId,
       plan: 'annual',
     });
   });
@@ -311,8 +314,8 @@ describe('DrizzleSubscriptionRepository', () => {
       query: {
         stripeSubscriptions: {
           findFirst: async () => ({
-            id: 'sub_row_1',
-            userId: 'user_1',
+            id: subscriptionRowId,
+            userId: userId,
             priceId: 'price_unknown',
             status: 'active',
             currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),

--- a/src/adapters/repositories/drizzle-tag-repository.test.ts
+++ b/src/adapters/repositories/drizzle-tag-repository.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { DrizzleTagRepository } from './drizzle-tag-repository';
 
+const firstTagId = crypto.randomUUID();
+const secondTagId = crypto.randomUUID();
+
 function createMockDb(rows: readonly Record<string, unknown>[]) {
   const chain = {
     from: vi.fn().mockReturnThis(),
@@ -22,13 +25,13 @@ describe('DrizzleTagRepository', () => {
     it('returns tags mapped to domain entities', async () => {
       const rows = [
         {
-          id: 'tag_1',
+          id: firstTagId,
           slug: 'pharmacology-neuroscience',
           name: 'Pharmacology & Neuroscience',
           kind: 'topic',
         },
         {
-          id: 'tag_2',
+          id: secondTagId,
           slug: 'alcohol',
           name: 'Alcohol',
           kind: 'substance',
@@ -41,13 +44,13 @@ describe('DrizzleTagRepository', () => {
 
       expect(result).toEqual([
         {
-          id: 'tag_1',
+          id: firstTagId,
           slug: 'pharmacology-neuroscience',
           name: 'Pharmacology & Neuroscience',
           kind: 'topic',
         },
         {
-          id: 'tag_2',
+          id: secondTagId,
           slug: 'alcohol',
           name: 'Alcohol',
           kind: 'substance',
@@ -66,7 +69,7 @@ describe('DrizzleTagRepository', () => {
     it('only includes id, slug, name, and kind in returned objects', async () => {
       const rows = [
         {
-          id: 'tag_1',
+          id: firstTagId,
           slug: 'opioid-use-disorder',
           name: 'Opioid Use Disorder',
           kind: 'topic',
@@ -80,7 +83,7 @@ describe('DrizzleTagRepository', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
-        id: 'tag_1',
+        id: firstTagId,
         slug: 'opioid-use-disorder',
         name: 'Opioid Use Disorder',
         kind: 'topic',

--- a/src/adapters/repositories/drizzle-user-repository.test.ts
+++ b/src/adapters/repositories/drizzle-user-repository.test.ts
@@ -5,6 +5,8 @@ import { ApplicationError } from '@/src/application/errors';
 
 type RepoDb = ConstructorParameters<typeof DrizzleUserRepository>[0];
 
+const userId = crypto.randomUUID();
+
 function createDbMock() {
   const queryFindFirst = vi.fn();
 
@@ -70,7 +72,7 @@ describe('DrizzleUserRepository', () => {
     it('returns the user when found', async () => {
       const db = createDbMock();
       const row = {
-        id: 'user_1',
+        id: userId,
         clerkUserId: 'clerk_1',
         email: 'a@example.com',
         createdAt: new Date('2026-02-01T00:00:00Z'),
@@ -81,7 +83,7 @@ describe('DrizzleUserRepository', () => {
       const repo = new DrizzleUserRepository(db as unknown as RepoDb);
 
       await expect(repo.findByClerkId('clerk_1')).resolves.toEqual({
-        id: 'user_1',
+        id: userId,
         email: 'a@example.com',
         createdAt: row.createdAt,
         updatedAt: row.updatedAt,
@@ -108,7 +110,7 @@ describe('DrizzleUserRepository', () => {
 
     it('locks and returns the user when found', async () => {
       const row = {
-        id: 'user_1',
+        id: userId,
         email: 'a@example.com',
         createdAt: new Date('2026-02-01T00:00:00Z'),
         updatedAt: new Date('2026-02-01T00:00:00Z'),
@@ -135,7 +137,7 @@ describe('DrizzleUserRepository', () => {
 
       const db = createDbMock();
       const row = {
-        id: 'user_1',
+        id: userId,
         clerkUserId: 'clerk_1',
         email: 'a@example.com',
         createdAt: now,
@@ -167,7 +169,7 @@ describe('DrizzleUserRepository', () => {
 
       const db = createDbMock();
       const row = {
-        id: 'user_1',
+        id: userId,
         clerkUserId: 'clerk_1',
         email: 'a@example.com',
         createdAt: observedAt,
@@ -231,7 +233,7 @@ describe('DrizzleUserRepository', () => {
       const observedAt = new Date('2026-02-01T00:30:00Z');
       const db = createDbMock();
       const row = {
-        id: 'user_1',
+        id: userId,
         email: 'a@example.com',
         createdAt: new Date('2026-02-01T00:00:00Z'),
         updatedAt: observedAt,
@@ -294,7 +296,7 @@ describe('DrizzleUserRepository', () => {
 
     it('returns true when a user row is deleted', async () => {
       const db = createDbMock();
-      db._mocks.deleteReturning.mockResolvedValue([{ id: 'user_1' }]);
+      db._mocks.deleteReturning.mockResolvedValue([{ id: userId }]);
 
       const repo = new DrizzleUserRepository(db as unknown as RepoDb);
 

--- a/src/adapters/repositories/practice-session-params.test.ts
+++ b/src/adapters/repositories/practice-session-params.test.ts
@@ -6,6 +6,9 @@ import {
   toPracticeSessionParamsJson,
 } from './practice-session-params';
 
+const questionId = crypto.randomUUID();
+const draftSelectedChoiceId = crypto.randomUUID();
+
 describe('parsePracticeSessionParamsJson', () => {
   it('defaults missing draft fields for legacy question state payloads', () => {
     const parsed = parsePracticeSessionParamsJson(
@@ -13,10 +16,10 @@ describe('parsePracticeSessionParamsJson', () => {
         count: 1,
         tagSlugs: [],
         difficulties: [],
-        questionIds: ['question-1'],
+        questionIds: [questionId],
         questionStates: [
           {
-            questionId: 'question-1',
+            questionId: questionId,
             markedForReview: false,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,
@@ -29,7 +32,7 @@ describe('parsePracticeSessionParamsJson', () => {
 
     expect(parsed.questionStates).toEqual([
       {
-        questionId: 'question-1',
+        questionId: questionId,
         markedForReview: false,
         latestSelectedChoiceId: null,
         latestIsCorrect: null,
@@ -47,15 +50,15 @@ describe('parsePracticeSessionParamsJson', () => {
         count: 1,
         tagSlugs: ['opioids'],
         difficulties: ['hard'],
-        questionIds: ['question-1'],
+        questionIds: [questionId],
         questionStates: [
           {
-            questionId: 'question-1',
+            questionId: questionId,
             markedForReview: true,
             latestSelectedChoiceId: null,
             latestIsCorrect: null,
             latestAnsweredAt: null,
-            draftSelectedChoiceId: 'choice-3',
+            draftSelectedChoiceId: draftSelectedChoiceId,
             draftSavedAt: '2026-03-17T12:00:00.000Z',
             draftCumulativeMs: 45_000,
           },
@@ -65,7 +68,7 @@ describe('parsePracticeSessionParamsJson', () => {
     );
 
     const domainSession = createPracticeSession({
-      questionIds: ['question-1'],
+      questionIds: [questionId],
       questionStates: toDomainPracticeSessionQuestionStates(parsed),
       tagFilters: ['opioids'],
       difficultyFilters: ['hard'],
@@ -75,15 +78,15 @@ describe('parsePracticeSessionParamsJson', () => {
       count: 1,
       tagSlugs: ['opioids'],
       difficulties: ['hard'],
-      questionIds: ['question-1'],
+      questionIds: [questionId],
       questionStates: [
         {
-          questionId: 'question-1',
+          questionId: questionId,
           markedForReview: true,
           latestSelectedChoiceId: null,
           latestIsCorrect: null,
           latestAnsweredAt: null,
-          draftSelectedChoiceId: 'choice-3',
+          draftSelectedChoiceId: draftSelectedChoiceId,
           draftSavedAt: '2026-03-17T12:00:00.000Z',
           draftCumulativeMs: 45_000,
         },


### PR DESCRIPTION
## Summary

DEBT-400 PR 2b — migrates repository test row fixtures that populate Drizzle `uuid()` columns to valid UUIDs, per the audited PR 2b classification table (`382b07f3`). Boundary SSOT: `db/schema.ts`.

## What changed (FIX = uuid columns only)

- App-entity repos (mechanical): attempt, practice-session-*, bookmark, question, tag, params, row-mappers — uuid-column row fixtures now use generated valid UUIDs; returned-row and error-message assertions capture those IDs.
- Surgical Stripe/Clerk repos (column-level): subscription fixes `stripe_subscriptions.id` and `userId`, stripe-customer fixes `userId`, user fixes app `users.id` values.
- Provider/text identifiers remain provider-shaped: `stripeSubscriptionId`, `stripeCustomerId`, `priceId`, `clerkUserId`, event/Svix IDs.

## Do-not-churn (preserved)

- Provider text columns: `stripeCustomerId`, `stripeSubscriptionId`, `clerkUserId`, `priceId`, Stripe event/Svix IDs.
- `drizzle-idempotency-key-repository.test.ts` — 0 FIX (userId literals already valid UUIDs; action/key are text). Unchanged.
- Non-uuid keys, slugs, labels, status/enum tokens, constraint names.

## Verification

- [x] `git diff --stat`: only `src/adapters/repositories/**` + `docs/debt/debt-400-test-fixture-integrity-zod-boundary.md`.
- [x] Provider churn checked. The exact broad regex reports only `sub_row_1`; that is the audited FIX row id for `stripe_subscriptions.id`, not a provider text id. With that app-row prefix excluded, provider set-difference is empty; `sub_123`, `price_*`, `cus_*`, and `clerk_*` values are preserved.
- [x] No `as any` / row-type widening / relaxed expectations added.
- [x] `drizzle-idempotency-key` unchanged.
- [x] Repository suite green: 19 files / 169 tests.
- [x] PR 1 `fixture-uuid-integrity` green: 2/2.
- [x] DEBT-398 scan green: 16/16.
- [x] Full local gate green: typecheck, lint, unit, browser, integration, build.
- [x] Authenticated E2E green: 35/35.

## Follow-ups

- PR 3 (app/application/browser fixtures), PR 4 (docs SSOT), then archive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized test fixtures across repository test suites to use dynamically generated UUIDs instead of hardcoded identifiers, enhancing test reliability and consistency across attempt, bookmark, practice session, question, user, subscription, and tag repositories.

* **Documentation**
  * Updated test fixture integrity documentation with re-audited UUID-boundary findings and refined execution plan for ongoing standardization efforts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->