### PR TITLE
DEBT-400 PR 3b — browser-spec mocked-DTO fixtures

### DIFF
--- a/app/(app)/app/history/components/history-questions-tab.browser.spec.tsx
+++ b/app/(app)/app/history/components/history-questions-tab.browser.spec.tsx
@@ -4,6 +4,8 @@ import { ok } from '@/tests/test-helpers/ok';
 import { buildHistoryQuestionsHref } from '../history-search-params';
 import { HistoryQuestionsTab } from './history-questions-tab';
 
+const fixtureQ1Id = crypto.randomUUID();
+
 const { pushMock } = vi.hoisted(() => ({
   pushMock: vi.fn(),
 }));
@@ -20,7 +22,7 @@ function createAttemptedQuestionsResult(input?: {
     rows: [
       {
         isAvailable: true as const,
-        questionId: 'q_1',
+        questionId: fixtureQ1Id,
         isCorrect: false,
         sessionId: null,
         sessionMode: null,

--- a/app/(app)/app/history/components/history-sessions-tab.browser.spec.tsx
+++ b/app/(app)/app/history/components/history-sessions-tab.browser.spec.tsx
@@ -4,6 +4,11 @@ import * as practiceController from '@/src/adapters/controllers/practice-control
 import { ok } from '@/tests/test-helpers/ok';
 import { HistorySessionsTab } from './history-sessions-tab';
 
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureSession2Id = crypto.randomUUID();
+const fixtureQuestion1Id = crypto.randomUUID();
+const fixtureQuestion2Id = crypto.randomUUID();
+
 const { pushMock } = vi.hoisted(() => ({
   pushMock: vi.fn(),
 }));
@@ -41,7 +46,7 @@ describe('HistorySessionsTab (browser)', () => {
         result={ok({
           rows: [
             {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
               questionCount: 10,
               firstQuestionSlug: 'q-1',
@@ -75,7 +80,7 @@ describe('HistorySessionsTab (browser)', () => {
         result={ok({
           rows: [
             {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
               questionCount: 10,
               firstQuestionSlug: 'q-1',
@@ -102,7 +107,7 @@ describe('HistorySessionsTab (browser)', () => {
       .element(summaryLink)
       .toHaveAttribute(
         'href',
-        '/app/questions/q-1?from=history&mode=review&sessionId=session-1&historyHref=%2Fapp%2Fhistory%3Ftab%3Dsessions%26offset%3D0%26limit%3D20',
+        `/app/questions/q-1?from=history&mode=review&sessionId=${fixtureSession1Id}&historyHref=%2Fapp%2Fhistory%3Ftab%3Dsessions%26offset%3D0%26limit%3D20`,
       );
     await expect.element(summaryLink).not.toHaveAttribute('tabindex');
   });
@@ -110,14 +115,14 @@ describe('HistorySessionsTab (browser)', () => {
   it('clicking the disclosure button loads and renders breakdown rows', async () => {
     getPracticeSessionReview.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQuestion1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -137,7 +142,7 @@ describe('HistorySessionsTab (browser)', () => {
         result={ok({
           rows: [
             {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
               questionCount: 10,
               firstQuestionSlug: 'q-1',
@@ -156,7 +161,7 @@ describe('HistorySessionsTab (browser)', () => {
       />,
     );
 
-    const breakdownToggle = getBreakdownToggle('session-1');
+    const breakdownToggle = getBreakdownToggle(fixtureSession1Id);
     await expect
       .element(breakdownToggle)
       .toHaveAttribute('aria-expanded', 'false');
@@ -164,7 +169,7 @@ describe('HistorySessionsTab (browser)', () => {
     await breakdownToggle.click();
 
     expect(getPracticeSessionReview).toHaveBeenCalledWith({
-      sessionId: 'session-1',
+      sessionId: fixtureSession1Id,
     });
 
     await expect.element(screen.getByText('Stem for q1')).toBeVisible();
@@ -173,14 +178,14 @@ describe('HistorySessionsTab (browser)', () => {
   it('does not navigate when clicking blank space inside the expanded breakdown region', async () => {
     getPracticeSessionReview.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQuestion1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -200,7 +205,7 @@ describe('HistorySessionsTab (browser)', () => {
         result={ok({
           rows: [
             {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
               questionCount: 10,
               firstQuestionSlug: 'q-1',
@@ -219,7 +224,7 @@ describe('HistorySessionsTab (browser)', () => {
       />,
     );
 
-    await getBreakdownToggle('session-1').click();
+    await getBreakdownToggle(fixtureSession1Id).click();
     await expect
       .element(screen.getByRole('region', { name: 'Question breakdown' }))
       .toBeVisible();
@@ -236,14 +241,14 @@ describe('HistorySessionsTab (browser)', () => {
   it('does not render a redundant Review session action in the expanded breakdown panel', async () => {
     getPracticeSessionReview.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQuestion1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -263,7 +268,7 @@ describe('HistorySessionsTab (browser)', () => {
         result={ok({
           rows: [
             {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
               questionCount: 10,
               firstQuestionSlug: 'q-1',
@@ -282,7 +287,7 @@ describe('HistorySessionsTab (browser)', () => {
       />,
     );
 
-    await getBreakdownToggle('session-1').click();
+    await getBreakdownToggle(fixtureSession1Id).click();
 
     await expect
       .element(screen.getByRole('link', { name: /Stem for q1/ }))
@@ -295,14 +300,14 @@ describe('HistorySessionsTab (browser)', () => {
   it('wires disclosure accessibility attributes and region semantics on expand', async () => {
     getPracticeSessionReview.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQuestion1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -322,7 +327,7 @@ describe('HistorySessionsTab (browser)', () => {
         result={ok({
           rows: [
             {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
               questionCount: 10,
               firstQuestionSlug: 'q-1',
@@ -341,13 +346,13 @@ describe('HistorySessionsTab (browser)', () => {
       />,
     );
 
-    const collapsedToggle = getBreakdownToggle('session-1');
+    const collapsedToggle = getBreakdownToggle(fixtureSession1Id);
     await expect
       .element(collapsedToggle)
       .toHaveAttribute('aria-expanded', 'false');
     await expect
       .element(collapsedToggle)
-      .toHaveAttribute('aria-controls', 'breakdown-session-1');
+      .toHaveAttribute('aria-controls', `breakdown-${fixtureSession1Id}`);
     await expect
       .element(collapsedToggle)
       .toHaveAttribute(
@@ -357,7 +362,7 @@ describe('HistorySessionsTab (browser)', () => {
 
     await collapsedToggle.click();
 
-    const expandedToggle = getBreakdownToggle('session-1');
+    const expandedToggle = getBreakdownToggle(fixtureSession1Id);
     await expect
       .element(expandedToggle)
       .toHaveAttribute('aria-expanded', 'true');
@@ -370,20 +375,20 @@ describe('HistorySessionsTab (browser)', () => {
 
     await expect
       .element(screen.getByRole('region', { name: 'Question breakdown' }))
-      .toHaveAttribute('id', 'breakdown-session-1');
+      .toHaveAttribute('id', `breakdown-${fixtureSession1Id}`);
   });
 
   it('threads canonical historyHref into breakdown question links', async () => {
     getPracticeSessionReview.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQuestion1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -403,7 +408,7 @@ describe('HistorySessionsTab (browser)', () => {
         result={ok({
           rows: [
             {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
               questionCount: 10,
               firstQuestionSlug: 'q-1',
@@ -422,10 +427,9 @@ describe('HistorySessionsTab (browser)', () => {
       />,
     );
 
-    await getBreakdownToggle('session-1').click();
+    await getBreakdownToggle(fixtureSession1Id).click();
 
-    const expectedHref =
-      '/app/questions/q-1?from=history&mode=review&sessionId=session-1&historyHref=%2Fapp%2Fhistory%3Ftab%3Dsessions%26offset%3D0%26limit%3D20';
+    const expectedHref = `/app/questions/q-1?from=history&mode=review&sessionId=${fixtureSession1Id}&historyHref=%2Fapp%2Fhistory%3Ftab%3Dsessions%26offset%3D0%26limit%3D20`;
 
     await expect
       .element(screen.getByRole('link', { name: /Stem for q1/ }))
@@ -435,14 +439,14 @@ describe('HistorySessionsTab (browser)', () => {
   it('clicking the expanded disclosure button collapses the selected session', async () => {
     getPracticeSessionReview.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQuestion1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -462,7 +466,7 @@ describe('HistorySessionsTab (browser)', () => {
         result={ok({
           rows: [
             {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
               questionCount: 10,
               firstQuestionSlug: 'q-1',
@@ -481,10 +485,10 @@ describe('HistorySessionsTab (browser)', () => {
       />,
     );
 
-    await getBreakdownToggle('session-1').click();
+    await getBreakdownToggle(fixtureSession1Id).click();
     await expect.element(screen.getByText('Stem for q1')).toBeVisible();
 
-    await getBreakdownToggle('session-1').click();
+    await getBreakdownToggle(fixtureSession1Id).click();
 
     await expect
       .element(screen.getByText('Stem for q1'))
@@ -494,7 +498,7 @@ describe('HistorySessionsTab (browser)', () => {
   it('clicking a different session collapses the previous breakdown', async () => {
     getPracticeSessionReview.mockImplementation(async (input) => {
       const sessionId = (input as { sessionId: string }).sessionId;
-      if (sessionId === 'session-1') {
+      if (sessionId === fixtureSession1Id) {
         return ok({
           sessionId,
           mode: 'exam',
@@ -503,7 +507,7 @@ describe('HistorySessionsTab (browser)', () => {
           markedCount: 0,
           rows: [
             {
-              questionId: 'q1',
+              questionId: fixtureQuestion1Id,
               slug: 'q-1',
               order: 1,
               isAvailable: true,
@@ -526,7 +530,7 @@ describe('HistorySessionsTab (browser)', () => {
         markedCount: 0,
         rows: [
           {
-            questionId: 'q2',
+            questionId: fixtureQuestion2Id,
             slug: 'q-2',
             order: 1,
             isAvailable: true,
@@ -546,7 +550,7 @@ describe('HistorySessionsTab (browser)', () => {
         result={ok({
           rows: [
             {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
               questionCount: 10,
               firstQuestionSlug: 'q-1',
@@ -558,7 +562,7 @@ describe('HistorySessionsTab (browser)', () => {
               endedAt: '2026-02-07T00:20:00.000Z',
             },
             {
-              sessionId: 'session-2',
+              sessionId: fixtureSession2Id,
               mode: 'tutor',
               questionCount: 10,
               firstQuestionSlug: 'q-2',
@@ -577,10 +581,10 @@ describe('HistorySessionsTab (browser)', () => {
       />,
     );
 
-    await getBreakdownToggle('session-1').click();
+    await getBreakdownToggle(fixtureSession1Id).click();
     await expect.element(screen.getByText('Stem for session 1')).toBeVisible();
 
-    await getBreakdownToggle('session-2').click();
+    await getBreakdownToggle(fixtureSession2Id).click();
     await expect.element(screen.getByText('Stem for session 2')).toBeVisible();
 
     await expect

--- a/app/(app)/app/history/hooks/use-history-sessions.browser.spec.tsx
+++ b/app/(app)/app/history/hooks/use-history-sessions.browser.spec.tsx
@@ -9,6 +9,7 @@ import { ok } from '@/tests/test-helpers/ok';
 import { installReportClientErrorMocks } from '@/tests/test-helpers/report-client-error-mocks';
 import { useHistorySessions } from './use-history-sessions';
 
+const fixtureQ1Id = crypto.randomUUID();
 vi.mock('@/src/adapters/controllers/practice-controller', { spy: true });
 vi.mock('@/lib/report-client-error', { spy: true });
 
@@ -28,7 +29,7 @@ function makeReviewOutput(sessionId: string): GetPracticeSessionReviewOutput {
     markedCount: 0,
     rows: [
       {
-        questionId: 'q1',
+        questionId: fixtureQ1Id,
         slug: 'q-1',
         order: 1,
         isAvailable: true,

--- a/app/(app)/app/practice/[sessionId]/components/exam-review-view.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/exam-review-view.browser.spec.tsx
@@ -4,6 +4,11 @@ import { render } from 'vitest-browser-react';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ExamReviewView, QuestionNavigator } from './exam-review-view';
 
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureQ1Id = crypto.randomUUID();
+const fixtureQ2Id = crypto.randomUUID();
+const fixtureQ3Id = crypto.randomUUID();
+
 const reviewInstructionText =
   'Select a question below to keep reviewing before you submit.';
 
@@ -13,14 +18,14 @@ test('renders navigator states and disables unavailable questions', async () => 
   const screen = await render(
     <QuestionNavigator
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 3,
         answeredCount: 2,
         markedCount: 1,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -32,7 +37,7 @@ test('renders navigator states and disables unavailable questions', async () => 
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             order: 2,
             isAvailable: true,
@@ -44,7 +49,7 @@ test('renders navigator states and disables unavailable questions', async () => 
             markedForReview: true,
           },
           {
-            questionId: 'q3',
+            questionId: fixtureQ3Id,
             order: 3,
             isAvailable: false,
             isAnswered: false,
@@ -54,7 +59,7 @@ test('renders navigator states and disables unavailable questions', async () => 
           },
         ],
       }}
-      currentQuestionId="q1"
+      currentQuestionId={fixtureQ1Id}
       controlledPanelId="practice-question-panel"
       onNavigateQuestion={onNavigateQuestion}
     />,
@@ -63,7 +68,7 @@ test('renders navigator states and disables unavailable questions', async () => 
   await screen
     .getByRole('button', { name: 'Question 2: Marked for review, Answered' })
     .click();
-  expect(onNavigateQuestion).toHaveBeenCalledWith('q2');
+  expect(onNavigateQuestion).toHaveBeenCalledWith(fixtureQ2Id);
   await expect
     .element(screen.getByRole('button', { name: 'Question 3: Unanswered' }))
     .toBeDisabled();
@@ -75,14 +80,14 @@ test('uses correctness labels only in tutor mode', async () => {
   const screen = await render(
     <QuestionNavigator
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
         totalCount: 2,
         answeredCount: 2,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -94,7 +99,7 @@ test('uses correctness labels only in tutor mode', async () => {
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             order: 2,
             isAvailable: true,
@@ -107,7 +112,7 @@ test('uses correctness labels only in tutor mode', async () => {
           },
         ],
       }}
-      currentQuestionId="q1"
+      currentQuestionId={fixtureQ1Id}
       controlledPanelId="practice-question-panel"
       onNavigateQuestion={onNavigateQuestion}
     />,
@@ -119,7 +124,7 @@ test('uses correctness labels only in tutor mode', async () => {
     )
     .toBeVisible();
   await screen.getByRole('button', { name: 'Question 2: Incorrect' }).click();
-  expect(onNavigateQuestion).toHaveBeenCalledWith('q2');
+  expect(onNavigateQuestion).toHaveBeenCalledWith(fixtureQ2Id);
 });
 
 test('opens a review question and finalizes the exam', async () => {
@@ -129,14 +134,14 @@ test('opens a review question and finalizes the exam', async () => {
   const screen = await render(
     <ExamReviewView
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 1,
         markedCount: 1,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -148,7 +153,7 @@ test('opens a review question and finalizes the exam', async () => {
             markedForReview: true,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             order: 2,
             isAvailable: false,
             isAnswered: false,
@@ -175,7 +180,7 @@ test('opens a review question and finalizes the exam', async () => {
       name: /Open question 1\..*A long stem for q1.*Answered.*Marked for review.*Incorrect/i,
     })
     .click();
-  expect(onOpenQuestion).toHaveBeenCalledWith('q1');
+  expect(onOpenQuestion).toHaveBeenCalledWith(fixtureQ1Id);
   await expect
     .element(screen.getByText(reviewInstructionText, { exact: true }))
     .toBeVisible();
@@ -201,7 +206,7 @@ test('guards against double-clicking confirm submit before pending state updates
   const screen = await render(
     <ExamReviewView
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 0,
@@ -229,7 +234,7 @@ test('allows submitting again after finalize resolves even when pending state ne
   const screen = await render(
     <ExamReviewView
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 0,
@@ -268,7 +273,7 @@ test('omits unanswered warning when all exam questions are answered', async () =
   const screen = await render(
     <ExamReviewView
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 2,
@@ -294,7 +299,7 @@ test('keeps the helper text visible and the first review row above the fold at 3
     const screen = await render(
       <ExamReviewView
         review={{
-          sessionId: 'session-1',
+          sessionId: fixtureSession1Id,
           mode: 'exam',
           totalCount: 10,
           answeredCount: 6,
@@ -358,14 +363,14 @@ test('keeps empty-stem rows discoverable by accessible name', async () => {
   const screen = await render(
     <ExamReviewView
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 0,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -387,7 +392,7 @@ test('keeps empty-stem rows discoverable by accessible name', async () => {
   await screen
     .getByRole('button', { name: /Open question 1\..*Unanswered/i })
     .click();
-  expect(onOpenQuestion).toHaveBeenCalledWith('q1');
+  expect(onOpenQuestion).toHaveBeenCalledWith(fixtureQ1Id);
 });
 
 test('supports keyboard activation for available review rows and leaves unavailable rows non-interactive', async () => {
@@ -396,14 +401,14 @@ test('supports keyboard activation for available review rows and leaves unavaila
   const screen = await render(
     <ExamReviewView
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 1,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -415,7 +420,7 @@ test('supports keyboard activation for available review rows and leaves unavaila
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             order: 2,
             isAvailable: false,
             isAnswered: false,
@@ -442,8 +447,8 @@ test('supports keyboard activation for available review rows and leaves unavaila
   await userEvent.keyboard(' ');
 
   expect(onOpenQuestion).toHaveBeenCalledTimes(2);
-  expect(onOpenQuestion).toHaveBeenNthCalledWith(1, 'q1');
-  expect(onOpenQuestion).toHaveBeenNthCalledWith(2, 'q1');
+  expect(onOpenQuestion).toHaveBeenNthCalledWith(1, fixtureQ1Id);
+  expect(onOpenQuestion).toHaveBeenNthCalledWith(2, fixtureQ1Id);
   await expect
     .element(screen.getByText('[Question no longer available]'))
     .toBeVisible();
@@ -456,14 +461,14 @@ test('renders decorative chevrons only on available review rows', async () => {
   const screen = await render(
     <ExamReviewView
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 3,
         answeredCount: 1,
         markedCount: 1,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -475,7 +480,7 @@ test('renders decorative chevrons only on available review rows', async () => {
             markedForReview: true,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             order: 2,
             isAvailable: true,
@@ -487,7 +492,7 @@ test('renders decorative chevrons only on available review rows', async () => {
             markedForReview: false,
           },
           {
-            questionId: 'q3',
+            questionId: fixtureQ3Id,
             order: 3,
             isAvailable: false,
             isAnswered: false,
@@ -529,14 +534,14 @@ test('keeps the row-to-submit tab order unchanged with the helper text skipped',
   const screen = await render(
     <ExamReviewView
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 3,
         answeredCount: 2,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -548,7 +553,7 @@ test('keeps the row-to-submit tab order unchanged with the helper text skipped',
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             order: 2,
             isAvailable: true,
@@ -560,7 +565,7 @@ test('keeps the row-to-submit tab order unchanged with the helper text skipped',
             markedForReview: false,
           },
           {
-            questionId: 'q3',
+            questionId: fixtureQ3Id,
             order: 3,
             isAvailable: false,
             isAnswered: false,

--- a/app/(app)/app/practice/[sessionId]/components/exam-review-view.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/exam-review-view.browser.spec.tsx
@@ -305,7 +305,7 @@ test('keeps the helper text visible and the first review row above the fold at 3
           answeredCount: 6,
           markedCount: 2,
           rows: Array.from({ length: 10 }, (_, index) => ({
-            questionId: `q${index + 1}`,
+            questionId: crypto.randomUUID(),
             slug: `q-${index + 1}`,
             order: index + 1,
             isAvailable: index < 9,

--- a/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.browser.spec.tsx
@@ -2,11 +2,16 @@ import { useState } from 'react';
 import { expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { PostExamReviewView } from './post-exam-review-view';
+
 import {
   createReview,
   createReviewRow,
   createSummary,
 } from './post-exam-review-view.fixtures';
+
+const fixtureChoiceAId = crypto.randomUUID();
+const fixtureQuestion2Id = crypto.randomUUID();
+const fixtureChoiceBId = crypto.randomUUID();
 
 const summary = createSummary({
   questionCount: 2,
@@ -17,16 +22,16 @@ const review = createReview([
   createReviewRow({
     isAnswered: true,
     isCorrect: false,
-    selectedChoiceId: 'choice-a',
+    selectedChoiceId: fixtureChoiceAId,
   }),
   createReviewRow({
-    questionId: 'question-2',
+    questionId: fixtureQuestion2Id,
     slug: 'question-2',
     stemMd: 'Second question stem',
     order: 2,
     isAnswered: true,
     isCorrect: true,
-    selectedChoiceId: 'choice-b',
+    selectedChoiceId: fixtureChoiceBId,
     explanationMd: 'Second explanation for review.',
   }),
 ]);
@@ -87,19 +92,19 @@ test('renders the post-exam review bottom action bar without sticky shell marker
       stemMd: createTallMarkdown('Review stem', 18),
       isAnswered: true,
       isCorrect: false,
-      selectedChoiceId: 'choice-a',
+      selectedChoiceId: fixtureChoiceAId,
       explanationMd: createTallMarkdown('Review explanation', 28),
       referenceMd: createTallMarkdown('Review reference', 10),
       choiceExplanations: [
         {
-          choiceId: 'choice-a',
+          choiceId: fixtureChoiceAId,
           displayLabel: 'A',
           textMd: 'Choice A',
           isCorrect: false,
           explanationMd: createTallMarkdown('Choice A explanation', 8),
         },
         {
-          choiceId: 'choice-b',
+          choiceId: fixtureChoiceBId,
           displayLabel: 'B',
           textMd: 'Choice B',
           isCorrect: true,
@@ -108,13 +113,13 @@ test('renders the post-exam review bottom action bar without sticky shell marker
       ],
     }),
     createReviewRow({
-      questionId: 'question-2',
+      questionId: fixtureQuestion2Id,
       slug: 'question-2',
       stemMd: 'Second question stem',
       order: 2,
       isAnswered: true,
       isCorrect: true,
-      selectedChoiceId: 'choice-b',
+      selectedChoiceId: fixtureChoiceBId,
       explanationMd: 'Second explanation for review.',
     }),
   ]);

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-active-question.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-active-question.browser.spec.tsx
@@ -3,6 +3,10 @@ import { render } from 'vitest-browser-react';
 import { PracticeSessionPageView } from './practice-session-page-view';
 import { noop } from './practice-session-page-view-test-helpers';
 
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureQ1Id = crypto.randomUUID();
+const fixtureQ2Id = crypto.randomUUID();
+
 test('renders active question branch with navigator and navigation callback', async () => {
   const onNavigateQuestion = vi.fn();
   const screen = await render(
@@ -10,14 +14,14 @@ test('renders active question branch with navigator and navigation callback', as
       summary={null}
       review={null}
       navigator={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 1,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -29,7 +33,7 @@ test('renders active question branch with navigator and navigation callback', as
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             order: 2,
             isAvailable: true,
@@ -43,7 +47,7 @@ test('renders active question branch with navigator and navigation callback', as
         ],
       }}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
 
         deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -54,7 +58,7 @@ test('renders active question branch with navigator and navigation callback', as
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'q1',
+        questionId: fixtureQ1Id,
         slug: 'q-1',
         stemMd: 'Stem 1',
         difficulty: 'easy',
@@ -87,7 +91,7 @@ test('renders active question branch with navigator and navigation callback', as
     .toBeVisible();
   await expect.element(screen.getByText('Question navigator')).toBeVisible();
   await screen.getByRole('button', { name: 'Question 2: Unanswered' }).click();
-  expect(onNavigateQuestion).toHaveBeenCalledWith('q2');
+  expect(onNavigateQuestion).toHaveBeenCalledWith(fixtureQ2Id);
 });
 
 test('does not render Review & Submit in the active exam-question header', async () => {
@@ -97,7 +101,7 @@ test('does not render Review & Submit in the active exam-question header', async
       review={null}
       navigator={null}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
 
         deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -108,7 +112,7 @@ test('does not render Review & Submit in the active exam-question header', async
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'q1',
+        questionId: fixtureQ1Id,
         slug: 'q-1',
         stemMd: 'Stem 1',
         difficulty: 'easy',
@@ -145,7 +149,7 @@ test('keeps End session in the active tutor-question header', async () => {
       review={null}
       navigator={null}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
 
         deadlineAt: null,
@@ -156,7 +160,7 @@ test('keeps End session in the active tutor-question header', async () => {
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'q1',
+        questionId: fixtureQ1Id,
         slug: 'q-1',
         stemMd: 'Stem 1',
         difficulty: 'easy',
@@ -189,14 +193,14 @@ test('wires navigator aria-controls to an existing question panel id', async () 
       summary={null}
       review={null}
       navigator={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 1,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -208,7 +212,7 @@ test('wires navigator aria-controls to an existing question panel id', async () 
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             order: 2,
             isAvailable: true,
@@ -222,7 +226,7 @@ test('wires navigator aria-controls to an existing question panel id', async () 
         ],
       }}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
 
         deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -233,7 +237,7 @@ test('wires navigator aria-controls to an existing question panel id', async () 
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'q1',
+        questionId: fixtureQ1Id,
         slug: 'q-1',
         stemMd: 'Stem 1',
         difficulty: 'easy',
@@ -284,7 +288,7 @@ test('renders navigator error with retry action', async () => {
         message: 'Navigator unavailable.',
       }}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
 
         deadlineAt: '2099-05-22T12:02:24.000Z',

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-focus-restoration.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-focus-restoration.browser.spec.tsx
@@ -9,6 +9,10 @@ import {
 import { PracticeSessionPageView } from './practice-session-page-view';
 import { noop } from './practice-session-page-view-test-helpers';
 
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureQ1Id = crypto.randomUUID();
+const fixtureQ2Id = crypto.randomUUID();
+
 const examQuestionNavigator = createReviewResponse({
   mode: 'exam',
   totalCount: 2,
@@ -16,14 +20,14 @@ const examQuestionNavigator = createReviewResponse({
   markedCount: 0,
   rows: [
     createReviewRow({
-      questionId: 'q1',
+      questionId: fixtureQ1Id,
       slug: 'q-1',
       order: 1,
       isAnswered: false,
       isCorrect: null,
     }),
     createReviewRow({
-      questionId: 'q2',
+      questionId: fixtureQ2Id,
       slug: 'q-2',
       order: 2,
       isAnswered: false,
@@ -39,12 +43,12 @@ function renderQuestionNavigationHarness() {
       setQuestionIndex((current) => Math.min(current + 1, 1));
     }, []);
     const handleNavigateQuestion = useCallback((nextQuestionId: string) => {
-      if (nextQuestionId === 'q1') {
+      if (nextQuestionId === fixtureQ1Id) {
         setQuestionIndex(0);
         return;
       }
 
-      if (nextQuestionId === 'q2') {
+      if (nextQuestionId === fixtureQ2Id) {
         setQuestionIndex(1);
         return;
       }
@@ -52,7 +56,7 @@ function renderQuestionNavigationHarness() {
       throw new Error(`Unexpected question id: ${nextQuestionId}`);
     }, []);
 
-    const questionId = questionIndex === 0 ? 'q1' : 'q2';
+    const questionId = questionIndex === 0 ? fixtureQ1Id : fixtureQ2Id;
     const stem = questionIndex === 0 ? 'Stem 1' : 'Stem 2';
 
     return (
@@ -61,7 +65,7 @@ function renderQuestionNavigationHarness() {
         review={null}
         navigator={examQuestionNavigator}
         sessionInfo={{
-          sessionId: 'session-1',
+          sessionId: fixtureSession1Id,
           mode: 'exam',
           deadlineAt: '2099-05-22T12:02:24.000Z',
           index: questionIndex,
@@ -151,7 +155,7 @@ test('restores the question panel when next-question navigation enters loading b
         typeof createNextQuestion
       > | null>(
         createNextQuestion({
-          questionId: 'q1',
+          questionId: fixtureQ1Id,
           slug: 'q1',
           stemMd: 'Stem 1',
           difficulty: 'easy',
@@ -169,7 +173,7 @@ test('restores the question panel when next-question navigation enters loading b
           review={null}
           navigator={examQuestionNavigator}
           sessionInfo={{
-            sessionId: 'session-1',
+            sessionId: fixtureSession1Id,
             mode: 'exam',
 
             deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -229,7 +233,7 @@ test('restores the question panel when navigation fails before the question id c
         { status: 'ready' } | { status: 'error'; message: string }
       >({ status: 'ready' });
       const question = createNextQuestion({
-        questionId: 'q1',
+        questionId: fixtureQ1Id,
         slug: 'q1',
         stemMd: 'Stem 1',
         difficulty: 'easy',
@@ -248,7 +252,7 @@ test('restores the question panel when navigation fails before the question id c
           review={null}
           navigator={examQuestionNavigator}
           sessionInfo={{
-            sessionId: 'session-1',
+            sessionId: fixtureSession1Id,
             mode: 'exam',
 
             deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -313,7 +317,7 @@ test('restores the question panel when retrying from an in-panel load error', as
         message: 'Failed to reload the question.',
       });
       const question = createNextQuestion({
-        questionId: 'q1',
+        questionId: fixtureQ1Id,
         slug: 'q1',
         stemMd: 'Stem 1',
         difficulty: 'easy',
@@ -329,7 +333,7 @@ test('restores the question panel when retrying from an in-panel load error', as
           review={null}
           navigator={examQuestionNavigator}
           sessionInfo={{
-            sessionId: 'session-1',
+            sessionId: fixtureSession1Id,
             mode: 'exam',
 
             deadlineAt: '2099-05-22T12:02:24.000Z',

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-question-navigation.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-question-navigation.browser.spec.tsx
@@ -8,20 +8,30 @@ import {
 import { PracticeSessionPageView } from './practice-session-page-view';
 import { noop } from './practice-session-page-view-test-helpers';
 
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureQMissingId = crypto.randomUUID();
+const fixtureAttempt1Id = crypto.randomUUID();
+const fixtureAttempt2Id = crypto.randomUUID();
+const fixtureChoice1Id = crypto.randomUUID();
+const fixtureQ1Id = crypto.randomUUID();
+const fixtureQ2Id = crypto.randomUUID();
+const fixtureQ3Id = crypto.randomUUID();
+const fixtureQ4Id = crypto.randomUUID();
+
 test('renders Previous button in the session answering branch', async () => {
   const screen = await render(
     <PracticeSessionPageView
       summary={null}
       review={null}
       navigator={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
         totalCount: 2,
         answeredCount: 0,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -33,7 +43,7 @@ test('renders Previous button in the session answering branch', async () => {
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             order: 2,
             isAvailable: true,
@@ -47,7 +57,7 @@ test('renders Previous button in the session answering branch', async () => {
         ],
       }}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
 
         deadlineAt: null,
@@ -58,7 +68,7 @@ test('renders Previous button in the session answering branch', async () => {
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'q2',
+        questionId: fixtureQ2Id,
         slug: 'q-2',
         stemMd: 'Stem 2',
         difficulty: 'medium',
@@ -91,14 +101,14 @@ test('hasPreviousQuestion is false when current question is first in navigator',
       summary={null}
       review={null}
       navigator={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
         totalCount: 2,
         answeredCount: 0,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -110,7 +120,7 @@ test('hasPreviousQuestion is false when current question is first in navigator',
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             order: 2,
             isAvailable: true,
@@ -124,7 +134,7 @@ test('hasPreviousQuestion is false when current question is first in navigator',
         ],
       }}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
 
         deadlineAt: null,
@@ -135,7 +145,7 @@ test('hasPreviousQuestion is false when current question is first in navigator',
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'q1',
+        questionId: fixtureQ1Id,
         slug: 'q-1',
         stemMd: 'Stem 1',
         difficulty: 'easy',
@@ -169,7 +179,7 @@ test('hasPreviousQuestion is false on the first question when navigator is missi
       review={null}
       navigator={null}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
 
         deadlineAt: null,
@@ -180,7 +190,7 @@ test('hasPreviousQuestion is false on the first question when navigator is missi
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'q-missing',
+        questionId: fixtureQMissingId,
         slug: 'q-missing',
         stemMd: 'Stem missing',
         difficulty: 'easy',
@@ -214,7 +224,7 @@ test('renders Previous when navigator is missing but sessionInfo indicates a pri
       review={null}
       navigator={null}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
 
         deadlineAt: null,
@@ -225,7 +235,7 @@ test('renders Previous when navigator is missing but sessionInfo indicates a pri
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'q2',
+        questionId: fixtureQ2Id,
         slug: 'q-2',
         stemMd: 'Stem 2',
         difficulty: 'medium',
@@ -267,13 +277,13 @@ test('routes the last exam-question footer Review & Submit button through onEndS
         markedCount: 0,
         rows: [
           createReviewRow({
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             order: 1,
             isAnswered: true,
             isCorrect: true,
           }),
           createReviewRow({
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             order: 2,
             isAnswered: true,
             isCorrect: true,
@@ -281,7 +291,7 @@ test('routes the last exam-question footer Review & Submit button through onEndS
         ],
       })}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
 
         deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -292,7 +302,7 @@ test('routes the last exam-question footer Review & Submit button through onEndS
       }}
       loadState={{ status: 'ready' }}
       question={createNextQuestion({
-        questionId: 'q2',
+        questionId: fixtureQ2Id,
         slug: 'q-2',
         stemMd: 'Last exam question',
         difficulty: 'medium',
@@ -324,14 +334,14 @@ test('hasPreviousQuestion is true when current question is not first', async () 
       summary={null}
       review={null}
       navigator={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
         totalCount: 2,
         answeredCount: 0,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -343,7 +353,7 @@ test('hasPreviousQuestion is true when current question is not first', async () 
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             order: 2,
             isAvailable: true,
@@ -357,7 +367,7 @@ test('hasPreviousQuestion is true when current question is not first', async () 
         ],
       }}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
 
         deadlineAt: null,
@@ -368,7 +378,7 @@ test('hasPreviousQuestion is true when current question is not first', async () 
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'q2',
+        questionId: fixtureQ2Id,
         slug: 'q-2',
         stemMd: 'Stem 2',
         difficulty: 'medium',
@@ -404,14 +414,14 @@ test('routes the last tutor-question footer End session button through onEndSess
       summary={null}
       review={null}
       navigator={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
         totalCount: 2,
         answeredCount: 2,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -423,7 +433,7 @@ test('routes the last tutor-question footer End session button through onEndSess
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             order: 2,
             isAvailable: true,
@@ -437,7 +447,7 @@ test('routes the last tutor-question footer End session button through onEndSess
         ],
       }}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
 
         deadlineAt: null,
@@ -448,7 +458,7 @@ test('routes the last tutor-question footer End session button through onEndSess
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'q2',
+        questionId: fixtureQ2Id,
         slug: 'q-2',
         stemMd: 'Stem 2',
         difficulty: 'medium',
@@ -458,7 +468,7 @@ test('routes the last tutor-question footer End session button through onEndSess
       selectedChoiceId="c1"
       isAnswered={true}
       submitResult={{
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: true,
         correctChoiceId: 'c1',
         explanationMd: 'Because',
@@ -505,25 +515,25 @@ test('clicking Next in a completed session navigates to the next available quest
         markedCount: 0,
         rows: [
           createReviewRow({
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             order: 1,
             isAnswered: true,
             isCorrect: true,
           }),
           createReviewRow({
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             order: 2,
             isAnswered: true,
             isCorrect: true,
           }),
           createReviewRow({
-            questionId: 'q3',
+            questionId: fixtureQ3Id,
             order: 3,
             isAnswered: true,
             isCorrect: true,
           }),
           createReviewRow({
-            questionId: 'q4',
+            questionId: fixtureQ4Id,
             order: 4,
             isAnswered: true,
             isCorrect: true,
@@ -531,7 +541,7 @@ test('clicking Next in a completed session navigates to the next available quest
         ],
       })}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
 
         deadlineAt: null,
@@ -542,10 +552,10 @@ test('clicking Next in a completed session navigates to the next available quest
       }}
       loadState={{ status: 'ready' }}
       question={createNextQuestion({
-        questionId: 'q2',
+        questionId: fixtureQ2Id,
         stemMd: 'Stem 2',
         session: {
-          sessionId: 'session-1',
+          sessionId: fixtureSession1Id,
           mode: 'tutor',
 
           deadlineAt: null,
@@ -553,16 +563,16 @@ test('clicking Next in a completed session navigates to the next available quest
           index: 1,
           total: 4,
           isMarkedForReview: false,
-          latestSelectedChoiceId: 'choice_1',
+          latestSelectedChoiceId: fixtureChoice1Id,
           latestIsCorrect: true,
         },
       })}
-      selectedChoiceId="choice_1"
+      selectedChoiceId={fixtureChoice1Id}
       isAnswered={true}
       submitResult={{
-        attemptId: 'attempt-2',
+        attemptId: fixtureAttempt2Id,
         isCorrect: true,
-        correctChoiceId: 'choice_1',
+        correctChoiceId: fixtureChoice1Id,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -581,7 +591,7 @@ test('clicking Next in a completed session navigates to the next available quest
 
   await screen.getByRole('button', { name: 'Next' }).click();
 
-  expect(onNavigateQuestion).toHaveBeenCalledWith('q3');
+  expect(onNavigateQuestion).toHaveBeenCalledWith(fixtureQ3Id);
   expect(onNextQuestion).not.toHaveBeenCalled();
 });
 
@@ -599,19 +609,19 @@ test('clicking Next falls back to onNextQuestion when id-based navigation is una
         markedCount: 0,
         rows: [
           createReviewRow({
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             order: 1,
             isAnswered: true,
             isCorrect: true,
           }),
           createReviewRow({
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             order: 2,
             isAnswered: false,
             isCorrect: null,
           }),
           createReviewRow({
-            questionId: 'q3',
+            questionId: fixtureQ3Id,
             order: 3,
             isAnswered: false,
             isCorrect: null,
@@ -619,7 +629,7 @@ test('clicking Next falls back to onNextQuestion when id-based navigation is una
         ],
       })}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
 
         deadlineAt: null,
@@ -630,10 +640,10 @@ test('clicking Next falls back to onNextQuestion when id-based navigation is una
       }}
       loadState={{ status: 'ready' }}
       question={createNextQuestion({
-        questionId: 'q1',
+        questionId: fixtureQ1Id,
         stemMd: 'Stem 1',
         session: {
-          sessionId: 'session-1',
+          sessionId: fixtureSession1Id,
           mode: 'tutor',
 
           deadlineAt: null,
@@ -641,16 +651,16 @@ test('clicking Next falls back to onNextQuestion when id-based navigation is una
           index: 0,
           total: 3,
           isMarkedForReview: false,
-          latestSelectedChoiceId: 'choice_1',
+          latestSelectedChoiceId: fixtureChoice1Id,
           latestIsCorrect: true,
         },
       })}
-      selectedChoiceId="choice_1"
+      selectedChoiceId={fixtureChoice1Id}
       isAnswered={true}
       submitResult={{
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: true,
-        correctChoiceId: 'choice_1',
+        correctChoiceId: fixtureChoice1Id,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -679,14 +689,14 @@ test("clicking Previous calls onNavigateQuestion with the previous question's ID
       summary={null}
       review={null}
       navigator={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
         totalCount: 2,
         answeredCount: 0,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -698,7 +708,7 @@ test("clicking Previous calls onNavigateQuestion with the previous question's ID
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             order: 2,
             isAvailable: true,
@@ -712,7 +722,7 @@ test("clicking Previous calls onNavigateQuestion with the previous question's ID
         ],
       }}
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
 
         deadlineAt: null,
@@ -723,7 +733,7 @@ test("clicking Previous calls onNavigateQuestion with the previous question's ID
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'q2',
+        questionId: fixtureQ2Id,
         slug: 'q-2',
         stemMd: 'Stem 2',
         difficulty: 'medium',
@@ -746,5 +756,5 @@ test("clicking Previous calls onNavigateQuestion with the previous question's ID
   );
 
   await screen.getByRole('button', { name: 'Previous' }).click();
-  expect(onNavigateQuestion).toHaveBeenCalledWith('q1');
+  expect(onNavigateQuestion).toHaveBeenCalledWith(fixtureQ1Id);
 });

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-results.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-results.browser.spec.tsx
@@ -8,9 +8,13 @@ import {
 import { PracticeSessionPageView } from './practice-session-page-view';
 import { noop } from './practice-session-page-view-test-helpers';
 
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureQ1Id = crypto.randomUUID();
+const fixtureQ2Id = crypto.randomUUID();
+
 function renderExamResultsContinuityHarness() {
   const summary = {
-    sessionId: 'session-1',
+    sessionId: fixtureSession1Id,
     endedAt: '2026-02-07T00:20:00.000Z',
     mode: 'exam' as const,
     questionCount: 2,
@@ -28,7 +32,7 @@ function renderExamResultsContinuityHarness() {
     markedCount: 0,
     rows: [
       createReviewRow({
-        questionId: 'q1',
+        questionId: fixtureQ1Id,
         slug: 'q-1',
         stemMd: 'Stem 1',
         order: 1,
@@ -37,7 +41,7 @@ function renderExamResultsContinuityHarness() {
         isOmitted: false,
       }),
       createReviewRow({
-        questionId: 'q2',
+        questionId: fixtureQ2Id,
         slug: 'q-2',
         stemMd: 'Stem 2',
         order: 2,
@@ -48,7 +52,7 @@ function renderExamResultsContinuityHarness() {
     ],
   });
   const postExamReview = {
-    sessionId: 'session-1',
+    sessionId: fixtureSession1Id,
     mode: 'exam' as const,
     totalCount: 2,
     answeredCount: 2,
@@ -56,7 +60,7 @@ function renderExamResultsContinuityHarness() {
     rows: [
       {
         isAvailable: true as const,
-        questionId: 'q1',
+        questionId: fixtureQ1Id,
         slug: 'q-1',
         stemMd: 'Stem 1',
         difficulty: 'easy' as const,
@@ -77,7 +81,7 @@ function renderExamResultsContinuityHarness() {
       },
       {
         isAvailable: true as const,
-        questionId: 'q2',
+        questionId: fixtureQ2Id,
         slug: 'q-2',
         stemMd: 'Stem 2',
         difficulty: 'medium' as const,
@@ -101,7 +105,7 @@ function renderExamResultsContinuityHarness() {
       'session_summary' | 'post_exam_review'
     >('session_summary');
     const [currentQuestionId, setCurrentQuestionId] = useState<string | null>(
-      'q1',
+      fixtureQ1Id,
     );
     const handleViewSummary = useCallback(() => {
       setSubstage('session_summary');
@@ -183,7 +187,7 @@ test('renders session summary branch when summary is present', async () => {
   const screen = await render(
     <PracticeSessionPageView
       summary={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:00:00.000Z',
         mode: 'tutor',
         questionCount: 10,
@@ -232,7 +236,7 @@ test('keeps exam summaries on the in-session review contract when the substage p
   const screen = await render(
     <PracticeSessionPageView
       summary={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:00:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -244,7 +248,7 @@ test('keeps exam summaries on the in-session review contract when the substage p
         },
       }}
       postExamSummary={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:00:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -262,7 +266,7 @@ test('keeps exam summaries on the in-session review contract when the substage p
         markedCount: 0,
         rows: [
           createReviewRow({
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             stemMd: 'Stem 1',
             order: 1,

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-review-stage.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view-review-stage.browser.spec.tsx
@@ -3,6 +3,10 @@ import { render } from 'vitest-browser-react';
 import { PracticeSessionPageView } from './practice-session-page-view';
 import { noop } from './practice-session-page-view-test-helpers';
 
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureQ1Id = crypto.randomUUID();
+const fixtureQ2Id = crypto.randomUUID();
+
 test('renders exam review branch and triggers review actions', async () => {
   const onOpenReviewQuestion = vi.fn();
   const onFinalizeReview = vi.fn(async () => undefined);
@@ -11,14 +15,14 @@ test('renders exam review branch and triggers review actions', async () => {
     <PracticeSessionPageView
       summary={null}
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -55,7 +59,7 @@ test('renders exam review branch and triggers review actions', async () => {
     .element(screen.getByRole('heading', { name: 'Review & Submit' }))
     .toBeVisible();
   await screen.getByRole('button', { name: 'Open question' }).click();
-  expect(onOpenReviewQuestion).toHaveBeenCalledWith('q1');
+  expect(onOpenReviewQuestion).toHaveBeenCalledWith(fixtureQ1Id);
 
   await screen.getByRole('button', { name: 'Submit exam' }).click();
   await expect
@@ -72,7 +76,7 @@ test('renders post-exam review with score banner, feedback, and a summary exit',
     <PracticeSessionPageView
       summary={null}
       postExamSummary={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -84,7 +88,7 @@ test('renders post-exam review with score banner, feedback, and a summary exit',
         },
       }}
       postExamReview={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 2,
@@ -92,7 +96,7 @@ test('renders post-exam review with score banner, feedback, and a summary exit',
         rows: [
           {
             isAvailable: true,
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             stemMd: 'Stem 1',
             difficulty: 'easy',
@@ -128,7 +132,7 @@ test('renders post-exam review with score banner, feedback, and a summary exit',
           },
           {
             isAvailable: true,
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             stemMd: 'Stem 2',
             difficulty: 'medium',
@@ -156,7 +160,7 @@ test('renders post-exam review with score banner, feedback, and a summary exit',
       }}
       examResultsSubstage="post_exam_review"
       postExamReviewLoadState={{ status: 'ready' }}
-      postExamReviewCurrentQuestionId="q1"
+      postExamReviewCurrentQuestionId={fixtureQ1Id}
       sessionInfo={null}
       loadState={{ status: 'ready' }}
       question={null}
@@ -213,7 +217,7 @@ test('renders post-exam review with score banner, feedback, and a summary exit',
     .not.toBeInTheDocument();
 
   await screen.getByRole('button', { name: 'Next' }).click();
-  expect(onNavigatePostExamReviewQuestion).toHaveBeenCalledWith('q2');
+  expect(onNavigatePostExamReviewQuestion).toHaveBeenCalledWith(fixtureQ2Id);
 
   const summaryActionBanner = screen
     .getByText('Exam complete')
@@ -236,7 +240,7 @@ test('renders a loading state while post-exam review is hydrating inside the ses
     <PracticeSessionPageView
       summary={null}
       postExamSummary={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -279,7 +283,7 @@ test('renders retry and summary actions when post-exam review hydration fails', 
     <PracticeSessionPageView
       summary={null}
       postExamSummary={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -332,14 +336,14 @@ test('falls back to onEndSession when onFinalizeReview is omitted in the review 
     <PracticeSessionPageView
       summary={null}
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,

--- a/app/(app)/app/practice/[sessionId]/components/session-summary-view.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/session-summary-view.browser.spec.tsx
@@ -3,11 +3,15 @@ import { render } from 'vitest-browser-react';
 import { ROUTES, toQuestionRoute } from '@/lib/routes';
 import { SessionSummaryView } from './session-summary-view';
 
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureQ1Id = crypto.randomUUID();
+const fixtureQ2Id = crypto.randomUUID();
+
 test('renders summary totals and per-question breakdown', async () => {
   const screen = await render(
     <SessionSummaryView
       summary={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:00:00.000Z',
         mode: 'exam',
         questionCount: 10,
@@ -19,14 +23,14 @@ test('renders summary totals and per-question breakdown', async () => {
         },
       }}
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 2,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -38,7 +42,7 @@ test('renders summary totals and per-question breakdown', async () => {
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             order: 2,
             isAvailable: false,
             isAnswered: false,
@@ -69,7 +73,7 @@ test('renders summary totals and per-question breakdown', async () => {
       toQuestionRoute('q-1', {
         from: 'summary',
         mode: 'review',
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
       }),
     );
 
@@ -80,7 +84,7 @@ test('renders summary totals and per-question breakdown', async () => {
       toQuestionRoute('q-1', {
         from: 'summary',
         mode: 'review',
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
       }),
     );
 });
@@ -89,7 +93,7 @@ test('omits the removed practice-missed CTA when all exam answers are correct', 
   const screen = await render(
     <SessionSummaryView
       summary={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:00:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -101,14 +105,14 @@ test('omits the removed practice-missed CTA when all exam answers are correct', 
         },
       }}
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 2,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -134,7 +138,7 @@ test('uses New Session as the primary CTA when no reviewable slug exists', async
   const screen = await render(
     <SessionSummaryView
       summary={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:00:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -146,14 +150,14 @@ test('uses New Session as the primary CTA when no reviewable slug exists', async
         },
       }}
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 2,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             order: 1,
             isAvailable: false,
             isAnswered: true,
@@ -182,7 +186,7 @@ test('renders loading and error states for summary review', async () => {
   const screen = await render(
     <SessionSummaryView
       summary={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:00:00.000Z',
         mode: 'tutor',
         questionCount: 1,
@@ -205,7 +209,7 @@ test('renders only the New Session action for tutor summaries', async () => {
   const screen = await render(
     <SessionSummaryView
       summary={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:00:00.000Z',
         mode: 'tutor',
         questionCount: 1,
@@ -241,7 +245,7 @@ test('renders callback-driven exam review controls as buttons and disables the C
   const screen = await render(
     <SessionSummaryView
       summary={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:00:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -253,14 +257,14 @@ test('renders callback-driven exam review controls as buttons and disables the C
         },
       }}
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 2,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -272,7 +276,7 @@ test('renders callback-driven exam review controls as buttons and disables the C
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             order: 2,
             isAvailable: false,
             isAnswered: false,
@@ -307,7 +311,7 @@ test('uses in-session callbacks for exam summary review re-entry when provided',
   const screen = await render(
     <SessionSummaryView
       summary={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:00:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -319,14 +323,14 @@ test('uses in-session callbacks for exam summary review re-entry when provided',
         },
       }}
       review={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 2,
         markedCount: 0,
         rows: [
           {
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             order: 1,
             isAvailable: true,
@@ -338,7 +342,7 @@ test('uses in-session callbacks for exam summary review re-entry when provided',
             markedForReview: false,
           },
           {
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             order: 2,
             isAvailable: false,
             isAnswered: false,
@@ -358,5 +362,5 @@ test('uses in-session callbacks for exam summary review re-entry when provided',
   expect(onReviewAnswers).toHaveBeenCalledTimes(1);
 
   await screen.getByRole('button', { name: /Stem for q1/i }).click();
-  expect(onOpenReviewQuestion).toHaveBeenCalledWith('q1');
+  expect(onOpenReviewQuestion).toHaveBeenCalledWith(fixtureQ1Id);
 });

--- a/app/(app)/app/practice/[sessionId]/hooks/practice-session-page-controller.browser.fixtures.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/practice-session-page-controller.browser.fixtures.ts
@@ -1,6 +1,15 @@
 type PracticeMode = 'tutor' | 'exam';
 type QuestionDifficulty = 'easy' | 'medium' | 'hard';
 
+export const BROWSER_SESSION_ID = crypto.randomUUID();
+export const BROWSER_QUESTION_1_ID = crypto.randomUUID();
+export const BROWSER_QUESTION_2_ID = crypto.randomUUID();
+export const BROWSER_QUESTION_3_ID = crypto.randomUUID();
+export const BROWSER_CHOICE_1_ID = crypto.randomUUID();
+export const BROWSER_CHOICE_2_ID = crypto.randomUUID();
+export const BROWSER_CHOICE_3_ID = crypto.randomUUID();
+export const BROWSER_ATTEMPT_1_ID = crypto.randomUUID();
+
 type ChoiceFixture = {
   id: string;
   label: string;
@@ -87,9 +96,9 @@ export function createQuestionResponse(input: QuestionFixtureInput) {
     slug: input.slug ?? input.questionId,
     stemMd: input.stemMd ?? `Question ${input.questionId}`,
     difficulty: input.difficulty ?? 'easy',
-    choices: input.choices ?? [createChoice({ id: 'choice_1' })],
+    choices: input.choices ?? [createChoice({ id: BROWSER_CHOICE_1_ID })],
     session: {
-      sessionId: input.session.sessionId ?? 'session-1',
+      sessionId: input.session.sessionId ?? BROWSER_SESSION_ID,
       mode: input.session.mode,
       deadlineAt:
         input.session.deadlineAt !== undefined
@@ -130,7 +139,7 @@ export function createReviewRow(input: ReviewRowFixtureInput) {
 
 export function createReviewResponse(input: ReviewFixtureInput) {
   return {
-    sessionId: input.sessionId ?? 'session-1',
+    sessionId: input.sessionId ?? BROWSER_SESSION_ID,
     mode: input.mode,
     totalCount: input.totalCount,
     answeredCount: input.answeredCount,

--- a/app/(app)/app/practice/[sessionId]/hooks/practice-session-page-controller.browser.probes.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/practice-session-page-controller.browser.probes.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react';
 import { PracticeSessionPageView } from '../components/practice-session-page-view';
+import {
+  BROWSER_CHOICE_1_ID,
+  BROWSER_QUESTION_1_ID,
+  BROWSER_SESSION_ID,
+} from './practice-session-page-controller.browser.fixtures';
 import { usePracticeSessionPageController } from './use-practice-session-page-controller';
 
 type HookStateValue = string | number | boolean | null | undefined;
@@ -50,7 +55,7 @@ function getActiveView(
 }
 
 export function PracticeSessionPageControllerHookProbe() {
-  const output = usePracticeSessionPageController('session-1');
+  const output = usePracticeSessionPageController(BROWSER_SESSION_ID);
   const errorMessage =
     output.loadState.status === 'error' ? output.loadState.message : '';
 
@@ -67,7 +72,7 @@ export function PracticeSessionPageControllerHookProbe() {
       {renderActionButtons([
         {
           label: 'select-choice-1',
-          onClick: () => output.onSelectChoice('choice_1'),
+          onClick: () => output.onSelectChoice(BROWSER_CHOICE_1_ID),
         },
         {
           label: 'submit-answer',
@@ -81,7 +86,7 @@ export function PracticeSessionPageControllerHookProbe() {
 }
 
 export function PracticeSessionPageControllerNavigationProbe() {
-  const output = usePracticeSessionPageController('session-1');
+  const output = usePracticeSessionPageController(BROWSER_SESSION_ID);
 
   return (
     <>
@@ -103,7 +108,7 @@ export function PracticeSessionPageControllerNavigationProbe() {
       {renderActionButtons([
         {
           label: 'select-choice-1',
-          onClick: () => output.onSelectChoice('choice_1'),
+          onClick: () => output.onSelectChoice(BROWSER_CHOICE_1_ID),
         },
         {
           label: 'submit-answer',
@@ -117,7 +122,7 @@ export function PracticeSessionPageControllerNavigationProbe() {
         },
         {
           label: 'navigate-question-1',
-          onClick: () => output.onNavigateQuestion?.('question-1'),
+          onClick: () => output.onNavigateQuestion?.(BROWSER_QUESTION_1_ID),
         },
       ])}
     </>
@@ -125,7 +130,7 @@ export function PracticeSessionPageControllerNavigationProbe() {
 }
 
 export function PracticeSessionPageControllerBookmarkProbe() {
-  const output = usePracticeSessionPageController('session-1');
+  const output = usePracticeSessionPageController(BROWSER_SESSION_ID);
   const [bookmarkFeedbackCount, setBookmarkFeedbackCount] = useState(0);
   const bookmarkMessage = output.bookmarkMessage;
   const bookmarkMessageVersion = output.bookmarkMessageVersion ?? 0;
@@ -155,7 +160,7 @@ export function PracticeSessionPageControllerBookmarkProbe() {
 }
 
 export function PracticeSessionPageControllerBookmarkPendingProbe() {
-  const output = usePracticeSessionPageController('session-1');
+  const output = usePracticeSessionPageController(BROWSER_SESSION_ID);
 
   return (
     <>
@@ -176,7 +181,7 @@ export function PracticeSessionPageControllerBookmarkPendingProbe() {
 }
 
 export function PracticeSessionPageControllerReviewProbe() {
-  const output = usePracticeSessionPageController('session-1');
+  const output = usePracticeSessionPageController(BROWSER_SESSION_ID);
 
   return (
     <>
@@ -216,11 +221,11 @@ export function PracticeSessionPageControllerReviewProbe() {
         },
         {
           label: 'open-review-question-1',
-          onClick: () => output.onOpenReviewQuestion?.('question-1'),
+          onClick: () => output.onOpenReviewQuestion?.(BROWSER_QUESTION_1_ID),
         },
         {
           label: 'select-choice-1',
-          onClick: () => output.onSelectChoice('choice_1'),
+          onClick: () => output.onSelectChoice(BROWSER_CHOICE_1_ID),
         },
         {
           label: 'submit-answer',
@@ -234,7 +239,7 @@ export function PracticeSessionPageControllerReviewProbe() {
 }
 
 export function PracticeSessionPageControllerSubmitDuringReviewProbe() {
-  const output = usePracticeSessionPageController('session-1');
+  const output = usePracticeSessionPageController(BROWSER_SESSION_ID);
 
   return (
     <>
@@ -246,7 +251,7 @@ export function PracticeSessionPageControllerSubmitDuringReviewProbe() {
       {renderActionButtons([
         {
           label: 'select-choice-1',
-          onClick: () => output.onSelectChoice('choice_1'),
+          onClick: () => output.onSelectChoice(BROWSER_CHOICE_1_ID),
         },
         {
           label: 'submit-answer',
@@ -270,7 +275,7 @@ export function PracticeSessionPageControllerSubmitDuringReviewProbe() {
 }
 
 export function PracticeSessionPageControllerMarkForReviewProbe() {
-  const output = usePracticeSessionPageController('session-1');
+  const output = usePracticeSessionPageController(BROWSER_SESSION_ID);
   const isMarkedForReview = output.sessionInfo?.isMarkedForReview ?? null;
 
   return (
@@ -298,7 +303,7 @@ export function PracticeSessionPageControllerMarkForReviewProbe() {
 }
 
 export function PracticeSessionPageControllerSummaryProbe() {
-  const output = usePracticeSessionPageController('session-1');
+  const output = usePracticeSessionPageController(BROWSER_SESSION_ID);
   const errorMessage =
     output.loadState.status === 'error' ? output.loadState.message : '';
 
@@ -327,7 +332,7 @@ export function PracticeSessionPageControllerSummaryProbe() {
 }
 
 export function PracticeSessionPageControllerViewProbe() {
-  const output = usePracticeSessionPageController('session-1');
+  const output = usePracticeSessionPageController(BROWSER_SESSION_ID);
 
   return (
     <>

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-exam-results-continuity.browser.spec.tsx
@@ -9,11 +9,17 @@ import type {
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
 import { usePracticeSessionExamResultsContinuity } from './use-practice-session-exam-results-continuity';
+
 import {
   createPostExamReview,
   createPostExamReviewRow,
   createSummary,
 } from './use-practice-session-exam-results-continuity.fixtures';
+
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureQ1Id = crypto.randomUUID();
+const fixtureQ2Id = crypto.randomUUID();
+const fixtureQ3Id = crypto.randomUUID();
 
 type GetCompletedSessionQuestionsWithFeedbackFn = Parameters<
   typeof usePracticeSessionExamResultsContinuity
@@ -36,7 +42,7 @@ async function renderContinuityHook(input?: {
       summary,
       setSummaryState,
       isMounted,
-      sessionId: 'session-1',
+      sessionId: fixtureSession1Id,
       getCompletedSessionQuestionsWithFeedbackFn,
     });
   });
@@ -50,12 +56,12 @@ describe('usePracticeSessionExamResultsContinuity (browser)', () => {
   it('resets untargeted cached summary re-entry to the first available row instead of the persisted cursor', async () => {
     const review = createPostExamReview(
       createPostExamReviewRow({
-        questionId: 'q1',
+        questionId: fixtureQ1Id,
         order: 1,
         isAvailable: false,
       }),
-      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
-      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
+      createPostExamReviewRow({ questionId: fixtureQ2Id, order: 2 }),
+      createPostExamReviewRow({ questionId: fixtureQ3Id, order: 3 }),
     );
     const getCompletedSessionQuestionsWithFeedbackFn = vi
       .fn<GetCompletedSessionQuestionsWithFeedbackFn>()
@@ -68,12 +74,14 @@ describe('usePracticeSessionExamResultsContinuity (browser)', () => {
     await expect
       .poll(() => harness.result.current.postExamReviewLoadState.status)
       .toBe('ready');
-    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe(
+      fixtureQ2Id,
+    );
 
-    harness.result.current.onNavigatePostExamReviewQuestion('q3');
+    harness.result.current.onNavigatePostExamReviewQuestion(fixtureQ3Id);
     await expect
       .poll(() => harness.result.current.postExamReviewCurrentQuestionId)
-      .toBe('q3');
+      .toBe(fixtureQ3Id);
 
     harness.result.current.onViewSummary();
     await expect
@@ -85,15 +93,17 @@ describe('usePracticeSessionExamResultsContinuity (browser)', () => {
     await expect
       .poll(() => harness.result.current.examResultsSubstage)
       .toBe('post_exam_review');
-    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe(
+      fixtureQ2Id,
+    );
     expect(getCompletedSessionQuestionsWithFeedbackFn).toHaveBeenCalledTimes(1);
   });
 
   it('preserves the requested cached summary re-entry row when a specific question id is provided', async () => {
     const review = createPostExamReview(
-      createPostExamReviewRow({ questionId: 'q1', order: 1 }),
-      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
-      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
+      createPostExamReviewRow({ questionId: fixtureQ1Id, order: 1 }),
+      createPostExamReviewRow({ questionId: fixtureQ2Id, order: 2 }),
+      createPostExamReviewRow({ questionId: fixtureQ3Id, order: 3 }),
     );
     const harness = await renderContinuityHook({
       getCompletedSessionQuestionsWithFeedbackFn: vi
@@ -106,29 +116,31 @@ describe('usePracticeSessionExamResultsContinuity (browser)', () => {
       .poll(() => harness.result.current.postExamReviewLoadState.status)
       .toBe('ready');
 
-    harness.result.current.onNavigatePostExamReviewQuestion('q3');
+    harness.result.current.onNavigatePostExamReviewQuestion(fixtureQ3Id);
     harness.result.current.onViewSummary();
     await expect
       .poll(() => harness.result.current.examResultsSubstage)
       .toBe('session_summary');
 
-    harness.result.current.onReenterPostExamReview('q2');
+    harness.result.current.onReenterPostExamReview(fixtureQ2Id);
 
     await expect
       .poll(() => harness.result.current.examResultsSubstage)
       .toBe('post_exam_review');
-    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe(
+      fixtureQ2Id,
+    );
   });
 
   it('resets untargeted lazy-hydrated summary re-entry to the first available row even when the persisted cursor points later in the review', async () => {
     const review = createPostExamReview(
       createPostExamReviewRow({
-        questionId: 'q1',
+        questionId: fixtureQ1Id,
         order: 1,
         isAvailable: false,
       }),
-      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
-      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
+      createPostExamReviewRow({ questionId: fixtureQ2Id, order: 2 }),
+      createPostExamReviewRow({ questionId: fixtureQ3Id, order: 3 }),
     );
     const reviewLoad =
       createDeferred<
@@ -146,10 +158,10 @@ describe('usePracticeSessionExamResultsContinuity (browser)', () => {
       .poll(() => harness.result.current.examResultsSubstage)
       .toBe('session_summary');
 
-    harness.result.current.onNavigatePostExamReviewQuestion('q3');
+    harness.result.current.onNavigatePostExamReviewQuestion(fixtureQ3Id);
     await expect
       .poll(() => harness.result.current.postExamReviewCurrentQuestionId)
-      .toBe('q3');
+      .toBe(fixtureQ3Id);
 
     harness.result.current.onReenterPostExamReview();
     await expect
@@ -162,15 +174,17 @@ describe('usePracticeSessionExamResultsContinuity (browser)', () => {
     await expect
       .poll(() => harness.result.current.postExamReviewLoadState.status)
       .toBe('ready');
-    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe(
+      fixtureQ2Id,
+    );
     expect(harness.result.current.examResultsSubstage).toBe('post_exam_review');
   });
 
   it('preserves the requested lazy-hydrated summary re-entry row when a specific question id is provided', async () => {
     const review = createPostExamReview(
-      createPostExamReviewRow({ questionId: 'q1', order: 1 }),
-      createPostExamReviewRow({ questionId: 'q2', order: 2 }),
-      createPostExamReviewRow({ questionId: 'q3', order: 3 }),
+      createPostExamReviewRow({ questionId: fixtureQ1Id, order: 1 }),
+      createPostExamReviewRow({ questionId: fixtureQ2Id, order: 2 }),
+      createPostExamReviewRow({ questionId: fixtureQ3Id, order: 3 }),
     );
     const reviewLoad =
       createDeferred<
@@ -183,12 +197,12 @@ describe('usePracticeSessionExamResultsContinuity (browser)', () => {
     });
 
     harness.result.current.setSummary(createSummary());
-    harness.result.current.onNavigatePostExamReviewQuestion('q3');
+    harness.result.current.onNavigatePostExamReviewQuestion(fixtureQ3Id);
     await expect
       .poll(() => harness.result.current.examResultsSubstage)
       .toBe('session_summary');
 
-    harness.result.current.onReenterPostExamReview('q2');
+    harness.result.current.onReenterPostExamReview(fixtureQ2Id);
     await expect
       .poll(() => harness.result.current.postExamReviewLoadState.status)
       .toBe('loading');
@@ -199,7 +213,9 @@ describe('usePracticeSessionExamResultsContinuity (browser)', () => {
     await expect
       .poll(() => harness.result.current.postExamReviewLoadState.status)
       .toBe('ready');
-    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe(
+      fixtureQ2Id,
+    );
     expect(harness.result.current.examResultsSubstage).toBe('post_exam_review');
   });
 });

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-mark-for-review.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-mark-for-review.browser.spec.tsx
@@ -5,6 +5,9 @@ import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
 import { usePracticeSessionMarkForReview } from './use-practice-session-mark-for-review';
 
+const fixtureQuestion1Id = crypto.randomUUID();
+const fixtureSession1Id = crypto.randomUUID();
+
 type ReviewState = {
   sessionId: string;
   mode: 'exam' | 'tutor';
@@ -42,7 +45,7 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
     const harness = await renderHook(() =>
       usePracticeSessionMarkForReview({
         question: {
-          questionId: 'question-1',
+          questionId: fixtureQuestion1Id,
           slug: 'question-1',
           stemMd: 'Question',
           difficulty: 'easy',
@@ -51,7 +54,7 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
         },
         sessionMode: 'exam',
         sessionInfo: {
-          sessionId: 'session-1',
+          sessionId: fixtureSession1Id,
           mode: 'exam',
 
           deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -60,7 +63,7 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
           total: 10,
           isMarkedForReview: false,
         },
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         applySessionInfo,
         setLoadState: vi.fn(),
         setReview,
@@ -76,8 +79,8 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
 
     deferred.resolve(
       ok({
-        sessionId: 'session-1',
-        questionId: 'question-1',
+        sessionId: fixtureSession1Id,
+        questionId: fixtureQuestion1Id,
         markedForReview: true,
       }),
     );
@@ -88,8 +91,8 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
       .toBe(false);
 
     expect(setPracticeSessionQuestionMarkFn).toHaveBeenCalledWith({
-      sessionId: 'session-1',
-      questionId: 'question-1',
+      sessionId: fixtureSession1Id,
+      questionId: fixtureQuestion1Id,
       markedForReview: true,
       idempotencyKey: expect.any(String),
     });
@@ -99,7 +102,7 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
     expect(sessionUpdater).toBeTypeOf('function');
     expect(
       (sessionUpdater as (prev: unknown) => unknown)({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
 
         deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -109,7 +112,7 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
         isMarkedForReview: false,
       }),
     ).toEqual({
-      sessionId: 'session-1',
+      sessionId: fixtureSession1Id,
       mode: 'exam',
 
       deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -126,20 +129,20 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
     expect(reviewUpdater).toBeDefined();
     expect(
       reviewUpdater?.({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
         markedCount: 0,
-        rows: [{ questionId: 'question-1', markedForReview: false }],
+        rows: [{ questionId: fixtureQuestion1Id, markedForReview: false }],
       }),
     ).toEqual({
-      sessionId: 'session-1',
+      sessionId: fixtureSession1Id,
       mode: 'exam',
       totalCount: 1,
       answeredCount: 1,
       markedCount: 1,
-      rows: [{ questionId: 'question-1', markedForReview: true }],
+      rows: [{ questionId: fixtureQuestion1Id, markedForReview: true }],
     });
   });
 
@@ -153,7 +156,7 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
     const harness = await renderHook(() =>
       usePracticeSessionMarkForReview({
         question: {
-          questionId: 'question-1',
+          questionId: fixtureQuestion1Id,
           slug: 'question-1',
           stemMd: 'Question',
           difficulty: 'easy',
@@ -162,7 +165,7 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
         },
         sessionMode: 'exam',
         sessionInfo: {
-          sessionId: 'session-1',
+          sessionId: fixtureSession1Id,
           mode: 'exam',
 
           deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -171,7 +174,7 @@ describe('usePracticeSessionMarkForReview (browser)', () => {
           total: 10,
           isMarkedForReview: false,
         },
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         applySessionInfo: vi.fn(),
         setLoadState,
         setReview: vi.fn(),

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-answer-flow.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-answer-flow.browser.spec.tsx
@@ -4,12 +4,19 @@ import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import type { SubmitAnswerOutput } from '@/src/application/use-cases/submit-answer';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
+
 import {
   createChoice,
   createQuestionResponse,
   createReviewResponse,
 } from './practice-session-page-controller.browser.fixtures';
 import {
+  BROWSER_ATTEMPT_1_ID,
+  BROWSER_CHOICE_1_ID,
+  BROWSER_CHOICE_2_ID,
+  BROWSER_QUESTION_1_ID,
+  BROWSER_QUESTION_2_ID,
+  BROWSER_SESSION_ID,
   CHOICE_1,
   CHOICE_2,
   CHOICE_3,
@@ -30,7 +37,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .mockResolvedValueOnce(
         ok(
           createQuestionResponse({
-            questionId: 'question-1',
+            questionId: BROWSER_QUESTION_1_ID,
             choices: [CHOICE_1, CHOICE_2, CHOICE_3],
             session: {
               mode: 'exam',
@@ -47,7 +54,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .mockResolvedValueOnce(
         ok(
           createQuestionResponse({
-            questionId: 'question-2',
+            questionId: BROWSER_QUESTION_2_ID,
             choices: [CHOICE_1, CHOICE_2, CHOICE_3],
             session: {
               mode: 'exam',
@@ -63,12 +70,12 @@ describe('usePracticeSessionPageController (browser)', () => {
       );
     saveExamDraftAnswerMock.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: BROWSER_QUESTION_1_ID,
         markedForReview: false,
         latestSelectedChoiceId: null,
         latestIsCorrect: null,
         latestAnsweredAt: null,
-        draftSelectedChoiceId: 'choice_1',
+        draftSelectedChoiceId: BROWSER_CHOICE_1_ID,
         draftSavedAt: new Date('2026-02-07T00:00:00.000Z'),
         draftCumulativeMs: 1_000,
       }),
@@ -88,18 +95,18 @@ describe('usePracticeSessionPageController (browser)', () => {
 
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
 
     await screen.getByRole('button', { name: 'select-choice-1' }).click();
     await screen.getByRole('button', { name: 'next-question' }).click();
 
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-2');
+      .toHaveTextContent(BROWSER_QUESTION_2_ID);
     expect(saveExamDraftAnswerMock).toHaveBeenCalledWith({
-      sessionId: 'session-1',
-      questionId: 'question-1',
-      selectedChoiceId: 'choice_1',
+      sessionId: BROWSER_SESSION_ID,
+      questionId: BROWSER_QUESTION_1_ID,
+      selectedChoiceId: BROWSER_CHOICE_1_ID,
       cumulativeMs: expect.any(Number),
     });
   });
@@ -107,13 +114,13 @@ describe('usePracticeSessionPageController (browser)', () => {
   it('loads the current question and allows selecting a choice', async () => {
     getNextQuestionMock.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: BROWSER_QUESTION_1_ID,
         slug: 'question-1',
         stemMd: 'Question 1',
         difficulty: 'easy',
         choices: [CHOICE_1],
         session: {
-          sessionId: 'session-1',
+          sessionId: BROWSER_SESSION_ID,
           mode: 'tutor',
 
           deadlineAt: null,
@@ -140,12 +147,12 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('ready');
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
 
     await screen.getByRole('button', { name: 'select-choice-1' }).click();
     await expect
       .element(screen.getByTestId('selected-choice-id'))
-      .toHaveTextContent('choice_1');
+      .toHaveTextContent(BROWSER_CHOICE_1_ID);
     await expect
       .element(screen.getByTestId('can-submit'))
       .toHaveTextContent('true');
@@ -156,13 +163,13 @@ describe('usePracticeSessionPageController (browser)', () => {
 
     getNextQuestionMock.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: BROWSER_QUESTION_1_ID,
         slug: 'question-1',
         stemMd: 'Question 1',
         difficulty: 'easy',
         choices: [CHOICE_1],
         session: {
-          sessionId: 'session-1',
+          sessionId: BROWSER_SESSION_ID,
           mode: 'tutor',
 
           deadlineAt: null,
@@ -201,9 +208,9 @@ describe('usePracticeSessionPageController (browser)', () => {
 
     deferred.resolve(
       ok({
-        attemptId: 'attempt-1',
+        attemptId: BROWSER_ATTEMPT_1_ID,
         isCorrect: true,
-        correctChoiceId: 'choice_1',
+        correctChoiceId: BROWSER_CHOICE_1_ID,
         explanationMd: 'Because',
         referenceMd: null,
         choiceExplanations: [],
@@ -219,13 +226,13 @@ describe('usePracticeSessionPageController (browser)', () => {
     getNextQuestionMock
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-1',
+          questionId: BROWSER_QUESTION_1_ID,
           slug: 'question-1',
           stemMd: 'Question 1',
           difficulty: 'easy',
           choices: [CHOICE_1],
           session: {
-            sessionId: 'session-1',
+            sessionId: BROWSER_SESSION_ID,
             mode: 'exam',
 
             deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -238,13 +245,13 @@ describe('usePracticeSessionPageController (browser)', () => {
       )
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-2',
+          questionId: BROWSER_QUESTION_2_ID,
           slug: 'question-2',
           stemMd: 'Question 2',
           difficulty: 'easy',
           choices: [CHOICE_1],
           session: {
-            sessionId: 'session-1',
+            sessionId: BROWSER_SESSION_ID,
             mode: 'exam',
 
             deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -265,7 +272,7 @@ describe('usePracticeSessionPageController (browser)', () => {
     );
     submitAnswerMock.mockResolvedValue(
       ok({
-        attemptId: 'attempt-1',
+        attemptId: BROWSER_ATTEMPT_1_ID,
         isCorrect: true,
         correctChoiceId: null,
         explanationMd: null,
@@ -281,7 +288,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('ready');
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
 
     await screen.getByRole('button', { name: 'select-choice-1' }).click();
     await screen.getByRole('button', { name: 'submit-answer' }).click();
@@ -290,20 +297,20 @@ describe('usePracticeSessionPageController (browser)', () => {
     await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
   });
 
   it('restores draft selections when navigating away and back before submit', async () => {
     getNextQuestionMock
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-1',
+          questionId: BROWSER_QUESTION_1_ID,
           slug: 'question-1',
           stemMd: 'Question 1',
           difficulty: 'easy',
           choices: [CHOICE_1],
           session: {
-            sessionId: 'session-1',
+            sessionId: BROWSER_SESSION_ID,
             mode: 'exam',
 
             deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -317,11 +324,11 @@ describe('usePracticeSessionPageController (browser)', () => {
       .mockResolvedValueOnce(
         ok(
           createQuestionResponse({
-            questionId: 'question-2',
+            questionId: BROWSER_QUESTION_2_ID,
             difficulty: 'easy',
-            choices: [createChoice({ id: 'choice_2' })],
+            choices: [createChoice({ id: BROWSER_CHOICE_2_ID })],
             session: {
-              sessionId: 'session-1',
+              sessionId: BROWSER_SESSION_ID,
               mode: 'exam',
 
               deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -335,13 +342,13 @@ describe('usePracticeSessionPageController (browser)', () => {
       )
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-1',
+          questionId: BROWSER_QUESTION_1_ID,
           slug: 'question-1',
           stemMd: 'Question 1',
           difficulty: 'easy',
           choices: [CHOICE_1],
           session: {
-            sessionId: 'session-1',
+            sessionId: BROWSER_SESSION_ID,
             mode: 'exam',
 
             deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -349,7 +356,7 @@ describe('usePracticeSessionPageController (browser)', () => {
             index: 0,
             total: 2,
             isMarkedForReview: false,
-            draftSelectedChoiceId: 'choice_1',
+            draftSelectedChoiceId: BROWSER_CHOICE_1_ID,
             draftCumulativeMs: 1_000,
           },
         }),
@@ -372,32 +379,32 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('ready');
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
 
     await screen.getByRole('button', { name: 'select-choice-1' }).click();
     await expect
       .element(screen.getByTestId('selected-choice-id'))
-      .toHaveTextContent('choice_1');
+      .toHaveTextContent(BROWSER_CHOICE_1_ID);
     await expect
       .element(screen.getByTestId('can-submit'))
       .toHaveTextContent('true');
 
     await screen.getByRole('button', { name: 'next-question' }).click();
     expect(getNextQuestionMock).toHaveBeenNthCalledWith(2, {
-      sessionId: 'session-1',
+      sessionId: BROWSER_SESSION_ID,
       fromIndex: 0,
     });
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-2');
+      .toHaveTextContent(BROWSER_QUESTION_2_ID);
 
     await screen.getByRole('button', { name: 'navigate-question-1' }).click();
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
     await expect
       .element(screen.getByTestId('selected-choice-id'))
-      .toHaveTextContent('choice_1');
+      .toHaveTextContent(BROWSER_CHOICE_1_ID);
     await expect
       .element(screen.getByTestId('can-submit'))
       .toHaveTextContent('true');
@@ -407,13 +414,13 @@ describe('usePracticeSessionPageController (browser)', () => {
     getNextQuestionMock
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-1',
+          questionId: BROWSER_QUESTION_1_ID,
           slug: 'question-1',
           stemMd: 'Question 1',
           difficulty: 'easy',
           choices: [CHOICE_1, CHOICE_2],
           session: {
-            sessionId: 'session-1',
+            sessionId: BROWSER_SESSION_ID,
             mode: 'tutor',
 
             deadlineAt: null,
@@ -428,13 +435,13 @@ describe('usePracticeSessionPageController (browser)', () => {
       )
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-2',
+          questionId: BROWSER_QUESTION_2_ID,
           slug: 'question-2',
           stemMd: 'Question 2',
           difficulty: 'easy',
           choices: [CHOICE_3],
           session: {
-            sessionId: 'session-1',
+            sessionId: BROWSER_SESSION_ID,
             mode: 'tutor',
 
             deadlineAt: null,
@@ -449,13 +456,13 @@ describe('usePracticeSessionPageController (browser)', () => {
       )
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-1',
+          questionId: BROWSER_QUESTION_1_ID,
           slug: 'question-1',
           stemMd: 'Question 1',
           difficulty: 'easy',
           choices: [CHOICE_1, CHOICE_2],
           session: {
-            sessionId: 'session-1',
+            sessionId: BROWSER_SESSION_ID,
             mode: 'tutor',
 
             deadlineAt: null,
@@ -463,22 +470,22 @@ describe('usePracticeSessionPageController (browser)', () => {
             index: 0,
             total: 2,
             isMarkedForReview: false,
-            latestSelectedChoiceId: 'choice_1',
+            latestSelectedChoiceId: BROWSER_CHOICE_1_ID,
             latestIsCorrect: false,
             previousSubmission: {
-              correctChoiceId: 'choice_2',
+              correctChoiceId: BROWSER_CHOICE_2_ID,
               explanationMd: 'Because',
               referenceMd: null,
               choiceExplanations: [
                 {
-                  choiceId: 'choice_1',
+                  choiceId: BROWSER_CHOICE_1_ID,
                   displayLabel: 'A',
                   textMd: 'Option A',
                   isCorrect: false,
                   explanationMd: null,
                 },
                 {
-                  choiceId: 'choice_2',
+                  choiceId: BROWSER_CHOICE_2_ID,
                   displayLabel: 'B',
                   textMd: 'Option B',
                   isCorrect: true,
@@ -492,21 +499,21 @@ describe('usePracticeSessionPageController (browser)', () => {
 
     submitAnswerMock.mockResolvedValue(
       ok({
-        attemptId: 'attempt-1',
+        attemptId: BROWSER_ATTEMPT_1_ID,
         isCorrect: false,
-        correctChoiceId: 'choice_2',
+        correctChoiceId: BROWSER_CHOICE_2_ID,
         explanationMd: 'Because',
         referenceMd: null,
         choiceExplanations: [
           {
-            choiceId: 'choice_1',
+            choiceId: BROWSER_CHOICE_1_ID,
             displayLabel: 'A',
             textMd: 'Option A',
             isCorrect: false,
             explanationMd: null,
           },
           {
-            choiceId: 'choice_2',
+            choiceId: BROWSER_CHOICE_2_ID,
             displayLabel: 'B',
             textMd: 'Option B',
             isCorrect: true,
@@ -534,7 +541,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('ready');
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
     await expect
       .element(screen.getByTestId('has-submit-result'))
       .toHaveTextContent('false');
@@ -542,14 +549,14 @@ describe('usePracticeSessionPageController (browser)', () => {
     await screen.getByRole('button', { name: 'select-choice-1' }).click();
     await expect
       .element(screen.getByTestId('selected-choice-id'))
-      .toHaveTextContent('choice_1');
+      .toHaveTextContent(BROWSER_CHOICE_1_ID);
 
     await expect
       .element(screen.getByTestId('has-submit-result'))
       .toHaveTextContent('true');
     await expect
       .element(screen.getByTestId('submit-result-correct-choice-id'))
-      .toHaveTextContent('choice_2');
+      .toHaveTextContent(BROWSER_CHOICE_2_ID);
     await expect
       .element(screen.getByTestId('submit-result-explanation-md'))
       .toHaveTextContent('Because');
@@ -557,7 +564,7 @@ describe('usePracticeSessionPageController (browser)', () => {
     await screen.getByRole('button', { name: 'next-question' }).click();
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-2');
+      .toHaveTextContent(BROWSER_QUESTION_2_ID);
     await expect
       .element(screen.getByTestId('has-submit-result'))
       .toHaveTextContent('false');
@@ -565,16 +572,16 @@ describe('usePracticeSessionPageController (browser)', () => {
     await screen.getByRole('button', { name: 'navigate-question-1' }).click();
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
     await expect
       .element(screen.getByTestId('selected-choice-id'))
-      .toHaveTextContent('choice_1');
+      .toHaveTextContent(BROWSER_CHOICE_1_ID);
     await expect
       .element(screen.getByTestId('has-submit-result'))
       .toHaveTextContent('true');
     await expect
       .element(screen.getByTestId('submit-result-correct-choice-id'))
-      .toHaveTextContent('choice_2');
+      .toHaveTextContent(BROWSER_CHOICE_2_ID);
     await expect
       .element(screen.getByTestId('submit-result-explanation-md'))
       .toHaveTextContent('Because');
@@ -583,13 +590,13 @@ describe('usePracticeSessionPageController (browser)', () => {
   it('locks selection when loading a previously answered question', async () => {
     getNextQuestionMock.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: BROWSER_QUESTION_1_ID,
         slug: 'question-1',
         stemMd: 'Question 1',
         difficulty: 'easy',
         choices: [CHOICE_1, CHOICE_2],
         session: {
-          sessionId: 'session-1',
+          sessionId: BROWSER_SESSION_ID,
           mode: 'exam',
 
           deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -597,7 +604,7 @@ describe('usePracticeSessionPageController (browser)', () => {
           index: 0,
           total: 2,
           isMarkedForReview: false,
-          latestSelectedChoiceId: 'choice_2',
+          latestSelectedChoiceId: BROWSER_CHOICE_2_ID,
           latestIsCorrect: false,
         },
       }),
@@ -619,7 +626,7 @@ describe('usePracticeSessionPageController (browser)', () => {
 
     await expect
       .element(screen.getByTestId('selected-choice-id'))
-      .toHaveTextContent('choice_2');
+      .toHaveTextContent(BROWSER_CHOICE_2_ID);
     await expect
       .element(screen.getByTestId('can-submit'))
       .toHaveTextContent('false');
@@ -627,6 +634,6 @@ describe('usePracticeSessionPageController (browser)', () => {
     await screen.getByRole('button', { name: 'select-choice-1' }).click();
     await expect
       .element(screen.getByTestId('selected-choice-id'))
-      .toHaveTextContent('choice_2');
+      .toHaveTextContent(BROWSER_CHOICE_2_ID);
   });
 });

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-bookmark-mark.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-bookmark-mark.browser.spec.tsx
@@ -4,7 +4,11 @@ import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
 import { createReviewResponse } from './practice-session-page-controller.browser.fixtures';
+
 import {
+  BROWSER_QUESTION_1_ID,
+  BROWSER_QUESTION_2_ID,
+  BROWSER_SESSION_ID,
   CHOICE_1,
   getNextQuestionMock,
   mockBookmarksAndReview,
@@ -22,13 +26,13 @@ describe('usePracticeSessionPageController (browser)', () => {
   it('emits bookmark feedback for repeated identical success messages', async () => {
     getNextQuestionMock.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: BROWSER_QUESTION_1_ID,
         slug: 'question-1',
         stemMd: 'Question 1',
         difficulty: 'easy',
         choices: [CHOICE_1],
         session: {
-          sessionId: 'session-1',
+          sessionId: BROWSER_SESSION_ID,
           mode: 'tutor',
 
           deadlineAt: null,
@@ -71,13 +75,13 @@ describe('usePracticeSessionPageController (browser)', () => {
 
     getNextQuestionMock.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: BROWSER_QUESTION_1_ID,
         slug: 'question-1',
         stemMd: 'Question 1',
         difficulty: 'easy',
         choices: [CHOICE_1],
         session: {
-          sessionId: 'session-1',
+          sessionId: BROWSER_SESSION_ID,
           mode: 'tutor',
 
           deadlineAt: null,
@@ -127,13 +131,13 @@ describe('usePracticeSessionPageController (browser)', () => {
     getNextQuestionMock
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-1',
+          questionId: BROWSER_QUESTION_1_ID,
           slug: 'question-1',
           stemMd: 'Question 1',
           difficulty: 'easy',
           choices: [CHOICE_1],
           session: {
-            sessionId: 'session-1',
+            sessionId: BROWSER_SESSION_ID,
             mode: 'exam',
 
             deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -146,13 +150,13 @@ describe('usePracticeSessionPageController (browser)', () => {
       )
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-2',
+          questionId: BROWSER_QUESTION_2_ID,
           slug: 'question-2',
           stemMd: 'Question 2',
           difficulty: 'easy',
           choices: [CHOICE_1],
           session: {
-            sessionId: 'session-1',
+            sessionId: BROWSER_SESSION_ID,
             mode: 'exam',
 
             deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -184,7 +188,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('ready');
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
     await expect
       .element(screen.getByTestId('marked-for-review'))
       .toHaveTextContent('false');
@@ -202,16 +206,18 @@ describe('usePracticeSessionPageController (browser)', () => {
 
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-2');
+      .toHaveTextContent(BROWSER_QUESTION_2_ID);
     await expect
       .element(screen.getByTestId('marked-for-review'))
       .toHaveTextContent('false');
 
-    deferred.resolve(ok({ questionId: 'question-1', markedForReview: true }));
+    deferred.resolve(
+      ok({ questionId: BROWSER_QUESTION_1_ID, markedForReview: true }),
+    );
 
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-2');
+      .toHaveTextContent(BROWSER_QUESTION_2_ID);
     await expect
       .element(screen.getByTestId('is-marking'))
       .toHaveTextContent('false');
@@ -229,13 +235,13 @@ describe('usePracticeSessionPageController (browser)', () => {
     getNextQuestionMock
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-1',
+          questionId: BROWSER_QUESTION_1_ID,
           slug: 'question-1',
           stemMd: 'Question 1',
           difficulty: 'easy',
           choices: [CHOICE_1],
           session: {
-            sessionId: 'session-1',
+            sessionId: BROWSER_SESSION_ID,
             mode: 'exam',
 
             deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -248,13 +254,13 @@ describe('usePracticeSessionPageController (browser)', () => {
       )
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-2',
+          questionId: BROWSER_QUESTION_2_ID,
           slug: 'question-2',
           stemMd: 'Question 2',
           difficulty: 'easy',
           choices: [CHOICE_1],
           session: {
-            sessionId: 'session-1',
+            sessionId: BROWSER_SESSION_ID,
             mode: 'exam',
 
             deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -286,7 +292,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('ready');
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
 
     await screen
       .getByRole('button', { name: 'toggle-mark-for-review' })
@@ -298,7 +304,7 @@ describe('usePracticeSessionPageController (browser)', () => {
     await screen.getByRole('button', { name: 'next-question' }).click();
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-2');
+      .toHaveTextContent(BROWSER_QUESTION_2_ID);
 
     deferred.reject(new Error('Network timeout'));
 
@@ -310,6 +316,6 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('ready');
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-2');
+      .toHaveTextContent(BROWSER_QUESTION_2_ID);
   });
 });

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-init-load.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-init-load.browser.spec.tsx
@@ -4,12 +4,15 @@ import { STANDARD_READ_TIMEOUT_MS } from '@/app/(app)/app/shared/timeout-tiers';
 import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
+
 import {
   createQuestionResponse,
   createReviewResponse,
   createReviewRow,
 } from './practice-session-page-controller.browser.fixtures';
 import {
+  BROWSER_QUESTION_1_ID,
+  BROWSER_SESSION_ID,
   endPracticeSessionMock,
   errorResult,
   getNextQuestionMock,
@@ -30,7 +33,7 @@ describe('usePracticeSessionPageController (browser)', () => {
     });
     getPracticeSessionSummaryMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: BROWSER_SESSION_ID,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'tutor',
         questionCount: 2,
@@ -49,7 +52,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           totalCount: 2,
           answeredCount: 1,
           markedCount: 0,
-          rows: [createReviewRow({ questionId: 'question-1', order: 1 })],
+          rows: [
+            createReviewRow({ questionId: BROWSER_QUESTION_1_ID, order: 1 }),
+          ],
         }),
       ),
     );
@@ -64,7 +69,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('tutor');
     await expect
       .element(screen.getByTestId('summary-session-id'))
-      .toHaveTextContent('session-1');
+      .toHaveTextContent(BROWSER_SESSION_ID);
     await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(0);
   });
 
@@ -74,7 +79,7 @@ describe('usePracticeSessionPageController (browser)', () => {
     });
     getPracticeSessionSummaryMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: BROWSER_SESSION_ID,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -93,7 +98,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           totalCount: 2,
           answeredCount: 2,
           markedCount: 0,
-          rows: [createReviewRow({ questionId: 'question-1', order: 1 })],
+          rows: [
+            createReviewRow({ questionId: BROWSER_QUESTION_1_ID, order: 1 }),
+          ],
         }),
       ),
     );
@@ -121,7 +128,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       callOrder.push('question');
       return ok(
         createQuestionResponse({
-          questionId: 'question-1',
+          questionId: BROWSER_QUESTION_1_ID,
           session: {
             mode: 'tutor',
 
@@ -162,7 +169,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('question');
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
     expect(callOrder).toEqual(['summary', 'question']);
   });
 
@@ -173,7 +180,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       )
       .mockResolvedValueOnce(
         ok({
-          sessionId: 'session-1',
+          sessionId: BROWSER_SESSION_ID,
           endedAt: '2026-02-07T00:20:00.000Z',
           mode: 'tutor',
           questionCount: 2,
@@ -188,7 +195,7 @@ describe('usePracticeSessionPageController (browser)', () => {
     getNextQuestionMock.mockResolvedValue(
       ok(
         createQuestionResponse({
-          questionId: 'question-1',
+          questionId: BROWSER_QUESTION_1_ID,
           session: {
             mode: 'tutor',
 
@@ -208,7 +215,9 @@ describe('usePracticeSessionPageController (browser)', () => {
           totalCount: 2,
           answeredCount: 1,
           markedCount: 0,
-          rows: [createReviewRow({ questionId: 'question-1', order: 1 })],
+          rows: [
+            createReviewRow({ questionId: BROWSER_QUESTION_1_ID, order: 1 }),
+          ],
         }),
       ),
     );
@@ -229,7 +238,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('summary');
     await expect
       .element(screen.getByTestId('summary-session-id'))
-      .toHaveTextContent('session-1');
+      .toHaveTextContent(BROWSER_SESSION_ID);
     await expect
       .element(screen.getByTestId('error-message'))
       .toHaveTextContent('');
@@ -246,7 +255,7 @@ describe('usePracticeSessionPageController (browser)', () => {
     getNextQuestionMock.mockResolvedValue(
       ok(
         createQuestionResponse({
-          questionId: 'question-1',
+          questionId: BROWSER_QUESTION_1_ID,
           session: {
             mode: 'tutor',
 
@@ -298,7 +307,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('ready');
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
     await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
   });
 
@@ -315,7 +324,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       getNextQuestionMock.mockResolvedValue(
         ok(
           createQuestionResponse({
-            questionId: 'question-1',
+            questionId: BROWSER_QUESTION_1_ID,
             session: {
               mode: 'tutor',
 
@@ -368,7 +377,7 @@ describe('usePracticeSessionPageController (browser)', () => {
         .toHaveTextContent('ready');
       await expect
         .element(screen.getByTestId('question-id'))
-        .toHaveTextContent('question-1');
+        .toHaveTextContent(BROWSER_QUESTION_1_ID);
     } finally {
       vi.useRealTimers();
     }

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-review-stage.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-review-stage.browser.spec.tsx
@@ -4,12 +4,20 @@ import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import type { SubmitAnswerOutput } from '@/src/application/use-cases/submit-answer';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
+
 import {
   createQuestionResponse,
   createReviewResponse,
   createReviewRow,
 } from './practice-session-page-controller.browser.fixtures';
 import {
+  BROWSER_ATTEMPT_1_ID,
+  BROWSER_CHOICE_1_ID,
+  BROWSER_CHOICE_2_ID,
+  BROWSER_QUESTION_1_ID,
+  BROWSER_QUESTION_2_ID,
+  BROWSER_QUESTION_3_ID,
+  BROWSER_SESSION_ID,
   CHOICE_1,
   CHOICE_2,
   CHOICE_3,
@@ -41,7 +49,7 @@ describe('usePracticeSessionPageController (browser)', () => {
     getNextQuestionMock.mockResolvedValue(
       ok(
         createQuestionResponse({
-          questionId: 'question-1',
+          questionId: BROWSER_QUESTION_1_ID,
           choices: [CHOICE_1, CHOICE_2, CHOICE_3],
           session: {
             mode: 'exam',
@@ -62,13 +70,15 @@ describe('usePracticeSessionPageController (browser)', () => {
           totalCount: 2,
           answeredCount: 1,
           markedCount: 0,
-          rows: [createReviewRow({ questionId: 'question-1', order: 1 })],
+          rows: [
+            createReviewRow({ questionId: BROWSER_QUESTION_1_ID, order: 1 }),
+          ],
         }),
       ),
     );
     finalizeExamAnswersMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: BROWSER_SESSION_ID,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -82,7 +92,7 @@ describe('usePracticeSessionPageController (browser)', () => {
     );
     getCompletedSessionQuestionsWithFeedbackMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: BROWSER_SESSION_ID,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 1,
@@ -90,7 +100,7 @@ describe('usePracticeSessionPageController (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'question-1',
+            questionId: BROWSER_QUESTION_1_ID,
             slug: 'question-1',
             stemMd: 'Question 1',
             difficulty: 'easy',
@@ -99,16 +109,18 @@ describe('usePracticeSessionPageController (browser)', () => {
             isCorrect: true,
             isOmitted: false,
             markedForReview: false,
-            choices: [{ id: 'choice_1', label: 'A', textMd: 'Choice A' }],
-            selectedChoiceId: 'choice_1',
-            correctChoiceId: 'choice_1',
+            choices: [
+              { id: BROWSER_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+            ],
+            selectedChoiceId: BROWSER_CHOICE_1_ID,
+            correctChoiceId: BROWSER_CHOICE_1_ID,
             explanationMd: 'Because A is correct.',
             referenceMd: null,
             choiceExplanations: [],
           },
           {
             isAvailable: true,
-            questionId: 'question-2',
+            questionId: BROWSER_QUESTION_2_ID,
             slug: 'question-2',
             stemMd: 'Question 2',
             difficulty: 'medium',
@@ -117,9 +129,11 @@ describe('usePracticeSessionPageController (browser)', () => {
             isCorrect: false,
             isOmitted: true,
             markedForReview: false,
-            choices: [{ id: 'choice_2', label: 'A', textMd: 'Choice B' }],
+            choices: [
+              { id: BROWSER_CHOICE_2_ID, label: 'A', textMd: 'Choice B' },
+            ],
             selectedChoiceId: null,
-            correctChoiceId: 'choice_2',
+            correctChoiceId: BROWSER_CHOICE_2_ID,
             explanationMd: 'Because B is correct.',
             referenceMd: null,
             choiceExplanations: [],
@@ -147,7 +161,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('post-exam-review');
     await expect
       .element(screen.getByTestId('post-exam-current-question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
     expect(finalizeExamAnswersMock).toHaveBeenCalledTimes(1);
     expect(endPracticeSessionMock).not.toHaveBeenCalled();
 
@@ -158,7 +172,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('summary');
     await expect
       .element(screen.getByTestId('summary-session-id'))
-      .toHaveTextContent('session-1');
+      .toHaveTextContent(BROWSER_SESSION_ID);
   });
 
   it('restores the navigator when opening an exam question from Review & Submit', async () => {
@@ -196,12 +210,12 @@ describe('usePracticeSessionPageController (browser)', () => {
     await screen.getByRole('button', { name: 'Previous' }).click();
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
 
     await screen.getByRole('button', { name: 'Next' }).click();
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-2');
+      .toHaveTextContent(BROWSER_QUESTION_2_ID);
   });
 
   it('returns to Review & Submit after navigating back out of a reopened exam question', async () => {
@@ -214,7 +228,7 @@ describe('usePracticeSessionPageController (browser)', () => {
     await screen.getByRole('button', { name: 'Next' }).click();
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-3');
+      .toHaveTextContent(BROWSER_QUESTION_3_ID);
 
     await screen.getByRole('button', { name: 'Review & Submit' }).click();
     await expect
@@ -228,13 +242,13 @@ describe('usePracticeSessionPageController (browser)', () => {
   it('refreshes review data after answering a review-opened question', async () => {
     getNextQuestionMock.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: BROWSER_QUESTION_1_ID,
         slug: 'question-1',
         stemMd: 'Question 1',
         difficulty: 'easy',
         choices: [CHOICE_1],
         session: {
-          sessionId: 'session-1',
+          sessionId: BROWSER_SESSION_ID,
           mode: 'exam',
 
           deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -249,11 +263,11 @@ describe('usePracticeSessionPageController (browser)', () => {
     );
     getBookmarksMock.mockResolvedValue(ok({ rows: [] }));
     const unansweredRow = createReviewRow({
-      questionId: 'question-1',
+      questionId: BROWSER_QUESTION_1_ID,
       order: 1,
     });
     const answeredRow = createReviewRow({
-      questionId: 'question-1',
+      questionId: BROWSER_QUESTION_1_ID,
       order: 1,
       isAnswered: true,
       isCorrect: true,
@@ -273,7 +287,7 @@ describe('usePracticeSessionPageController (browser)', () => {
     submitAnswerMock.mockImplementation(async () => {
       hasAnsweredReviewQuestion = true;
       return ok({
-        attemptId: 'attempt-1',
+        attemptId: BROWSER_ATTEMPT_1_ID,
         isCorrect: true,
         correctChoiceId: null,
         explanationMd: null,
@@ -330,13 +344,13 @@ describe('usePracticeSessionPageController (browser)', () => {
     getNextQuestionMock
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-1',
+          questionId: BROWSER_QUESTION_1_ID,
           slug: 'question-1',
           stemMd: 'Question 1',
           difficulty: 'easy',
           choices: [CHOICE_1],
           session: {
-            sessionId: 'session-1',
+            sessionId: BROWSER_SESSION_ID,
             mode: 'exam',
 
             deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -349,13 +363,13 @@ describe('usePracticeSessionPageController (browser)', () => {
       )
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-2',
+          questionId: BROWSER_QUESTION_2_ID,
           slug: 'question-2',
           stemMd: 'Question 2',
           difficulty: 'easy',
           choices: [CHOICE_1],
           session: {
-            sessionId: 'session-1',
+            sessionId: BROWSER_SESSION_ID,
             mode: 'exam',
 
             deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -388,7 +402,7 @@ describe('usePracticeSessionPageController (browser)', () => {
       .toHaveTextContent('question');
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
 
     await screen.getByRole('button', { name: 'select-choice-1' }).click();
     await screen.getByRole('button', { name: 'submit-answer' }).click();
@@ -403,7 +417,7 @@ describe('usePracticeSessionPageController (browser)', () => {
 
     deferred.resolve(
       ok({
-        attemptId: 'attempt-1',
+        attemptId: BROWSER_ATTEMPT_1_ID,
         isCorrect: true,
         correctChoiceId: null,
         explanationMd: null,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-test-helpers.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-test-helpers.ts
@@ -6,6 +6,12 @@ import type {
 } from '@/src/adapters/controllers/action-result';
 import { ok } from '@/tests/test-helpers/ok';
 import {
+  BROWSER_CHOICE_1_ID,
+  BROWSER_CHOICE_2_ID,
+  BROWSER_CHOICE_3_ID,
+  BROWSER_QUESTION_1_ID,
+  BROWSER_QUESTION_2_ID,
+  BROWSER_QUESTION_3_ID,
   createChoice,
   createQuestionResponse,
   createReviewResponse,
@@ -41,19 +47,30 @@ export const {
 } = getPracticeSessionPageControllerBrowserMocks();
 
 export const EMPTY_BOOKMARKS_RESULT = ok({ rows: [] });
-export const CHOICE_1 = createChoice({ id: 'choice_1' });
+export const CHOICE_1 = createChoice({ id: BROWSER_CHOICE_1_ID });
 export const CHOICE_2 = createChoice({
-  id: 'choice_2',
+  id: BROWSER_CHOICE_2_ID,
   label: 'B',
   textMd: 'Option B',
   sortOrder: 2,
 });
 export const CHOICE_3 = createChoice({
-  id: 'choice_3',
+  id: BROWSER_CHOICE_3_ID,
   label: 'C',
   textMd: 'Option C',
   sortOrder: 3,
 });
+
+export {
+  BROWSER_ATTEMPT_1_ID,
+  BROWSER_CHOICE_1_ID,
+  BROWSER_CHOICE_2_ID,
+  BROWSER_CHOICE_3_ID,
+  BROWSER_QUESTION_1_ID,
+  BROWSER_QUESTION_2_ID,
+  BROWSER_QUESTION_3_ID,
+  BROWSER_SESSION_ID,
+} from './practice-session-page-controller.browser.fixtures';
 
 export function errorResult(
   code: ActionErrorCode,
@@ -84,17 +101,17 @@ export function mockExamReviewNavigationSession() {
       markedCount: 0,
       rows: [
         createReviewRow({
-          questionId: 'question-1',
+          questionId: BROWSER_QUESTION_1_ID,
           order: 1,
           isAnswered: true,
         }),
         createReviewRow({
-          questionId: 'question-2',
+          questionId: BROWSER_QUESTION_2_ID,
           order: 2,
           isAnswered: true,
         }),
         createReviewRow({
-          questionId: 'question-3',
+          questionId: BROWSER_QUESTION_3_ID,
           order: 3,
           isAnswered: true,
         }),
@@ -110,11 +127,11 @@ export function mockExamReviewNavigationSession() {
     ) {
       const questionId = input.questionId;
       const questionIndex =
-        questionId === 'question-1'
+        questionId === BROWSER_QUESTION_1_ID
           ? 0
-          : questionId === 'question-2'
+          : questionId === BROWSER_QUESTION_2_ID
             ? 1
-            : questionId === 'question-3'
+            : questionId === BROWSER_QUESTION_3_ID
               ? 2
               : null;
 
@@ -149,7 +166,7 @@ export function mockExamReviewNavigationSession() {
 
     return ok(
       createQuestionResponse({
-        questionId: 'question-3',
+        questionId: BROWSER_QUESTION_3_ID,
         stemMd: 'Stem question-3',
         choices: [CHOICE_1, CHOICE_2, CHOICE_3],
         session: {
@@ -171,7 +188,7 @@ export async function openExamReviewQuestion(
 ) {
   await expect
     .element(screen.getByTestId('question-id'))
-    .toHaveTextContent('question-3');
+    .toHaveTextContent(BROWSER_QUESTION_3_ID);
   await screen.getByRole('button', { name: 'Review & Submit' }).click();
   await expect
     .element(screen.getByRole('heading', { name: 'Review & Submit' }))
@@ -183,7 +200,7 @@ export async function openExamReviewQuestion(
     .click();
   await expect
     .element(screen.getByTestId('question-id'))
-    .toHaveTextContent('question-2');
+    .toHaveTextContent(BROWSER_QUESTION_2_ID);
 }
 
 export function setupPracticeSessionPageControllerBrowserSpec() {
@@ -224,7 +241,7 @@ export function setupPracticeSessionPageControllerBrowserSpec() {
           'questionId' in input &&
           typeof input.questionId === 'string'
             ? input.questionId
-            : 'question-1',
+            : BROWSER_QUESTION_1_ID,
         markedForReview: false,
         latestSelectedChoiceId: null,
         latestIsCorrect: null,
@@ -235,7 +252,7 @@ export function setupPracticeSessionPageControllerBrowserSpec() {
           'selectedChoiceId' in input &&
           typeof input.selectedChoiceId === 'string'
             ? input.selectedChoiceId
-            : 'choice_1',
+            : BROWSER_CHOICE_1_ID,
         draftSavedAt: new Date('2026-02-07T00:00:00.000Z'),
         draftCumulativeMs:
           typeof input === 'object' &&

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-timer.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-timer.browser.spec.tsx
@@ -1,11 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { ok } from '@/tests/test-helpers/ok';
+
 import {
   createQuestionResponse,
   createReviewResponse,
 } from './practice-session-page-controller.browser.fixtures';
 import {
+  BROWSER_QUESTION_1_ID,
+  BROWSER_SESSION_ID,
   CHOICE_1,
   CHOICE_2,
   CHOICE_3,
@@ -28,7 +31,7 @@ function mockActiveTimedExam(deadlineAt: string) {
   getNextQuestionMock.mockResolvedValue(
     ok(
       createQuestionResponse({
-        questionId: 'question-1',
+        questionId: BROWSER_QUESTION_1_ID,
         choices: [CHOICE_1, CHOICE_2, CHOICE_3],
         session: {
           mode: 'exam',
@@ -53,7 +56,7 @@ function mockActiveTimedExam(deadlineAt: string) {
 function mockFinalizeSummary() {
   finalizeExamAnswersMock.mockResolvedValue(
     ok({
-      sessionId: 'session-1',
+      sessionId: BROWSER_SESSION_ID,
       endedAt: '2026-05-22T12:01:12.000Z',
       mode: 'exam',
       questionCount: 1,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow-click-commit.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow-click-commit.browser.spec.tsx
@@ -9,17 +9,24 @@ import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
 import { usePracticeSessionQuestionFlow } from './use-practice-session-question-flow';
 
+const fixtureChoice1Id = crypto.randomUUID();
+const fixtureChoice2Id = crypto.randomUUID();
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureAttempt1Id = crypto.randomUUID();
+const fixtureQ1Id = crypto.randomUUID();
+
 function createSessionQuestion(
   mode: 'tutor' | 'exam',
   overrides: Partial<NextQuestion> = {},
 ): NextQuestion {
   return createNextQuestion({
+    questionId: fixtureQ1Id,
     choices: [
-      { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-      { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+      { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+      { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
     ],
     session: {
-      sessionId: 'session-1',
+      sessionId: fixtureSession1Id,
       mode,
       deadlineAt: mode === 'exam' ? '2099-05-22T12:02:24.000Z' : null,
       index: 0,
@@ -31,10 +38,10 @@ function createSessionQuestion(
 }
 
 function createSubmitOutput(
-  correctChoiceId: string = 'choice_2',
+  correctChoiceId: string = fixtureChoice2Id,
 ): SubmitAnswerOutput {
   return {
-    attemptId: 'attempt-1',
+    attemptId: fixtureAttempt1Id,
     isCorrect: true,
     correctChoiceId,
     explanationMd: null,
@@ -54,7 +61,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
       .mockResolvedValue(ok(createSessionQuestion('tutor')));
     const submitAnswerFn = vi
       .fn<(input: unknown) => Promise<ActionResult<SubmitAnswerOutput>>>()
-      .mockResolvedValue(ok(createSubmitOutput('choice_2')));
+      .mockResolvedValue(ok(createSubmitOutput(fixtureChoice2Id)));
     const saveExamDraftAnswerFn =
       vi.fn<
         (input: unknown) => Promise<ActionResult<SaveExamDraftAnswerOutput>>
@@ -62,7 +69,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -72,16 +79,16 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_2');
+    harness.result.current.onSelectChoice(fixtureChoice2Id);
 
     await expect.poll(() => submitAnswerFn.mock.calls.length).toBe(1);
     expect(submitAnswerFn).toHaveBeenCalledWith(
       expect.objectContaining({
-        sessionId: 'session-1',
-        questionId: 'q_1',
-        choiceId: 'choice_2',
+        sessionId: fixtureSession1Id,
+        questionId: fixtureQ1Id,
+        choiceId: fixtureChoice2Id,
       }),
     );
   });
@@ -99,7 +106,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -109,13 +116,13 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_2');
+    harness.result.current.onSelectChoice(fixtureChoice2Id);
 
     await expect
       .poll(() => harness.result.current.selectedChoiceId)
-      .toBe('choice_2');
+      .toBe(fixtureChoice2Id);
     expect(submitAnswerFn).not.toHaveBeenCalled();
   });
 
@@ -132,7 +139,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -142,16 +149,16 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
     harness.result.current.setSessionMode('tutor');
     await expect.poll(() => harness.result.current.sessionMode).toBe('tutor');
 
-    harness.result.current.onSelectChoice('choice_2');
+    harness.result.current.onSelectChoice(fixtureChoice2Id);
 
     await expect
       .poll(() => harness.result.current.selectedChoiceId)
-      .toBe('choice_2');
+      .toBe(fixtureChoice2Id);
     expect(submitAnswerFn).not.toHaveBeenCalled();
   });
 
@@ -161,7 +168,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
       .mockResolvedValue(ok(createSessionQuestion('exam')));
     const submitAnswerFn = vi
       .fn<(input: unknown) => Promise<ActionResult<SubmitAnswerOutput>>>()
-      .mockResolvedValue(ok(createSubmitOutput('choice_2')));
+      .mockResolvedValue(ok(createSubmitOutput(fixtureChoice2Id)));
     const saveExamDraftAnswerFn =
       vi.fn<
         (input: unknown) => Promise<ActionResult<SaveExamDraftAnswerOutput>>
@@ -169,7 +176,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -179,13 +186,13 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_2');
+    harness.result.current.onSelectChoice(fixtureChoice2Id);
 
     await expect
       .poll(() => harness.result.current.selectedChoiceId)
-      .toBe('choice_2');
+      .toBe(fixtureChoice2Id);
 
     const result = await harness.result.current.onSubmit();
 
@@ -199,7 +206,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
       .mockResolvedValue(ok(createSessionQuestion('exam')));
     const submitAnswerFn = vi
       .fn<(input: unknown) => Promise<ActionResult<SubmitAnswerOutput>>>()
-      .mockResolvedValue(ok(createSubmitOutput('choice_2')));
+      .mockResolvedValue(ok(createSubmitOutput(fixtureChoice2Id)));
     const saveExamDraftAnswerFn =
       vi.fn<
         (input: unknown) => Promise<ActionResult<SaveExamDraftAnswerOutput>>
@@ -207,7 +214,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -217,24 +224,24 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_2');
+    harness.result.current.onSelectChoice(fixtureChoice2Id);
     await expect
       .poll(() => harness.result.current.selectedChoiceId)
-      .toBe('choice_2');
+      .toBe(fixtureChoice2Id);
 
     const result = await harness.result.current.onSubmit({
       allowExamCommit: true,
     });
 
-    expect(result).toEqual(createSubmitOutput('choice_2'));
+    expect(result).toEqual(createSubmitOutput(fixtureChoice2Id));
     expect(submitAnswerFn).toHaveBeenCalledTimes(1);
     expect(submitAnswerFn).toHaveBeenCalledWith(
       expect.objectContaining({
-        sessionId: 'session-1',
-        questionId: 'q_1',
-        choiceId: 'choice_2',
+        sessionId: fixtureSession1Id,
+        questionId: fixtureQ1Id,
+        choiceId: fixtureChoice2Id,
       }),
     );
   });
@@ -254,7 +261,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -264,24 +271,24 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_1');
-    harness.result.current.onSelectChoice('choice_2');
+    harness.result.current.onSelectChoice(fixtureChoice1Id);
+    harness.result.current.onSelectChoice(fixtureChoice2Id);
 
     await expect.poll(() => submitAnswerFn.mock.calls.length).toBe(1);
     await expect
       .poll(() => harness.result.current.selectedChoiceId)
-      .toBe('choice_1');
+      .toBe(fixtureChoice1Id);
     expect(submitAnswerFn).toHaveBeenCalledWith(
       expect.objectContaining({
-        sessionId: 'session-1',
-        questionId: 'q_1',
-        choiceId: 'choice_1',
+        sessionId: fixtureSession1Id,
+        questionId: fixtureQ1Id,
+        choiceId: fixtureChoice1Id,
       }),
     );
 
-    submitDeferred.resolve(ok(createSubmitOutput('choice_1')));
+    submitDeferred.resolve(ok(createSubmitOutput(fixtureChoice1Id)));
     await expect.poll(() => harness.result.current.isPending).toBe(false);
   });
 
@@ -300,7 +307,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -310,16 +317,16 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_1');
+    harness.result.current.onSelectChoice(fixtureChoice1Id);
 
     await expect.poll(() => submitAnswerFn.mock.calls.length).toBe(1);
     await expect.poll(() => harness.result.current.isPending).toBe(true);
 
-    harness.result.current.onSelectChoice('choice_2');
+    harness.result.current.onSelectChoice(fixtureChoice2Id);
 
-    submitDeferred.resolve(ok(createSubmitOutput('choice_1')));
+    submitDeferred.resolve(ok(createSubmitOutput(fixtureChoice1Id)));
     await expect.poll(() => harness.result.current.isPending).toBe(false);
     expect(submitAnswerFn).toHaveBeenCalledTimes(1);
   });
@@ -339,7 +346,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -349,9 +356,9 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_1');
+    harness.result.current.onSelectChoice(fixtureChoice1Id);
 
     await harness.result.current.onSubmit();
 
@@ -359,16 +366,16 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
     await expect.poll(() => harness.result.current.isPending).toBe(true);
     expect(submitAnswerFn).toHaveBeenCalledWith(
       expect.objectContaining({
-        sessionId: 'session-1',
-        questionId: 'q_1',
-        choiceId: 'choice_1',
+        sessionId: fixtureSession1Id,
+        questionId: fixtureQ1Id,
+        choiceId: fixtureChoice1Id,
       }),
     );
 
     await harness.result.current.onSubmit();
 
     expect(submitAnswerFn).toHaveBeenCalledTimes(1);
-    submitDeferred.resolve(ok(createSubmitOutput('choice_1')));
+    submitDeferred.resolve(ok(createSubmitOutput(fixtureChoice1Id)));
     await expect.poll(() => harness.result.current.isPending).toBe(false);
     expect(submitAnswerFn).toHaveBeenCalledTimes(1);
   });
@@ -379,7 +386,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
       .mockResolvedValue(ok(createSessionQuestion('tutor')));
     const submitAnswerFn = vi
       .fn<(input: unknown) => Promise<ActionResult<SubmitAnswerOutput>>>()
-      .mockResolvedValue(ok(createSubmitOutput('choice_1')));
+      .mockResolvedValue(ok(createSubmitOutput(fixtureChoice1Id)));
     const saveExamDraftAnswerFn =
       vi.fn<
         (input: unknown) => Promise<ActionResult<SaveExamDraftAnswerOutput>>
@@ -387,7 +394,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -397,7 +404,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
     await expect.poll(() => harness.result.current.canSubmit).toBe(false);
 
     const result = await harness.result.current.onSubmit();
@@ -412,7 +419,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
       .mockResolvedValue(ok(createSessionQuestion('tutor')));
     const submitAnswerFn = vi
       .fn<(input: unknown) => Promise<ActionResult<SubmitAnswerOutput>>>()
-      .mockResolvedValue(ok(createSubmitOutput('choice_1')));
+      .mockResolvedValue(ok(createSubmitOutput(fixtureChoice1Id)));
     const saveExamDraftAnswerFn =
       vi.fn<
         (input: unknown) => Promise<ActionResult<SaveExamDraftAnswerOutput>>
@@ -420,7 +427,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -430,15 +437,15 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_1');
+    harness.result.current.onSelectChoice(fixtureChoice1Id);
     await expect.poll(() => submitAnswerFn.mock.calls.length).toBe(1);
     await expect
       .poll(() => harness.result.current.submitResult?.correctChoiceId ?? null)
-      .toBe('choice_1');
+      .toBe(fixtureChoice1Id);
 
-    harness.result.current.onSelectChoice('choice_2');
+    harness.result.current.onSelectChoice(fixtureChoice2Id);
 
     expect(submitAnswerFn).toHaveBeenCalledTimes(1);
   });
@@ -449,7 +456,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
       .mockResolvedValue(ok(createSessionQuestion('tutor')));
     const submitAnswerFn = vi
       .fn<(input: unknown) => Promise<ActionResult<SubmitAnswerOutput>>>()
-      .mockResolvedValue(ok(createSubmitOutput('choice_1')));
+      .mockResolvedValue(ok(createSubmitOutput(fixtureChoice1Id)));
     const saveExamDraftAnswerFn =
       vi.fn<
         (input: unknown) => Promise<ActionResult<SaveExamDraftAnswerOutput>>
@@ -457,7 +464,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -467,13 +474,13 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_1');
+    harness.result.current.onSelectChoice(fixtureChoice1Id);
     await expect.poll(() => submitAnswerFn.mock.calls.length).toBe(1);
     await expect
       .poll(() => harness.result.current.submitResult?.correctChoiceId ?? null)
-      .toBe('choice_1');
+      .toBe(fixtureChoice1Id);
     await expect.poll(() => harness.result.current.canSubmit).toBe(false);
 
     await harness.result.current.onSubmit();
@@ -489,7 +496,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
     const submitAnswerFn = vi
       .fn<(input: unknown) => Promise<ActionResult<SubmitAnswerOutput>>>()
       .mockRejectedValueOnce(submitError)
-      .mockResolvedValueOnce(ok(createSubmitOutput('choice_2')));
+      .mockResolvedValueOnce(ok(createSubmitOutput(fixtureChoice2Id)));
     const saveExamDraftAnswerFn =
       vi.fn<
         (input: unknown) => Promise<ActionResult<SaveExamDraftAnswerOutput>>
@@ -497,7 +504,7 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -507,9 +514,9 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_1');
+    harness.result.current.onSelectChoice(fixtureChoice1Id);
 
     await expect
       .poll(() => harness.result.current.loadState.status)
@@ -520,13 +527,15 @@ describe('usePracticeSessionQuestionFlow click-to-commit behavior', () => {
     const secondRetry = harness.result.current.onSubmit();
 
     await expect.poll(() => submitAnswerFn.mock.calls.length).toBe(2);
-    await expect(firstRetry).resolves.toEqual(createSubmitOutput('choice_2'));
+    await expect(firstRetry).resolves.toEqual(
+      createSubmitOutput(fixtureChoice2Id),
+    );
     await expect(secondRetry).resolves.toBeNull();
     expect(submitAnswerFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        sessionId: 'session-1',
-        questionId: 'q_1',
-        choiceId: 'choice_1',
+        sessionId: fixtureSession1Id,
+        questionId: fixtureQ1Id,
+        choiceId: fixtureChoice1Id,
       }),
     );
   });

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.browser.spec.tsx
@@ -8,6 +8,13 @@ import type { SubmitAnswerOutput } from '@/src/application/use-cases/submit-answ
 import { ok } from '@/tests/test-helpers/ok';
 import { usePracticeSessionQuestionFlow } from './use-practice-session-question-flow';
 
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureQ2Id = crypto.randomUUID();
+const fixtureQ1Id = crypto.randomUUID();
+const fixtureChoice1Id = crypto.randomUUID();
+const fixtureChoice2Id = crypto.randomUUID();
+const fixtureSession2Id = crypto.randomUUID();
+
 describe('usePracticeSessionQuestionFlow (browser)', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -30,7 +37,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
     await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         autoload: false,
         isMounted: () => true,
         getNextQuestionFn,
@@ -55,7 +62,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
     await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -78,7 +85,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         autoload: false,
         isMounted: () => true,
         getNextQuestionFn,
@@ -88,7 +95,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
     );
 
     harness.result.current.applySessionInfo({
-      sessionId: 'session-1',
+      sessionId: fixtureSession1Id,
       mode: 'tutor',
 
       deadlineAt: null,
@@ -100,7 +107,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
     await expect
       .poll(() => harness.result.current.sessionInfo?.sessionId ?? null)
-      .toBe('session-1');
+      .toBe(fixtureSession1Id);
 
     harness.result.current.resetQuestionState();
 
@@ -125,9 +132,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
         ) {
           return ok(
             createNextQuestion({
-              questionId: 'q_2',
+              questionId: fixtureQ2Id,
               session: {
-                sessionId: 'session-1',
+                sessionId: fixtureSession1Id,
                 mode: 'exam',
 
                 deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -142,13 +149,13 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
         return ok(
           createNextQuestion({
-            questionId: 'q_1',
+            questionId: fixtureQ1Id,
             choices: [
-              { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-              { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+              { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+              { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
             ],
             session: {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
 
               deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -169,12 +176,12 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
       .mockImplementation(async () => {
         callOrder.push('save');
         return ok({
-          questionId: 'q_1',
+          questionId: fixtureQ1Id,
           markedForReview: false,
           latestSelectedChoiceId: null,
           latestIsCorrect: null,
           latestAnsweredAt: null,
-          draftSelectedChoiceId: 'choice_2',
+          draftSelectedChoiceId: fixtureChoice2Id,
           draftSavedAt: new Date('2026-02-01T00:00:00.000Z'),
           draftCumulativeMs: 30_000,
         });
@@ -182,7 +189,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -192,23 +199,23 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_2');
+    harness.result.current.onSelectChoice(fixtureChoice2Id);
     await expect
       .poll(() => harness.result.current.selectedChoiceId)
-      .toBe('choice_2');
+      .toBe(fixtureChoice2Id);
     nowMs = 31_000;
     harness.result.current.onNextQuestion();
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_2');
+      .toBe(fixtureQ2Id);
     expect(callOrder).toEqual(['load', 'save', 'load']);
     expect(saveExamDraftAnswerFn).toHaveBeenCalledWith({
-      sessionId: 'session-1',
-      questionId: 'q_1',
-      selectedChoiceId: 'choice_2',
+      sessionId: fixtureSession1Id,
+      questionId: fixtureQ1Id,
+      selectedChoiceId: fixtureChoice2Id,
       cumulativeMs: 30_000,
     });
   });
@@ -219,9 +226,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
       .mockResolvedValueOnce(
         ok(
           createNextQuestion({
-            questionId: 'q_1',
+            questionId: fixtureQ1Id,
             session: {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
 
               deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -236,9 +243,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
       .mockResolvedValueOnce(
         ok(
           createNextQuestion({
-            questionId: 'q_2',
+            questionId: fixtureQ2Id,
             session: {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
 
               deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -259,7 +266,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -269,13 +276,13 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
     harness.result.current.onNextQuestion();
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_2');
+      .toBe(fixtureQ2Id);
     expect(saveExamDraftAnswerFn).not.toHaveBeenCalled();
   });
 
@@ -290,17 +297,17 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
           typeof request === 'object' &&
           request &&
           'questionId' in request &&
-          request.questionId === 'q_1'
+          request.questionId === fixtureQ1Id
         ) {
           return ok(
             createNextQuestion({
-              questionId: 'q_1',
+              questionId: fixtureQ1Id,
               choices: [
-                { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-                { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+                { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+                { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
               ],
               session: {
-                sessionId: 'session-1',
+                sessionId: fixtureSession1Id,
                 mode: 'exam',
 
                 deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -308,7 +315,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
                 index: 0,
                 total: 2,
                 isMarkedForReview: false,
-                draftSelectedChoiceId: 'choice_2',
+                draftSelectedChoiceId: fixtureChoice2Id,
                 draftCumulativeMs: 30_000,
               },
             }),
@@ -323,9 +330,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
         ) {
           return ok(
             createNextQuestion({
-              questionId: 'q_2',
+              questionId: fixtureQ2Id,
               session: {
-                sessionId: 'session-1',
+                sessionId: fixtureSession1Id,
                 mode: 'exam',
 
                 deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -340,13 +347,13 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
         return ok(
           createNextQuestion({
-            questionId: 'q_1',
+            questionId: fixtureQ1Id,
             choices: [
-              { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-              { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+              { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+              { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
             ],
             session: {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
 
               deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -372,7 +379,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             'questionId' in input &&
             typeof input.questionId === 'string'
               ? input.questionId
-              : 'q_1',
+              : fixtureQ1Id,
           markedForReview: false,
           latestSelectedChoiceId: null,
           latestIsCorrect: null,
@@ -383,7 +390,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             'selectedChoiceId' in input &&
             typeof input.selectedChoiceId === 'string'
               ? input.selectedChoiceId
-              : 'choice_2',
+              : fixtureChoice2Id,
           draftSavedAt: new Date('2026-02-01T00:00:00.000Z'),
           draftCumulativeMs:
             typeof input === 'object' &&
@@ -397,7 +404,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -407,44 +414,44 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_2');
+    harness.result.current.onSelectChoice(fixtureChoice2Id);
     await expect
       .poll(() => harness.result.current.selectedChoiceId)
-      .toBe('choice_2');
+      .toBe(fixtureChoice2Id);
 
     nowMs = 31_000;
     harness.result.current.onNextQuestion();
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_2');
+      .toBe(fixtureQ2Id);
 
     nowMs = 31_500;
-    harness.result.current.onNavigateQuestion('q_1');
+    harness.result.current.onNavigateQuestion(fixtureQ1Id);
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
     await expect
       .poll(() => harness.result.current.selectedChoiceId)
-      .toBe('choice_2');
+      .toBe(fixtureChoice2Id);
 
     nowMs = 51_500;
     harness.result.current.onNextQuestion();
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_2');
+      .toBe(fixtureQ2Id);
 
     expect(saveExamDraftAnswerFn).toHaveBeenNthCalledWith(1, {
-      sessionId: 'session-1',
-      questionId: 'q_1',
-      selectedChoiceId: 'choice_2',
+      sessionId: fixtureSession1Id,
+      questionId: fixtureQ1Id,
+      selectedChoiceId: fixtureChoice2Id,
       cumulativeMs: 30_000,
     });
     expect(saveExamDraftAnswerFn).toHaveBeenNthCalledWith(2, {
-      sessionId: 'session-1',
-      questionId: 'q_1',
-      selectedChoiceId: 'choice_2',
+      sessionId: fixtureSession1Id,
+      questionId: fixtureQ1Id,
+      selectedChoiceId: fixtureChoice2Id,
       cumulativeMs: 50_000,
     });
   });
@@ -460,17 +467,17 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
           typeof request === 'object' &&
           request &&
           'questionId' in request &&
-          request.questionId === 'q_1'
+          request.questionId === fixtureQ1Id
         ) {
           return ok(
             createNextQuestion({
-              questionId: 'q_1',
+              questionId: fixtureQ1Id,
               choices: [
-                { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-                { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+                { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+                { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
               ],
               session: {
-                sessionId: 'session-1',
+                sessionId: fixtureSession1Id,
                 mode: 'exam',
 
                 deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -493,9 +500,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
         ) {
           return ok(
             createNextQuestion({
-              questionId: 'q_2',
+              questionId: fixtureQ2Id,
               session: {
-                sessionId: 'session-1',
+                sessionId: fixtureSession1Id,
                 mode: 'exam',
 
                 deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -510,13 +517,13 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
         return ok(
           createNextQuestion({
-            questionId: 'q_1',
+            questionId: fixtureQ1Id,
             choices: [
-              { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-              { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+              { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+              { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
             ],
             session: {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
 
               deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -542,7 +549,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             'questionId' in input &&
             typeof input.questionId === 'string'
               ? input.questionId
-              : 'q_1',
+              : fixtureQ1Id,
           markedForReview: false,
           latestSelectedChoiceId: null,
           latestIsCorrect: null,
@@ -567,7 +574,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
     const harness = await renderHook(() =>
       usePracticeSessionQuestionFlow({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         isMounted: () => true,
         getNextQuestionFn,
         submitAnswerFn,
@@ -577,37 +584,37 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
     nowMs = 31_000;
     harness.result.current.onNextQuestion();
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_2');
+      .toBe(fixtureQ2Id);
     expect(saveExamDraftAnswerFn).not.toHaveBeenCalled();
 
     nowMs = 31_500;
-    harness.result.current.onNavigateQuestion('q_1');
+    harness.result.current.onNavigateQuestion(fixtureQ1Id);
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_2');
+    harness.result.current.onSelectChoice(fixtureChoice2Id);
     await expect
       .poll(() => harness.result.current.selectedChoiceId)
-      .toBe('choice_2');
+      .toBe(fixtureChoice2Id);
 
     nowMs = 51_500;
     harness.result.current.onNextQuestion();
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_2');
+      .toBe(fixtureQ2Id);
 
     expect(saveExamDraftAnswerFn).toHaveBeenCalledTimes(1);
     expect(saveExamDraftAnswerFn).toHaveBeenCalledWith({
-      sessionId: 'session-1',
-      questionId: 'q_1',
-      selectedChoiceId: 'choice_2',
+      sessionId: fixtureSession1Id,
+      questionId: fixtureQ1Id,
+      selectedChoiceId: fixtureChoice2Id,
       cumulativeMs: 50_000,
     });
   });
@@ -623,17 +630,17 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
           typeof request === 'object' &&
           request &&
           'sessionId' in request &&
-          request.sessionId === 'session-2'
+          request.sessionId === fixtureSession2Id
         ) {
           return ok(
             createNextQuestion({
-              questionId: 'q_1',
+              questionId: fixtureQ1Id,
               choices: [
-                { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-                { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+                { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+                { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
               ],
               session: {
-                sessionId: 'session-2',
+                sessionId: fixtureSession2Id,
                 mode: 'exam',
 
                 deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -656,9 +663,9 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
         ) {
           return ok(
             createNextQuestion({
-              questionId: 'q_2',
+              questionId: fixtureQ2Id,
               session: {
-                sessionId: 'session-1',
+                sessionId: fixtureSession1Id,
                 mode: 'exam',
 
                 deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -673,13 +680,13 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
 
         return ok(
           createNextQuestion({
-            questionId: 'q_1',
+            questionId: fixtureQ1Id,
             choices: [
-              { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-              { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+              { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+              { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
             ],
             session: {
-              sessionId: 'session-1',
+              sessionId: fixtureSession1Id,
               mode: 'exam',
 
               deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -707,7 +714,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             'questionId' in input &&
             typeof input.questionId === 'string'
               ? input.questionId
-              : 'q_1',
+              : fixtureQ1Id,
           markedForReview: false,
           latestSelectedChoiceId: null,
           latestIsCorrect: null,
@@ -718,7 +725,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             'selectedChoiceId' in input &&
             typeof input.selectedChoiceId === 'string'
               ? input.selectedChoiceId
-              : 'choice_2',
+              : fixtureChoice2Id,
           draftSavedAt: new Date('2026-02-01T00:00:00.000Z'),
           draftCumulativeMs:
             typeof input === 'object' &&
@@ -733,36 +740,36 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
     const harness = await renderHook(
       (props?: { sessionId: string }) =>
         usePracticeSessionQuestionFlow({
-          sessionId: props?.sessionId ?? 'session-1',
+          sessionId: props?.sessionId ?? fixtureSession1Id,
           isMounted: () => true,
           getNextQuestionFn,
           submitAnswerFn,
           saveExamDraftAnswerFn,
         }),
       {
-        initialProps: { sessionId: 'session-1' },
+        initialProps: { sessionId: fixtureSession1Id },
       },
     );
 
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_1');
+      .toBe(fixtureQ1Id);
 
-    harness.result.current.onSelectChoice('choice_2');
+    harness.result.current.onSelectChoice(fixtureChoice2Id);
     await expect
       .poll(() => harness.result.current.selectedChoiceId)
-      .toBe('choice_2');
+      .toBe(fixtureChoice2Id);
 
     nowMs = 31_000;
     harness.result.current.onNextQuestion();
     await expect
       .poll(() => harness.result.current.question?.questionId)
-      .toBe('q_2');
+      .toBe(fixtureQ2Id);
 
-    await harness.rerender({ sessionId: 'session-2' });
+    await harness.rerender({ sessionId: fixtureSession2Id });
     await expect
       .poll(() => harness.result.current.question?.session?.sessionId ?? null)
-      .toBe('session-2');
+      .toBe(fixtureSession2Id);
     await expect.poll(() => harness.result.current.selectedChoiceId).toBeNull();
   });
 });

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.browser.spec.tsx
@@ -6,10 +6,14 @@ import type { GetPracticeSessionReviewOutput } from '@/src/adapters/controllers/
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
 import { installReportClientErrorMocks } from '@/tests/test-helpers/report-client-error-mocks';
+
 import {
   type UsePracticeSessionReviewStageStateInput,
   usePracticeSessionReviewStageState,
 } from './use-practice-session-review-stage-state';
+
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureQ1Id = crypto.randomUUID();
 
 const getPracticeSessionReviewMock =
   vi.fn<
@@ -31,7 +35,7 @@ function createInput(
   sessionMode: 'tutor' | 'exam' | null,
 ): UsePracticeSessionReviewStageStateInput {
   return {
-    sessionId: 'session-1',
+    sessionId: fixtureSession1Id,
     isMounted: () => true,
     sessionMode,
     setSessionMode: vi.fn(),
@@ -64,7 +68,7 @@ describe('usePracticeSessionReviewStageState (browser)', () => {
   it('loads exam review data when ending an exam session', async () => {
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 1,
@@ -83,7 +87,7 @@ describe('usePracticeSessionReviewStageState (browser)', () => {
     await expect
       .poll(() => harness.result.current.reviewLoadState.status)
       .toBe('ready');
-    expect(harness.result.current.review?.sessionId).toBe('session-1');
+    expect(harness.result.current.review?.sessionId).toBe(fixtureSession1Id);
     expect(harness.result.current.isInReviewStage).toBe(true);
     expect(vi.mocked(input.setSessionMode)).toHaveBeenCalledWith('exam');
     expect(vi.mocked(input.resetQuestionState)).toHaveBeenCalledTimes(1);
@@ -92,7 +96,7 @@ describe('usePracticeSessionReviewStageState (browser)', () => {
   it('finalizes the session when review data reports a non-exam mode', async () => {
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
         totalCount: 1,
         answeredCount: 1,
@@ -121,7 +125,7 @@ describe('usePracticeSessionReviewStageState (browser)', () => {
   it('sets an error state when finalizeSession rejects after loading non-exam review data', async () => {
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
         totalCount: 1,
         answeredCount: 1,
@@ -169,7 +173,7 @@ describe('usePracticeSessionReviewStageState (browser)', () => {
 
     deferred.resolve(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
         totalCount: 1,
         answeredCount: 1,
@@ -235,10 +239,12 @@ describe('usePracticeSessionReviewStageState (browser)', () => {
       usePracticeSessionReviewStageState(input),
     );
 
-    harness.result.current.onOpenReviewQuestion('q1');
+    harness.result.current.onOpenReviewQuestion(fixtureQ1Id);
 
     await expect.poll(() => harness.result.current.isInReviewStage).toBe(false);
-    expect(vi.mocked(input.loadSpecificQuestion)).toHaveBeenCalledWith('q1');
+    expect(vi.mocked(input.loadSpecificQuestion)).toHaveBeenCalledWith(
+      fixtureQ1Id,
+    );
   });
 
   it('finalizes review state when requested', async () => {

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
@@ -10,10 +10,15 @@ import type {
 } from '@/src/adapters/controllers/practice-controller';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
+
 import {
   type UsePracticeSessionReviewStageInput,
   usePracticeSessionReviewStage,
 } from './use-practice-session-review-stage';
+
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureQ1Id = crypto.randomUUID();
+const fixtureQ2Id = crypto.randomUUID();
 
 const endPracticeSessionMock =
   vi.fn<(input: unknown) => Promise<ActionResult<EndPracticeSessionOutput>>>();
@@ -37,7 +42,7 @@ const saveCurrentExamDraftMock = vi.fn<() => Promise<boolean>>();
 
 function createInput(sessionMode: 'tutor' | 'exam') {
   return {
-    sessionId: 'session-1',
+    sessionId: fixtureSession1Id,
     isMounted: () => true,
     sessionInfo: null as UsePracticeSessionReviewStageInput['sessionInfo'],
     questionId: null,
@@ -111,10 +116,10 @@ function createPostExamReview(
               })
             : row,
         )
-      : [createPostExamReviewRow({ questionId: 'q1' })];
+      : [createPostExamReviewRow({ questionId: fixtureQ1Id })];
 
   return {
-    sessionId: 'session-1',
+    sessionId: fixtureSession1Id,
     mode: 'exam',
     totalCount: reviewRows.length,
     answeredCount: reviewRows.filter((row) => row.isAnswered).length,
@@ -145,7 +150,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
   it('finalizes tutor sessions and loads summary review data', async () => {
     endPracticeSessionMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'tutor',
         questionCount: 10,
@@ -159,7 +164,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
         totalCount: 10,
         answeredCount: 10,
@@ -177,11 +182,13 @@ describe('usePracticeSessionReviewStage (browser)', () => {
 
     await expect
       .poll(() => harness.result.current.summary?.sessionId ?? null)
-      .toBe('session-1');
+      .toBe(fixtureSession1Id);
     await expect
       .poll(() => harness.result.current.summaryReviewLoadState.status)
       .toBe('ready');
-    expect(harness.result.current.summaryReview?.sessionId).toBe('session-1');
+    expect(harness.result.current.summaryReview?.sessionId).toBe(
+      fixtureSession1Id,
+    );
   });
 
   it('sets review load error when exam review loading throws', async () => {
@@ -214,7 +221,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
     getPracticeSessionReviewMock.mockResolvedValueOnce(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 1,
@@ -222,7 +229,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             stemMd: 'Stem 1',
             difficulty: 'easy',
@@ -234,7 +241,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
           },
           {
             isAvailable: true,
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             stemMd: 'Stem 2',
             difficulty: 'medium',
@@ -250,7 +257,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
 
     const input = createInput('exam');
     input.sessionInfo = {
-      sessionId: 'session-1',
+      sessionId: fixtureSession1Id,
       mode: 'exam',
 
       deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -279,13 +286,13 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     await expect
       .poll(() => harness.result.current.navigatorLoadState.status)
       .toBe('ready');
-    expect(harness.result.current.navigator?.sessionId).toBe('session-1');
+    expect(harness.result.current.navigator?.sessionId).toBe(fixtureSession1Id);
   });
 
   it('finalizes exam review via finalizeExamAnswers instead of endPracticeSession', async () => {
     finalizeExamAnswersMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -299,7 +306,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
@@ -309,7 +316,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
     getCompletedSessionQuestionsWithFeedbackMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 2,
@@ -336,7 +343,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
   it('enters post-exam review after finalizing an exam instead of showing summary immediately', async () => {
     finalizeExamAnswersMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -350,7 +357,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
@@ -360,7 +367,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
     getCompletedSessionQuestionsWithFeedbackMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 2,
@@ -368,7 +375,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             slug: 'q-1',
             stemMd: 'Stem 1',
             difficulty: 'easy',
@@ -389,7 +396,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
           },
           {
             isAvailable: true,
-            questionId: 'q2',
+            questionId: fixtureQ2Id,
             slug: 'q-2',
             stemMd: 'Stem 2',
             difficulty: 'medium',
@@ -420,14 +427,18 @@ describe('usePracticeSessionReviewStage (browser)', () => {
       .poll(() => harness.result.current.postExamReviewLoadState.status)
       .toBe('ready');
     expect(harness.result.current.summary).toBeNull();
-    expect(harness.result.current.postExamReview?.sessionId).toBe('session-1');
-    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q1');
+    expect(harness.result.current.postExamReview?.sessionId).toBe(
+      fixtureSession1Id,
+    );
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe(
+      fixtureQ1Id,
+    );
   });
 
   it('switches to session summary without clearing completed feedback or the current reviewed question', async () => {
     finalizeExamAnswersMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 1,
@@ -441,7 +452,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
@@ -452,8 +463,8 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     getCompletedSessionQuestionsWithFeedbackMock.mockResolvedValue(
       ok(
         createPostExamReview(
-          createPostExamReviewRow({ questionId: 'q1', order: 1 }),
-          createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+          createPostExamReviewRow({ questionId: fixtureQ1Id, order: 1 }),
+          createPostExamReviewRow({ questionId: fixtureQ2Id, order: 2 }),
         ),
       ),
     );
@@ -467,25 +478,29 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     await expect
       .poll(() => harness.result.current.postExamReviewLoadState.status)
       .toBe('ready');
-    harness.result.current.onNavigatePostExamReviewQuestion('q2');
+    harness.result.current.onNavigatePostExamReviewQuestion(fixtureQ2Id);
 
     harness.result.current.onViewSummary();
 
     await expect
       .poll(() => harness.result.current.summary?.sessionId ?? null)
-      .toBe('session-1');
+      .toBe(fixtureSession1Id);
     await expect
       .poll(() => harness.result.current.summaryReviewLoadState.status)
       .toBe('ready');
     expect(harness.result.current.examResultsSubstage).toBe('session_summary');
-    expect(harness.result.current.postExamReview?.sessionId).toBe('session-1');
-    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.result.current.postExamReview?.sessionId).toBe(
+      fixtureSession1Id,
+    );
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe(
+      fixtureQ2Id,
+    );
   });
 
   it('re-enters post-exam review without a question id at the first available row instead of the current reviewed question', async () => {
     finalizeExamAnswersMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -499,7 +514,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
@@ -510,8 +525,8 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     getCompletedSessionQuestionsWithFeedbackMock.mockResolvedValue(
       ok(
         createPostExamReview(
-          createPostExamReviewRow({ questionId: 'q1', order: 1 }),
-          createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+          createPostExamReviewRow({ questionId: fixtureQ1Id, order: 1 }),
+          createPostExamReviewRow({ questionId: fixtureQ2Id, order: 2 }),
         ),
       ),
     );
@@ -525,7 +540,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     await expect
       .poll(() => harness.result.current.postExamReviewLoadState.status)
       .toBe('ready');
-    harness.result.current.onNavigatePostExamReviewQuestion('q2');
+    harness.result.current.onNavigatePostExamReviewQuestion(fixtureQ2Id);
     harness.result.current.onViewSummary();
 
     await expect
@@ -537,7 +552,9 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     await expect
       .poll(() => harness.result.current.examResultsSubstage)
       .toBe('post_exam_review');
-    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q1');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe(
+      fixtureQ1Id,
+    );
     expect(getCompletedSessionQuestionsWithFeedbackMock).toHaveBeenCalledTimes(
       1,
     );
@@ -546,7 +563,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
   it('re-enters post-exam review on the specifically requested summary question', async () => {
     finalizeExamAnswersMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -560,7 +577,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
@@ -571,8 +588,8 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     getCompletedSessionQuestionsWithFeedbackMock.mockResolvedValue(
       ok(
         createPostExamReview(
-          createPostExamReviewRow({ questionId: 'q1', order: 1 }),
-          createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+          createPostExamReviewRow({ questionId: fixtureQ1Id, order: 1 }),
+          createPostExamReviewRow({ questionId: fixtureQ2Id, order: 2 }),
         ),
       ),
     );
@@ -592,18 +609,20 @@ describe('usePracticeSessionReviewStage (browser)', () => {
       .poll(() => harness.result.current.examResultsSubstage)
       .toBe('session_summary');
 
-    harness.result.current.onReenterPostExamReview('q2');
+    harness.result.current.onReenterPostExamReview(fixtureQ2Id);
 
     await expect
       .poll(() => harness.result.current.examResultsSubstage)
       .toBe('post_exam_review');
-    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe(
+      fixtureQ2Id,
+    );
   });
 
   it('falls back to the first available reviewed question on untargeted re-entry when the current cursor points at an unavailable row', async () => {
     finalizeExamAnswersMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 2,
@@ -617,7 +636,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
@@ -629,11 +648,11 @@ describe('usePracticeSessionReviewStage (browser)', () => {
       ok(
         createPostExamReview(
           createPostExamReviewRow({
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             order: 1,
             isAvailable: false,
           }),
-          createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+          createPostExamReviewRow({ questionId: fixtureQ2Id, order: 2 }),
         ),
       ),
     );
@@ -647,7 +666,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     await expect
       .poll(() => harness.result.current.postExamReviewLoadState.status)
       .toBe('ready');
-    harness.result.current.onNavigatePostExamReviewQuestion('q1');
+    harness.result.current.onNavigatePostExamReviewQuestion(fixtureQ1Id);
     harness.result.current.onViewSummary();
 
     await expect
@@ -658,13 +677,13 @@ describe('usePracticeSessionReviewStage (browser)', () => {
 
     await expect
       .poll(() => harness.result.current.postExamReviewCurrentQuestionId)
-      .toBe('q2');
+      .toBe(fixtureQ2Id);
   });
 
   it('lazy-hydrates completed feedback to the first available row when summary re-entry has no preserved post-exam review payload', async () => {
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 2,
@@ -676,11 +695,11 @@ describe('usePracticeSessionReviewStage (browser)', () => {
       ok(
         createPostExamReview(
           createPostExamReviewRow({
-            questionId: 'q1',
+            questionId: fixtureQ1Id,
             order: 1,
             isAvailable: false,
           }),
-          createPostExamReviewRow({ questionId: 'q2', order: 2 }),
+          createPostExamReviewRow({ questionId: fixtureQ2Id, order: 2 }),
         ),
       ),
     );
@@ -691,7 +710,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
 
     harness.result.current.setSummary({
-      sessionId: 'session-1',
+      sessionId: fixtureSession1Id,
       endedAt: '2026-02-07T00:20:00.000Z',
       mode: 'exam',
       questionCount: 2,
@@ -715,7 +734,9 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     expect(getCompletedSessionQuestionsWithFeedbackMock).toHaveBeenCalledTimes(
       1,
     );
-    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe('q2');
+    expect(harness.result.current.postExamReviewCurrentQuestionId).toBe(
+      fixtureQ2Id,
+    );
     expect(harness.result.current.examResultsSubstage).toBe('post_exam_review');
   });
 
@@ -726,7 +747,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
       >();
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 2,
@@ -744,7 +765,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
 
     harness.result.current.setSummary({
-      sessionId: 'session-1',
+      sessionId: fixtureSession1Id,
       endedAt: '2026-02-07T00:20:00.000Z',
       mode: 'exam',
       questionCount: 2,
@@ -773,7 +794,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
       1,
     );
 
-    reviewLoad.resolve(ok(createPostExamReview('q2')));
+    reviewLoad.resolve(ok(createPostExamReview(fixtureQ2Id)));
     await expect
       .poll(() => harness.result.current.postExamReviewLoadState.status)
       .toBe('ready');
@@ -782,7 +803,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
   it('preserves the deferred exam summary when post-exam review loading fails so retry and summary recovery still work', async () => {
     finalizeExamAnswersMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 1,
@@ -796,7 +817,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
@@ -808,7 +829,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
       .mockRejectedValueOnce(new Error('Review fetch failed'))
       .mockResolvedValueOnce(
         ok({
-          sessionId: 'session-1',
+          sessionId: fixtureSession1Id,
           mode: 'exam',
           totalCount: 1,
           answeredCount: 1,
@@ -816,7 +837,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
           rows: [
             {
               isAvailable: true,
-              questionId: 'q1',
+              questionId: fixtureQ1Id,
               slug: 'q-1',
               stemMd: 'Stem 1',
               difficulty: 'easy',
@@ -846,20 +867,24 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     await expect
       .poll(() => harness.result.current.postExamReviewLoadState.status)
       .toBe('error');
-    expect(harness.result.current.postExamSummary?.sessionId).toBe('session-1');
+    expect(harness.result.current.postExamSummary?.sessionId).toBe(
+      fixtureSession1Id,
+    );
 
     harness.result.current.onRetryPostExamReview();
 
     await expect
       .poll(() => harness.result.current.postExamReviewLoadState.status)
       .toBe('ready');
-    expect(harness.result.current.postExamReview?.sessionId).toBe('session-1');
+    expect(harness.result.current.postExamReview?.sessionId).toBe(
+      fixtureSession1Id,
+    );
 
     harness.result.current.onViewSummary();
 
     await expect
       .poll(() => harness.result.current.summary?.sessionId ?? null)
-      .toBe('session-1');
+      .toBe(fixtureSession1Id);
   });
 
   it("keeps retry request B's success when stale retry request A rejects afterward", async () => {
@@ -873,7 +898,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
       >();
     finalizeExamAnswersMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 1,
@@ -887,7 +912,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
@@ -956,7 +981,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
       >();
     finalizeExamAnswersMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         endedAt: '2026-02-07T00:20:00.000Z',
         mode: 'exam',
         questionCount: 1,
@@ -970,7 +995,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
     getPracticeSessionReviewMock.mockResolvedValue(
       ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 1,
         answeredCount: 1,
@@ -1030,7 +1055,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     getPracticeSessionReviewMock.mockImplementation(async () => {
       callOrder.push('review');
       return ok({
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         totalCount: 2,
         answeredCount: 1,

--- a/app/(app)/app/practice/components/incomplete-session-card.browser.spec.tsx
+++ b/app/(app)/app/practice/components/incomplete-session-card.browser.spec.tsx
@@ -2,13 +2,15 @@ import { expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { IncompleteSessionCard } from './incomplete-session-card';
 
+const fixtureSession1Id = crypto.randomUUID();
+
 test('renders resume link and calls abandon handler', async () => {
   const onAbandon = vi.fn();
 
   const screen = await render(
     <IncompleteSessionCard
       session={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
         answeredCount: 4,
         totalCount: 10,
@@ -24,7 +26,7 @@ test('renders resume link and calls abandon handler', async () => {
     .toBeVisible();
   await expect
     .element(screen.getByRole('link', { name: 'Resume session' }))
-    .toHaveAttribute('href', '/app/practice/session-1');
+    .toHaveAttribute('href', `/app/practice/${fixtureSession1Id}`);
 
   await screen.getByRole('button', { name: 'Abandon session' }).click();
   await expect
@@ -38,7 +40,7 @@ test('disables abandon button when pending', async () => {
   const screen = await render(
     <IncompleteSessionCard
       session={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
         answeredCount: 1,
         totalCount: 20,

--- a/app/(app)/app/practice/components/practice-session-starter.browser.spec.tsx
+++ b/app/(app)/app/practice/components/practice-session-starter.browser.spec.tsx
@@ -1,9 +1,12 @@
 import { expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
+
 import {
   PracticeSessionStarter,
   type PracticeSessionStarterProps,
 } from '@/app/(app)/app/practice/components/practice-session-starter';
+
+const fixtureTag1Id = crypto.randomUUID();
 
 function starterProps(
   overrides: Partial<PracticeSessionStarterProps> = {},
@@ -17,7 +20,7 @@ function starterProps(
     tagLoadStatus: 'idle',
     availableTags: [
       {
-        id: 'tag_1',
+        id: fixtureTag1Id,
         slug: 'opioids',
         name: 'Opioids',
         kind: 'substance',

--- a/app/(app)/app/practice/components/practice-view-notification.browser.spec.tsx
+++ b/app/(app)/app/practice/components/practice-view-notification.browser.spec.tsx
@@ -5,6 +5,8 @@ import * as notificationProvider from '@/components/ui/notification-provider';
 import { createNextQuestion } from '@/src/application/test-helpers/create-next-question';
 import { PracticeView } from './practice-view';
 
+const fixtureQuestion1Id = crypto.randomUUID();
+
 const notifySpy = vi.fn();
 
 vi.mock('@/components/ui/notification-provider', { spy: true });
@@ -19,7 +21,7 @@ beforeEach(() => {
 
 function createBaseProps() {
   const question = createNextQuestion({
-    questionId: 'question-1',
+    questionId: fixtureQuestion1Id,
     slug: 'question-1',
     stemMd: 'What is the next best step?',
     difficulty: 'easy',

--- a/app/(app)/app/practice/components/practice-view-test-helpers.tsx
+++ b/app/(app)/app/practice/components/practice-view-test-helpers.tsx
@@ -1,13 +1,14 @@
 import { vi } from 'vitest';
 import { createNextQuestion } from '@/src/application/test-helpers/create-next-question';
 
+const fixtureQuestion1Id = crypto.randomUUID();
 vi.mock('next/link', () => ({
   default: (props: Record<string, unknown>) => <a {...props} />,
 }));
 
 export function createQuestionProps() {
   return createNextQuestion({
-    questionId: 'question-1',
+    questionId: fixtureQuestion1Id,
     slug: 'question-1',
     stemMd: 'Stem',
     difficulty: 'easy',

--- a/app/(app)/app/practice/components/practice-view.browser.spec.tsx
+++ b/app/(app)/app/practice/components/practice-view.browser.spec.tsx
@@ -4,6 +4,13 @@ import { render } from 'vitest-browser-react';
 import { NotificationProvider } from '@/components/ui/notification-provider';
 import { PracticeView } from './practice-view';
 
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureQuestion1Id = crypto.randomUUID();
+const fixtureChoiceAId = crypto.randomUUID();
+const fixtureChoiceBId = crypto.randomUUID();
+const fixtureAttempt1Id = crypto.randomUUID();
+const fixtureQuestion2Id = crypto.randomUUID();
+
 function createTallMarkdown(label: string, paragraphCount: number) {
   return Array.from(
     { length: paragraphCount },
@@ -21,7 +28,7 @@ function ExamPracticeViewHarness(input: {
   return (
     <PracticeView
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
 
         deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -32,13 +39,23 @@ function ExamPracticeViewHarness(input: {
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'question-1',
+        questionId: fixtureQuestion1Id,
         slug: 'question-1',
         stemMd: 'What is the next best step?',
         difficulty: 'easy',
         choices: [
-          { id: 'choice_a', label: 'A', textMd: 'Option A', sortOrder: 1 },
-          { id: 'choice_b', label: 'B', textMd: 'Option B', sortOrder: 2 },
+          {
+            id: fixtureChoiceAId,
+            label: 'A',
+            textMd: 'Option A',
+            sortOrder: 1,
+          },
+          {
+            id: fixtureChoiceBId,
+            label: 'B',
+            textMd: 'Option B',
+            sortOrder: 2,
+          },
         ],
         session: null,
       }}
@@ -123,7 +140,7 @@ test('renders the exam bottom action bar without sticky shell markers', async ()
   const screen = await render(
     <PracticeView
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
 
         deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -134,7 +151,7 @@ test('renders the exam bottom action bar without sticky shell markers', async ()
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'question-1',
+        questionId: fixtureQuestion1Id,
         slug: 'question-1',
         stemMd: createTallMarkdown('Exam stem', 36),
         difficulty: 'easy',
@@ -202,34 +219,44 @@ test('renders the tutor feedback bottom action bar without sticky shell markers'
     <PracticeView
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'question-1',
+        questionId: fixtureQuestion1Id,
         slug: 'question-1',
         stemMd: createTallMarkdown('Tutor stem', 18),
         difficulty: 'easy',
         choices: [
-          { id: 'choice_a', label: 'A', textMd: 'Option A', sortOrder: 1 },
-          { id: 'choice_b', label: 'B', textMd: 'Option B', sortOrder: 2 },
+          {
+            id: fixtureChoiceAId,
+            label: 'A',
+            textMd: 'Option A',
+            sortOrder: 1,
+          },
+          {
+            id: fixtureChoiceBId,
+            label: 'B',
+            textMd: 'Option B',
+            sortOrder: 2,
+          },
         ],
         session: null,
       }}
-      selectedChoiceId="choice_a"
+      selectedChoiceId={fixtureChoiceAId}
       isAnswered={true}
       submitResult={{
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: false,
-        correctChoiceId: 'choice_b',
+        correctChoiceId: fixtureChoiceBId,
         explanationMd: createTallMarkdown('Tutor explanation', 24),
         referenceMd: createTallMarkdown('Tutor reference', 8),
         choiceExplanations: [
           {
-            choiceId: 'choice_a',
+            choiceId: fixtureChoiceAId,
             displayLabel: 'A',
             textMd: 'Option A',
             isCorrect: false,
             explanationMd: createTallMarkdown('Choice A explanation', 8),
           },
           {
-            choiceId: 'choice_b',
+            choiceId: fixtureChoiceBId,
             displayLabel: 'B',
             textMd: 'Option B',
             isCorrect: true,
@@ -278,13 +305,13 @@ test('disables mutation controls while internal question loading is in progress'
     <PracticeView
       loadState={{ status: 'loading' }}
       question={{
-        questionId: 'question-1',
+        questionId: fixtureQuestion1Id,
         slug: 'question-1',
         stemMd: 'What is the next best step?',
         difficulty: 'easy',
         choices: [
           {
-            id: 'choice_a',
+            id: fixtureChoiceAId,
             label: 'A',
             textMd: 'Tutor Option A',
             sortOrder: 1,
@@ -292,7 +319,7 @@ test('disables mutation controls while internal question loading is in progress'
         ],
         session: null,
       }}
-      selectedChoiceId="choice_a"
+      selectedChoiceId={fixtureChoiceAId}
       isAnswered={false}
       submitResult={null}
       isPending={false}
@@ -318,7 +345,7 @@ test('disables mutation controls while internal question loading is in progress'
   const examScreen = await render(
     <PracticeView
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
 
         deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -329,13 +356,13 @@ test('disables mutation controls while internal question loading is in progress'
       }}
       loadState={{ status: 'loading' }}
       question={{
-        questionId: 'question-1',
+        questionId: fixtureQuestion1Id,
         slug: 'question-1',
         stemMd: 'What is the next best step?',
         difficulty: 'easy',
         choices: [
           {
-            id: 'choice_a',
+            id: fixtureChoiceAId,
             label: 'A',
             textMd: 'Exam Option A',
             sortOrder: 1,
@@ -343,7 +370,7 @@ test('disables mutation controls while internal question loading is in progress'
         ],
         session: null,
       }}
-      selectedChoiceId="choice_a"
+      selectedChoiceId={fixtureChoiceAId}
       isAnswered={false}
       submitResult={null}
       isPending={false}
@@ -375,7 +402,7 @@ test('disables choice selection after a submit in exam mode', async () => {
   const screen = await render(
     <PracticeView
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
 
         deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -386,22 +413,32 @@ test('disables choice selection after a submit in exam mode', async () => {
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'question-1',
+        questionId: fixtureQuestion1Id,
         slug: 'question-1',
         stemMd: 'What is the next best step?',
         difficulty: 'easy',
         choices: [
-          { id: 'choice_a', label: 'A', textMd: 'Option A', sortOrder: 1 },
-          { id: 'choice_b', label: 'B', textMd: 'Option B', sortOrder: 2 },
+          {
+            id: fixtureChoiceAId,
+            label: 'A',
+            textMd: 'Option A',
+            sortOrder: 1,
+          },
+          {
+            id: fixtureChoiceBId,
+            label: 'B',
+            textMd: 'Option B',
+            sortOrder: 2,
+          },
         ],
         session: null,
       }}
-      selectedChoiceId="choice_a"
+      selectedChoiceId={fixtureChoiceAId}
       isAnswered={false}
       submitResult={{
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: true,
-        correctChoiceId: 'choice_a',
+        correctChoiceId: fixtureChoiceAId,
         explanationMd: 'Because',
         referenceMd: null,
         choiceExplanations: [],
@@ -436,21 +473,26 @@ test('scrolls feedback into view when a submit result is present', async () => {
       <PracticeView
         loadState={{ status: 'ready' }}
         question={{
-          questionId: 'question-1',
+          questionId: fixtureQuestion1Id,
           slug: 'question-1',
           stemMd: 'What is the next best step?',
           difficulty: 'easy',
           choices: [
-            { id: 'choice_a', label: 'A', textMd: 'Option A', sortOrder: 1 },
+            {
+              id: fixtureChoiceAId,
+              label: 'A',
+              textMd: 'Option A',
+              sortOrder: 1,
+            },
           ],
           session: null,
         }}
-        selectedChoiceId="choice_a"
+        selectedChoiceId={fixtureChoiceAId}
         isAnswered={true}
         submitResult={{
-          attemptId: 'attempt-1',
+          attemptId: fixtureAttempt1Id,
           isCorrect: true,
-          correctChoiceId: 'choice_a',
+          correctChoiceId: fixtureChoiceAId,
           explanationMd: 'Because',
           referenceMd: null,
           choiceExplanations: [],
@@ -485,7 +527,7 @@ test('does not scroll feedback in exam mode', async () => {
     await render(
       <PracticeView
         sessionInfo={{
-          sessionId: 'session-1',
+          sessionId: fixtureSession1Id,
           mode: 'exam',
 
           deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -496,21 +538,26 @@ test('does not scroll feedback in exam mode', async () => {
         }}
         loadState={{ status: 'ready' }}
         question={{
-          questionId: 'question-1',
+          questionId: fixtureQuestion1Id,
           slug: 'question-1',
           stemMd: 'What is the next best step?',
           difficulty: 'easy',
           choices: [
-            { id: 'choice_a', label: 'A', textMd: 'Option A', sortOrder: 1 },
+            {
+              id: fixtureChoiceAId,
+              label: 'A',
+              textMd: 'Option A',
+              sortOrder: 1,
+            },
           ],
           session: null,
         }}
-        selectedChoiceId="choice_a"
+        selectedChoiceId={fixtureChoiceAId}
         isAnswered={true}
         submitResult={{
-          attemptId: 'attempt-1',
+          attemptId: fixtureAttempt1Id,
           isCorrect: true,
-          correctChoiceId: 'choice_a',
+          correctChoiceId: fixtureChoiceAId,
           explanationMd: 'Because',
           referenceMd: null,
           choiceExplanations: [],
@@ -539,12 +586,17 @@ test('renders bookmark feedback in shared toast region', async () => {
       <PracticeView
         loadState={{ status: 'ready' }}
         question={{
-          questionId: 'question-1',
+          questionId: fixtureQuestion1Id,
           slug: 'question-1',
           stemMd: 'What is the next best step?',
           difficulty: 'easy',
           choices: [
-            { id: 'choice_a', label: 'A', textMd: 'Option A', sortOrder: 1 },
+            {
+              id: fixtureChoiceAId,
+              label: 'A',
+              textMd: 'Option A',
+              sortOrder: 1,
+            },
           ],
           session: null,
         }}
@@ -577,12 +629,17 @@ test('calls onPreviousQuestion when clicked', async () => {
     <PracticeView
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'question-1',
+        questionId: fixtureQuestion1Id,
         slug: 'question-1',
         stemMd: 'What is the next best step?',
         difficulty: 'easy',
         choices: [
-          { id: 'choice_a', label: 'A', textMd: 'Option A', sortOrder: 1 },
+          {
+            id: fixtureChoiceAId,
+            label: 'A',
+            textMd: 'Option A',
+            sortOrder: 1,
+          },
         ],
         session: null,
       }}
@@ -611,7 +668,7 @@ test('calls onEndSession from the bottom-bar Review & Submit button on the last 
   const screen = await render(
     <PracticeView
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'exam',
 
         deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -622,21 +679,26 @@ test('calls onEndSession from the bottom-bar Review & Submit button on the last 
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'question-2',
+        questionId: fixtureQuestion2Id,
         slug: 'question-2',
         stemMd: 'What is the next best step?',
         difficulty: 'easy',
         choices: [
-          { id: 'choice_a', label: 'A', textMd: 'Option A', sortOrder: 1 },
+          {
+            id: fixtureChoiceAId,
+            label: 'A',
+            textMd: 'Option A',
+            sortOrder: 1,
+          },
         ],
         session: null,
       }}
-      selectedChoiceId="choice_a"
+      selectedChoiceId={fixtureChoiceAId}
       isAnswered={true}
       submitResult={{
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: true,
-        correctChoiceId: 'choice_a',
+        correctChoiceId: fixtureChoiceAId,
         explanationMd: 'Because',
         referenceMd: null,
         choiceExplanations: [],
@@ -670,7 +732,7 @@ test('calls onEndSession from the bottom-bar End session button on the last tuto
   const screen = await render(
     <PracticeView
       sessionInfo={{
-        sessionId: 'session-1',
+        sessionId: fixtureSession1Id,
         mode: 'tutor',
 
         deadlineAt: null,
@@ -681,21 +743,26 @@ test('calls onEndSession from the bottom-bar End session button on the last tuto
       }}
       loadState={{ status: 'ready' }}
       question={{
-        questionId: 'question-2',
+        questionId: fixtureQuestion2Id,
         slug: 'question-2',
         stemMd: 'What is the next best step?',
         difficulty: 'easy',
         choices: [
-          { id: 'choice_a', label: 'A', textMd: 'Option A', sortOrder: 1 },
+          {
+            id: fixtureChoiceAId,
+            label: 'A',
+            textMd: 'Option A',
+            sortOrder: 1,
+          },
         ],
         session: null,
       }}
-      selectedChoiceId="choice_a"
+      selectedChoiceId={fixtureChoiceAId}
       isAnswered={true}
       submitResult={{
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: true,
-        correctChoiceId: 'choice_a',
+        correctChoiceId: fixtureChoiceAId,
         explanationMd: 'Because',
         referenceMd: null,
         choiceExplanations: [],

--- a/app/(app)/app/practice/components/practice-view.browser.spec.tsx
+++ b/app/(app)/app/practice/components/practice-view.browser.spec.tsx
@@ -156,7 +156,7 @@ test('renders the exam bottom action bar without sticky shell markers', async ()
         stemMd: createTallMarkdown('Exam stem', 36),
         difficulty: 'easy',
         choices: Array.from({ length: 6 }, (_, index) => ({
-          id: `choice_${index + 1}`,
+          id: crypto.randomUUID(),
           label: String.fromCharCode(65 + index),
           textMd: `Option ${index + 1}`,
           sortOrder: index + 1,

--- a/app/(app)/app/practice/hooks/use-practice-question-answer-flow.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-question-answer-flow.browser.spec.tsx
@@ -10,6 +10,11 @@ import { ok } from '@/tests/test-helpers/ok';
 import { installReportClientErrorMocks } from '@/tests/test-helpers/report-client-error-mocks';
 import { usePracticeQuestionAnswerFlow } from './use-practice-question-answer-flow';
 
+const fixtureAttempt1Id = crypto.randomUUID();
+const fixtureQ2Id = crypto.randomUUID();
+const fixtureChoice1Id = crypto.randomUUID();
+const fixtureChoice2Id = crypto.randomUUID();
+
 vi.mock('@/lib/report-client-error', { spy: true });
 
 const { getNextQuestionMock, isMountedMock, submitAnswerMock } = vi.hoisted(
@@ -30,10 +35,10 @@ const TEST_FILTERS = {
 } satisfies PracticeFilters;
 
 function createSubmitOutput(
-  correctChoiceId: string = 'choice_1',
+  correctChoiceId: string = fixtureChoice1Id,
 ): SubmitAnswerOutput {
   return {
-    attemptId: 'attempt-1',
+    attemptId: fixtureAttempt1Id,
     isCorrect: true,
     correctChoiceId,
     explanationMd: null,
@@ -63,17 +68,23 @@ function PracticeQuestionAnswerFlowProbe() {
       </div>
       <div data-testid="can-submit">{String(output.canSubmit)}</div>
       <div data-testid="error-message">{errorMessage}</div>
-      <button type="button" onClick={() => output.onSelectChoice('choice_1')}>
+      <button
+        type="button"
+        onClick={() => output.onSelectChoice(fixtureChoice1Id)}
+      >
         select-choice-1
       </button>
-      <button type="button" onClick={() => output.onSelectChoice('choice_2')}>
+      <button
+        type="button"
+        onClick={() => output.onSelectChoice(fixtureChoice2Id)}
+      >
         select-choice-2
       </button>
       <button
         type="button"
         onClick={() => {
-          output.onSelectChoice('choice_1');
-          output.onSelectChoice('choice_2');
+          output.onSelectChoice(fixtureChoice1Id);
+          output.onSelectChoice(fixtureChoice2Id);
         }}
       >
         select-choice-1-then-2
@@ -93,7 +104,7 @@ function PracticeQuestionAnswerFlowProbe() {
       <button
         type="button"
         onClick={() => {
-          output.onSelectChoice('choice_1');
+          output.onSelectChoice(fixtureChoice1Id);
           void output.onSubmit();
         }}
       >
@@ -149,7 +160,9 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
 
     getNextQuestionMock
       .mockResolvedValueOnce(ok(createNextQuestion()))
-      .mockResolvedValueOnce(ok(createNextQuestion({ questionId: 'q_2' })));
+      .mockResolvedValueOnce(
+        ok(createNextQuestion({ questionId: fixtureQ2Id })),
+      );
     submitAnswerMock.mockImplementation(async () => submitDeferred.promise);
 
     const screen = await render(<PracticeQuestionAnswerFlowProbe />);
@@ -163,7 +176,7 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
       .click();
     await expect
       .element(screen.getByTestId('selected-choice-id'))
-      .toHaveTextContent('choice_1');
+      .toHaveTextContent(fixtureChoice1Id);
     await expect
       .element(screen.getByTestId('is-pending'))
       .toHaveTextContent('true');
@@ -173,9 +186,9 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
 
     submitDeferred.resolve(
       ok({
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: true,
-        correctChoiceId: 'choice_1',
+        correctChoiceId: fixtureChoice1Id,
         explanationMd: null,
         referenceMd: null,
         choiceExplanations: [],
@@ -189,7 +202,7 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
     await screen.getByRole('button', { name: 'next-question' }).click();
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('q_2');
+      .toHaveTextContent(fixtureQ2Id);
   });
 
   it('commits the clicked choice without waiting for selectedChoiceId to re-render', async () => {
@@ -197,17 +210,17 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
       ok(
         createNextQuestion({
           choices: [
-            { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-            { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+            { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+            { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
           ],
         }),
       ),
     );
     submitAnswerMock.mockResolvedValue(
       ok({
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: true,
-        correctChoiceId: 'choice_2',
+        correctChoiceId: fixtureChoice2Id,
         explanationMd: null,
         referenceMd: null,
         choiceExplanations: [],
@@ -224,7 +237,7 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
     await expect.poll(() => submitAnswerMock.mock.calls.length).toBe(1);
     expect(submitAnswerMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        choiceId: 'choice_2',
+        choiceId: fixtureChoice2Id,
       }),
     );
   });
@@ -234,8 +247,8 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
       ok(
         createNextQuestion({
           choices: [
-            { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-            { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+            { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+            { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
           ],
         }),
       ),
@@ -255,17 +268,17 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
     await expect.poll(() => submitAnswerMock.mock.calls.length).toBe(1);
     await expect
       .element(screen.getByTestId('selected-choice-id'))
-      .toHaveTextContent('choice_1');
+      .toHaveTextContent(fixtureChoice1Id);
     expect(submitAnswerMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        choiceId: 'choice_1',
+        choiceId: fixtureChoice1Id,
       }),
     );
     submitDeferred.resolve(
       ok({
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: true,
-        correctChoiceId: 'choice_1',
+        correctChoiceId: fixtureChoice1Id,
         explanationMd: null,
         referenceMd: null,
         choiceExplanations: [],
@@ -283,8 +296,8 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
       ok(
         createNextQuestion({
           choices: [
-            { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-            { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+            { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+            { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
           ],
         }),
       ),
@@ -309,9 +322,9 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
     expect(submitAnswerMock).toHaveBeenCalledTimes(1);
     submitDeferred.resolve(
       ok({
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: true,
-        correctChoiceId: 'choice_1',
+        correctChoiceId: fixtureChoice1Id,
         explanationMd: null,
         referenceMd: null,
         choiceExplanations: [],
@@ -329,8 +342,8 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
       ok(
         createNextQuestion({
           choices: [
-            { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-            { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+            { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+            { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
           ],
         }),
       ),
@@ -351,7 +364,7 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
       .element(screen.getByTestId('is-pending'))
       .toHaveTextContent('true');
     expect(submitAnswerMock).toHaveBeenCalledWith(
-      expect.objectContaining({ choiceId: 'choice_1' }),
+      expect.objectContaining({ choiceId: fixtureChoice1Id }),
     );
 
     await screen
@@ -361,9 +374,9 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
     expect(submitAnswerMock).toHaveBeenCalledTimes(1);
     submitDeferred.resolve(
       ok({
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: true,
-        correctChoiceId: 'choice_1',
+        correctChoiceId: fixtureChoice1Id,
         explanationMd: null,
         referenceMd: null,
         choiceExplanations: [],
@@ -401,17 +414,17 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
       ok(
         createNextQuestion({
           choices: [
-            { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-            { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+            { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+            { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
           ],
         }),
       ),
     );
     submitAnswerMock.mockResolvedValue(
       ok({
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: true,
-        correctChoiceId: 'choice_1',
+        correctChoiceId: fixtureChoice1Id,
         explanationMd: null,
         referenceMd: null,
         choiceExplanations: [],
@@ -429,7 +442,7 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
     await expect.poll(() => submitAnswerMock.mock.calls.length).toBe(1);
     await expect
       .element(screen.getByTestId('selected-choice-id'))
-      .toHaveTextContent('choice_1');
+      .toHaveTextContent(fixtureChoice1Id);
     await expect
       .element(screen.getByTestId('is-pending'))
       .toHaveTextContent('false');
@@ -443,9 +456,9 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
     getNextQuestionMock.mockResolvedValue(ok(createNextQuestion()));
     submitAnswerMock.mockResolvedValue(
       ok({
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: true,
-        correctChoiceId: 'choice_1',
+        correctChoiceId: fixtureChoice1Id,
         explanationMd: null,
         referenceMd: null,
         choiceExplanations: [],
@@ -482,15 +495,15 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
       ok(
         createNextQuestion({
           choices: [
-            { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-            { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+            { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+            { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
           ],
         }),
       ),
     );
     submitAnswerMock
       .mockRejectedValueOnce(submitError)
-      .mockResolvedValueOnce(ok(createSubmitOutput('choice_2')));
+      .mockResolvedValueOnce(ok(createSubmitOutput(fixtureChoice2Id)));
 
     const screen = await render(<PracticeQuestionAnswerFlowProbe />);
     await expect
@@ -515,7 +528,7 @@ describe('usePracticeQuestionAnswerFlow (browser)', () => {
 
     await expect.poll(() => submitAnswerMock.mock.calls.length).toBe(2);
     expect(submitAnswerMock).toHaveBeenLastCalledWith(
-      expect.objectContaining({ choiceId: 'choice_1' }),
+      expect.objectContaining({ choiceId: fixtureChoice1Id }),
     );
   });
 

--- a/app/(app)/app/practice/hooks/use-practice-question-bookmarks.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-question-bookmarks.browser.spec.tsx
@@ -6,6 +6,9 @@ import { createNextQuestion } from '@/src/application/test-helpers/create-next-q
 import { ok } from '@/tests/test-helpers/ok';
 import { usePracticeQuestionBookmarks } from './use-practice-question-bookmarks';
 
+const fixtureQuestion1Id = crypto.randomUUID();
+const fixtureQuestion2Id = crypto.randomUUID();
+
 vi.mock('@/src/adapters/controllers/bookmark-controller', { spy: true });
 
 const getBookmarks = vi.mocked(bookmarkController.getBookmarks);
@@ -14,7 +17,7 @@ const toggleBookmark = vi.mocked(bookmarkController.toggleBookmark);
 function PracticeQuestionBookmarksProbe() {
   const [question, setQuestion] = useState(
     createNextQuestion({
-      questionId: 'question-1',
+      questionId: fixtureQuestion1Id,
       slug: 'question-1',
     }),
   );
@@ -35,7 +38,7 @@ function PracticeQuestionBookmarksProbe() {
         onClick={() =>
           setQuestion(
             createNextQuestion({
-              questionId: 'question-2',
+              questionId: fixtureQuestion2Id,
               slug: 'question-2',
             }),
           )
@@ -69,7 +72,7 @@ describe('usePracticeQuestionBookmarks (browser)', () => {
 
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-1');
+      .toHaveTextContent(fixtureQuestion1Id);
 
     await screen.getByRole('button', { name: 'toggle-bookmark' }).click();
 
@@ -86,7 +89,7 @@ describe('usePracticeQuestionBookmarks (browser)', () => {
     await screen.getByRole('button', { name: 'set-question-2' }).click();
     await expect
       .element(screen.getByTestId('question-id'))
-      .toHaveTextContent('question-2');
+      .toHaveTextContent(fixtureQuestion2Id);
 
     await screen.getByRole('button', { name: 'toggle-bookmark' }).click();
 
@@ -96,8 +99,8 @@ describe('usePracticeQuestionBookmarks (browser)', () => {
       questionId: string;
     };
 
-    expect(firstInput.questionId).toBe('question-1');
-    expect(secondInput.questionId).toBe('question-2');
+    expect(firstInput.questionId).toBe(fixtureQuestion1Id);
+    expect(secondInput.questionId).toBe(fixtureQuestion2Id);
     expect(secondInput.idempotencyKey).not.toBe(firstInput.idempotencyKey);
   });
 });

--- a/app/(app)/app/practice/hooks/use-practice-question-flow.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-question-flow.browser.spec.tsx
@@ -11,6 +11,9 @@ import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
 import { usePracticeQuestionFlow } from './use-practice-question-flow';
 
+const fixtureAttempt1Id = crypto.randomUUID();
+const fixtureChoice1Id = crypto.randomUUID();
+
 vi.mock('@/src/adapters/controllers/bookmark-controller', { spy: true });
 vi.mock('@/src/adapters/controllers/question-controller', { spy: true });
 
@@ -72,7 +75,10 @@ function PracticeQuestionFlowSubmitProbe() {
     <>
       <div data-testid="load-status">{output.loadState.status}</div>
       <div data-testid="is-pending">{String(output.isPending)}</div>
-      <button type="button" onClick={() => output.onSelectChoice('choice_1')}>
+      <button
+        type="button"
+        onClick={() => output.onSelectChoice(fixtureChoice1Id)}
+      >
         select-choice-1
       </button>
       <button type="button" onClick={() => void output.onSubmit()}>
@@ -181,9 +187,9 @@ describe('usePracticeQuestionFlow (browser)', () => {
 
     deferred.resolve(
       ok({
-        attemptId: 'attempt-1',
+        attemptId: fixtureAttempt1Id,
         isCorrect: true,
-        correctChoiceId: 'choice_1',
+        correctChoiceId: fixtureChoice1Id,
         explanationMd: 'Because',
         referenceMd: null,
         choiceExplanations: [],

--- a/app/(app)/app/practice/hooks/use-practice-session-controls.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-controls.browser.spec.tsx
@@ -7,6 +7,8 @@ import { ok } from '@/tests/test-helpers/ok';
 import { installReportClientErrorMocks } from '@/tests/test-helpers/report-client-error-mocks';
 import { usePracticeSessionControls } from './use-practice-session-controls';
 
+const fixtureTag1Id = crypto.randomUUID();
+
 vi.mock('@/src/adapters/controllers/tag-controller', { spy: true });
 vi.mock('@/src/adapters/controllers/practice-controller', { spy: true });
 vi.mock('@/lib/report-client-error', { spy: true });
@@ -73,7 +75,7 @@ describe('usePracticeSessionControls (browser)', () => {
       ok({
         rows: [
           {
-            id: 'tag_1',
+            id: fixtureTag1Id,
             slug: 'opioids',
             name: 'Opioids',
             kind: 'substance',

--- a/app/(app)/app/practice/hooks/use-practice-session-start.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-start.browser.spec.tsx
@@ -10,6 +10,8 @@ import { installReportClientErrorMocks } from '@/tests/test-helpers/report-clien
 import * as clientNavigation from '../client-navigation';
 import { usePracticeSessionStart } from './use-practice-session-start';
 
+const fixtureSession1Id = crypto.randomUUID();
+
 vi.mock('@/src/adapters/controllers/practice-controller', { spy: true });
 vi.mock('@/lib/report-client-error', { spy: true });
 vi.mock('../client-navigation', { spy: true });
@@ -81,7 +83,7 @@ afterEach(() => {
 test('rotates the session start idempotency key when changing status', async () => {
   startPracticeSession.mockResolvedValue({
     ok: true,
-    data: { sessionId: 'session_1', requestedCount: 20, actualCount: 20 },
+    data: { sessionId: fixtureSession1Id, requestedCount: 20, actualCount: 20 },
   });
 
   const screen = await render(<Probe />);
@@ -134,11 +136,11 @@ test('ignores stale successful session starts after config changes mid-flight', 
     .toHaveTextContent('incorrect');
 
   deferred.resolve(
-    ok({ sessionId: 'session_1', requestedCount: 20, actualCount: 20 }),
+    ok({ sessionId: fixtureSession1Id, requestedCount: 20, actualCount: 20 }),
   );
   await expect(deferred.promise).resolves.toEqual({
     ok: true,
-    data: { sessionId: 'session_1', requestedCount: 20, actualCount: 20 },
+    data: { sessionId: fixtureSession1Id, requestedCount: 20, actualCount: 20 },
   });
   await flushDeferredSettlement();
 

--- a/app/(app)/app/practice/shared/use-question-flow-core.browser.spec.tsx
+++ b/app/(app)/app/practice/shared/use-question-flow-core.browser.spec.tsx
@@ -4,6 +4,13 @@ import { render } from 'vitest-browser-react';
 import { useQuestionFlowCore } from '@/app/(app)/app/practice/shared/use-question-flow-core';
 import { createNextQuestion } from '@/src/application/test-helpers/create-next-question';
 
+const fixtureQ1Id = crypto.randomUUID();
+const fixtureQ2Id = crypto.randomUUID();
+const fixtureChoice1Id = crypto.randomUUID();
+const fixtureChoice2Id = crypto.randomUUID();
+const fixtureSession1Id = crypto.randomUUID();
+const fixtureAttempt1Id = crypto.randomUUID();
+
 function QuestionFlowCoreProbe() {
   const core = useQuestionFlowCore({ isMounted: () => true });
   const [lastSelectResult, setLastSelectResult] = useState<boolean | null>(
@@ -41,7 +48,7 @@ function QuestionFlowCoreProbe() {
       <button
         type="button"
         onClick={() => {
-          core.setQuestion(createNextQuestion({ questionId: 'q_1' }));
+          core.setQuestion(createNextQuestion({ questionId: fixtureQ1Id }));
           core.setLoadState({ status: 'ready' });
         }}
       >
@@ -50,7 +57,7 @@ function QuestionFlowCoreProbe() {
       <button
         type="button"
         onClick={() => {
-          core.setQuestion(createNextQuestion({ questionId: 'q_2' }));
+          core.setQuestion(createNextQuestion({ questionId: fixtureQ2Id }));
           core.setLoadState({ status: 'ready' });
         }}
       >
@@ -61,35 +68,35 @@ function QuestionFlowCoreProbe() {
         onClick={() => {
           core.setQuestion(
             createNextQuestion({
-              questionId: 'q_1',
+              questionId: fixtureQ1Id,
               choices: [
-                { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-                { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+                { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+                { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
               ],
               session: {
-                sessionId: 'session_1',
+                sessionId: fixtureSession1Id,
                 mode: 'tutor',
 
                 deadlineAt: null,
 
                 index: 0,
                 total: 1,
-                latestSelectedChoiceId: 'choice_2',
+                latestSelectedChoiceId: fixtureChoice2Id,
                 latestIsCorrect: false,
                 previousSubmission: {
-                  correctChoiceId: 'choice_1',
+                  correctChoiceId: fixtureChoice1Id,
                   explanationMd: 'Explanation',
                   referenceMd: 'Anton RF et al. JAMA. 2006;295(17):2003-2017.',
                   choiceExplanations: [
                     {
-                      choiceId: 'choice_1',
+                      choiceId: fixtureChoice1Id,
                       displayLabel: 'A',
                       textMd: 'A',
                       isCorrect: true,
                       explanationMd: 'Choice 1 explainer',
                     },
                     {
-                      choiceId: 'choice_2',
+                      choiceId: fixtureChoice2Id,
                       displayLabel: 'B',
                       textMd: 'B',
                       isCorrect: false,
@@ -110,20 +117,20 @@ function QuestionFlowCoreProbe() {
         onClick={() => {
           core.setQuestion(
             createNextQuestion({
-              questionId: 'q_1',
+              questionId: fixtureQ1Id,
               choices: [
-                { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-                { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+                { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+                { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
               ],
               session: {
-                sessionId: 'session_1',
+                sessionId: fixtureSession1Id,
                 mode: 'exam',
 
                 deadlineAt: '2099-05-22T12:02:24.000Z',
 
                 index: 0,
                 total: 1,
-                draftSelectedChoiceId: 'choice_2',
+                draftSelectedChoiceId: fixtureChoice2Id,
                 draftCumulativeMs: 30_000,
               },
             }),
@@ -138,13 +145,13 @@ function QuestionFlowCoreProbe() {
         onClick={() => {
           core.setQuestion(
             createNextQuestion({
-              questionId: 'q_1',
+              questionId: fixtureQ1Id,
               choices: [
-                { id: 'choice_1', label: 'A', textMd: 'A', sortOrder: 1 },
-                { id: 'choice_2', label: 'B', textMd: 'B', sortOrder: 2 },
+                { id: fixtureChoice1Id, label: 'A', textMd: 'A', sortOrder: 1 },
+                { id: fixtureChoice2Id, label: 'B', textMd: 'B', sortOrder: 2 },
               ],
               session: {
-                sessionId: 'session_1',
+                sessionId: fixtureSession1Id,
                 mode: 'exam',
 
                 deadlineAt: '2099-05-22T12:02:24.000Z',
@@ -163,7 +170,9 @@ function QuestionFlowCoreProbe() {
       </button>
       <button
         type="button"
-        onClick={() => setLastSelectResult(core.onSelectChoice('choice_1'))}
+        onClick={() =>
+          setLastSelectResult(core.onSelectChoice(fixtureChoice1Id))
+        }
       >
         select-choice-1
       </button>
@@ -174,9 +183,9 @@ function QuestionFlowCoreProbe() {
         type="button"
         onClick={() =>
           core.setSubmitResult({
-            attemptId: 'attempt_1',
+            attemptId: fixtureAttempt1Id,
             isCorrect: false,
-            correctChoiceId: 'choice_1',
+            correctChoiceId: fixtureChoice1Id,
             explanationMd: 'Explanation',
             referenceMd: null,
             choiceExplanations: [],
@@ -190,9 +199,9 @@ function QuestionFlowCoreProbe() {
         onClick={() => {
           // Contrived probe state: isolate the submitResult guard from the isAnswered guard.
           core.setSubmitResult({
-            attemptId: 'attempt_1',
+            attemptId: fixtureAttempt1Id,
             isCorrect: false,
-            correctChoiceId: 'choice_1',
+            correctChoiceId: fixtureChoice1Id,
             explanationMd: 'Explanation',
             referenceMd: null,
             choiceExplanations: [],
@@ -207,14 +216,14 @@ function QuestionFlowCoreProbe() {
         onClick={() => {
           core.setSubmitResult(
             {
-              attemptId: 'attempt_1',
+              attemptId: fixtureAttempt1Id,
               isCorrect: false,
-              correctChoiceId: 'choice_1',
+              correctChoiceId: fixtureChoice1Id,
               explanationMd: 'Explanation',
               referenceMd: null,
               choiceExplanations: [],
             },
-            'q_1',
+            fixtureQ1Id,
           );
         }}
       >
@@ -232,7 +241,7 @@ function QuestionFlowCoreProbe() {
       <button
         type="button"
         onClick={() => {
-          core.onSelectChoice('choice_1');
+          core.onSelectChoice(fixtureChoice1Id);
           core.setLoadState({ status: 'ready' });
         }}
       >
@@ -259,7 +268,7 @@ test('clears derived selection state when the current question becomes null', as
     .click();
   await expect
     .element(screen.getByTestId('selected-choice-id'))
-    .toHaveTextContent('choice_1');
+    .toHaveTextContent(fixtureChoice1Id);
 
   await screen.getByRole('button', { name: 'mark-answered' }).click();
   await expect
@@ -288,7 +297,7 @@ test('returns true from onSelectChoice when selection changes', async () => {
 
   await expect
     .element(screen.getByTestId('selected-choice-id'))
-    .toHaveTextContent('choice_1');
+    .toHaveTextContent(fixtureChoice1Id);
   await expect
     .element(screen.getByTestId('last-select-result'))
     .toHaveTextContent('true');
@@ -342,7 +351,7 @@ test('restores exam draft selections without locking the answer', async () => {
     .click();
   await expect
     .element(screen.getByTestId('selected-choice-id'))
-    .toHaveTextContent('choice_1');
+    .toHaveTextContent(fixtureChoice1Id);
   await expect
     .element(screen.getByTestId('is-answered'))
     .toHaveTextContent('false');
@@ -352,7 +361,7 @@ test('restores exam draft selections without locking the answer', async () => {
   await screen.getByRole('button', { name: 'load-with-exam-draft' }).click();
   await expect
     .element(screen.getByTestId('selected-choice-id'))
-    .toHaveTextContent('choice_2');
+    .toHaveTextContent(fixtureChoice2Id);
   await expect
     .element(screen.getByTestId('is-answered'))
     .toHaveTextContent('false');
@@ -374,19 +383,19 @@ test('preserves a newer local exam selection during same-question resync', async
   await screen.getByRole('button', { name: 'load-with-exam-draft' }).click();
   await expect
     .element(screen.getByTestId('selected-choice-id'))
-    .toHaveTextContent('choice_2');
+    .toHaveTextContent(fixtureChoice2Id);
 
   await screen
     .getByRole('button', { name: 'select-choice-1', exact: true })
     .click();
   await expect
     .element(screen.getByTestId('selected-choice-id'))
-    .toHaveTextContent('choice_1');
+    .toHaveTextContent(fixtureChoice1Id);
 
   await screen.getByRole('button', { name: 'load-with-exam-draft' }).click();
   await expect
     .element(screen.getByTestId('selected-choice-id'))
-    .toHaveTextContent('choice_1');
+    .toHaveTextContent(fixtureChoice1Id);
   await expect
     .element(screen.getByTestId('is-answered'))
     .toHaveTextContent('false');
@@ -406,12 +415,12 @@ test('preserves an unsaved exam selection on same-question ready resync', async 
     .click();
   await expect
     .element(screen.getByTestId('selected-choice-id'))
-    .toHaveTextContent('choice_1');
+    .toHaveTextContent(fixtureChoice1Id);
 
   await screen.getByRole('button', { name: 'set-ready' }).click();
   await expect
     .element(screen.getByTestId('selected-choice-id'))
-    .toHaveTextContent('choice_1');
+    .toHaveTextContent(fixtureChoice1Id);
   await expect
     .element(screen.getByTestId('is-answered'))
     .toHaveTextContent('false');
@@ -434,7 +443,7 @@ test('preserves a freshly selected exam choice during same-tick ready resync', a
     .click();
   await expect
     .element(screen.getByTestId('selected-choice-id'))
-    .toHaveTextContent('choice_1');
+    .toHaveTextContent(fixtureChoice1Id);
   await expect
     .element(screen.getByTestId('is-answered'))
     .toHaveTextContent('false');
@@ -472,7 +481,7 @@ test('restores submitResult when previousSubmission exists in session data', asy
     .toHaveTextContent('false');
   await expect
     .element(screen.getByTestId('submit-result-correct-choice-id'))
-    .toHaveTextContent('choice_1');
+    .toHaveTextContent(fixtureChoice1Id);
   await expect
     .element(screen.getByTestId('submit-result-explanation-md'))
     .toHaveTextContent('Explanation');
@@ -540,7 +549,7 @@ test('preserves the selected choice when a local submit result is resynchronized
     .click();
   await expect
     .element(screen.getByTestId('selected-choice-id'))
-    .toHaveTextContent('choice_1');
+    .toHaveTextContent(fixtureChoice1Id);
 
   await screen.getByRole('button', { name: 'set-submit-result' }).click();
   await expect
@@ -550,7 +559,7 @@ test('preserves the selected choice when a local submit result is resynchronized
   await screen.getByRole('button', { name: 'set-ready' }).click();
   await expect
     .element(screen.getByTestId('selected-choice-id'))
-    .toHaveTextContent('choice_1');
+    .toHaveTextContent(fixtureChoice1Id);
   await expect
     .element(screen.getByTestId('has-submit-result'))
     .toHaveTextContent('true');

--- a/app/(app)/app/questions/[slug]/question-page-controller.browser.fixtures.ts
+++ b/app/(app)/app/questions/[slug]/question-page-controller.browser.fixtures.ts
@@ -1,0 +1,13 @@
+export const QUESTION_PAGE_QUESTION_1_ID = crypto.randomUUID();
+export const QUESTION_PAGE_QUESTION_2_ID = crypto.randomUUID();
+export const QUESTION_PAGE_CHOICE_1_ID = crypto.randomUUID();
+export const QUESTION_PAGE_CHOICE_2_ID = crypto.randomUUID();
+export const QUESTION_PAGE_ATTEMPT_1_ID = crypto.randomUUID();
+export const QUESTION_PAGE_ATTEMPT_2_ID = crypto.randomUUID();
+export const QUESTION_PAGE_ATTEMPT_3_ID = crypto.randomUUID();
+
+export function getQuestionPageQuestionIdForSlug(slug: string) {
+  return slug === 'q-2'
+    ? QUESTION_PAGE_QUESTION_2_ID
+    : QUESTION_PAGE_QUESTION_1_ID;
+}

--- a/app/(app)/app/questions/[slug]/use-question-page-bookmarks.browser.spec.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-bookmarks.browser.spec.tsx
@@ -8,6 +8,9 @@ import { ok } from '@/tests/test-helpers/ok';
 import { installReportClientErrorMocks } from '@/tests/test-helpers/report-client-error-mocks';
 import { useQuestionPageBookmarks } from './use-question-page-bookmarks';
 
+const fixtureQuestion1Id = crypto.randomUUID();
+const fixtureChoice1Id = crypto.randomUUID();
+
 vi.mock('@/src/adapters/controllers/bookmark-controller', { spy: true });
 vi.mock('@/lib/report-client-error', { spy: true });
 
@@ -18,11 +21,11 @@ installReportClientErrorMocks(reportClientError);
 
 function createQuestion(): GetQuestionBySlugOutput {
   return {
-    questionId: 'question-1',
+    questionId: fixtureQuestion1Id,
     slug: 'q-1',
     stemMd: 'Stem',
     difficulty: 'easy',
-    choices: [{ id: 'choice-1', label: 'A', textMd: 'Choice A' }],
+    choices: [{ id: fixtureChoice1Id, label: 'A', textMd: 'Choice A' }],
   };
 }
 
@@ -81,7 +84,7 @@ describe('useQuestionPageBookmarks (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'question-1',
+            questionId: fixtureQuestion1Id,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -120,7 +123,7 @@ describe('useQuestionPageBookmarks (browser)', () => {
 
     await expect.poll(() => toggleBookmark.mock.calls.length).toBe(1);
     expect(toggleBookmark).toHaveBeenCalledWith({
-      questionId: 'question-1',
+      questionId: fixtureQuestion1Id,
       idempotencyKey: expect.any(String),
     });
     await expect

--- a/app/(app)/app/questions/[slug]/use-question-page-bookmarks.browser.spec.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-bookmarks.browser.spec.tsx
@@ -6,10 +6,11 @@ import type { GetQuestionBySlugOutput } from '@/src/adapters/controllers/questio
 import type { GetBookmarksOutput } from '@/src/application/ports/bookmarks';
 import { ok } from '@/tests/test-helpers/ok';
 import { installReportClientErrorMocks } from '@/tests/test-helpers/report-client-error-mocks';
+import {
+  QUESTION_PAGE_CHOICE_1_ID,
+  QUESTION_PAGE_QUESTION_1_ID,
+} from './question-page-controller.browser.fixtures';
 import { useQuestionPageBookmarks } from './use-question-page-bookmarks';
-
-const fixtureQuestion1Id = crypto.randomUUID();
-const fixtureChoice1Id = crypto.randomUUID();
 
 vi.mock('@/src/adapters/controllers/bookmark-controller', { spy: true });
 vi.mock('@/lib/report-client-error', { spy: true });
@@ -21,11 +22,13 @@ installReportClientErrorMocks(reportClientError);
 
 function createQuestion(): GetQuestionBySlugOutput {
   return {
-    questionId: fixtureQuestion1Id,
+    questionId: QUESTION_PAGE_QUESTION_1_ID,
     slug: 'q-1',
     stemMd: 'Stem',
     difficulty: 'easy',
-    choices: [{ id: fixtureChoice1Id, label: 'A', textMd: 'Choice A' }],
+    choices: [
+      { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+    ],
   };
 }
 
@@ -84,7 +87,7 @@ describe('useQuestionPageBookmarks (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: fixtureQuestion1Id,
+            questionId: QUESTION_PAGE_QUESTION_1_ID,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -123,7 +126,7 @@ describe('useQuestionPageBookmarks (browser)', () => {
 
     await expect.poll(() => toggleBookmark.mock.calls.length).toBe(1);
     expect(toggleBookmark).toHaveBeenCalledWith({
-      questionId: fixtureQuestion1Id,
+      questionId: QUESTION_PAGE_QUESTION_1_ID,
       idempotencyKey: expect.any(String),
     });
     await expect

--- a/app/(app)/app/questions/[slug]/use-question-page-controller-bookmarks.browser.spec.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-controller-bookmarks.browser.spec.tsx
@@ -5,11 +5,17 @@ import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import type { GetBookmarksOutput } from '@/src/application/ports/bookmarks';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
+
 import {
   getBookmarks,
   getPreviousAttempt,
   getQuestionBySlug,
+  getQuestionPageQuestionIdForSlug,
   Probe,
+  QUESTION_PAGE_ATTEMPT_1_ID,
+  QUESTION_PAGE_CHOICE_1_ID,
+  QUESTION_PAGE_QUESTION_1_ID,
+  QUESTION_PAGE_QUESTION_2_ID,
   setupQuestionPageControllerBrowserSpec,
   toggleBookmark,
 } from './use-question-page-controller-test-helpers';
@@ -20,22 +26,24 @@ describe('useQuestionPageController (browser)', () => {
   it('loads bookmark state for the current review question', async () => {
     getQuestionBySlug.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
         slug: 'q-1',
         stemMd: 'Stem',
         difficulty: 'easy',
-        choices: [{ id: 'choice-1', label: 'A', textMd: 'Choice A' }],
+        choices: [
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+        ],
       }),
     );
     getPreviousAttempt.mockResolvedValue(
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-1',
-        selectedChoiceId: 'choice-1',
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-1',
+        correctChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -47,7 +55,7 @@ describe('useQuestionPageController (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'question-1',
+            questionId: QUESTION_PAGE_QUESTION_1_ID,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -74,22 +82,24 @@ describe('useQuestionPageController (browser)', () => {
   it('keeps bookmark state unhydrated until the bookmark lookup resolves', async () => {
     getQuestionBySlug.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
         slug: 'q-1',
         stemMd: 'Stem',
         difficulty: 'easy',
-        choices: [{ id: 'choice-1', label: 'A', textMd: 'Choice A' }],
+        choices: [
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+        ],
       }),
     );
     getPreviousAttempt.mockResolvedValue(
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-1',
-        selectedChoiceId: 'choice-1',
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-1',
+        correctChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -113,7 +123,7 @@ describe('useQuestionPageController (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'question-1',
+            questionId: QUESTION_PAGE_QUESTION_1_ID,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -138,22 +148,24 @@ describe('useQuestionPageController (browser)', () => {
   it('toggles bookmark state for the current review question', async () => {
     getQuestionBySlug.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
         slug: 'q-1',
         stemMd: 'Stem',
         difficulty: 'easy',
-        choices: [{ id: 'choice-1', label: 'A', textMd: 'Choice A' }],
+        choices: [
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+        ],
       }),
     );
     getPreviousAttempt.mockResolvedValue(
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-1',
-        selectedChoiceId: 'choice-1',
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-1',
+        correctChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -175,7 +187,7 @@ describe('useQuestionPageController (browser)', () => {
 
     await expect.poll(() => toggleBookmark.mock.calls.length).toBe(1);
     expect(toggleBookmark).toHaveBeenCalledWith({
-      questionId: 'question-1',
+      questionId: QUESTION_PAGE_QUESTION_1_ID,
       idempotencyKey: expect.any(String),
     });
     await expect
@@ -192,22 +204,24 @@ describe('useQuestionPageController (browser)', () => {
   it('reports saving state while a bookmark toggle is in flight', async () => {
     getQuestionBySlug.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
         slug: 'q-1',
         stemMd: 'Stem',
         difficulty: 'easy',
-        choices: [{ id: 'choice-1', label: 'A', textMd: 'Choice A' }],
+        choices: [
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+        ],
       }),
     );
     getPreviousAttempt.mockResolvedValue(
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-1',
-        selectedChoiceId: 'choice-1',
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-1',
+        correctChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -241,22 +255,24 @@ describe('useQuestionPageController (browser)', () => {
     getQuestionBySlug.mockImplementation(async (input: unknown) => {
       const slug = (input as { slug: string }).slug;
       return ok({
-        questionId: `question-${slug}`,
+        questionId: getQuestionPageQuestionIdForSlug(slug),
         slug,
         stemMd: 'Stem',
         difficulty: 'easy',
-        choices: [{ id: 'choice-1', label: 'A', textMd: 'Choice A' }],
+        choices: [
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+        ],
       });
     });
     getPreviousAttempt.mockResolvedValue(
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-1',
-        selectedChoiceId: 'choice-1',
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-1',
+        correctChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -324,8 +340,8 @@ describe('useQuestionPageController (browser)', () => {
       questionId: string;
     };
 
-    expect(firstInput.questionId).toBe('question-q-1');
-    expect(secondInput.questionId).toBe('question-q-2');
+    expect(firstInput.questionId).toBe(QUESTION_PAGE_QUESTION_1_ID);
+    expect(secondInput.questionId).toBe(QUESTION_PAGE_QUESTION_2_ID);
     expect(secondInput.idempotencyKey).not.toBe(firstInput.idempotencyKey);
   });
 });

--- a/app/(app)/app/questions/[slug]/use-question-page-controller-retry-reveal.browser.spec.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-controller-retry-reveal.browser.spec.tsx
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { ok } from '@/tests/test-helpers/ok';
+
 import {
   getPracticeSessionReview,
   getPreviousAttempt,
   getQuestionBySlug,
   Probe,
+  QUESTION_PAGE_ATTEMPT_1_ID,
+  QUESTION_PAGE_ATTEMPT_2_ID,
+  QUESTION_PAGE_ATTEMPT_3_ID,
+  QUESTION_PAGE_CHOICE_1_ID,
+  QUESTION_PAGE_CHOICE_2_ID,
+  QUESTION_PAGE_QUESTION_1_ID,
   setupQuestionPageControllerBrowserSpec,
   submitAnswer,
 } from './use-question-page-controller-test-helpers';
@@ -18,13 +25,13 @@ describe('useQuestionPageController (browser)', () => {
 
     getQuestionBySlug.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
         slug: 'q-1',
         stemMd: 'Stem',
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       }),
     );
@@ -39,7 +46,7 @@ describe('useQuestionPageController (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'question-1',
+            questionId: QUESTION_PAGE_QUESTION_1_ID,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -57,11 +64,11 @@ describe('useQuestionPageController (browser)', () => {
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-1',
-        selectedChoiceId: 'choice-2',
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-2',
+        correctChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -71,9 +78,9 @@ describe('useQuestionPageController (browser)', () => {
 
     submitAnswer.mockResolvedValue(
       ok({
-        attemptId: 'attempt-2',
+        attemptId: QUESTION_PAGE_ATTEMPT_2_ID,
         isCorrect: true,
-        correctChoiceId: 'choice-1',
+        correctChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -84,10 +91,10 @@ describe('useQuestionPageController (browser)', () => {
 
     await expect
       .element(screen.getByTestId('selected-choice'))
-      .toHaveTextContent('choice-2');
+      .toHaveTextContent(QUESTION_PAGE_CHOICE_2_ID);
     await expect
       .element(screen.getByTestId('attempt-id'))
-      .toHaveTextContent('attempt-1');
+      .toHaveTextContent(QUESTION_PAGE_ATTEMPT_1_ID);
     await expect
       .element(screen.getByTestId('session-nav-current-was-retried'))
       .toHaveTextContent('false');
@@ -107,9 +114,9 @@ describe('useQuestionPageController (browser)', () => {
       .poll(() => submitAnswer.mock.calls.length)
       .toBeGreaterThanOrEqual(1);
     expect(submitAnswer.mock.calls[0]?.[0]).toMatchObject({
-      questionId: 'question-1',
-      choiceId: 'choice-1',
-      retryOfAttemptId: 'attempt-1',
+      questionId: QUESTION_PAGE_QUESTION_1_ID,
+      choiceId: QUESTION_PAGE_CHOICE_1_ID,
+      retryOfAttemptId: QUESTION_PAGE_ATTEMPT_1_ID,
       retryOrigin: 'session_review',
       retrySessionId: sessionId,
     });
@@ -123,13 +130,13 @@ describe('useQuestionPageController (browser)', () => {
 
     getQuestionBySlug.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
         slug: 'q-1',
         stemMd: 'Stem',
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       }),
     );
@@ -144,7 +151,7 @@ describe('useQuestionPageController (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'question-1',
+            questionId: QUESTION_PAGE_QUESTION_1_ID,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -162,7 +169,7 @@ describe('useQuestionPageController (browser)', () => {
       ok({
         kind: 'session_unanswered',
         sessionMode: null,
-        correctChoiceId: 'choice-2',
+        correctChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         explanationMd: null,
         referenceMd: null,
         choiceExplanations: [],
@@ -182,19 +189,19 @@ describe('useQuestionPageController (browser)', () => {
       .toHaveTextContent(/^$/);
     await expect
       .element(screen.getByTestId('unanswered-reveal-correct-choice'))
-      .toHaveTextContent('choice-2');
+      .toHaveTextContent(QUESTION_PAGE_CHOICE_2_ID);
   });
 
   it('requires explicit answer-as-new action after hydration error before submitting', async () => {
     getQuestionBySlug.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
         slug: 'q-1',
         stemMd: 'Stem',
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       }),
     );
@@ -206,9 +213,9 @@ describe('useQuestionPageController (browser)', () => {
 
     submitAnswer.mockResolvedValue(
       ok({
-        attemptId: 'attempt-3',
+        attemptId: QUESTION_PAGE_ATTEMPT_3_ID,
         isCorrect: true,
-        correctChoiceId: 'choice-1',
+        correctChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -233,8 +240,8 @@ describe('useQuestionPageController (browser)', () => {
       .poll(() => submitAnswer.mock.calls.length)
       .toBeGreaterThanOrEqual(1);
     expect(submitAnswer.mock.calls[0]?.[0]).toMatchObject({
-      questionId: 'question-1',
-      choiceId: 'choice-1',
+      questionId: QUESTION_PAGE_QUESTION_1_ID,
+      choiceId: QUESTION_PAGE_CHOICE_1_ID,
     });
     expect(submitAnswer.mock.calls[0]?.[0]).not.toHaveProperty('retryOrigin');
     expect(submitAnswer.mock.calls[0]?.[0]).not.toHaveProperty(

--- a/app/(app)/app/questions/[slug]/use-question-page-controller-review-hydration.browser.spec.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-controller-review-hydration.browser.spec.tsx
@@ -4,11 +4,16 @@ import { render } from 'vitest-browser-react';
 import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
+
 import {
   getPracticeSessionReview,
   getPreviousAttempt,
   getQuestionBySlug,
   Probe,
+  QUESTION_PAGE_ATTEMPT_1_ID,
+  QUESTION_PAGE_CHOICE_1_ID,
+  QUESTION_PAGE_CHOICE_2_ID,
+  QUESTION_PAGE_QUESTION_1_ID,
   setupQuestionPageControllerBrowserSpec,
 } from './use-question-page-controller-test-helpers';
 
@@ -18,13 +23,13 @@ describe('useQuestionPageController (browser)', () => {
   it('loads previous attempt and pre-populates state in review mode', async () => {
     getQuestionBySlug.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
         slug: 'q-1',
         stemMd: 'Stem',
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       }),
     );
@@ -33,11 +38,11 @@ describe('useQuestionPageController (browser)', () => {
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-1',
-        selectedChoiceId: 'choice-2',
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-2',
+        correctChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -53,26 +58,26 @@ describe('useQuestionPageController (browser)', () => {
 
     await expect
       .element(screen.getByTestId('selected-choice'))
-      .toHaveTextContent('choice-2');
+      .toHaveTextContent(QUESTION_PAGE_CHOICE_2_ID);
     await expect
       .element(screen.getByTestId('attempt-id'))
-      .toHaveTextContent('attempt-1');
+      .toHaveTextContent(QUESTION_PAGE_ATTEMPT_1_ID);
 
     expect(getPreviousAttempt).toHaveBeenCalledWith({
-      questionId: 'question-1',
+      questionId: QUESTION_PAGE_QUESTION_1_ID,
     });
   });
 
   it('starts in loading-review state and clears it when previous attempt resolves', async () => {
     getQuestionBySlug.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
         slug: 'q-1',
         stemMd: 'Stem',
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       }),
     );
@@ -108,11 +113,11 @@ describe('useQuestionPageController (browser)', () => {
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-1',
-        selectedChoiceId: 'choice-2',
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-2',
+        correctChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -129,13 +134,13 @@ describe('useQuestionPageController (browser)', () => {
   it('shows review loading state on the first render after mode changes to review', async () => {
     getQuestionBySlug.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
         slug: 'q-1',
         stemMd: 'Stem',
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       }),
     );
@@ -212,11 +217,11 @@ describe('useQuestionPageController (browser)', () => {
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-1',
-        selectedChoiceId: 'choice-2',
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-2',
+        correctChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -232,13 +237,13 @@ describe('useQuestionPageController (browser)', () => {
 
     getQuestionBySlug.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
         slug: 'q-1',
         stemMd: 'Stem',
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       }),
     );
@@ -253,7 +258,7 @@ describe('useQuestionPageController (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'question-1',
+            questionId: QUESTION_PAGE_QUESTION_1_ID,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -272,10 +277,10 @@ describe('useQuestionPageController (browser)', () => {
         kind: 'attempt',
         sessionMode: null,
         attemptId,
-        selectedChoiceId: 'choice-2',
+        selectedChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-2',
+        correctChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -292,7 +297,7 @@ describe('useQuestionPageController (browser)', () => {
       .toHaveTextContent('ready');
 
     expect(getPreviousAttempt).toHaveBeenCalledWith({
-      questionId: 'question-1',
+      questionId: QUESTION_PAGE_QUESTION_1_ID,
       sessionId,
     });
   });

--- a/app/(app)/app/questions/[slug]/use-question-page-controller-session-navigation.browser.spec.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-controller-session-navigation.browser.spec.tsx
@@ -5,10 +5,16 @@ import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import type { GetPracticeSessionReviewOutput } from '@/src/application/use-cases/get-practice-session-review';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
+
 import {
   getPracticeSessionReview,
   getQuestionBySlug,
+  getQuestionPageQuestionIdForSlug,
   Probe,
+  QUESTION_PAGE_CHOICE_1_ID,
+  QUESTION_PAGE_CHOICE_2_ID,
+  QUESTION_PAGE_QUESTION_1_ID,
+  QUESTION_PAGE_QUESTION_2_ID,
   reportClientErrorSpy,
   setupQuestionPageControllerBrowserSpec,
 } from './use-question-page-controller-test-helpers';
@@ -21,13 +27,13 @@ describe('useQuestionPageController (browser)', () => {
 
     getQuestionBySlug.mockResolvedValue(
       ok({
-        questionId: 'question-1',
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
         slug: 'q-1',
         stemMd: 'Stem',
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       }),
     );
@@ -42,7 +48,7 @@ describe('useQuestionPageController (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'question-1',
+            questionId: QUESTION_PAGE_QUESTION_1_ID,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -54,7 +60,7 @@ describe('useQuestionPageController (browser)', () => {
           },
           {
             isAvailable: true,
-            questionId: 'question-2',
+            questionId: QUESTION_PAGE_QUESTION_2_ID,
             slug: 'q-2',
             stemMd: 'Stem 2',
             difficulty: 'medium',
@@ -93,13 +99,13 @@ describe('useQuestionPageController (browser)', () => {
   it('builds navigation from history sequence when sessionId is absent', async () => {
     getQuestionBySlug.mockResolvedValue(
       ok({
-        questionId: 'question-2',
+        questionId: QUESTION_PAGE_QUESTION_2_ID,
         slug: 'q-2',
         stemMd: 'Stem',
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       }),
     );
@@ -137,13 +143,13 @@ describe('useQuestionPageController (browser)', () => {
     getQuestionBySlug.mockImplementation(async (input: unknown) => {
       const slug = (input as { slug: string }).slug;
       return ok({
-        questionId: `question-${slug}`,
+        questionId: getQuestionPageQuestionIdForSlug(slug),
         slug,
         stemMd: 'Stem',
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       });
     });
@@ -159,7 +165,7 @@ describe('useQuestionPageController (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'question-q-1',
+            questionId: QUESTION_PAGE_QUESTION_1_ID,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -171,7 +177,7 @@ describe('useQuestionPageController (browser)', () => {
           },
           {
             isAvailable: true,
-            questionId: 'question-q-2',
+            questionId: QUESTION_PAGE_QUESTION_2_ID,
             slug: 'q-2',
             stemMd: 'Stem 2',
             difficulty: 'easy',
@@ -221,13 +227,13 @@ describe('useQuestionPageController (browser)', () => {
     getQuestionBySlug.mockImplementation(async (input: unknown) => {
       const slug = (input as { slug: string }).slug;
       return ok({
-        questionId: `question-${slug}`,
+        questionId: getQuestionPageQuestionIdForSlug(slug),
         slug,
         stemMd: 'Stem',
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       });
     });
@@ -243,7 +249,7 @@ describe('useQuestionPageController (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'question-q-1',
+            questionId: QUESTION_PAGE_QUESTION_1_ID,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -255,7 +261,7 @@ describe('useQuestionPageController (browser)', () => {
           },
           {
             isAvailable: true,
-            questionId: 'question-q-2',
+            questionId: QUESTION_PAGE_QUESTION_2_ID,
             slug: 'q-2',
             stemMd: 'Stem 2',
             difficulty: 'easy',
@@ -308,13 +314,13 @@ describe('useQuestionPageController (browser)', () => {
     getQuestionBySlug.mockImplementation(async (input: unknown) => {
       const slug = (input as { slug: string }).slug;
       return ok({
-        questionId: `question-${slug}`,
+        questionId: getQuestionPageQuestionIdForSlug(slug),
         slug,
         stemMd: 'Stem',
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       });
     });
@@ -333,7 +339,7 @@ describe('useQuestionPageController (browser)', () => {
           rows: [
             {
               isAvailable: true,
-              questionId: 'question-q-1',
+              questionId: QUESTION_PAGE_QUESTION_1_ID,
               slug: 'q-1',
               stemMd: 'Stem',
               difficulty: 'easy',
@@ -345,7 +351,7 @@ describe('useQuestionPageController (browser)', () => {
             },
             {
               isAvailable: true,
-              questionId: 'question-q-2',
+              questionId: QUESTION_PAGE_QUESTION_2_ID,
               slug: 'q-2',
               stemMd: 'Stem 2',
               difficulty: 'easy',
@@ -412,13 +418,13 @@ describe('useQuestionPageController (browser)', () => {
     getQuestionBySlug.mockImplementation(async (input: unknown) => {
       const slug = (input as { slug: string }).slug;
       return ok({
-        questionId: `question-${slug}`,
+        questionId: getQuestionPageQuestionIdForSlug(slug),
         slug,
         stemMd: 'Stem',
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       });
     });
@@ -433,7 +439,7 @@ describe('useQuestionPageController (browser)', () => {
       rows: [
         {
           isAvailable: true,
-          questionId: 'question-q-1',
+          questionId: QUESTION_PAGE_QUESTION_1_ID,
           slug: 'q-1',
           stemMd: 'Stem',
           difficulty: 'easy',
@@ -445,7 +451,7 @@ describe('useQuestionPageController (browser)', () => {
         },
         {
           isAvailable: true,
-          questionId: 'question-q-2',
+          questionId: QUESTION_PAGE_QUESTION_2_ID,
           slug: 'q-2',
           stemMd: 'Stem 2',
           difficulty: 'easy',

--- a/app/(app)/app/questions/[slug]/use-question-page-controller-stale-responses.browser.spec.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-controller-stale-responses.browser.spec.tsx
@@ -4,10 +4,18 @@ import { render } from 'vitest-browser-react';
 import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
+
 import {
   getPreviousAttempt,
   getQuestionBySlug,
+  getQuestionPageQuestionIdForSlug,
   Probe,
+  QUESTION_PAGE_ATTEMPT_1_ID,
+  QUESTION_PAGE_ATTEMPT_2_ID,
+  QUESTION_PAGE_CHOICE_1_ID,
+  QUESTION_PAGE_CHOICE_2_ID,
+  QUESTION_PAGE_QUESTION_1_ID,
+  QUESTION_PAGE_QUESTION_2_ID,
   setupQuestionPageControllerBrowserSpec,
   submitAnswer,
 } from './use-question-page-controller-test-helpers';
@@ -68,11 +76,13 @@ describe('useQuestionPageController (browser)', () => {
 
     deferredSecond.resolve(
       ok({
-        questionId: 'question-q-2',
+        questionId: QUESTION_PAGE_QUESTION_2_ID,
         slug: 'q-2',
         stemMd: 'Stem 2',
         difficulty: 'easy',
-        choices: [{ id: 'choice-1', label: 'A', textMd: 'Choice A' }],
+        choices: [
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+        ],
       }),
     );
     await expect
@@ -81,11 +91,13 @@ describe('useQuestionPageController (browser)', () => {
 
     deferredFirst.resolve(
       ok({
-        questionId: 'question-q-1',
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
         slug: 'q-1',
         stemMd: 'Stem 1',
         difficulty: 'easy',
-        choices: [{ id: 'choice-1', label: 'A', textMd: 'Choice A' }],
+        choices: [
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+        ],
       }),
     );
     await deferredFirst.promise;
@@ -98,13 +110,13 @@ describe('useQuestionPageController (browser)', () => {
     getQuestionBySlug.mockImplementation(async (input: unknown) => {
       const slug = (input as { slug: string }).slug;
       return ok({
-        questionId: `question-${slug}`,
+        questionId: getQuestionPageQuestionIdForSlug(slug),
         slug,
         stemMd: `Stem ${slug}`,
         difficulty: 'easy',
         choices: [
-          { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-          { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
         ],
       });
     });
@@ -175,11 +187,11 @@ describe('useQuestionPageController (browser)', () => {
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-q2',
-        selectedChoiceId: 'choice-1',
+        attemptId: QUESTION_PAGE_ATTEMPT_2_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-1',
+        correctChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         explanationMd: 'Because q2',
         referenceMd: null,
         choiceExplanations: [],
@@ -188,20 +200,20 @@ describe('useQuestionPageController (browser)', () => {
     );
     await expect
       .element(screen.getByTestId('attempt-id'))
-      .toHaveTextContent('attempt-q2');
+      .toHaveTextContent(QUESTION_PAGE_ATTEMPT_2_ID);
     await expect
       .element(screen.getByTestId('selected-choice'))
-      .toHaveTextContent('choice-1');
+      .toHaveTextContent(QUESTION_PAGE_CHOICE_1_ID);
 
     deferredFirst.resolve(
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-q1-stale',
-        selectedChoiceId: 'choice-2',
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         isOmitted: false,
         isCorrect: false,
-        correctChoiceId: 'choice-1',
+        correctChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         explanationMd: 'Because q1',
         referenceMd: null,
         choiceExplanations: [],
@@ -211,21 +223,23 @@ describe('useQuestionPageController (browser)', () => {
     await deferredFirst.promise;
     await expect
       .element(screen.getByTestId('attempt-id'))
-      .toHaveTextContent('attempt-q2');
+      .toHaveTextContent(QUESTION_PAGE_ATTEMPT_2_ID);
     await expect
       .element(screen.getByTestId('selected-choice'))
-      .toHaveTextContent('choice-1');
+      .toHaveTextContent(QUESTION_PAGE_CHOICE_1_ID);
   });
 
   it('clears previous-attempt loading when stale hydration is invalidated by a failed question reload', async () => {
     getQuestionBySlug
       .mockResolvedValueOnce(
         ok({
-          questionId: 'question-q-1',
+          questionId: QUESTION_PAGE_QUESTION_1_ID,
           slug: 'q-1',
           stemMd: 'Stem 1',
           difficulty: 'easy',
-          choices: [{ id: 'choice-1', label: 'A', textMd: 'Choice A' }],
+          choices: [
+            { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          ],
         }),
       )
       .mockResolvedValueOnce({
@@ -286,11 +300,11 @@ describe('useQuestionPageController (browser)', () => {
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-q1-stale',
-        selectedChoiceId: 'choice-1',
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-1',
+        correctChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         explanationMd: 'Because q1',
         referenceMd: null,
         choiceExplanations: [],
@@ -308,11 +322,13 @@ describe('useQuestionPageController (browser)', () => {
     getQuestionBySlug.mockImplementation(async (input: unknown) => {
       const slug = (input as { slug: string }).slug;
       return ok({
-        questionId: `question-${slug}`,
+        questionId: getQuestionPageQuestionIdForSlug(slug),
         slug,
         stemMd: `Stem ${slug}`,
         difficulty: 'easy',
-        choices: [{ id: 'choice-1', label: 'A', textMd: 'Choice A' }],
+        choices: [
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+        ],
       });
     });
 
@@ -366,9 +382,9 @@ describe('useQuestionPageController (browser)', () => {
 
     deferredSubmit.resolve(
       ok({
-        attemptId: 'attempt-q1-stale',
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
         isCorrect: true,
-        correctChoiceId: 'choice-1',
+        correctChoiceId: QUESTION_PAGE_CHOICE_1_ID,
         explanationMd: 'Because q1',
         referenceMd: null,
         choiceExplanations: [],

--- a/app/(app)/app/questions/[slug]/use-question-page-controller-test-helpers.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-controller-test-helpers.tsx
@@ -34,6 +34,20 @@ export const reportClientErrorSpy = vi.mocked(
 
 installReportClientErrorMocks(reportClientError);
 
+export const QUESTION_PAGE_QUESTION_1_ID = crypto.randomUUID();
+export const QUESTION_PAGE_QUESTION_2_ID = crypto.randomUUID();
+export const QUESTION_PAGE_CHOICE_1_ID = crypto.randomUUID();
+export const QUESTION_PAGE_CHOICE_2_ID = crypto.randomUUID();
+export const QUESTION_PAGE_ATTEMPT_1_ID = crypto.randomUUID();
+export const QUESTION_PAGE_ATTEMPT_2_ID = crypto.randomUUID();
+export const QUESTION_PAGE_ATTEMPT_3_ID = crypto.randomUUID();
+
+export function getQuestionPageQuestionIdForSlug(slug: string) {
+  return slug === 'q-2'
+    ? QUESTION_PAGE_QUESTION_2_ID
+    : QUESTION_PAGE_QUESTION_1_ID;
+}
+
 const emptyBookmarksResult: { ok: true; data: GetBookmarksOutput } = ok({
   rows: [],
 });
@@ -135,7 +149,7 @@ export function Probe({
       <button
         type="button"
         data-testid="select-choice-1"
-        onClick={() => output.onSelectChoice('choice-1')}
+        onClick={() => output.onSelectChoice(QUESTION_PAGE_CHOICE_1_ID)}
       >
         Select choice 1
       </button>

--- a/app/(app)/app/questions/[slug]/use-question-page-controller-test-helpers.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-controller-test-helpers.tsx
@@ -8,7 +8,19 @@ import * as questionViewController from '@/src/adapters/controllers/question-vie
 import type { GetBookmarksOutput } from '@/src/application/ports/bookmarks';
 import { ok } from '@/tests/test-helpers/ok';
 import { installReportClientErrorMocks } from '@/tests/test-helpers/report-client-error-mocks';
+import { QUESTION_PAGE_CHOICE_1_ID } from './question-page-controller.browser.fixtures';
 import { useQuestionPageController } from './use-question-page-controller';
+
+export {
+  getQuestionPageQuestionIdForSlug,
+  QUESTION_PAGE_ATTEMPT_1_ID,
+  QUESTION_PAGE_ATTEMPT_2_ID,
+  QUESTION_PAGE_ATTEMPT_3_ID,
+  QUESTION_PAGE_CHOICE_1_ID,
+  QUESTION_PAGE_CHOICE_2_ID,
+  QUESTION_PAGE_QUESTION_1_ID,
+  QUESTION_PAGE_QUESTION_2_ID,
+} from './question-page-controller.browser.fixtures';
 
 vi.mock('@/src/adapters/controllers/question-view-controller', { spy: true });
 vi.mock('@/src/adapters/controllers/question-controller', { spy: true });
@@ -33,20 +45,6 @@ export const reportClientErrorSpy = vi.mocked(
 );
 
 installReportClientErrorMocks(reportClientError);
-
-export const QUESTION_PAGE_QUESTION_1_ID = crypto.randomUUID();
-export const QUESTION_PAGE_QUESTION_2_ID = crypto.randomUUID();
-export const QUESTION_PAGE_CHOICE_1_ID = crypto.randomUUID();
-export const QUESTION_PAGE_CHOICE_2_ID = crypto.randomUUID();
-export const QUESTION_PAGE_ATTEMPT_1_ID = crypto.randomUUID();
-export const QUESTION_PAGE_ATTEMPT_2_ID = crypto.randomUUID();
-export const QUESTION_PAGE_ATTEMPT_3_ID = crypto.randomUUID();
-
-export function getQuestionPageQuestionIdForSlug(slug: string) {
-  return slug === 'q-2'
-    ? QUESTION_PAGE_QUESTION_2_ID
-    : QUESTION_PAGE_QUESTION_1_ID;
-}
 
 const emptyBookmarksResult: { ok: true; data: GetBookmarksOutput } = ok({
   rows: [],

--- a/app/(app)/app/questions/[slug]/use-question-page-previous-attempt.browser.spec.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-previous-attempt.browser.spec.tsx
@@ -14,6 +14,11 @@ import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
 import { useQuestionPagePreviousAttempt } from './use-question-page-previous-attempt';
 
+const fixtureQuestion1Id = crypto.randomUUID();
+const fixtureChoice1Id = crypto.randomUUID();
+const fixtureChoice2Id = crypto.randomUUID();
+const fixtureAttempt1Id = crypto.randomUUID();
+
 vi.mock('@/src/adapters/controllers/question-view-controller', { spy: true });
 vi.mock('@/lib/report-client-error', { spy: true });
 
@@ -21,13 +26,13 @@ const getPreviousAttempt = vi.mocked(questionViewController.getPreviousAttempt);
 const reportClientErrorSpy = vi.mocked(reportClientError.reportClientError);
 
 const defaultQuestion: GetQuestionBySlugOutput = {
-  questionId: 'question-1',
+  questionId: fixtureQuestion1Id,
   slug: 'q-1',
   stemMd: 'Stem',
   difficulty: 'easy',
   choices: [
-    { id: 'choice-1', label: 'A', textMd: 'Choice A' },
-    { id: 'choice-2', label: 'B', textMd: 'Choice B' },
+    { id: fixtureChoice1Id, label: 'A', textMd: 'Choice A' },
+    { id: fixtureChoice2Id, label: 'B', textMd: 'Choice B' },
   ],
 };
 
@@ -118,11 +123,11 @@ describe('useQuestionPagePreviousAttempt (browser)', () => {
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-1',
-        selectedChoiceId: 'choice-2',
+        attemptId: fixtureAttempt1Id,
+        selectedChoiceId: fixtureChoice2Id,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-2',
+        correctChoiceId: fixtureChoice2Id,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -134,16 +139,16 @@ describe('useQuestionPagePreviousAttempt (browser)', () => {
 
     await expect
       .element(screen.getByTestId('selected-choice'))
-      .toHaveTextContent('choice-2');
+      .toHaveTextContent(fixtureChoice2Id);
     await expect
       .element(screen.getByTestId('attempt-id'))
-      .toHaveTextContent('attempt-1');
+      .toHaveTextContent(fixtureAttempt1Id);
     await expect
       .element(screen.getByTestId('review-hydration-state'))
       .toHaveTextContent('attempt');
 
     expect(getPreviousAttempt).toHaveBeenCalledWith({
-      questionId: 'question-1',
+      questionId: fixtureQuestion1Id,
     });
   });
 
@@ -217,11 +222,11 @@ describe('useQuestionPagePreviousAttempt (browser)', () => {
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-1',
-        selectedChoiceId: 'choice-2',
+        attemptId: fixtureAttempt1Id,
+        selectedChoiceId: fixtureChoice2Id,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-2',
+        correctChoiceId: fixtureChoice2Id,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -269,11 +274,11 @@ describe('useQuestionPagePreviousAttempt (browser)', () => {
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: 'attempt-1',
-        selectedChoiceId: 'choice-2',
+        attemptId: fixtureAttempt1Id,
+        selectedChoiceId: fixtureChoice2Id,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: 'choice-2',
+        correctChoiceId: fixtureChoice2Id,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],

--- a/app/(app)/app/questions/[slug]/use-question-page-previous-attempt.browser.spec.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-previous-attempt.browser.spec.tsx
@@ -12,12 +12,13 @@ import * as questionViewController from '@/src/adapters/controllers/question-vie
 import type { SubmitAnswerOutput } from '@/src/application/use-cases/submit-answer';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
+import {
+  QUESTION_PAGE_ATTEMPT_1_ID,
+  QUESTION_PAGE_CHOICE_1_ID,
+  QUESTION_PAGE_CHOICE_2_ID,
+  QUESTION_PAGE_QUESTION_1_ID,
+} from './question-page-controller.browser.fixtures';
 import { useQuestionPagePreviousAttempt } from './use-question-page-previous-attempt';
-
-const fixtureQuestion1Id = crypto.randomUUID();
-const fixtureChoice1Id = crypto.randomUUID();
-const fixtureChoice2Id = crypto.randomUUID();
-const fixtureAttempt1Id = crypto.randomUUID();
 
 vi.mock('@/src/adapters/controllers/question-view-controller', { spy: true });
 vi.mock('@/lib/report-client-error', { spy: true });
@@ -26,13 +27,13 @@ const getPreviousAttempt = vi.mocked(questionViewController.getPreviousAttempt);
 const reportClientErrorSpy = vi.mocked(reportClientError.reportClientError);
 
 const defaultQuestion: GetQuestionBySlugOutput = {
-  questionId: fixtureQuestion1Id,
+  questionId: QUESTION_PAGE_QUESTION_1_ID,
   slug: 'q-1',
   stemMd: 'Stem',
   difficulty: 'easy',
   choices: [
-    { id: fixtureChoice1Id, label: 'A', textMd: 'Choice A' },
-    { id: fixtureChoice2Id, label: 'B', textMd: 'Choice B' },
+    { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+    { id: QUESTION_PAGE_CHOICE_2_ID, label: 'B', textMd: 'Choice B' },
   ],
 };
 
@@ -123,11 +124,11 @@ describe('useQuestionPagePreviousAttempt (browser)', () => {
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: fixtureAttempt1Id,
-        selectedChoiceId: fixtureChoice2Id,
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: fixtureChoice2Id,
+        correctChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -139,16 +140,16 @@ describe('useQuestionPagePreviousAttempt (browser)', () => {
 
     await expect
       .element(screen.getByTestId('selected-choice'))
-      .toHaveTextContent(fixtureChoice2Id);
+      .toHaveTextContent(QUESTION_PAGE_CHOICE_2_ID);
     await expect
       .element(screen.getByTestId('attempt-id'))
-      .toHaveTextContent(fixtureAttempt1Id);
+      .toHaveTextContent(QUESTION_PAGE_ATTEMPT_1_ID);
     await expect
       .element(screen.getByTestId('review-hydration-state'))
       .toHaveTextContent('attempt');
 
     expect(getPreviousAttempt).toHaveBeenCalledWith({
-      questionId: fixtureQuestion1Id,
+      questionId: QUESTION_PAGE_QUESTION_1_ID,
     });
   });
 
@@ -222,11 +223,11 @@ describe('useQuestionPagePreviousAttempt (browser)', () => {
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: fixtureAttempt1Id,
-        selectedChoiceId: fixtureChoice2Id,
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: fixtureChoice2Id,
+        correctChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],
@@ -274,11 +275,11 @@ describe('useQuestionPagePreviousAttempt (browser)', () => {
       ok({
         kind: 'attempt',
         sessionMode: null,
-        attemptId: fixtureAttempt1Id,
-        selectedChoiceId: fixtureChoice2Id,
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         isOmitted: false,
         isCorrect: true,
-        correctChoiceId: fixtureChoice2Id,
+        correctChoiceId: QUESTION_PAGE_CHOICE_2_ID,
         explanationMd: 'Because.',
         referenceMd: null,
         choiceExplanations: [],

--- a/app/(app)/app/questions/[slug]/use-question-page-session-navigation.browser.spec.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-session-navigation.browser.spec.tsx
@@ -8,6 +8,9 @@ import { ok } from '@/tests/test-helpers/ok';
 import { installReportClientErrorMocks } from '@/tests/test-helpers/report-client-error-mocks';
 import { useQuestionPageSessionNavigation } from './use-question-page-session-navigation';
 
+const fixtureQuestion1Id = crypto.randomUUID();
+const fixtureQuestion2Id = crypto.randomUUID();
+
 vi.mock('@/src/adapters/controllers/practice-controller', { spy: true });
 vi.mock('@/lib/report-client-error', { spy: true });
 
@@ -83,7 +86,7 @@ describe('useQuestionPageSessionNavigation (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'question-1',
+            questionId: fixtureQuestion1Id,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -95,7 +98,7 @@ describe('useQuestionPageSessionNavigation (browser)', () => {
           },
           {
             isAvailable: true,
-            questionId: 'question-2',
+            questionId: fixtureQuestion2Id,
             slug: 'q-2',
             stemMd: 'Stem 2',
             difficulty: 'easy',
@@ -138,7 +141,7 @@ describe('useQuestionPageSessionNavigation (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: 'question-1',
+            questionId: fixtureQuestion1Id,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -150,7 +153,7 @@ describe('useQuestionPageSessionNavigation (browser)', () => {
           },
           {
             isAvailable: true,
-            questionId: 'question-2',
+            questionId: fixtureQuestion2Id,
             slug: 'q-2',
             stemMd: 'Stem 2',
             difficulty: 'easy',

--- a/app/(app)/app/questions/[slug]/use-question-page-session-navigation.browser.spec.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-session-navigation.browser.spec.tsx
@@ -6,10 +6,11 @@ import type { QuestionOrigin } from '@/lib/routes';
 import * as practiceController from '@/src/adapters/controllers/practice-controller';
 import { ok } from '@/tests/test-helpers/ok';
 import { installReportClientErrorMocks } from '@/tests/test-helpers/report-client-error-mocks';
+import {
+  QUESTION_PAGE_QUESTION_1_ID,
+  QUESTION_PAGE_QUESTION_2_ID,
+} from './question-page-controller.browser.fixtures';
 import { useQuestionPageSessionNavigation } from './use-question-page-session-navigation';
-
-const fixtureQuestion1Id = crypto.randomUUID();
-const fixtureQuestion2Id = crypto.randomUUID();
 
 vi.mock('@/src/adapters/controllers/practice-controller', { spy: true });
 vi.mock('@/lib/report-client-error', { spy: true });
@@ -86,7 +87,7 @@ describe('useQuestionPageSessionNavigation (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: fixtureQuestion1Id,
+            questionId: QUESTION_PAGE_QUESTION_1_ID,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -98,7 +99,7 @@ describe('useQuestionPageSessionNavigation (browser)', () => {
           },
           {
             isAvailable: true,
-            questionId: fixtureQuestion2Id,
+            questionId: QUESTION_PAGE_QUESTION_2_ID,
             slug: 'q-2',
             stemMd: 'Stem 2',
             difficulty: 'easy',
@@ -141,7 +142,7 @@ describe('useQuestionPageSessionNavigation (browser)', () => {
         rows: [
           {
             isAvailable: true,
-            questionId: fixtureQuestion1Id,
+            questionId: QUESTION_PAGE_QUESTION_1_ID,
             slug: 'q-1',
             stemMd: 'Stem',
             difficulty: 'easy',
@@ -153,7 +154,7 @@ describe('useQuestionPageSessionNavigation (browser)', () => {
           },
           {
             isAvailable: true,
-            questionId: fixtureQuestion2Id,
+            questionId: QUESTION_PAGE_QUESTION_2_ID,
             slug: 'q-2',
             stemMd: 'Stem 2',
             difficulty: 'easy',

--- a/components/question/QuestionCard.browser.spec.tsx
+++ b/components/question/QuestionCard.browser.spec.tsx
@@ -2,14 +2,17 @@ import { expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { QuestionCard } from './question-card';
 
+const fixtureChoiceAId = crypto.randomUUID();
+const fixtureChoiceBId = crypto.randomUUID();
+
 test('calls onSelectChoice with the clicked choice id', async () => {
   const onSelectChoice = vi.fn();
   const screen = await render(
     <QuestionCard
       stemMd="Stem"
       choices={[
-        { id: 'choice_a', label: 'A', textMd: 'Choice A' },
-        { id: 'choice_b', label: 'B', textMd: 'Choice B' },
+        { id: fixtureChoiceAId, label: 'A', textMd: 'Choice A' },
+        { id: fixtureChoiceBId, label: 'B', textMd: 'Choice B' },
       ]}
       selectedChoiceId={null}
       correctChoiceId={null}
@@ -19,7 +22,7 @@ test('calls onSelectChoice with the clicked choice id', async () => {
 
   await screen.getByRole('radio', { name: /Choice B/i }).click();
 
-  expect(onSelectChoice).toHaveBeenCalledWith('choice_b');
+  expect(onSelectChoice).toHaveBeenCalledWith(fixtureChoiceBId);
 });
 
 test('disables choices when correctChoiceId is present', async () => {
@@ -28,11 +31,11 @@ test('disables choices when correctChoiceId is present', async () => {
     <QuestionCard
       stemMd="Stem"
       choices={[
-        { id: 'choice_a', label: 'A', textMd: 'Choice A' },
-        { id: 'choice_b', label: 'B', textMd: 'Choice B' },
+        { id: fixtureChoiceAId, label: 'A', textMd: 'Choice A' },
+        { id: fixtureChoiceBId, label: 'B', textMd: 'Choice B' },
       ]}
       selectedChoiceId={null}
-      correctChoiceId="choice_a"
+      correctChoiceId={fixtureChoiceAId}
       onSelectChoice={onSelectChoice}
     />,
   );

--- a/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
+++ b/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
@@ -695,6 +695,7 @@ PR 3 must not ship as one mega-PR. Ship the code sweep as three execution PRs af
    - Branch: `feat/debt-400-pr-3b-browser-fixtures`
    - Scope: the rows labeled `3b` above plus the browser-only helper/probe/fixture files enumerated in the PR 3b pre-execution audit subsection when they define shared boundary IDs.
    - Proof: run touched browser specs directly and `pnpm test:browser`, plus PR 1 harness, DEBT-398 scan, shuffled unit suite, full local gate, and the no-unnecessary-`vi.hoisted()` proof.
+   - Status: implementation complete on branch; PR number pending. PR 3c, PR 4, and archive follow.
 3. **PR 3c - application use-case/shared fixtures**
    - Branch: `feat/debt-400-pr-3c-application-fixtures`
    - Scope: the rows labeled `3c` above.

--- a/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
+++ b/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
@@ -1,8 +1,8 @@
 # DEBT-400: Test Fixture Integrity (Zod Boundary Class)
 
-**Priority:** P2 (latent bug class. After PR 2b, the current canonical candidate grep finds 2,040 placeholder-ID assignments across 129 test files; the remaining PR 3 app/browser/application slice accounts for 2,021 candidate assignments across 125 files. This is a candidate set, not a mandate to replace every string: the execution scope is only IDs that cross `zUuid = z.guid()` controller schemas or model Drizzle `uuid()` columns.)
+**Priority:** P2 (latent bug class. After PR 3a, the current canonical candidate grep finds 1,330 remaining placeholder-ID assignments across 78 PR 3 app/browser/application files. This is a candidate set, not a mandate to replace every string: the execution scope is only IDs that cross `zUuid = z.guid()` controller schemas or model Drizzle `uuid()` columns.)
 **Created:** 2026-05-26
-**Source:** Deep schema/boundary integrity audit conducted alongside DEBT-394 archival; re-audited on 2026-05-28 from `dev` at `f2dc0793`, PR 2 scope re-audited on 2026-05-28 from `dev` at `e7f1029a` after PR 1 merged, repository-slice PR 2b scope re-audited on 2026-05-29 from `dev` at `a98b5922` after PR 2a merged, and app/browser/application PR 3 scope re-audited on 2026-05-29 from `dev` at `3b225505` after PR 2b merged. Direct precedent is PR #330, which bumped Zod from 3 to 4 and deliberately kept historical UUID/GUID behavior by replacing the shared controller ID schema with Zod 4 `z.guid()`.
+**Source:** Deep schema/boundary integrity audit conducted alongside DEBT-394 archival; re-audited on 2026-05-28 from `dev` at `f2dc0793`, PR 2 scope re-audited on 2026-05-28 from `dev` at `e7f1029a` after PR 1 merged, repository-slice PR 2b scope re-audited on 2026-05-29 from `dev` at `a98b5922` after PR 2a merged, app/browser/application PR 3 scope re-audited on 2026-05-29 from `dev` at `3b225505` after PR 2b merged, and browser-slice PR 3b scope re-audited on 2026-05-30 from `dev` at `895d03a5` after PR 3a merged. Direct precedent is PR #330, which bumped Zod from 3 to 4 and deliberately kept historical UUID/GUID behavior by replacing the shared controller ID schema with Zod 4 `z.guid()`.
 **Related:** [src/adapters/shared/zod-schemas.ts](../../src/adapters/shared/zod-schemas.ts), [db/schema.ts](../../db/schema.ts), [src/domain/test-helpers/](../../src/domain/test-helpers/), [src/application/test-helpers/fakes/](../../src/application/test-helpers/fakes/), [docs/dev/dependency-update-protocol.md](../dev/dependency-update-protocol.md), [DEBT-397](./debt-397-datetime-boundary-type-normalization.md), [DEBT-394 (archived)](../_archive/debt/debt-394-supply-chain-hardening.md), PR #330
 
 **Status:** Active
@@ -104,7 +104,7 @@ rg -n "\b(questionId|sessionId|attemptId|choiceId|selectedChoiceId|correctChoice
   --glob '!**/_archive/**'
 ```
 
-Current result on `3b225505` after PR 2b: **2,040 lines across 129 files**. The PR 3 slice (`app/`, `components/`, `src/application/`, `tests/e2e/helpers/`) is **2,021 lines across 125 files**. The result on `a98b5922` after PR 2a was **2,244 lines across 140 files** with the earlier command that did not include the `db_user` E2E-helper prefix. The result on `e7f1029a` after PR 1 was **2,438 lines across 162 files**. The pre-PR1 audit result on `f2dc0793` was **2,447 lines across 163 files**.
+Current result on `895d03a5` after PR 3a: **1,349 lines across 82 files** repo-wide. The remaining PR 3 slice (`app/`, `components/`, `src/application/`, `tests/e2e/helpers/`) is **1,330 lines across 78 files**. Historical result on `3b225505` after PR 2b was **2,040 lines across 129 files**, with the PR 3 slice accounting for **2,021 lines across 125 files** before PR 3a shipped. The result on `a98b5922` after PR 2a was **2,244 lines across 140 files** with the earlier command that did not include the `db_user` E2E-helper prefix. The result on `e7f1029a` after PR 1 was **2,438 lines across 162 files**. The pre-PR1 audit result on `f2dc0793` was **2,447 lines across 163 files**.
 
 This replaces the old narrower `604 / 64` count. The old grep only searched `app/ src/ components/`, only camel-case object properties, only five field names, and only underscore-prefixed values. It missed hyphenated placeholders (`session-1`), choice/tag/subscription fields, snake_case SQL-row fixtures (`user_id`), E2E app-user sentinels such as `db_user_123`, and `tests/**` helper fixtures.
 
@@ -463,7 +463,7 @@ PR 2b status: shipped in PR #370 at `3b225505`. The repository-slice PR migrated
 
 Root audit branch: `feat/debt-400-pr-3-app-application-fixtures`
 
-Pre-execution audit status: current from `dev` at `3b225505` after PR 2b merged. PRs 1, 2a, and 2b are merged, so this is the remaining code sweep.
+Pre-execution audit status: current from `dev` at `895d03a5` after PR 3a merged. PRs 1, 2a, 2b, and 3a are merged. Remaining code sweeps are PR 3b (browser specs and browser-only helper fixtures) and PR 3c (application use-case/shared fixtures), followed by PR 4 docs.
 
 #### PR 3 candidate count
 
@@ -473,13 +473,15 @@ Use the canonical command above. For the PR 3 slice, run it against:
 app/ components/ src/application/ tests/e2e/helpers/
 ```
 
-Current result: **2,021 candidate lines across 125 files**.
+Historical result before PR 3a: **2,021 candidate lines across 125 files**.
+
+Current result on `895d03a5` after PR 3a: **1,330 candidate lines across 78 files**.
 
 Breakdown:
 
 | Slice | Candidate lines | Files | Decision |
 |---|---:|---:|---|
-| App/components non-browser tests plus E2E helper unit tests | 700 | 52 | PR 3a, Tier 1 FIX where the fixture models controller/app UUID shape; provider/component-only hits stay. Includes the execution-discovered `tests/e2e/helpers/e2e-reset-shared.test.ts` app-user SQL row fixture. |
+| App/components non-browser tests plus E2E helper unit tests | 8 | 4 | PR 3a shipped in PR #371 at `895d03a5`. Remaining hits are expected LEAVE cases: DEBT-398 regression fixture strings and provider-shaped Clerk IDs in E2E helper tests. Do not pull these into PR 3b. |
 | App/components browser specs | 601 | 40 | PR 3b, Tier 1 FIX where browser fixtures mock controller DTOs or hook controller responses; component-only/provider hits stay. |
 | `src/application/use-cases/**` and `src/application/shared/**` | 579 | 27 | PR 3c, Tier 2 FIX for entity/port fixtures that model Drizzle UUID columns. |
 | `src/application/test-helpers/fakes/*.test.ts` | 142 | 7 | Tier 3 LEAVE. These are fake behavior tests with semantic internal keys; PR 1 already fixed fake-generated defaults. |
@@ -629,6 +631,57 @@ Candidate counts are grep hits, not exact edit counts. One semantic UUID variabl
 | LEAVE | `src/application/test-helpers/fakes/fake-subscription-repository.test.ts` | 6 | Tier 3 LEAVE | Fake subscription behavior keys; provider IDs remain provider-shaped. |
 | LEAVE | `src/application/test-helpers/fakes/fake-tag-repository.test.ts` | 2 | Tier 3 LEAVE | Fake tag behavior keys/slugs; no boundary. |
 
+#### PR 3b pre-execution audit: browser target list and hoisting rule
+
+Re-audited on 2026-05-30 from `dev` at `895d03a5` after PR 3a merged. The canonical browser-spec grep is:
+
+```sh
+rg -n "\b(questionId|sessionId|attemptId|choiceId|selectedChoiceId|correctChoiceId|retryOfAttemptId|retrySessionId|userId|tagId|subscriptionId|idempotencyKey|question_id|session_id|attempt_id|choice_id|selected_choice_id|correct_choice_id|retry_of_attempt_id|retry_session_id|user_id|tag_id|subscription_id|idempotency_key|id)\s*[:=]\s*['\"](q|question|choice|session|attempt|user|db_user|tag|subscription|test|mock|fake|other|correct|incorrect|bookmark)[_-][A-Za-z0-9_-]+['\"]" \
+  app/ components/ \
+  --glob '*.browser.spec.tsx' \
+  --glob '!**/_archive/**'
+```
+
+Current result: **601 candidate lines across 40 browser spec files**. The 3b rows in the table above remain the per-file execution target list.
+
+Browser-only helper/probe files also contain shared boundary-ID fixtures consumed by the 3b specs. They are **in PR 3b scope even though the canonical `*.browser.spec.tsx` count excludes them**:
+
+| Helper file | Candidate shape | Execution note |
+|---|---|---|
+| `app/(app)/app/questions/[slug]/use-question-page-controller-test-helpers.tsx` | Probe action calls `output.onSelectChoice('choice-1')`; test IDs/slugs are LEAVE. | Keep `data-testid` values and slug defaults readable. Replace only the choice ID value when execution introduces shared question-page choice ID constants/props, so button actions still match mocked choice DTO IDs. |
+| `app/(app)/app/practice/[sessionId]/hooks/practice-session-page-controller.browser.fixtures.ts` | Shared `createQuestionResponse` / `createReviewResponse` defaults for `choice_1` and `session-1`. | Replace boundary defaults with named UUID values or require caller-supplied values where that preserves linkage more clearly. |
+| `app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller-test-helpers.ts` | `CHOICE_1` / `CHOICE_2` / `CHOICE_3`, question navigation graph (`question-1` / `question-2` / `question-3`), and assertions referencing those IDs. | Use role-bearing constants once and reuse them in row fixtures, branching logic, and assertions. Do not blind-replace linked values independently. |
+| `app/(app)/app/practice/[sessionId]/hooks/practice-session-page-controller.browser.probes.tsx` | Probe calls `usePracticeSessionPageController('session-1')`, `onSelectChoice('choice_1')`, `onNavigateQuestion('question-1')`, and `onOpenReviewQuestion('question-1')`; `data-testid` strings are LEAVE. | Import/reuse the same named ID constants as the shared browser helper fixtures so probe actions continue to target real DTO IDs. |
+
+Browser file classification:
+
+- **Controller-hook specs (Tier 1 FIX):** the `use-question-page-*`, `use-practice-session-page-controller-*`, `use-practice-session-question-flow*`, `use-practice-question-*`, `use-practice-session-start`, `use-practice-session-controls`, and `use-history-sessions` browser specs. These use `.claude/rules/testing-browser.md`'s controller-mocking pattern: `vi.mock(path, { spy: true })`, then `vi.mocked(controllerFn).mockResolvedValue(...)` or `mockImplementation(...)` in normal test scope. Mocked DTO/input IDs are FIX; test IDs, labels, slugs, and negative sentinels are LEAVE.
+- **Component/render specs (Tier 1 FIX where props are controller-shaped):** `practice-view.browser.spec.tsx`, `practice-session-page-view-*.browser.spec.tsx`, `history-*-tab.browser.spec.tsx`, `QuestionCard.browser.spec.tsx`, `session-summary-view.browser.spec.tsx`, `exam-review-view.browser.spec.tsx`, `post-exam-review-view.browser.spec.tsx`, `incomplete-session-card.browser.spec.tsx`, `practice-session-starter.browser.spec.tsx`, and `practice-view-notification.browser.spec.tsx`. Props that model controller DTOs or app UUID columns are FIX; pure DOM/test tokens are LEAVE.
+- **Browser specs with no canonical DEBT-400 target hits:** `theme-toggle.browser.spec.tsx`, `mobile-nav.browser.spec.tsx`, `notification-provider.browser.spec.tsx`, `ChoiceButton.browser.spec.tsx`, `bookmarks-toast.browser.spec.tsx`, `bookmark-row-shell.browser.spec.tsx`, `practice-session-toast.browser.spec.tsx`, `quick-practice-client.browser.spec.tsx`, and `use-exam-timer.browser.spec.tsx` are not migration targets unless execution discovers a concrete boundary-ID fixture while reading. Existing provider/navigation mock IDs remain out of scope.
+
+Hoisting rule for PR 3b:
+
+- `vi.hoisted()` is required only when a value is referenced inside a `vi.mock(path, () => ...)` factory body, because Vitest hoists the factory before ordinary module-scope constants initialize.
+- `vi.hoisted()` is **not** required for UUID values passed to `vi.mocked(controllerFn).mockResolvedValue(...)`, `mockResolvedValueOnce(...)`, or `mockImplementation(...)` in `beforeEach` / `it` bodies after a `{ spy: true }` controller mock. Those values execute in normal scope.
+- Current browser factory-mock exceptions are for external/mock-function setup, not UUID fixture constants: `next/navigation`, `next-themes`, and the practice-session page-controller browser setup hoist mock functions that feed factory mocks. No current browser UUID fixture constant feeds a `vi.mock(...)` factory body.
+- PR 3b must therefore **not** consistency-hoist UUID constants across the slice. Add `vi.hoisted()` only if execution creates a UUID value that is directly read inside a `vi.mock(path, () => ...)` factory body; document that exception in the PR body if it happens.
+
+PR 3b linkage/capture rule:
+
+- Use named UUID variables for linked DTO graphs (`questionId`, choice IDs, `selectedChoiceId`, `correctChoiceId`, `attemptId`, `sessionId`) and reuse the same variable in mocked controller payloads, probe actions, and assertions.
+- Capture and assert the generated ID where the test checks rendered text, calls, error messages, or route/navigation behavior.
+- Do not change `data-testid`, button labels, slugs, provider IDs, or intentional invalid strings just because they resemble IDs.
+
+PR 3b proof method:
+
+- Scope proof: diff contains only `*.browser.spec.tsx`, the explicitly listed browser helper/probe/fixture files above when needed, and this DEBT doc. No PR 3a non-browser tests, no `src/application/**` PR 3c files, no adapters, no factories/fakes.
+- Hoist proof: `git --no-pager diff origin/dev...HEAD | grep -E '^\+.*vi\.hoisted'` should be empty, unless a reviewed exception shows the new hoisted value is read inside a `vi.mock(path, () => ...)` factory body. Do not add `vi.hoisted()` for ordinary `mockResolvedValue` UUID constants.
+- Type proof: no new `as any`, `as unknown as`, `@ts-ignore`, widened DTO types, or relaxed expectations.
+- Linkage proof: call out at least one question/choice/session graph where named UUID variables preserve previous cross-reference semantics.
+- Test proof: run touched browser specs directly where practical, then `pnpm test:browser`, `pnpm test --run tests/shared/fixture-uuid-integrity.test.ts`, `pnpm test --run components/theme-token-regression.test.tsx`, `pnpm test --run --sequence.shuffle`, and the full local gate.
+
+PR 3b split decision: ship as **one browser PR** on `feat/debt-400-pr-3b-browser-fixtures`, with sub-area commits for reviewability (question-page controller hooks, practice-session controller hooks/helpers, component/render specs, history/misc). The slice is homogeneous and the hoisting rule above removes the main 3a review churn risk. Splitting further would add branch choreography without changing the boundary decision. If execution discovers the helper/probe changes are materially larger than the browser-spec edits, keep them in the same PR because they are shared browser fixture infrastructure for the same tests.
+
 #### PR 3 split plan
 
 PR 3 must not ship as one mega-PR. Ship the code sweep as three execution PRs after this audit:
@@ -637,11 +690,11 @@ PR 3 must not ship as one mega-PR. Ship the code sweep as three execution PRs af
    - Branch: `feat/debt-400-pr-3a-app-component-fixtures`
    - Scope: the rows labeled `3a` above.
    - Proof: run the touched files directly, `pnpm test --run app/ components/ tests/e2e/helpers`, PR 1 harness, DEBT-398 scan, shuffled unit suite, full local gate.
-   - Status: implementation complete on the PR 3a branch; PR 3b, PR 3c, PR 4, and archive follow.
+   - Status: shipped in PR #371 at `895d03a5`; PR 3b, PR 3c, PR 4, and archive follow.
 2. **PR 3b - browser fixture sweep**
    - Branch: `feat/debt-400-pr-3b-browser-fixtures`
-   - Scope: the rows labeled `3b` above.
-   - Proof: run touched browser specs directly and `pnpm test:browser`, plus PR 1 harness, DEBT-398 scan, shuffled unit suite, full local gate.
+   - Scope: the rows labeled `3b` above plus the browser-only helper/probe/fixture files enumerated in the PR 3b pre-execution audit subsection when they define shared boundary IDs.
+   - Proof: run touched browser specs directly and `pnpm test:browser`, plus PR 1 harness, DEBT-398 scan, shuffled unit suite, full local gate, and the no-unnecessary-`vi.hoisted()` proof.
 3. **PR 3c - application use-case/shared fixtures**
    - Branch: `feat/debt-400-pr-3c-application-fixtures`
    - Scope: the rows labeled `3c` above.

--- a/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
+++ b/docs/debt/debt-400-test-fixture-integrity-zod-boundary.md
@@ -695,7 +695,7 @@ PR 3 must not ship as one mega-PR. Ship the code sweep as three execution PRs af
    - Branch: `feat/debt-400-pr-3b-browser-fixtures`
    - Scope: the rows labeled `3b` above plus the browser-only helper/probe/fixture files enumerated in the PR 3b pre-execution audit subsection when they define shared boundary IDs.
    - Proof: run touched browser specs directly and `pnpm test:browser`, plus PR 1 harness, DEBT-398 scan, shuffled unit suite, full local gate, and the no-unnecessary-`vi.hoisted()` proof.
-   - Status: implementation complete on branch; PR number pending. PR 3c, PR 4, and archive follow.
+   - Status: implementation in PR #372; docs updated here. PR 3c, PR 4, and archive follow.
 3. **PR 3c - application use-case/shared fixtures**
    - Branch: `feat/debt-400-pr-3c-application-fixtures`
    - Scope: the rows labeled `3c` above.


### PR DESCRIPTION
## Summary

DEBT-400 PR 3b — migrates Tier-1 mocked-controller-DTO app-UUID fixtures in browser specs plus shared browser helper/probe/fixture files to valid UUIDs, per the audited 3b plan (`059bd3ef`). Application use-cases (3c) and docs SSOT (PR 4) follow.

## What changed (Tier-1 FIX only)

- Mocked DTO IDs in browser `mockResolvedValue` / `mockReturnValue` payloads now use named `crypto.randomUUID()` values, with question/choice/session/attempt linkage preserved.
- Shared browser infra was migrated so consumers inherit valid IDs: question-page controller helpers, practice-session page-controller fixtures, probes, and helper files.
- Component/render browser specs that pass controller-shaped DTO props now use valid UUIDs for app boundary IDs.

## Hoisting discipline (deliberate)

Per `testing-browser.md`, browser specs use `vi.mock(path, { spy: true })` plus `mockResolvedValue` in `beforeEach`/test bodies, so UUID constants are in normal scope. No `vi.hoisted()` was added for fixtures. Existing `vi.hoisted()` blocks for non-UUID mock functions are unchanged.

## Do-not-churn (preserved)

- Component tokens: keys, `data-testid`, slugs, labels, and form names.
- Provider IDs and intentional invalids.
- DEBT-402 `as unknown as ...Output` casts.
- Existing non-UUID `vi.hoisted` mock-function blocks.

## Verification

- [x] Scope proof: browser specs + browser helper/probe/fixture files + DEBT doc only; no 3a non-browser tests, no 3c `src/application/**`, no adapter/factory changes.
- [x] Boundary grep: no placeholder `questionId`/`sessionId`/`choiceId`/`attemptId` browser DTO values remain in the 3b surface.
- [x] No new fixture `vi.hoisted`; no `as any` / `as unknown as` / `@ts-ignore` / `@ts-expect-error`; provider-churn set-diff empty.
- [x] Cross-reference linkage preserved via named UUID variables, including shared practice-session probe/helper IDs (`BROWSER_SESSION_ID`, `BROWSER_QUESTION_*_ID`, `BROWSER_CHOICE_*_ID`) and question-page controller helper IDs (`QUESTION_PAGE_*_ID`).
- [x] `pnpm test:browser` — 50/50 files, 271/271 tests pass.
- [x] `pnpm test --run tests/shared/fixture-uuid-integrity.test.ts` — 2/2 pass.
- [x] `pnpm test --run components/theme-token-regression.test.tsx` — 16/16 pass.
- [x] `pnpm test --run --sequence.shuffle` — 312/312 files, 2526/2526 tests pass.
- [x] Full local gate green: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`.
- [x] Authenticated E2E green: `pnpm test:e2e` — 35/35 pass.

## Follow-ups

- PR 3c (application use-cases), PR 4 (fixture-integrity docs SSOT), DEBT-402 (separate P3), then DEBT-400 archive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switched many browser and component tests to use runtime-generated UUID fixtures instead of hardcoded IDs, improving reliability and preventing identifier collisions.
  * Introduced shared fixture constants and helpers so multiple test suites use consistent identifiers.
* **Documentation**
  * Updated fixture-integrity audit doc with refreshed results, scope adjustments, and revised PR sequencing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Obstacle-Is-The-Way/naltrexone-university/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->