### PR TITLE
DEBT-397 PR 1 — canonical ISO datetime contract

### DIFF
--- a/docs/debt/debt-397-datetime-boundary-type-normalization.md
+++ b/docs/debt/debt-397-datetime-boundary-type-normalization.md
@@ -87,6 +87,8 @@ Ship in three single-concern PRs.
 
 Branch: `docs/debt-397-datetime-boundary-decision`
 
+**Status:** Complete in DEBT-397 PR 1. `docs/practice-engine/interaction-contracts.md` now states the canonical controller action-output datetime rule: output datetimes are ISO 8601 strings, schema-backed fields use `z.string().datetime()`, pass-through outputs still return ISO strings, domain/use-case layers may keep `Date`, and controllers serialize to ISO at the boundary. PR 2 and PR 3 remain active.
+
 This is the architectural decision PR. No code changes; produces a written decision that the implementation PR will follow.
 
 Three real options, each defensible:

--- a/docs/practice-engine/interaction-contracts.md
+++ b/docs/practice-engine/interaction-contracts.md
@@ -20,9 +20,13 @@ These principles govern both modes. They are derived from BS-055 first-principle
 
 ### Datetime representation at the controller boundary
 
-Controller action-output datetimes are ISO 8601 strings. Schema-backed output fields in `src/adapters/controllers/` use `z.string().datetime()` or its nullable equivalent; pass-through output fields without a controller output schema must still be ISO strings produced from `Date.toISOString()`. `z.date()` and date-like epoch `z.number()` fields are not allowed at the controller action-output boundary.
+Controller action-output datetimes must be ISO 8601 strings. Schema-backed output fields in `src/adapters/controllers/` must use `z.string().datetime()` or its nullable equivalent; pass-through output fields without a controller output schema must still be ISO strings produced from `Date.toISOString()`. `z.date()` and date-like epoch `z.number()` fields are not allowed at the controller action-output boundary.
+
+Migration status: this is the required target state. [DEBT-397](../debt/debt-397-datetime-boundary-type-normalization.md) tracks the current known violations in `SaveExamDraftAnswerOutputSchema.latestAnsweredAt` and `SaveExamDraftAnswerOutputSchema.draftSavedAt`; PR 2 migrates those fields and their consumers to ISO strings.
 
 Domain entities and application use cases may keep `Date` objects where date math belongs. The controller adapter is responsible for serializing those `Date` values to ISO strings before returning an action output. This keeps the boundary JSON-native and consistent with persisted practice-session JSON while avoiding per-field exceptions such as the `latestAnsweredAt` / `draftSavedAt` Date drift tracked by DEBT-397.
+
+Controller input schemas are separate from this output-boundary rule. Client-supplied datetimes should enter as ISO 8601 strings, preferably with `z.string().datetime()`. Relaxed input parsing or coercion such as `z.coerce.date()` is allowed only inside a controller adapter that immediately converts the input into domain/application `Date` values; those parsed `Date` values and any epoch numbers must not leak into controller action outputs.
 
 ---
 

--- a/docs/practice-engine/interaction-contracts.md
+++ b/docs/practice-engine/interaction-contracts.md
@@ -4,7 +4,7 @@
 > **Scope:** Click-by-click UI contracts for tutor and exam modes — buttons, persistence, locking, navigation, and post-session flows
 > **Related:** [Practice Modes](./practice-modes.md) (lifecycle/data), [BS-055](../brainstorming/bs-055-exam-session-interaction-model-rethink.md) (decisions)
 > **Status:** Current implementation. Historical BS-055 rationale remains, but the contracts below now describe shipped behavior; follow-up deltas are tracked separately in debt docs where noted.
-> **Last Updated:** 2026-04-23
+> **Last Updated:** 2026-06-01
 
 ---
 
@@ -17,6 +17,12 @@ These principles govern both modes. They are derived from BS-055 first-principle
 3. **What you see is what gets saved.** If the UI shows a highlighted selection, that selection must be durable. A visual state that silently disappears on navigation is a contract violation.
 4. **Exam answers are drafts until the exam is submitted.** Like a paper exam — circle, erase, re-circle freely until you hand it in. Nothing is locked until `Submit exam`.
 5. **Tutor answers are locked after feedback.** Once you see the correct answer, your response is permanently recorded. This prevents gaming.
+
+### Datetime representation at the controller boundary
+
+Controller action-output datetimes are ISO 8601 strings. Schema-backed output fields in `src/adapters/controllers/` use `z.string().datetime()` or its nullable equivalent; pass-through output fields without a controller output schema must still be ISO strings produced from `Date.toISOString()`. `z.date()` and date-like epoch `z.number()` fields are not allowed at the controller action-output boundary.
+
+Domain entities and application use cases may keep `Date` objects where date math belongs. The controller adapter is responsible for serializing those `Date` values to ISO strings before returning an action output. This keeps the boundary JSON-native and consistent with persisted practice-session JSON while avoiding per-field exceptions such as the `latestAnsweredAt` / `draftSavedAt` Date drift tracked by DEBT-397.
 
 ---
 


### PR DESCRIPTION
## Summary
- Documents the canonical DEBT-397 controller action-output datetime contract in `docs/practice-engine/interaction-contracts.md`.
- Marks DEBT-397 PR 1 complete while leaving PR 2 (schema migration) and PR 3 (regression guard) active.

## Contract
Controller action-output datetimes are ISO 8601 strings. Schema-backed output fields use `z.string().datetime()` or the nullable equivalent; pass-through output fields without a controller output schema still return ISO strings produced from `Date.toISOString()`. `z.date()` and date-like epoch `z.number()` fields are not allowed at the controller action-output boundary. Domain entities and application use cases may keep `Date`; controller adapters serialize to ISO at the boundary.

## Rationale
This follows the audited DEBT-397 scope from `c079e1a7`: persistence already stores practice-session timestamp JSON as ISO, most controller outputs already return ISO strings, and the contract removes per-field Date-vs-string exceptions while preserving `Date` where date math belongs.

## Follow-ups
- PR 2: migrate `SaveExamDraftAnswerOutputSchema.latestAnsweredAt` and `draftSavedAt` from `z.date()` to ISO strings and add the boundary serializer.
- PR 3: add the controller-output datetime regression guard.

## Verification
- `pnpm typecheck && pnpm lint && pnpm build`
- `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- E2E skipped: pure documentation-only PR per execution scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified datetime handling at API boundaries: outputs must be ISO 8601 strings; Date objects and epoch timestamps are not allowed.
  * Updated debt-tracking notes to mark PR 1 as complete (with branch recorded) and indicate PR 2 and PR 3 remain active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->