### PR TITLE
DEBT-397 PR 2 — output-schema datetime normalization

### DIFF
--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.browser.spec.tsx
@@ -182,7 +182,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
           latestIsCorrect: null,
           latestAnsweredAt: null,
           draftSelectedChoiceId: fixtureChoice2Id,
-          draftSavedAt: new Date('2026-02-01T00:00:00.000Z'),
+          draftSavedAt: '2026-02-01T00:00:00.000Z',
           draftCumulativeMs: 30_000,
         });
       });
@@ -391,7 +391,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             typeof input.selectedChoiceId === 'string'
               ? input.selectedChoiceId
               : fixtureChoice2Id,
-          draftSavedAt: new Date('2026-02-01T00:00:00.000Z'),
+          draftSavedAt: '2026-02-01T00:00:00.000Z',
           draftCumulativeMs:
             typeof input === 'object' &&
             input &&
@@ -561,7 +561,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             typeof input.selectedChoiceId === 'string'
               ? input.selectedChoiceId
               : null,
-          draftSavedAt: new Date('2026-02-01T00:00:00.000Z'),
+          draftSavedAt: '2026-02-01T00:00:00.000Z',
           draftCumulativeMs:
             typeof input === 'object' &&
             input &&
@@ -726,7 +726,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             typeof input.selectedChoiceId === 'string'
               ? input.selectedChoiceId
               : fixtureChoice2Id,
-          draftSavedAt: new Date('2026-02-01T00:00:00.000Z'),
+          draftSavedAt: '2026-02-01T00:00:00.000Z',
           draftCumulativeMs:
             typeof input === 'object' &&
             input &&

--- a/app/(app)/app/practice/shared/question-flow-actions.test.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions.test.ts
@@ -704,7 +704,7 @@ describe('question-flow-actions', () => {
           latestIsCorrect: null,
           latestAnsweredAt: null,
           draftSelectedChoiceId: fixtureChoice2Id,
-          draftSavedAt: new Date('2026-02-01T00:00:00.000Z'),
+          draftSavedAt: '2026-02-01T00:00:00.000Z',
           draftCumulativeMs: 50_000,
         }),
       );
@@ -765,7 +765,7 @@ describe('question-flow-actions', () => {
           latestIsCorrect: null,
           latestAnsweredAt: null,
           draftSelectedChoiceId: fixtureChoice1Id,
-          draftSavedAt: new Date('2026-02-01T00:00:00.000Z'),
+          draftSavedAt: '2026-02-01T00:00:00.000Z',
           draftCumulativeMs: 50_000,
         }),
       );
@@ -815,7 +815,7 @@ describe('question-flow-actions', () => {
           markedForReview: false,
           latestSelectedChoiceId: fixtureChoice2Id,
           latestIsCorrect: true,
-          latestAnsweredAt: new Date('2026-02-01T00:00:00.000Z'),
+          latestAnsweredAt: '2026-02-01T00:00:00.000Z',
           draftSelectedChoiceId: null,
           draftSavedAt: null,
           draftCumulativeMs: 50_000,

--- a/docs/debt/debt-397-datetime-boundary-type-normalization.md
+++ b/docs/debt/debt-397-datetime-boundary-type-normalization.md
@@ -138,6 +138,8 @@ See DEBT-397 for migration history.
 
 Branch: `fix/debt-397-output-schema-datetime-normalization`
 
+**Status:** Complete in DEBT-397 PR 2. `SaveExamDraftAnswerOutputSchema.latestAnsweredAt` and `SaveExamDraftAnswerOutputSchema.draftSavedAt` now use `z.string().datetime().nullable()`, the practice controller serializes the use-case `Date` values to ISO strings at the action-output boundary, and typecheck-driven controller-output fixtures now construct those fields as ISO strings. Domain/use-case/persistence Date handling remains unchanged. PR 3 remains active for the regression guard.
+
 Assuming Option A (the recommendation):
 
 1. Change `practice-schemas.ts:162` `latestAnsweredAt: z.date().nullable()` -> `z.string().datetime().nullable()`.

--- a/src/adapters/controllers/practice-controller-exam-draft.test.ts
+++ b/src/adapters/controllers/practice-controller-exam-draft.test.ts
@@ -65,7 +65,7 @@ describe('practice-controller', () => {
         markedForReview: false,
         latestSelectedChoiceId: null,
         latestIsCorrect: null,
-        latestAnsweredAt: null,
+        latestAnsweredAt: new Date('2026-02-01T00:00:10.000Z'),
         draftSelectedChoiceId: '33333333-3333-3333-3333-333333333333',
         draftSavedAt: new Date('2026-02-01T00:00:00.000Z'),
         draftCumulativeMs: MAX_DRAFT_CUMULATIVE_MS,
@@ -73,6 +73,7 @@ describe('practice-controller', () => {
       const deps = createDeps({ saveDraftOutput });
       const expectedOutput = {
         ...saveDraftOutput,
+        latestAnsweredAt: '2026-02-01T00:00:10.000Z',
         draftSavedAt: '2026-02-01T00:00:00.000Z',
       };
 
@@ -144,7 +145,7 @@ describe('practice-controller', () => {
         markedForReview: false,
         latestSelectedChoiceId: null,
         latestIsCorrect: null,
-        latestAnsweredAt: null,
+        latestAnsweredAt: new Date('2026-02-01T00:00:10.000Z'),
         draftSelectedChoiceId: '33333333-3333-3333-3333-333333333333',
         draftSavedAt: new Date('2026-02-01T00:00:00.000Z'),
         draftCumulativeMs: 50_000,
@@ -153,6 +154,7 @@ describe('practice-controller', () => {
       const deps = createDeps({ saveDraftOutput });
       const expectedOutput = {
         ...saveDraftOutput,
+        latestAnsweredAt: '2026-02-01T00:00:10.000Z',
         draftSavedAt: '2026-02-01T00:00:00.000Z',
       };
 

--- a/src/adapters/controllers/practice-controller-exam-draft.test.ts
+++ b/src/adapters/controllers/practice-controller-exam-draft.test.ts
@@ -71,6 +71,10 @@ describe('practice-controller', () => {
         draftCumulativeMs: MAX_DRAFT_CUMULATIVE_MS,
       } as const;
       const deps = createDeps({ saveDraftOutput });
+      const expectedOutput = {
+        ...saveDraftOutput,
+        draftSavedAt: '2026-02-01T00:00:00.000Z',
+      };
 
       const result = await saveExamDraftAnswer(
         {
@@ -82,7 +86,7 @@ describe('practice-controller', () => {
         deps,
       );
 
-      expect(result).toEqual({ ok: true, data: saveDraftOutput });
+      expect(result).toEqual({ ok: true, data: expectedOutput });
       expect(deps.saveExamDraftAnswerUseCase.inputs).toEqual([
         {
           userId: deps._fixtures.userId,
@@ -147,6 +151,10 @@ describe('practice-controller', () => {
       } as const;
 
       const deps = createDeps({ saveDraftOutput });
+      const expectedOutput = {
+        ...saveDraftOutput,
+        draftSavedAt: '2026-02-01T00:00:00.000Z',
+      };
 
       const result = await saveExamDraftAnswer(
         {
@@ -158,7 +166,7 @@ describe('practice-controller', () => {
         deps,
       );
 
-      expect(result).toEqual({ ok: true, data: saveDraftOutput });
+      expect(result).toEqual({ ok: true, data: expectedOutput });
       expect(deps.saveExamDraftAnswerUseCase.inputs).toEqual([
         {
           userId: deps._fixtures.userId,

--- a/src/adapters/controllers/practice-controller.ts
+++ b/src/adapters/controllers/practice-controller.ts
@@ -27,13 +27,14 @@ import type {
   GetSessionHistoryInput,
   GetSessionHistoryOutput,
   SaveExamDraftAnswerInput,
-  SaveExamDraftAnswerOutput,
+  SaveExamDraftAnswerOutput as SaveExamDraftAnswerUseCaseOutput,
   SetPracticeSessionQuestionMarkInput,
   SetPracticeSessionQuestionMarkOutput,
   StartPracticeSessionInput,
   StartPracticeSessionOutput,
 } from '@/src/application/use-cases';
 import { createAction } from './create-action';
+import type { SaveExamDraftAnswerOutput } from './practice-schemas';
 import {
   CountAvailableQuestionsInputSchema,
   CountAvailableQuestionsOutputSchema,
@@ -68,10 +69,10 @@ export type {
   GetPracticeSessionReviewOutput,
   GetPracticeSessionSummaryOutput,
   GetSessionHistoryOutput,
-  SaveExamDraftAnswerOutput,
   SetPracticeSessionQuestionMarkOutput,
   StartPracticeSessionOutput,
 } from '@/src/application/use-cases';
+export type { SaveExamDraftAnswerOutput } from './practice-schemas';
 
 export type PracticeControllerDeps = {
   authGateway: AuthGateway;
@@ -112,7 +113,7 @@ export type PracticeControllerDeps = {
   saveExamDraftAnswerUseCase: {
     execute: (
       input: SaveExamDraftAnswerInput,
-    ) => Promise<SaveExamDraftAnswerOutput>;
+    ) => Promise<SaveExamDraftAnswerUseCaseOutput>;
   };
   getPracticeSessionReviewUseCase: {
     execute: (
@@ -145,6 +146,16 @@ const getDeps = createDepsResolver<
   PracticeControllerDeps,
   PracticeControllerContainer
 >((container) => container.createPracticeControllerDeps(), loadAppContainer);
+
+function serializeSaveExamDraftAnswerOutput(
+  output: SaveExamDraftAnswerUseCaseOutput,
+): SaveExamDraftAnswerOutput {
+  return {
+    ...output,
+    latestAnsweredAt: output.latestAnsweredAt?.toISOString() ?? null,
+    draftSavedAt: output.draftSavedAt?.toISOString() ?? null,
+  };
+}
 
 export const startPracticeSession = createAction({
   schema: StartPracticeSessionInputSchema,
@@ -298,14 +309,16 @@ export const saveExamDraftAnswer = createAction({
   execute: async (input, d, meta) => {
     const userId = await requireEntitledUserId(d, meta);
 
+    const output = await d.saveExamDraftAnswerUseCase.execute({
+      userId,
+      sessionId: input.sessionId,
+      questionId: input.questionId,
+      selectedChoiceId: input.selectedChoiceId,
+      cumulativeMs: input.cumulativeMs,
+    });
+
     return SaveExamDraftAnswerOutputSchema.parse(
-      await d.saveExamDraftAnswerUseCase.execute({
-        userId,
-        sessionId: input.sessionId,
-        questionId: input.questionId,
-        selectedChoiceId: input.selectedChoiceId,
-        cumulativeMs: input.cumulativeMs,
-      }),
+      serializeSaveExamDraftAnswerOutput(output),
     );
   },
 });

--- a/src/adapters/controllers/practice-schemas.ts
+++ b/src/adapters/controllers/practice-schemas.ts
@@ -159,12 +159,16 @@ export const SaveExamDraftAnswerOutputSchema = z
     markedForReview: z.boolean(),
     latestSelectedChoiceId: zUuid.nullable(),
     latestIsCorrect: z.boolean().nullable(),
-    latestAnsweredAt: z.date().nullable(),
+    latestAnsweredAt: z.string().datetime().nullable(),
     draftSelectedChoiceId: zUuid.nullable(),
-    draftSavedAt: z.date().nullable(),
+    draftSavedAt: z.string().datetime().nullable(),
     draftCumulativeMs: z.number().int().min(0),
   })
   .strict();
+
+export type SaveExamDraftAnswerOutput = z.infer<
+  typeof SaveExamDraftAnswerOutputSchema
+>;
 
 export const SetPracticeSessionQuestionMarkOutputSchema = z
   .object({


### PR DESCRIPTION
## Summary

- Migrates `SaveExamDraftAnswerOutputSchema.latestAnsweredAt` and `draftSavedAt` from `z.date().nullable()` to `z.string().datetime().nullable()`.
- Serializes the use-case `Date` values with `toISOString()` in `saveExamDraftAnswer`, at the controller action-output boundary.
- Updates only typecheck-identified controller-output fixtures so mocked `SaveExamDraftAnswerOutput` values now use ISO strings.
- Marks DEBT-397 PR 2 complete; PR 3 follows with the durable schema-shape regression guard.

## Boundary scope

Domain entities, use cases, fakes, repositories, and persistence Date handling stay unchanged. The use case still returns domain `Date` values; the controller adapter owns the Date-to-ISO conversion before output validation/return.

Scope proof run locally:

```bash
git --no-pager diff --name-only origin/dev...HEAD | grep -E 'domain/(entities|services)|fakes/|use-cases/[^.]*\.ts$' | grep -v '\.test\.' && echo "REVIEW: production domain/use-case file changed — should be output-boundary only" || echo "OK: no production domain/use-case logic touched"
```

Result: `OK: no production domain/use-case logic touched`.

## Validation

- `pnpm test --run src/adapters/controllers/practice-controller-exam-draft.test.ts` (red before implementation, green after)
- `pnpm typecheck`
- `pnpm test --run src/adapters/controllers "app/(app)/app/practice/shared/question-flow-actions.test.ts" src/adapters/repositories`
- `pnpm test --run components/theme-token-regression.test.tsx` (16/16)
- `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- `pnpm test:e2e` (35/35; authenticated E2E env was present, no DB migrations in this branch)

Notes: lint still reports the existing excessive-line nursery warnings; there are no lint errors. Local Node is v25.6.0 while package metadata wants Node 24.x, matching prior gate warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized exam-draft save API responses so timestamp fields are serialized as ISO datetime strings (or null) instead of Date objects.

* **Tests**
  * Updated test suites and assertions across practice session and draft-saving workflows to expect the new serialized timestamp format.

* **Documentation**
  * Clarified datetime boundary/type normalization and noted the updated serialized timestamp behavior for draft-save operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->