### PR TITLE
DEBT-397 PR 3 — output-datetime contract regression test

### DIFF
--- a/docs/debt/debt-397-datetime-boundary-type-normalization.md
+++ b/docs/debt/debt-397-datetime-boundary-type-normalization.md
@@ -138,7 +138,7 @@ See DEBT-397 for migration history.
 
 Branch: `fix/debt-397-output-schema-datetime-normalization`
 
-**Status:** Complete in DEBT-397 PR 2. `SaveExamDraftAnswerOutputSchema.latestAnsweredAt` and `SaveExamDraftAnswerOutputSchema.draftSavedAt` now use `z.string().datetime().nullable()`, the practice controller serializes the use-case `Date` values to ISO strings at the action-output boundary, and typecheck-driven controller-output fixtures now construct those fields as ISO strings. Domain/use-case/persistence Date handling remains unchanged. PR 3 remains active for the regression guard.
+**Status:** Complete in DEBT-397 PR 2. `SaveExamDraftAnswerOutputSchema.latestAnsweredAt` and `SaveExamDraftAnswerOutputSchema.draftSavedAt` now use `z.string().datetime().nullable()`, the practice controller serializes the use-case `Date` values to ISO strings at the action-output boundary, and typecheck-driven controller-output fixtures now construct those fields as ISO strings. Domain/use-case/persistence Date handling remains unchanged. PR 3 adds the final regression guard.
 
 Assuming Option A (the recommendation):
 
@@ -155,6 +155,8 @@ Full local gate. Browser tests must pass — if a React component was depending 
 ### PR 3 — Add a regression guard
 
 Branch: `tests/debt-397-output-schema-shape-regression`
+
+**Status:** Complete in DEBT-397 PR 3. `src/adapters/controllers/controller-output-datetime-contract.test.ts` now runs in the default unit suite and enforces the controller-output datetime contract: exported output schemas are runtime-walked for `z.string().datetime()`, production controller output schema declarations are source-scanned to reject `z.date()`, date-like `z.number()`, and unvalidated date-like strings, and schema-less pass-through controller outputs keep an explicit datetime inventory. The guard was red-proven by temporarily reverting `SaveExamDraftAnswerOutputSchema.draftSavedAt` to `z.date().nullable()` and confirming the focused test failed, then restoring the ISO schema and confirming it passed. DEBT-397 code work is complete; archival remains a separate follow-up.
 
 Add `tests/integration/output-schema-shape.test.ts` (or extend an existing schema regression test) that:
 

--- a/docs/debt/debt-397-datetime-boundary-type-normalization.md
+++ b/docs/debt/debt-397-datetime-boundary-type-normalization.md
@@ -158,12 +158,12 @@ Branch: `tests/debt-397-output-schema-shape-regression`
 
 **Status:** Complete in DEBT-397 PR 3. `src/adapters/controllers/controller-output-datetime-contract.test.ts` now runs in the default unit suite and enforces the controller-output datetime contract: exported output schemas are runtime-walked for `z.string().datetime()`, production controller output schema declarations are source-scanned to reject `z.date()`, date-like `z.number()`, and unvalidated date-like strings, and schema-less pass-through controller outputs keep an explicit datetime inventory. The guard was red-proven by temporarily reverting `SaveExamDraftAnswerOutputSchema.draftSavedAt` to `z.date().nullable()` and confirming the focused test failed, then restoring the ISO schema and confirming it passed. DEBT-397 code work is complete; archival remains a separate follow-up.
 
-Add `tests/integration/output-schema-shape.test.ts` (or extend an existing schema regression test) that:
+`src/adapters/controllers/controller-output-datetime-contract.test.ts` now:
 
-1. Walks every output schema in `src/adapters/controllers/practice-schemas.ts` (and any other controller schema file).
-2. For each schema, introspects the `.shape` and finds fields named with `*At` suffix or with datetime-shaped Zod definitions.
-3. Asserts every datetime field is `z.string().datetime()` (or `z.string().datetime().nullable()`), NOT `z.date()` or `z.date().nullable()`.
-4. Fails loudly if a new field is added with the wrong representation.
+1. Runtime-walks exported controller output schemas and asserts date-like fields use `z.string().datetime()` (or its nullable equivalent), not `z.date()`.
+2. Source-scans production controller `*OutputSchema` declarations and rejects `z.date()`, date-like `z.number()` epoch fields, and unvalidated date-like strings, including union/or branches.
+3. Tracks every schema-less `createAction` output in an explicit pass-through inventory and type-scans those output aliases so pass-through datetimes stay ISO strings.
+4. Runs in the default unit suite, so `pnpm test --run` fails loudly if a new controller output datetime drifts off the contract.
 
 This is the enforcement layer. Without it, future drift is invisible.
 
@@ -187,7 +187,8 @@ PR 2 done when:
 
 PR 3 done when:
 
-- The regression test exists, runs in unit/integration, and fails if a future PR adds a divergent datetime field.
+- The regression test exists in `src/adapters/controllers/controller-output-datetime-contract.test.ts`, runs in the default unit suite, and fails if a future PR adds a divergent datetime field.
+- Exported output schemas are runtime-walked, production controller output schema declarations are source-scanned, and schema-less pass-through output datetime inventories are enforced.
 - Test execution is part of the default `pnpm test --run` gate.
 
 ---

--- a/src/adapters/controllers/controller-output-datetime-contract.test.ts
+++ b/src/adapters/controllers/controller-output-datetime-contract.test.ts
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noExcessiveLinesPerFile: Keep the DEBT-397 AST scanner and assertions colocated so the controller-output datetime contract is auditable in one guardrail.
 import { readdirSync, readFileSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
 import ts from 'typescript';
@@ -28,6 +29,13 @@ type PassThroughTypeScan = {
 
 type ZodSchema = z.ZodType<unknown>;
 
+type TypeScanContext = {
+  activeAliases: Set<string>;
+  aliases: ReadonlyMap<string, ts.TypeNode>;
+  issues: ContractIssue[];
+  sourceFile: SourceFile;
+};
+
 type ZodDef = {
   checks?: readonly unknown[];
   element?: ZodSchema;
@@ -41,6 +49,18 @@ const DATETIME_CONTRACT_REF =
   'docs/practice-engine/interaction-contracts.md#datetime-representation-at-the-controller-boundary';
 const DATE_LIKE_FIELD_PATTERN =
   /(?:At|Date)$|^expires|^period|^created|^updated/i;
+const ZOD_SOURCE_WRAPPER_METHODS = new Set([
+  'brand',
+  'catch',
+  'default',
+  'describe',
+  'nullable',
+  'optional',
+  'readonly',
+  'refine',
+  'strict',
+  'superRefine',
+]);
 
 const EXPECTED_SCHEMALESS_ACTIONS: readonly PassThroughAction[] = [
   {
@@ -109,6 +129,13 @@ const PASS_THROUGH_TYPE_SCANS: readonly PassThroughTypeScan[] = [
     action: 'getBookmarks',
   },
   {
+    filePath:
+      'src/application/use-cases/get-completed-session-questions-with-feedback.ts',
+    typeName: 'GetCompletedSessionQuestionsWithFeedbackOutput',
+    prefix: '',
+    action: 'getCompletedSessionQuestionsWithFeedback',
+  },
+  {
     filePath: 'src/application/use-cases/get-attempted-questions.ts',
     typeName: 'AvailableAttemptedQuestionRow',
     prefix: 'rows[]',
@@ -133,6 +160,18 @@ const PASS_THROUGH_TYPE_SCANS: readonly PassThroughTypeScan[] = [
     action: 'getPreviousAttempt',
   },
   {
+    filePath: 'src/application/use-cases/get-practice-session-review.ts',
+    typeName: 'GetPracticeSessionReviewOutput',
+    prefix: '',
+    action: 'getPracticeSessionReview',
+  },
+  {
+    filePath: 'src/adapters/controllers/question-view-controller.ts',
+    typeName: 'GetQuestionBySlugOutput',
+    prefix: '',
+    action: 'getQuestionBySlug',
+  },
+  {
     filePath: 'src/application/use-cases/get-session-history.ts',
     typeName: 'SessionHistoryRow',
     prefix: 'rows[]',
@@ -143,6 +182,12 @@ const PASS_THROUGH_TYPE_SCANS: readonly PassThroughTypeScan[] = [
     typeName: 'UserStatsOutput',
     prefix: '',
     action: 'getUserStats',
+  },
+  {
+    filePath: 'src/adapters/controllers/tag-controller.ts',
+    typeName: 'GetTagsOutput',
+    prefix: '',
+    action: 'getTags',
   },
 ];
 
@@ -172,10 +217,14 @@ function readControllerSources(dir = CONTROLLER_ROOT): SourceFile[] {
 function parseRepoSource(filePath: string): SourceFile {
   const absolutePath = resolve(process.cwd(), filePath);
   const source = readFileSync(absolutePath, 'utf8');
+  return parseSourceText(filePath, source);
+}
+
+function parseSourceText(filePath: string, source: string): SourceFile {
   return {
     filePath,
     source,
-    ast: ts.createSourceFile(absolutePath, source, ts.ScriptTarget.Latest),
+    ast: ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest),
   };
 }
 
@@ -292,9 +341,13 @@ function unwrapSourceCallChain(expression: ts.Expression): ts.Expression {
     if (
       methodName === 'array' ||
       methodName === 'date' ||
+      methodName === 'literal' ||
+      methodName === 'null' ||
       methodName === 'number' ||
       methodName === 'object' ||
-      methodName === 'string'
+      methodName === 'string' ||
+      methodName === 'undefined' ||
+      methodName === 'union'
     ) {
       return current;
     }
@@ -331,12 +384,56 @@ function getZodArrayElement(expression: ts.Expression): ts.Expression | null {
   return unwrapped.arguments[0] ?? null;
 }
 
+function stripSourceWrappers(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (
+    ts.isCallExpression(current) &&
+    ts.isPropertyAccessExpression(current.expression) &&
+    ZOD_SOURCE_WRAPPER_METHODS.has(current.expression.name.text)
+  ) {
+    current = current.expression.expression;
+  }
+  return current;
+}
+
+function getZodUnionOptions(expression: ts.Expression): ts.Expression[] {
+  const stripped = stripSourceWrappers(expression);
+  const unwrapped = unwrapSourceCallChain(stripped);
+
+  if (isZodFactoryCall(unwrapped, 'union')) {
+    const [options] = unwrapped.arguments;
+    if (!options || !ts.isArrayLiteralExpression(options)) return [];
+    return [...options.elements];
+  }
+
+  if (
+    ts.isCallExpression(stripped) &&
+    ts.isPropertyAccessExpression(stripped.expression) &&
+    stripped.expression.name.text === 'or'
+  ) {
+    const [right] = stripped.arguments;
+    return right ? [stripped.expression.expression, right] : [];
+  }
+
+  return [];
+}
+
 function isDirectZodFactoryExpression(
   expression: ts.Expression,
-  methodName: 'date' | 'number',
+  methodName: string,
 ): boolean {
   const unwrapped = unwrapSourceCallChain(expression);
   return isZodFactoryCall(unwrapped, methodName);
+}
+
+function isNullishZodExpression(expression: ts.Expression): boolean {
+  const unwrapped = unwrapSourceCallChain(expression);
+  return (
+    isZodFactoryCall(unwrapped, 'null') ||
+    isZodFactoryCall(unwrapped, 'undefined') ||
+    (isZodFactoryCall(unwrapped, 'literal') &&
+      unwrapped.arguments[0]?.kind === ts.SyntaxKind.NullKeyword)
+  );
 }
 
 function containsZodStringDatetimeCall(
@@ -354,9 +451,13 @@ function containsZodStringDatetimeCall(
     );
   }
 
-  return node
-    .getChildren(sourceFile)
-    .some((child) => containsZodStringDatetimeCall(child, sourceFile));
+  let found = false;
+  ts.forEachChild(node, (child) => {
+    if (!found && containsZodStringDatetimeCall(child, sourceFile)) {
+      found = true;
+    }
+  });
+  return found;
 }
 
 function getPropertyName(name: ts.PropertyName): string | null {
@@ -380,6 +481,16 @@ function scanSchemaExpression(
   const issues: ContractIssue[] = [];
   const fieldName = getLastFieldName(path);
   const displayPath = formatPath(path) || '<root>';
+  const unionOptions = getZodUnionOptions(expression);
+
+  if (unionOptions.length > 0) {
+    for (const option of unionOptions) {
+      issues.push(
+        ...scanSchemaExpression(option, sourceFile, schemaName, path),
+      );
+    }
+    return issues;
+  }
 
   if (isDirectZodFactoryExpression(expression, 'date')) {
     issues.push(
@@ -390,7 +501,10 @@ function scanSchemaExpression(
     );
   }
 
-  if (DATE_LIKE_FIELD_PATTERN.test(fieldName)) {
+  if (
+    DATE_LIKE_FIELD_PATTERN.test(fieldName) &&
+    !isNullishZodExpression(expression)
+  ) {
     if (isDirectZodFactoryExpression(expression, 'number')) {
       issues.push(
         `${sourceFile.filePath}:${getSourcePosition(
@@ -531,23 +645,27 @@ function collectSchemaLessActions(
   );
 }
 
-function getTypeAlias(sourceFile: SourceFile, typeName: string): ts.TypeNode {
-  let typeNode: ts.TypeNode | null = null;
+function collectTypeAliases(sourceFile: SourceFile): Map<string, ts.TypeNode> {
+  const aliases = new Map<string, ts.TypeNode>();
 
   const visit = (node: ts.Node): void => {
-    if (
-      ts.isTypeAliasDeclaration(node) &&
-      node.name.text === typeName &&
-      !typeNode
-    ) {
-      typeNode = node.type;
-      return;
+    if (ts.isTypeAliasDeclaration(node)) {
+      aliases.set(node.name.text, node.type);
     }
 
     ts.forEachChild(node, visit);
   };
 
   visit(sourceFile.ast);
+  return aliases;
+}
+
+function getTypeAlias(
+  sourceFile: SourceFile,
+  aliases: ReadonlyMap<string, ts.TypeNode>,
+  typeName: string,
+): ts.TypeNode {
+  const typeNode = aliases.get(typeName);
 
   if (!typeNode) {
     throw new Error(`Missing type alias ${typeName} in ${sourceFile.filePath}`);
@@ -577,14 +695,43 @@ function isStringNullishType(typeNode: ts.TypeNode): boolean {
 
 function collectDateLikeStringFieldsFromType(
   typeNode: ts.TypeNode,
-  sourceFile: SourceFile,
+  context: TypeScanContext,
   path: string,
-  issues: ContractIssue[],
 ): string[] {
   if (ts.isUnionTypeNode(typeNode)) {
     return typeNode.types.flatMap((type) =>
-      collectDateLikeStringFieldsFromType(type, sourceFile, path, issues),
+      collectDateLikeStringFieldsFromType(type, context, path),
     );
+  }
+
+  if (ts.isArrayTypeNode(typeNode)) {
+    return collectDateLikeStringFieldsFromType(
+      typeNode.elementType,
+      context,
+      `${path}[]`,
+    );
+  }
+
+  if (ts.isTypeReferenceNode(typeNode)) {
+    const typeName = typeNode.typeName.getText(context.sourceFile.ast);
+
+    if (typeName === 'Array' && typeNode.typeArguments?.[0]) {
+      return collectDateLikeStringFieldsFromType(
+        typeNode.typeArguments[0],
+        context,
+        `${path}[]`,
+      );
+    }
+
+    const alias = context.aliases.get(typeName);
+    if (!alias || context.activeAliases.has(typeName)) return [];
+
+    context.activeAliases.add(typeName);
+    try {
+      return collectDateLikeStringFieldsFromType(alias, context, path);
+    } finally {
+      context.activeAliases.delete(typeName);
+    }
   }
 
   if (!ts.isTypeLiteralNode(typeNode)) return [];
@@ -602,9 +749,9 @@ function collectDateLikeStringFieldsFromType(
       if (isStringNullishType(member.type)) {
         fields.push(propertyPath);
       } else {
-        issues.push(
-          `${sourceFile.filePath}:${getSourcePosition(
-            sourceFile.ast,
+        context.issues.push(
+          `${context.sourceFile.filePath}:${getSourcePosition(
+            context.sourceFile.ast,
             member,
           )} ${propertyPath} is date-like but is not typed as string/string|null in a pass-through controller output (${DATETIME_CONTRACT_REF}).`,
         );
@@ -615,9 +762,8 @@ function collectDateLikeStringFieldsFromType(
       fields.push(
         ...collectDateLikeStringFieldsFromType(
           member.type.elementType,
-          sourceFile,
+          context,
           `${propertyPath}[]`,
-          issues,
         ),
       );
       continue;
@@ -625,15 +771,14 @@ function collectDateLikeStringFieldsFromType(
 
     if (
       ts.isTypeReferenceNode(member.type) &&
-      member.type.typeName.getText(sourceFile.ast) === 'Array' &&
+      member.type.typeName.getText(context.sourceFile.ast) === 'Array' &&
       member.type.typeArguments?.[0]
     ) {
       fields.push(
         ...collectDateLikeStringFieldsFromType(
           member.type.typeArguments[0],
-          sourceFile,
+          context,
           `${propertyPath}[]`,
-          issues,
         ),
       );
       continue;
@@ -642,9 +787,8 @@ function collectDateLikeStringFieldsFromType(
     fields.push(
       ...collectDateLikeStringFieldsFromType(
         member.type,
-        sourceFile,
+        context,
         propertyPath,
-        issues,
       ),
     );
   }
@@ -661,12 +805,19 @@ function collectPassThroughDatetimeFields(): {
 
   for (const scan of PASS_THROUGH_TYPE_SCANS) {
     const sourceFile = parseRepoSource(scan.filePath);
-    const typeNode = getTypeAlias(sourceFile, scan.typeName);
+    const aliases = collectTypeAliases(sourceFile);
+    const typeNode = getTypeAlias(sourceFile, aliases, scan.typeName);
+    const context: TypeScanContext = {
+      activeAliases: new Set([scan.typeName]),
+      aliases,
+      sourceFile,
+      issues,
+    };
+
     for (const field of collectDateLikeStringFieldsFromType(
       typeNode,
-      sourceFile,
+      context,
       scan.prefix,
-      issues,
     )) {
       fields.add(`${scan.action}:${field}`);
     }
@@ -693,6 +844,45 @@ describe('controller output datetime contract', () => {
     );
 
     expect(schemaIssues).toEqual([]);
+  });
+
+  it('reports date-like union output schema branches that drift away from ISO strings', () => {
+    const sourceFile = parseSourceText(
+      'src/adapters/controllers/example-controller.ts',
+      `
+import { z } from 'zod';
+
+const ExampleOutputSchema = z
+  .object({
+    answeredAt: z.union([z.string().datetime(), z.number()]),
+    expiresAt: z.string().datetime().or(z.date()),
+    updatedAt: z.union([z.string().datetime(), z.null()]),
+  })
+  .strict();
+`,
+    );
+
+    const schemaIssues = collectOutputSchemaSourceIssues([sourceFile]);
+
+    expect(schemaIssues).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'ExampleOutputSchema.answeredAt uses date-like z.number()',
+        ),
+        expect.stringContaining(
+          'ExampleOutputSchema.answeredAt is date-like but is not z.string().datetime()',
+        ),
+        expect.stringContaining('ExampleOutputSchema.expiresAt uses z.date()'),
+        expect.stringContaining(
+          'ExampleOutputSchema.expiresAt is date-like but is not z.string().datetime()',
+        ),
+      ]),
+    );
+    expect(
+      schemaIssues.some((issue) =>
+        issue.includes('ExampleOutputSchema.updatedAt'),
+      ),
+    ).toBe(false);
   });
 
   it('keeps pass-through controller datetime outputs explicit and ISO-shaped', () => {

--- a/src/adapters/controllers/controller-output-datetime-contract.test.ts
+++ b/src/adapters/controllers/controller-output-datetime-contract.test.ts
@@ -1,0 +1,716 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import type { z } from 'zod';
+import * as practiceSchemas from './practice-schemas';
+
+type ContractIssue = string;
+
+type SourceFile = {
+  filePath: string;
+  source: string;
+  ast: ts.SourceFile;
+};
+
+type PassThroughAction = {
+  action: string;
+  datetimeFields: readonly string[];
+  filePath: string;
+};
+
+type PassThroughTypeScan = {
+  action: string;
+  filePath: string;
+  prefix: string;
+  typeName: string;
+};
+
+type ZodSchema = z.ZodType<unknown>;
+
+type ZodDef = {
+  checks?: readonly unknown[];
+  element?: ZodSchema;
+  innerType?: ZodSchema;
+  options?: readonly ZodSchema[];
+  type?: string;
+};
+
+const CONTROLLER_ROOT = resolve(process.cwd(), 'src/adapters/controllers');
+const DATETIME_CONTRACT_REF =
+  'docs/practice-engine/interaction-contracts.md#datetime-representation-at-the-controller-boundary';
+const DATE_LIKE_FIELD_PATTERN =
+  /(?:At|Date)$|^expires|^period|^created|^updated/i;
+
+const EXPECTED_SCHEMALESS_ACTIONS: readonly PassThroughAction[] = [
+  {
+    filePath: 'src/adapters/controllers/bookmark-controller.ts',
+    action: 'getBookmarks',
+    datetimeFields: ['rows[].bookmarkedAt'],
+  },
+  {
+    filePath: 'src/adapters/controllers/practice-controller.ts',
+    action: 'getCompletedSessionQuestionsWithFeedback',
+    datetimeFields: [],
+  },
+  {
+    filePath: 'src/adapters/controllers/practice-controller.ts',
+    action: 'getPracticeSessionReview',
+    datetimeFields: [],
+  },
+  {
+    filePath: 'src/adapters/controllers/practice-controller.ts',
+    action: 'getSessionHistory',
+    datetimeFields: ['rows[].startedAt', 'rows[].endedAt'],
+  },
+  {
+    filePath: 'src/adapters/controllers/question-controller.ts',
+    action: 'getNextQuestion',
+    datetimeFields: ['session.deadlineAt'],
+  },
+  {
+    filePath: 'src/adapters/controllers/question-view-controller.ts',
+    action: 'getPreviousAttempt',
+    datetimeFields: ['answeredAt'],
+  },
+  {
+    filePath: 'src/adapters/controllers/question-view-controller.ts',
+    action: 'getQuestionBySlug',
+    datetimeFields: [],
+  },
+  {
+    filePath: 'src/adapters/controllers/review-controller.ts',
+    action: 'getAttemptedQuestions',
+    datetimeFields: ['rows[].lastAnsweredAt'],
+  },
+  {
+    filePath: 'src/adapters/controllers/stats-controller.ts',
+    action: 'getUserStats',
+    datetimeFields: ['recentActivity[].answeredAt'],
+  },
+  {
+    filePath: 'src/adapters/controllers/tag-controller.ts',
+    action: 'getTags',
+    datetimeFields: [],
+  },
+];
+
+const PASS_THROUGH_TYPE_SCANS: readonly PassThroughTypeScan[] = [
+  {
+    filePath: 'src/application/ports/bookmarks.ts',
+    typeName: 'AvailableBookmarkRow',
+    prefix: 'rows[]',
+    action: 'getBookmarks',
+  },
+  {
+    filePath: 'src/application/ports/bookmarks.ts',
+    typeName: 'UnavailableBookmarkRow',
+    prefix: 'rows[]',
+    action: 'getBookmarks',
+  },
+  {
+    filePath: 'src/application/use-cases/get-attempted-questions.ts',
+    typeName: 'AvailableAttemptedQuestionRow',
+    prefix: 'rows[]',
+    action: 'getAttemptedQuestions',
+  },
+  {
+    filePath: 'src/application/use-cases/get-attempted-questions.ts',
+    typeName: 'UnavailableAttemptedQuestionRow',
+    prefix: 'rows[]',
+    action: 'getAttemptedQuestions',
+  },
+  {
+    filePath: 'src/application/use-cases/get-next-question.ts',
+    typeName: 'NextQuestion',
+    prefix: '',
+    action: 'getNextQuestion',
+  },
+  {
+    filePath: 'src/application/use-cases/get-previous-attempt.ts',
+    typeName: 'AttemptPreviousAttemptOutput',
+    prefix: '',
+    action: 'getPreviousAttempt',
+  },
+  {
+    filePath: 'src/application/use-cases/get-session-history.ts',
+    typeName: 'SessionHistoryRow',
+    prefix: 'rows[]',
+    action: 'getSessionHistory',
+  },
+  {
+    filePath: 'src/application/use-cases/get-user-stats.ts',
+    typeName: 'UserStatsOutput',
+    prefix: '',
+    action: 'getUserStats',
+  },
+];
+
+function toRepoPath(filePath: string): string {
+  return relative(process.cwd(), filePath).replaceAll('\\', '/');
+}
+
+function readControllerSources(dir = CONTROLLER_ROOT): SourceFile[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = resolve(dir, entry.name);
+    if (entry.isDirectory()) return readControllerSources(entryPath);
+    if (!entry.name.endsWith('.ts')) return [];
+    if (entry.name.endsWith('.test.ts')) return [];
+    if (entry.name.endsWith('-test-helpers.ts')) return [];
+
+    const source = readFileSync(entryPath, 'utf8');
+    return [
+      {
+        filePath: toRepoPath(entryPath),
+        source,
+        ast: ts.createSourceFile(entryPath, source, ts.ScriptTarget.Latest),
+      },
+    ];
+  });
+}
+
+function parseRepoSource(filePath: string): SourceFile {
+  const absolutePath = resolve(process.cwd(), filePath);
+  const source = readFileSync(absolutePath, 'utf8');
+  return {
+    filePath,
+    source,
+    ast: ts.createSourceFile(absolutePath, source, ts.ScriptTarget.Latest),
+  };
+}
+
+function getZodDef(schema: ZodSchema): ZodDef {
+  return (schema as unknown as { _def: ZodDef })._def;
+}
+
+function isZodSchema(value: unknown): value is ZodSchema {
+  return typeof value === 'object' && value !== null && '_def' in value;
+}
+
+function unwrapZodSchema(schema: ZodSchema): ZodSchema {
+  let current = schema;
+  while (true) {
+    const innerType = getZodDef(current).innerType;
+    if (!innerType) return current;
+    current = innerType;
+  }
+}
+
+function getCheckDef(check: unknown): Record<string, unknown> | null {
+  if (typeof check !== 'object' || check === null) return null;
+  const nested = (check as { _zod?: { def?: Record<string, unknown> } })._zod
+    ?.def;
+  if (nested) return nested;
+  return check as Record<string, unknown>;
+}
+
+function isDatetimeStringSchema(schema: ZodSchema): boolean {
+  const unwrapped = unwrapZodSchema(schema);
+  const def = getZodDef(unwrapped);
+
+  return (
+    def.type === 'string' &&
+    (def.checks ?? []).some(
+      (check) => getCheckDef(check)?.format === 'datetime',
+    )
+  );
+}
+
+function formatPath(path: readonly string[]): string {
+  return path.join('.');
+}
+
+function withArrayMarker(path: readonly string[]): string[] {
+  if (path.length === 0) return ['[]'];
+  return [...path.slice(0, -1), `${path[path.length - 1]}[]`];
+}
+
+function getLastFieldName(path: readonly string[]): string {
+  return (path[path.length - 1] ?? '').replace(/\[\]$/, '');
+}
+
+function getZodContractIssues(
+  schema: ZodSchema,
+  schemaName: string,
+  path: readonly string[] = [],
+): ContractIssue[] {
+  const issues: ContractIssue[] = [];
+  const unwrapped = unwrapZodSchema(schema);
+  const def = getZodDef(unwrapped);
+  const fieldName = getLastFieldName(path);
+  const displayPath = formatPath(path) || '<root>';
+
+  if (def.type === 'date') {
+    issues.push(
+      `${schemaName}.${displayPath} uses z.date(); controller output datetimes must use z.string().datetime() (${DATETIME_CONTRACT_REF}).`,
+    );
+  }
+
+  if (
+    DATE_LIKE_FIELD_PATTERN.test(fieldName) &&
+    !isDatetimeStringSchema(schema)
+  ) {
+    const representation =
+      def.type === 'number'
+        ? 'date-like z.number()'
+        : `z.${def.type ?? 'unknown'}()`;
+    issues.push(
+      `${schemaName}.${displayPath} uses ${representation}; schema-backed controller output datetime fields must use z.string().datetime() (${DATETIME_CONTRACT_REF}).`,
+    );
+  }
+
+  if (def.type === 'object') {
+    const shape = (unwrapped as unknown as { shape: Record<string, ZodSchema> })
+      .shape;
+    for (const [key, childSchema] of Object.entries(shape)) {
+      issues.push(
+        ...getZodContractIssues(childSchema, schemaName, [...path, key]),
+      );
+    }
+  }
+
+  if (def.type === 'array' && def.element) {
+    issues.push(
+      ...getZodContractIssues(def.element, schemaName, withArrayMarker(path)),
+    );
+  }
+
+  for (const option of def.options ?? []) {
+    issues.push(...getZodContractIssues(option, schemaName, path));
+  }
+
+  return issues;
+}
+
+function unwrapSourceCallChain(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (
+    ts.isCallExpression(current) &&
+    ts.isPropertyAccessExpression(current.expression)
+  ) {
+    const methodName = current.expression.name.text;
+    if (
+      methodName === 'array' ||
+      methodName === 'date' ||
+      methodName === 'number' ||
+      methodName === 'object' ||
+      methodName === 'string'
+    ) {
+      return current;
+    }
+    current = current.expression.expression;
+  }
+  return current;
+}
+
+function isZodFactoryCall(
+  expression: ts.Expression,
+  methodName: string,
+): expression is ts.CallExpression {
+  if (!ts.isCallExpression(expression)) return false;
+  if (!ts.isPropertyAccessExpression(expression.expression)) return false;
+  if (expression.expression.name.text !== methodName) return false;
+  return (
+    ts.isIdentifier(expression.expression.expression) &&
+    expression.expression.expression.text === 'z'
+  );
+}
+
+function getZodObjectShape(
+  expression: ts.Expression,
+): ts.ObjectLiteralExpression | null {
+  const unwrapped = unwrapSourceCallChain(expression);
+  if (!isZodFactoryCall(unwrapped, 'object')) return null;
+  const [shape] = unwrapped.arguments;
+  return shape && ts.isObjectLiteralExpression(shape) ? shape : null;
+}
+
+function getZodArrayElement(expression: ts.Expression): ts.Expression | null {
+  const unwrapped = unwrapSourceCallChain(expression);
+  if (!isZodFactoryCall(unwrapped, 'array')) return null;
+  return unwrapped.arguments[0] ?? null;
+}
+
+function isDirectZodFactoryExpression(
+  expression: ts.Expression,
+  methodName: 'date' | 'number',
+): boolean {
+  const unwrapped = unwrapSourceCallChain(expression);
+  return isZodFactoryCall(unwrapped, methodName);
+}
+
+function containsZodStringDatetimeCall(
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+): boolean {
+  if (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === 'datetime'
+  ) {
+    const receiver = node.expression.expression;
+    return (
+      ts.isCallExpression(receiver) && isZodFactoryCall(receiver, 'string')
+    );
+  }
+
+  return node
+    .getChildren(sourceFile)
+    .some((child) => containsZodStringDatetimeCall(child, sourceFile));
+}
+
+function getPropertyName(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) return name.text;
+  return null;
+}
+
+function getSourcePosition(sourceFile: ts.SourceFile, node: ts.Node): string {
+  const { line, character } = sourceFile.getLineAndCharacterOfPosition(
+    node.getStart(sourceFile),
+  );
+  return `${line + 1}:${character + 1}`;
+}
+
+function scanSchemaExpression(
+  expression: ts.Expression,
+  sourceFile: SourceFile,
+  schemaName: string,
+  path: readonly string[],
+): ContractIssue[] {
+  const issues: ContractIssue[] = [];
+  const fieldName = getLastFieldName(path);
+  const displayPath = formatPath(path) || '<root>';
+
+  if (isDirectZodFactoryExpression(expression, 'date')) {
+    issues.push(
+      `${sourceFile.filePath}:${getSourcePosition(
+        sourceFile.ast,
+        expression,
+      )} ${schemaName}.${displayPath} uses z.date(); controller output datetimes must use z.string().datetime() (${DATETIME_CONTRACT_REF}).`,
+    );
+  }
+
+  if (DATE_LIKE_FIELD_PATTERN.test(fieldName)) {
+    if (isDirectZodFactoryExpression(expression, 'number')) {
+      issues.push(
+        `${sourceFile.filePath}:${getSourcePosition(
+          sourceFile.ast,
+          expression,
+        )} ${schemaName}.${displayPath} uses date-like z.number(); epoch numbers are not allowed at the controller output boundary (${DATETIME_CONTRACT_REF}).`,
+      );
+    }
+
+    if (!containsZodStringDatetimeCall(expression, sourceFile.ast)) {
+      issues.push(
+        `${sourceFile.filePath}:${getSourcePosition(
+          sourceFile.ast,
+          expression,
+        )} ${schemaName}.${displayPath} is date-like but is not z.string().datetime() (${DATETIME_CONTRACT_REF}).`,
+      );
+    }
+  }
+
+  const objectShape = getZodObjectShape(expression);
+  if (objectShape) {
+    issues.push(...scanObjectShape(objectShape, sourceFile, schemaName, path));
+  }
+
+  const arrayElement = getZodArrayElement(expression);
+  if (arrayElement) {
+    issues.push(
+      ...scanSchemaExpression(
+        arrayElement,
+        sourceFile,
+        schemaName,
+        withArrayMarker(path),
+      ),
+    );
+  }
+
+  return issues;
+}
+
+function scanObjectShape(
+  shape: ts.ObjectLiteralExpression,
+  sourceFile: SourceFile,
+  schemaName: string,
+  path: readonly string[],
+): ContractIssue[] {
+  const issues: ContractIssue[] = [];
+
+  for (const property of shape.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+
+    const propertyName = getPropertyName(property.name);
+    if (!propertyName) continue;
+
+    issues.push(
+      ...scanSchemaExpression(property.initializer, sourceFile, schemaName, [
+        ...path,
+        propertyName,
+      ]),
+    );
+  }
+
+  return issues;
+}
+
+function collectOutputSchemaSourceIssues(
+  sourceFiles: readonly SourceFile[],
+): ContractIssue[] {
+  const issues: ContractIssue[] = [];
+
+  for (const sourceFile of sourceFiles) {
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.name.text.endsWith('OutputSchema') &&
+        node.initializer
+      ) {
+        issues.push(
+          ...scanSchemaExpression(
+            node.initializer,
+            sourceFile,
+            node.name.text,
+            [],
+          ),
+        );
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile.ast);
+  }
+
+  return issues;
+}
+
+function containsOutputSchemaIdentifier(node: ts.Node): boolean {
+  if (ts.isIdentifier(node) && node.text.endsWith('OutputSchema')) {
+    return true;
+  }
+
+  let found = false;
+  ts.forEachChild(node, (child) => {
+    if (!found && containsOutputSchemaIdentifier(child)) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+function collectSchemaLessActions(
+  sourceFiles: readonly SourceFile[],
+): Pick<PassThroughAction, 'action' | 'filePath'>[] {
+  const actions: Pick<PassThroughAction, 'action' | 'filePath'>[] = [];
+
+  for (const sourceFile of sourceFiles) {
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.initializer &&
+        ts.isCallExpression(node.initializer) &&
+        node.initializer.expression.getText(sourceFile.ast) ===
+          'createAction' &&
+        !containsOutputSchemaIdentifier(node.initializer)
+      ) {
+        actions.push({ filePath: sourceFile.filePath, action: node.name.text });
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile.ast);
+  }
+
+  return actions.sort((a, b) =>
+    `${a.filePath}:${a.action}`.localeCompare(`${b.filePath}:${b.action}`),
+  );
+}
+
+function getTypeAlias(sourceFile: SourceFile, typeName: string): ts.TypeNode {
+  let typeNode: ts.TypeNode | null = null;
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isTypeAliasDeclaration(node) &&
+      node.name.text === typeName &&
+      !typeNode
+    ) {
+      typeNode = node.type;
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile.ast);
+
+  if (!typeNode) {
+    throw new Error(`Missing type alias ${typeName} in ${sourceFile.filePath}`);
+  }
+
+  return typeNode;
+}
+
+function isStringNullishType(typeNode: ts.TypeNode): boolean {
+  if (typeNode.kind === ts.SyntaxKind.StringKeyword) return true;
+  if (typeNode.kind === ts.SyntaxKind.NullKeyword) return true;
+  if (typeNode.kind === ts.SyntaxKind.UndefinedKeyword) return true;
+
+  if (ts.isLiteralTypeNode(typeNode)) {
+    return (
+      typeNode.literal.kind === ts.SyntaxKind.NullKeyword ||
+      typeNode.literal.kind === ts.SyntaxKind.StringLiteral
+    );
+  }
+
+  if (ts.isUnionTypeNode(typeNode)) {
+    return typeNode.types.every(isStringNullishType);
+  }
+
+  return false;
+}
+
+function collectDateLikeStringFieldsFromType(
+  typeNode: ts.TypeNode,
+  sourceFile: SourceFile,
+  path: string,
+  issues: ContractIssue[],
+): string[] {
+  if (ts.isUnionTypeNode(typeNode)) {
+    return typeNode.types.flatMap((type) =>
+      collectDateLikeStringFieldsFromType(type, sourceFile, path, issues),
+    );
+  }
+
+  if (!ts.isTypeLiteralNode(typeNode)) return [];
+
+  const fields: string[] = [];
+  for (const member of typeNode.members) {
+    if (!ts.isPropertySignature(member) || !member.type) continue;
+
+    const propertyName = member.name ? getPropertyName(member.name) : null;
+    if (!propertyName) continue;
+
+    const propertyPath = path ? `${path}.${propertyName}` : propertyName;
+
+    if (DATE_LIKE_FIELD_PATTERN.test(propertyName)) {
+      if (isStringNullishType(member.type)) {
+        fields.push(propertyPath);
+      } else {
+        issues.push(
+          `${sourceFile.filePath}:${getSourcePosition(
+            sourceFile.ast,
+            member,
+          )} ${propertyPath} is date-like but is not typed as string/string|null in a pass-through controller output (${DATETIME_CONTRACT_REF}).`,
+        );
+      }
+    }
+
+    if (ts.isArrayTypeNode(member.type)) {
+      fields.push(
+        ...collectDateLikeStringFieldsFromType(
+          member.type.elementType,
+          sourceFile,
+          `${propertyPath}[]`,
+          issues,
+        ),
+      );
+      continue;
+    }
+
+    if (
+      ts.isTypeReferenceNode(member.type) &&
+      member.type.typeName.getText(sourceFile.ast) === 'Array' &&
+      member.type.typeArguments?.[0]
+    ) {
+      fields.push(
+        ...collectDateLikeStringFieldsFromType(
+          member.type.typeArguments[0],
+          sourceFile,
+          `${propertyPath}[]`,
+          issues,
+        ),
+      );
+      continue;
+    }
+
+    fields.push(
+      ...collectDateLikeStringFieldsFromType(
+        member.type,
+        sourceFile,
+        propertyPath,
+        issues,
+      ),
+    );
+  }
+
+  return fields;
+}
+
+function collectPassThroughDatetimeFields(): {
+  fields: string[];
+  issues: ContractIssue[];
+} {
+  const issues: ContractIssue[] = [];
+  const fields = new Set<string>();
+
+  for (const scan of PASS_THROUGH_TYPE_SCANS) {
+    const sourceFile = parseRepoSource(scan.filePath);
+    const typeNode = getTypeAlias(sourceFile, scan.typeName);
+    for (const field of collectDateLikeStringFieldsFromType(
+      typeNode,
+      sourceFile,
+      scan.prefix,
+      issues,
+    )) {
+      fields.add(`${scan.action}:${field}`);
+    }
+  }
+
+  return { fields: [...fields].sort(), issues };
+}
+
+describe('controller output datetime contract', () => {
+  it('keeps exported controller output schemas on ISO datetime strings', () => {
+    const schemaIssues = Object.entries(practiceSchemas)
+      .filter(
+        ([name, schema]) =>
+          name.endsWith('OutputSchema') && isZodSchema(schema),
+      )
+      .flatMap(([name, schema]) => getZodContractIssues(schema, name));
+
+    expect(schemaIssues).toEqual([]);
+  });
+
+  it('blocks z.date(), date-like z.number(), and unvalidated datetime strings in controller output schemas', () => {
+    const schemaIssues = collectOutputSchemaSourceIssues(
+      readControllerSources(),
+    );
+
+    expect(schemaIssues).toEqual([]);
+  });
+
+  it('keeps pass-through controller datetime outputs explicit and ISO-shaped', () => {
+    const schemaLessActions = collectSchemaLessActions(readControllerSources());
+    const expectedSchemaLessActions = EXPECTED_SCHEMALESS_ACTIONS.map(
+      ({ action, filePath }) => ({ action, filePath }),
+    ).sort((a, b) =>
+      `${a.filePath}:${a.action}`.localeCompare(`${b.filePath}:${b.action}`),
+    );
+
+    expect(schemaLessActions).toEqual(expectedSchemaLessActions);
+
+    const { fields, issues } = collectPassThroughDatetimeFields();
+    const expectedFields = EXPECTED_SCHEMALESS_ACTIONS.flatMap((action) =>
+      action.datetimeFields.map((field) => `${action.action}:${field}`),
+    ).sort();
+
+    expect(issues).toEqual([]);
+    expect(fields).toEqual(expectedFields);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the DEBT-397 PR 3 guardrail for the canonical controller-output datetime contract. The new default unit test enforces that schema-backed controller output datetimes stay ISO strings via `z.string().datetime()`, rejects `z.date()` and date-like epoch `z.number()` fields, and keeps schema-less pass-through datetime outputs explicitly inventoried.

This closes the DEBT-397 code work after PR 1 documented the contract and PR 2 migrated `SaveExamDraftAnswerOutputSchema.latestAnsweredAt` / `draftSavedAt` to ISO strings. The debt archive remains a separate follow-up.

## Red/Green Proof

- Green: `pnpm test --run src/adapters/controllers/controller-output-datetime-contract.test.ts` passes on current `dev`.
- Red: temporarily changed `SaveExamDraftAnswerOutputSchema.draftSavedAt` back to `z.date().nullable()`; the focused test failed on the exported schema walk and controller source scan with the DEBT-397 contract reference.
- Restored the ISO schema and re-ran the focused test green.

## Validation

- `pnpm test --run src/adapters/controllers/controller-output-datetime-contract.test.ts`
- `pnpm test --run components/theme-token-regression.test.tsx`
- `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- `pnpm test:e2e`

Notes: lint passes with the existing 19 `noExcessiveLinesPerFile` warnings; local Node is `v25.6.0` while the package requests Node `24.x`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized API datetime representation to ISO string format across controller outputs.

* **Tests**
  * Added a new regression guard that scans and enforces controller output schemas emit ISO datetime strings; includes comprehensive tests covering schema- and schema-less action outputs.

* **Documentation**
  * Updated documentation to reflect completed normalization, final scope, and updated acceptance criteria for the datetime enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->