### PR TITLE
SPEC-041 PR1: add question feedback backend

### DIFF
--- a/db/migrations/0019_illegal_warbound.sql
+++ b/db/migrations/0019_illegal_warbound.sql
@@ -1,0 +1,26 @@
+CREATE TYPE "public"."question_feedback_category" AS ENUM('incorrect_answer', 'ambiguous_wording', 'typo_formatting', 'outdated_reference', 'other');--> statement-breakpoint
+CREATE TYPE "public"."question_feedback_kind" AS ENUM('rating', 'report');--> statement-breakpoint
+CREATE TYPE "public"."question_feedback_rating" AS ENUM('helpful', 'not_helpful');--> statement-breakpoint
+CREATE TABLE "question_feedback" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"question_id" uuid NOT NULL,
+	"attempt_id" uuid,
+	"practice_session_id" uuid,
+	"kind" "question_feedback_kind" NOT NULL,
+	"rating" "question_feedback_rating",
+	"category" "question_feedback_category",
+	"comment" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "question_feedback_kind_shape_chk" CHECK (("question_feedback"."kind" = 'rating' AND "question_feedback"."category" IS NULL AND "question_feedback"."comment" IS NULL)
+          OR ("question_feedback"."kind" = 'report' AND "question_feedback"."category" IS NOT NULL AND "question_feedback"."rating" IS NULL)),
+	CONSTRAINT "question_feedback_comment_len_chk" CHECK ("question_feedback"."comment" IS NULL OR char_length("question_feedback"."comment") <= 2000)
+);
+--> statement-breakpoint
+ALTER TABLE "question_feedback" ADD CONSTRAINT "question_feedback_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "question_feedback" ADD CONSTRAINT "question_feedback_question_id_questions_id_fk" FOREIGN KEY ("question_id") REFERENCES "public"."questions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "question_feedback" ADD CONSTRAINT "question_feedback_attempt_id_attempts_id_fk" FOREIGN KEY ("attempt_id") REFERENCES "public"."attempts"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "question_feedback" ADD CONSTRAINT "question_feedback_practice_session_id_practice_sessions_id_fk" FOREIGN KEY ("practice_session_id") REFERENCES "public"."practice_sessions"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "question_feedback_question_created_at_idx" ON "question_feedback" USING btree ("question_id","created_at" desc,"id" desc);--> statement-breakpoint
+CREATE INDEX "question_feedback_rating_user_question_created_at_idx" ON "question_feedback" USING btree ("user_id","question_id","created_at" desc,"id" desc) WHERE "question_feedback"."kind" = 'rating';--> statement-breakpoint
+CREATE INDEX "question_feedback_kind_created_at_idx" ON "question_feedback" USING btree ("kind","created_at" desc,"id" desc);

--- a/db/migrations/0020_fat_ironclad.sql
+++ b/db/migrations/0020_fat_ironclad.sql
@@ -1,0 +1,3 @@
+CREATE INDEX "question_feedback_user_created_at_idx" ON "question_feedback" USING btree ("user_id","created_at" desc,"id" desc);--> statement-breakpoint
+CREATE INDEX "question_feedback_attempt_created_at_idx" ON "question_feedback" USING btree ("attempt_id","created_at" desc,"id" desc);--> statement-breakpoint
+CREATE INDEX "question_feedback_practice_session_created_at_idx" ON "question_feedback" USING btree ("practice_session_id","created_at" desc,"id" desc);

--- a/db/migrations/meta/0019_snapshot.json
+++ b/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,2041 @@
+{
+  "id": "d798e372-c003-4a06-8e37-8b9688c9bec7",
+  "prevId": "352abbd4-7a4d-49af-8873-e4bcad3886d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.attempts": {
+      "name": "attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_choice_id": {
+          "name": "selected_choice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_omitted": {
+          "name": "is_omitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_spent_seconds": {
+          "name": "time_spent_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_of_attempt_id": {
+          "name": "retry_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_origin": {
+          "name": "retry_origin",
+          "type": "attempt_retry_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_session_id": {
+          "name": "retry_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attempts_user_answered_at_idx": {
+          "name": "attempts_user_answered_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_user_question_answered_at_idx": {
+          "name": "attempts_user_question_answered_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_user_is_correct_answered_at_idx": {
+          "name": "attempts_user_is_correct_answered_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_correct",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_session_answered_at_idx": {
+          "name": "attempts_session_answered_at_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_session_user_answered_at_idx": {
+          "name": "attempts_session_user_answered_at_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_question_id_idx": {
+          "name": "attempts_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_retry_of_attempt_id_idx": {
+          "name": "attempts_retry_of_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "retry_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_session_question_uq": {
+          "name": "attempts_session_question_uq",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "practice_session_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attempts_user_id_users_id_fk": {
+          "name": "attempts_user_id_users_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_question_id_questions_id_fk": {
+          "name": "attempts_question_id_questions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_practice_session_id_practice_sessions_id_fk": {
+          "name": "attempts_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "practice_sessions",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "attempts_selected_choice_id_choices_id_fk": {
+          "name": "attempts_selected_choice_id_choices_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "choices",
+          "columnsFrom": [
+            "selected_choice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attempts_selected_choice_or_omitted_chk": {
+          "name": "attempts_selected_choice_or_omitted_chk",
+          "value": "(\"attempts\".\"selected_choice_id\" IS NOT NULL) <> \"attempts\".\"is_omitted\""
+        },
+        "attempts_omitted_incorrect_chk": {
+          "name": "attempts_omitted_incorrect_chk",
+          "value": "NOT \"attempts\".\"is_omitted\" OR \"attempts\".\"is_correct\" = false"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_created_at_idx": {
+          "name": "bookmarks_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_question_id_idx": {
+          "name": "bookmarks_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_question_id_questions_id_fk": {
+          "name": "bookmarks_question_id_questions_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bookmarks_user_id_question_id_pk": {
+          "name": "bookmarks_user_id_question_id_pk",
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.choices": {
+      "name": "choices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_md": {
+          "name": "text_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation_md": {
+          "name": "explanation_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "choices_question_id_idx": {
+          "name": "choices_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "choices_question_id_label_uq": {
+          "name": "choices_question_id_label_uq",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "choices_question_id_sort_order_uq": {
+          "name": "choices_question_id_sort_order_uq",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "choices_question_id_questions_id_fk": {
+          "name": "choices_question_id_questions_id_fk",
+          "tableFrom": "choices",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clerk_events": {
+      "name": "clerk_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clerk_events_type_idx": {
+          "name": "clerk_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clerk_events_processed_at_idx": {
+          "name": "clerk_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deleted_clerk_users": {
+      "name": "deleted_clerk_users",
+      "schema": "",
+      "columns": {
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deleted_clerk_users_deleted_at_idx": {
+          "name": "deleted_clerk_users_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idempotency_keys_expires_at_idx": {
+          "name": "idempotency_keys_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_user_id_users_id_fk": {
+          "name": "idempotency_keys_user_id_users_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotency_keys_user_id_action_key_pk": {
+          "name": "idempotency_keys_user_id_action_key_pk",
+          "columns": [
+            "user_id",
+            "action",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_stripe_cancellations": {
+      "name": "pending_stripe_cancellations",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_stripe_cancellations_created_at_idx": {
+          "name": "pending_stripe_cancellations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_stripe_cancellations_event_id_clerk_events_id_fk": {
+          "name": "pending_stripe_cancellations_event_id_clerk_events_id_fk",
+          "tableFrom": "pending_stripe_cancellations",
+          "tableTo": "clerk_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_sessions": {
+      "name": "practice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "practice_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_json": {
+          "name": "params_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_sessions_user_started_at_idx": {
+          "name": "practice_sessions_user_started_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"started_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_sessions_user_ended_at_idx": {
+          "name": "practice_sessions_user_ended_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"ended_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_sessions_user_incomplete_uq": {
+          "name": "practice_sessions_user_incomplete_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "ended_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_sessions_user_id_users_id_fk": {
+          "name": "practice_sessions_user_id_users_id_fk",
+          "tableFrom": "practice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_feedback": {
+      "name": "question_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "question_feedback_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "question_feedback_rating",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "question_feedback_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_feedback_question_created_at_idx": {
+          "name": "question_feedback_question_created_at_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_rating_user_question_created_at_idx": {
+          "name": "question_feedback_rating_user_question_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"question_feedback\".\"kind\" = 'rating'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_kind_created_at_idx": {
+          "name": "question_feedback_kind_created_at_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_feedback_user_id_users_id_fk": {
+          "name": "question_feedback_user_id_users_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_feedback_question_id_questions_id_fk": {
+          "name": "question_feedback_question_id_questions_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_feedback_attempt_id_attempts_id_fk": {
+          "name": "question_feedback_attempt_id_attempts_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "question_feedback_practice_session_id_practice_sessions_id_fk": {
+          "name": "question_feedback_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "practice_sessions",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "question_feedback_kind_shape_chk": {
+          "name": "question_feedback_kind_shape_chk",
+          "value": "(\"question_feedback\".\"kind\" = 'rating' AND \"question_feedback\".\"category\" IS NULL AND \"question_feedback\".\"comment\" IS NULL)\n          OR (\"question_feedback\".\"kind\" = 'report' AND \"question_feedback\".\"category\" IS NOT NULL AND \"question_feedback\".\"rating\" IS NULL)"
+        },
+        "question_feedback_comment_len_chk": {
+          "name": "question_feedback_comment_len_chk",
+          "value": "\"question_feedback\".\"comment\" IS NULL OR char_length(\"question_feedback\".\"comment\") <= 2000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.question_tags": {
+      "name": "question_tags",
+      "schema": "",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "question_tags_tag_id_idx": {
+          "name": "question_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_tags_question_id_idx": {
+          "name": "question_tags_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_tags_question_id_questions_id_fk": {
+          "name": "question_tags_question_id_questions_id_fk",
+          "tableFrom": "question_tags",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_tags_tag_id_tags_id_fk": {
+          "name": "question_tags_tag_id_tags_id_fk",
+          "tableFrom": "question_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "question_tags_question_id_tag_id_pk": {
+          "name": "question_tags_question_id_tag_id_pk",
+          "columns": [
+            "question_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stem_md": {
+          "name": "stem_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation_md": {
+          "name": "explanation_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_md": {
+          "name": "reference_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_slug_uq": {
+          "name": "questions_slug_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_status_difficulty_idx": {
+          "name": "questions_status_difficulty_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_status_created_at_idx": {
+          "name": "questions_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limits_window_start_idx": {
+          "name": "rate_limits_window_start_idx",
+          "columns": [
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limits_key_window_start_pk": {
+          "name": "rate_limits_key_window_start_pk",
+          "columns": [
+            "key",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_customers": {
+      "name": "stripe_customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_customers_user_id_uq": {
+          "name": "stripe_customers_user_id_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_customers_stripe_customer_id_uq": {
+          "name": "stripe_customers_stripe_customer_id_uq",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_customers_user_id_users_id_fk": {
+          "name": "stripe_customers_user_id_users_id_fk",
+          "tableFrom": "stripe_customers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "stripe_events_type_idx": {
+          "name": "stripe_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_events_processed_at_idx": {
+          "name": "stripe_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_subscriptions": {
+      "name": "stripe_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_subscriptions_user_id_uq": {
+          "name": "stripe_subscriptions_user_id_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_subscriptions_stripe_subscription_id_uq": {
+          "name": "stripe_subscriptions_stripe_subscription_id_uq",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_subscriptions_user_status_idx": {
+          "name": "stripe_subscriptions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_subscriptions_user_id_users_id_fk": {
+          "name": "stripe_subscriptions_user_id_users_id_fk",
+          "tableFrom": "stripe_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "tag_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_slug_uq": {
+          "name": "tags_slug_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_kind_slug_idx": {
+          "name": "tags_kind_slug_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_uq": {
+          "name": "users_clerk_user_id_uq",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_uq": {
+          "name": "users_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attempt_retry_origin": {
+      "name": "attempt_retry_origin",
+      "schema": "public",
+      "values": [
+        "history",
+        "dashboard",
+        "bookmarks",
+        "session_review",
+        "other"
+      ]
+    },
+    "public.practice_mode": {
+      "name": "practice_mode",
+      "schema": "public",
+      "values": [
+        "tutor",
+        "exam"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "easy",
+        "medium",
+        "hard"
+      ]
+    },
+    "public.question_feedback_category": {
+      "name": "question_feedback_category",
+      "schema": "public",
+      "values": [
+        "incorrect_answer",
+        "ambiguous_wording",
+        "typo_formatting",
+        "outdated_reference",
+        "other"
+      ]
+    },
+    "public.question_feedback_kind": {
+      "name": "question_feedback_kind",
+      "schema": "public",
+      "values": [
+        "rating",
+        "report"
+      ]
+    },
+    "public.question_feedback_rating": {
+      "name": "question_feedback_rating",
+      "schema": "public",
+      "values": [
+        "helpful",
+        "not_helpful"
+      ]
+    },
+    "public.question_status": {
+      "name": "question_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.stripe_subscription_status": {
+      "name": "stripe_subscription_status",
+      "schema": "public",
+      "values": [
+        "incomplete",
+        "incomplete_expired",
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid",
+        "paused"
+      ]
+    },
+    "public.tag_kind": {
+      "name": "tag_kind",
+      "schema": "public",
+      "values": [
+        "topic",
+        "substance",
+        "treatment",
+        "diagnosis"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/0020_snapshot.json
+++ b/db/migrations/meta/0020_snapshot.json
@@ -1,0 +1,2122 @@
+{
+  "id": "552ddfc3-0be2-419f-8009-20f6a92b51e8",
+  "prevId": "d798e372-c003-4a06-8e37-8b9688c9bec7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.attempts": {
+      "name": "attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_choice_id": {
+          "name": "selected_choice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_omitted": {
+          "name": "is_omitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_spent_seconds": {
+          "name": "time_spent_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_of_attempt_id": {
+          "name": "retry_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_origin": {
+          "name": "retry_origin",
+          "type": "attempt_retry_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_session_id": {
+          "name": "retry_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attempts_user_answered_at_idx": {
+          "name": "attempts_user_answered_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_user_question_answered_at_idx": {
+          "name": "attempts_user_question_answered_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_user_is_correct_answered_at_idx": {
+          "name": "attempts_user_is_correct_answered_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_correct",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_session_answered_at_idx": {
+          "name": "attempts_session_answered_at_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_session_user_answered_at_idx": {
+          "name": "attempts_session_user_answered_at_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_question_id_idx": {
+          "name": "attempts_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_retry_of_attempt_id_idx": {
+          "name": "attempts_retry_of_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "retry_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_session_question_uq": {
+          "name": "attempts_session_question_uq",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "practice_session_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attempts_user_id_users_id_fk": {
+          "name": "attempts_user_id_users_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_question_id_questions_id_fk": {
+          "name": "attempts_question_id_questions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_practice_session_id_practice_sessions_id_fk": {
+          "name": "attempts_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "practice_sessions",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "attempts_selected_choice_id_choices_id_fk": {
+          "name": "attempts_selected_choice_id_choices_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "choices",
+          "columnsFrom": [
+            "selected_choice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attempts_selected_choice_or_omitted_chk": {
+          "name": "attempts_selected_choice_or_omitted_chk",
+          "value": "(\"attempts\".\"selected_choice_id\" IS NOT NULL) <> \"attempts\".\"is_omitted\""
+        },
+        "attempts_omitted_incorrect_chk": {
+          "name": "attempts_omitted_incorrect_chk",
+          "value": "NOT \"attempts\".\"is_omitted\" OR \"attempts\".\"is_correct\" = false"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_created_at_idx": {
+          "name": "bookmarks_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_question_id_idx": {
+          "name": "bookmarks_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_question_id_questions_id_fk": {
+          "name": "bookmarks_question_id_questions_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bookmarks_user_id_question_id_pk": {
+          "name": "bookmarks_user_id_question_id_pk",
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.choices": {
+      "name": "choices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_md": {
+          "name": "text_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation_md": {
+          "name": "explanation_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "choices_question_id_idx": {
+          "name": "choices_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "choices_question_id_label_uq": {
+          "name": "choices_question_id_label_uq",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "choices_question_id_sort_order_uq": {
+          "name": "choices_question_id_sort_order_uq",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "choices_question_id_questions_id_fk": {
+          "name": "choices_question_id_questions_id_fk",
+          "tableFrom": "choices",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clerk_events": {
+      "name": "clerk_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clerk_events_type_idx": {
+          "name": "clerk_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clerk_events_processed_at_idx": {
+          "name": "clerk_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deleted_clerk_users": {
+      "name": "deleted_clerk_users",
+      "schema": "",
+      "columns": {
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deleted_clerk_users_deleted_at_idx": {
+          "name": "deleted_clerk_users_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idempotency_keys_expires_at_idx": {
+          "name": "idempotency_keys_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_user_id_users_id_fk": {
+          "name": "idempotency_keys_user_id_users_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotency_keys_user_id_action_key_pk": {
+          "name": "idempotency_keys_user_id_action_key_pk",
+          "columns": [
+            "user_id",
+            "action",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_stripe_cancellations": {
+      "name": "pending_stripe_cancellations",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_stripe_cancellations_created_at_idx": {
+          "name": "pending_stripe_cancellations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_stripe_cancellations_event_id_clerk_events_id_fk": {
+          "name": "pending_stripe_cancellations_event_id_clerk_events_id_fk",
+          "tableFrom": "pending_stripe_cancellations",
+          "tableTo": "clerk_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_sessions": {
+      "name": "practice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "practice_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_json": {
+          "name": "params_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_sessions_user_started_at_idx": {
+          "name": "practice_sessions_user_started_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"started_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_sessions_user_ended_at_idx": {
+          "name": "practice_sessions_user_ended_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"ended_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_sessions_user_incomplete_uq": {
+          "name": "practice_sessions_user_incomplete_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "ended_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_sessions_user_id_users_id_fk": {
+          "name": "practice_sessions_user_id_users_id_fk",
+          "tableFrom": "practice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_feedback": {
+      "name": "question_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "question_feedback_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "question_feedback_rating",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "question_feedback_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_feedback_user_created_at_idx": {
+          "name": "question_feedback_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_question_created_at_idx": {
+          "name": "question_feedback_question_created_at_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_attempt_created_at_idx": {
+          "name": "question_feedback_attempt_created_at_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_practice_session_created_at_idx": {
+          "name": "question_feedback_practice_session_created_at_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_rating_user_question_created_at_idx": {
+          "name": "question_feedback_rating_user_question_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"question_feedback\".\"kind\" = 'rating'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_kind_created_at_idx": {
+          "name": "question_feedback_kind_created_at_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_feedback_user_id_users_id_fk": {
+          "name": "question_feedback_user_id_users_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_feedback_question_id_questions_id_fk": {
+          "name": "question_feedback_question_id_questions_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_feedback_attempt_id_attempts_id_fk": {
+          "name": "question_feedback_attempt_id_attempts_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "question_feedback_practice_session_id_practice_sessions_id_fk": {
+          "name": "question_feedback_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "practice_sessions",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "question_feedback_kind_shape_chk": {
+          "name": "question_feedback_kind_shape_chk",
+          "value": "(\"question_feedback\".\"kind\" = 'rating' AND \"question_feedback\".\"category\" IS NULL AND \"question_feedback\".\"comment\" IS NULL)\n          OR (\"question_feedback\".\"kind\" = 'report' AND \"question_feedback\".\"category\" IS NOT NULL AND \"question_feedback\".\"rating\" IS NULL)"
+        },
+        "question_feedback_comment_len_chk": {
+          "name": "question_feedback_comment_len_chk",
+          "value": "\"question_feedback\".\"comment\" IS NULL OR char_length(\"question_feedback\".\"comment\") <= 2000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.question_tags": {
+      "name": "question_tags",
+      "schema": "",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "question_tags_tag_id_idx": {
+          "name": "question_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_tags_question_id_idx": {
+          "name": "question_tags_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_tags_question_id_questions_id_fk": {
+          "name": "question_tags_question_id_questions_id_fk",
+          "tableFrom": "question_tags",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_tags_tag_id_tags_id_fk": {
+          "name": "question_tags_tag_id_tags_id_fk",
+          "tableFrom": "question_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "question_tags_question_id_tag_id_pk": {
+          "name": "question_tags_question_id_tag_id_pk",
+          "columns": [
+            "question_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stem_md": {
+          "name": "stem_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation_md": {
+          "name": "explanation_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_md": {
+          "name": "reference_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_slug_uq": {
+          "name": "questions_slug_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_status_difficulty_idx": {
+          "name": "questions_status_difficulty_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_status_created_at_idx": {
+          "name": "questions_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limits_window_start_idx": {
+          "name": "rate_limits_window_start_idx",
+          "columns": [
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limits_key_window_start_pk": {
+          "name": "rate_limits_key_window_start_pk",
+          "columns": [
+            "key",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_customers": {
+      "name": "stripe_customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_customers_user_id_uq": {
+          "name": "stripe_customers_user_id_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_customers_stripe_customer_id_uq": {
+          "name": "stripe_customers_stripe_customer_id_uq",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_customers_user_id_users_id_fk": {
+          "name": "stripe_customers_user_id_users_id_fk",
+          "tableFrom": "stripe_customers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "stripe_events_type_idx": {
+          "name": "stripe_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_events_processed_at_idx": {
+          "name": "stripe_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_subscriptions": {
+      "name": "stripe_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_subscriptions_user_id_uq": {
+          "name": "stripe_subscriptions_user_id_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_subscriptions_stripe_subscription_id_uq": {
+          "name": "stripe_subscriptions_stripe_subscription_id_uq",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_subscriptions_user_status_idx": {
+          "name": "stripe_subscriptions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_subscriptions_user_id_users_id_fk": {
+          "name": "stripe_subscriptions_user_id_users_id_fk",
+          "tableFrom": "stripe_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "tag_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_slug_uq": {
+          "name": "tags_slug_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_kind_slug_idx": {
+          "name": "tags_kind_slug_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_uq": {
+          "name": "users_clerk_user_id_uq",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_uq": {
+          "name": "users_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attempt_retry_origin": {
+      "name": "attempt_retry_origin",
+      "schema": "public",
+      "values": [
+        "history",
+        "dashboard",
+        "bookmarks",
+        "session_review",
+        "other"
+      ]
+    },
+    "public.practice_mode": {
+      "name": "practice_mode",
+      "schema": "public",
+      "values": [
+        "tutor",
+        "exam"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "easy",
+        "medium",
+        "hard"
+      ]
+    },
+    "public.question_feedback_category": {
+      "name": "question_feedback_category",
+      "schema": "public",
+      "values": [
+        "incorrect_answer",
+        "ambiguous_wording",
+        "typo_formatting",
+        "outdated_reference",
+        "other"
+      ]
+    },
+    "public.question_feedback_kind": {
+      "name": "question_feedback_kind",
+      "schema": "public",
+      "values": [
+        "rating",
+        "report"
+      ]
+    },
+    "public.question_feedback_rating": {
+      "name": "question_feedback_rating",
+      "schema": "public",
+      "values": [
+        "helpful",
+        "not_helpful"
+      ]
+    },
+    "public.question_status": {
+      "name": "question_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.stripe_subscription_status": {
+      "name": "stripe_subscription_status",
+      "schema": "public",
+      "values": [
+        "incomplete",
+        "incomplete_expired",
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid",
+        "paused"
+      ]
+    },
+    "public.tag_kind": {
+      "name": "tag_kind",
+      "schema": "public",
+      "values": [
+        "topic",
+        "substance",
+        "treatment",
+        "diagnosis"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1780352345440,
       "tag": "0019_illegal_warbound",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1780410037334,
+      "tag": "0020_fat_ironclad",
+      "breakpoints": true
     }
   ]
 }

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1779498169302,
       "tag": "0018_backfill-omitted-exam-attempts",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1780352345440,
+      "tag": "0019_illegal_warbound",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -71,6 +71,27 @@ export const attemptRetryOriginEnum = pgEnum('attempt_retry_origin', [
   'other',
 ]);
 
+export const questionFeedbackKindEnum = pgEnum('question_feedback_kind', [
+  'rating',
+  'report',
+]);
+
+export const questionFeedbackRatingEnum = pgEnum('question_feedback_rating', [
+  'helpful',
+  'not_helpful',
+]);
+
+export const questionFeedbackCategoryEnum = pgEnum(
+  'question_feedback_category',
+  [
+    'incorrect_answer',
+    'ambiguous_wording',
+    'typo_formatting',
+    'outdated_reference',
+    'other',
+  ],
+);
+
 /**
  * TYPES (shared)
  */
@@ -83,6 +104,12 @@ export type StripeSubscriptionStatus =
   (typeof stripeSubscriptionStatusEnum.enumValues)[number];
 export type AttemptRetryOrigin =
   (typeof attemptRetryOriginEnum.enumValues)[number];
+export type QuestionFeedbackKind =
+  (typeof questionFeedbackKindEnum.enumValues)[number];
+export type QuestionFeedbackRating =
+  (typeof questionFeedbackRatingEnum.enumValues)[number];
+export type QuestionFeedbackCategory =
+  (typeof questionFeedbackCategoryEnum.enumValues)[number];
 
 export type PracticeSessionParams = {
   count: number; // number of questions in this session
@@ -513,6 +540,59 @@ export const bookmarks = pgTable(
   }),
 );
 
+export const questionFeedback = pgTable(
+  'question_feedback',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    questionId: uuid('question_id')
+      .notNull()
+      .references(() => questions.id, { onDelete: 'cascade' }),
+    attemptId: uuid('attempt_id').references(() => attempts.id, {
+      onDelete: 'set null',
+    }),
+    practiceSessionId: uuid('practice_session_id').references(
+      () => practiceSessions.id,
+      { onDelete: 'set null' },
+    ),
+    kind: questionFeedbackKindEnum('kind').notNull(),
+    rating: questionFeedbackRatingEnum('rating'),
+    category: questionFeedbackCategoryEnum('category'),
+    comment: text('comment'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    questionCreatedAtIdx: index('question_feedback_question_created_at_idx').on(
+      t.questionId,
+      desc(t.createdAt),
+      desc(t.id),
+    ),
+    ratingUserQuestionCreatedAtIdx: index(
+      'question_feedback_rating_user_question_created_at_idx',
+    )
+      .on(t.userId, t.questionId, desc(t.createdAt), desc(t.id))
+      .where(sql`${t.kind} = 'rating'`),
+    kindCreatedAtIdx: index('question_feedback_kind_created_at_idx').on(
+      t.kind,
+      desc(t.createdAt),
+      desc(t.id),
+    ),
+    kindShapeCheck: check(
+      'question_feedback_kind_shape_chk',
+      sql`(${t.kind} = 'rating' AND ${t.category} IS NULL AND ${t.comment} IS NULL)
+          OR (${t.kind} = 'report' AND ${t.category} IS NOT NULL AND ${t.rating} IS NULL)`,
+    ),
+    commentLengthCheck: check(
+      'question_feedback_comment_len_chk',
+      sql`${t.comment} IS NULL OR char_length(${t.comment}) <= 2000`,
+    ),
+  }),
+);
+
 /**
  * RELATIONS
  */
@@ -529,6 +609,7 @@ export const usersRelations = relations(users, ({ one, many }) => ({
   sessions: many(practiceSessions),
   attempts: many(attempts),
   bookmarks: many(bookmarks),
+  feedback: many(questionFeedback),
 }));
 
 export const questionsRelations = relations(questions, ({ many }) => ({
@@ -536,6 +617,7 @@ export const questionsRelations = relations(questions, ({ many }) => ({
   questionTags: many(questionTags),
   attempts: many(attempts),
   bookmarks: many(bookmarks),
+  feedback: many(questionFeedback),
 }));
 
 export const choicesRelations = relations(choices, ({ one }) => ({
@@ -568,10 +650,11 @@ export const practiceSessionsRelations = relations(
       references: [users.id],
     }),
     attempts: many(attempts),
+    feedback: many(questionFeedback),
   }),
 );
 
-export const attemptsRelations = relations(attempts, ({ one }) => ({
+export const attemptsRelations = relations(attempts, ({ one, many }) => ({
   user: one(users, {
     fields: [attempts.userId],
     references: [users.id],
@@ -588,6 +671,7 @@ export const attemptsRelations = relations(attempts, ({ one }) => ({
     fields: [attempts.selectedChoiceId],
     references: [choices.id],
   }),
+  feedback: many(questionFeedback),
 }));
 
 export const bookmarksRelations = relations(bookmarks, ({ one }) => ({
@@ -600,6 +684,28 @@ export const bookmarksRelations = relations(bookmarks, ({ one }) => ({
     references: [questions.id],
   }),
 }));
+
+export const questionFeedbackRelations = relations(
+  questionFeedback,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [questionFeedback.userId],
+      references: [users.id],
+    }),
+    question: one(questions, {
+      fields: [questionFeedback.questionId],
+      references: [questions.id],
+    }),
+    attempt: one(attempts, {
+      fields: [questionFeedback.attemptId],
+      references: [attempts.id],
+    }),
+    practiceSession: one(practiceSessions, {
+      fields: [questionFeedback.practiceSessionId],
+      references: [practiceSessions.id],
+    }),
+  }),
+);
 
 /**
  * EXPORTED TS TYPES
@@ -647,3 +753,6 @@ export type NewAttempt = typeof attempts.$inferInsert;
 
 export type Bookmark = typeof bookmarks.$inferSelect;
 export type NewBookmark = typeof bookmarks.$inferInsert;
+
+export type QuestionFeedback = typeof questionFeedback.$inferSelect;
+export type NewQuestionFeedback = typeof questionFeedback.$inferInsert;

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -566,11 +566,24 @@ export const questionFeedback = pgTable(
       .defaultNow(),
   },
   (t) => ({
+    userCreatedAtIdx: index('question_feedback_user_created_at_idx').on(
+      t.userId,
+      desc(t.createdAt),
+      desc(t.id),
+    ),
     questionCreatedAtIdx: index('question_feedback_question_created_at_idx').on(
       t.questionId,
       desc(t.createdAt),
       desc(t.id),
     ),
+    attemptCreatedAtIdx: index('question_feedback_attempt_created_at_idx').on(
+      t.attemptId,
+      desc(t.createdAt),
+      desc(t.id),
+    ),
+    practiceSessionCreatedAtIdx: index(
+      'question_feedback_practice_session_created_at_idx',
+    ).on(t.practiceSessionId, desc(t.createdAt), desc(t.id)),
     ratingUserQuestionCreatedAtIdx: index(
       'question_feedback_rating_user_question_created_at_idx',
     )

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -583,6 +583,7 @@ export const questionFeedback = pgTable(
     ),
     kindShapeCheck: check(
       'question_feedback_kind_shape_chk',
+      // Rating NULL is a valid append-only retraction event.
       sql`(${t.kind} = 'rating' AND ${t.category} IS NULL AND ${t.comment} IS NULL)
           OR (${t.kind} = 'report' AND ${t.category} IS NOT NULL AND ${t.rating} IS NULL)`,
     ),

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -1,7 +1,7 @@
 # Implementation Specifications
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-05-23
+**Last Updated:** 2026-06-01
 
 ---
 
@@ -22,6 +22,7 @@ Implementation specifications provide detailed technical guidance for building e
 | [SPEC-017](./spec-017-rate-limiting.md) | Rate Limiting | Implemented (MVP complete) | Infrastructure |
 | [SPEC-039](./spec-039-exam-mode-timer.md) | Exam Mode Timer (whole-block countdown, auto-submit) | Implemented (PR #319) | Feature |
 | [SPEC-040](./spec-040-omitted-exam-answer-scoring.md) | Omitted Exam Answer Scoring (DEBT-390 fix; prerequisite for SPEC-039) | Implemented (PR #317) | Feature |
+| [SPEC-041](./spec-041-question-feedback.md) | Question Feedback (per-question 👍/👎 ratings + problem reports) | Proposed | Feature |
 
 **Master Spec split parts (readability):**
 
@@ -30,7 +31,7 @@ Implementation specifications provide detailed technical guidance for building e
 - [Master Spec — Part 3](./master_spec_part3.md) — Content Pipeline, Directory Structure, Vertical Slices
 - [Master Spec — Part 4](./master_spec_part4.md) — Testing, Security, Env Vars, Deployment
 
-**Next Spec ID:** SPEC-041
+**Next Spec ID:** SPEC-042
 
 ## Archived Specs
 

--- a/docs/specs/spec-041-question-feedback.md
+++ b/docs/specs/spec-041-question-feedback.md
@@ -32,6 +32,8 @@ rich, actionable signal for content fixes.
 Both tiers write to a single **append-only event-log table** (`question_feedback`), chosen because
 the primary goal is a long-lived analytical substrate ("forever maintain and improve"): history is
 signal, storage is trivial relative to attempts, and pure-insert is the simplest persistence shape.
+The **domain/application shape is not a nullable bag**: it is a discriminated event union, with the
+relational table using nullable columns plus a `CHECK` only as the storage representation.
 
 ### ⚠️ Naming collision (read first)
 
@@ -83,8 +85,9 @@ confusion this spec uses distinct names everywhere:
 
 1. **Auth + entitlement:** all actions go through `requireEntitledUserId` (authenticated + subscribed),
    identical to bookmark/practice controllers.
-2. **Rate limited:** per-user limit via the existing `RateLimiter` gateway and a new
-   `QUESTION_FEEDBACK_RATE_LIMIT` constant.
+2. **Rate limited:** per-user limits via the existing `RateLimiter` gateway and two named constants:
+   `QUESTION_RATING_RATE_LIMIT` for one-click ratings and `QUESTION_REPORT_RATE_LIMIT` for free-text
+   reports.
 3. **Clean Architecture:** domain stays pure (no vendor IDs, no DB imports); port in `application`,
    Drizzle impl in `adapters`; fakes over mocks in tests.
 4. **Design system:** new `Dialog` primitive follows `docs/frontend/standards.md` (canonical focus
@@ -104,11 +107,45 @@ confusion this spec uses distinct names everywhere:
 
 Dependency direction (inward only): `db` ← `adapters` ← `application` ← `domain`.
 
+### First-principles design decisions
+
+- **DDD / Simple Design — one domain event stream, not two unrelated aggregates.** Ratings and
+  reports share the same actor, question, attempt/session context, append time, privacy posture, and
+  extraction path. Two physical tables would duplicate those columns and force every analytics query
+  to union them back together. The better split is a discriminated union in domain/application and
+  one relational event table with a shape `CHECK`: type safety at the inner boundary, cohesive
+  extraction at the outer boundary. Repo evidence: the domain already uses discriminated unions for
+  closed shapes (`AnswerOutcome`, `src/domain/value-objects/answer-outcome.ts:1`) and factories for
+  invariants (`createAttempt`, `src/domain/entities/attempt.ts:54`), while plain records like
+  `Bookmark` stay factory-free because they have no cross-field invariant
+  (`src/domain/entities/bookmark.ts:4`).
+- **Data engineering — append-only, no current-state table in v1.** The display read path is a
+  single latest-rating lookup, and the analytics read path needs history. A materialized
+  `question_feedback_current_rating` table would add synchronization and delete/GDPR complexity
+  before scale proves it necessary. Use the partial latest-rating index below first; add a
+  projection table only after observed query plans justify it.
+- **SOLID / YAGNI — no Strategy hierarchy yet.** There are exactly two commands with different UX,
+  validation, and rate-limit keys (`rateQuestion`, `submitQuestionReport`). The use cases remain
+  separate commands; the shared abstraction is only the repository append port and typed domain
+  constructors. Add a Strategy only when a third feedback kind introduces real branching inside one
+  command.
+- **Frontend — feedback belongs to reflection surfaces.** Post-answer timing follows the repo's
+  question-zone model: actions live in Zone 2 after the learner has read the explanation
+  (`docs/frontend/design-principles.md:42`), and the analogous Bookmark policy explicitly keeps
+  curation on reflection surfaces rather than assessment/performance surfaces
+  (`docs/frontend/bookmark-surface-policy.md:16`, `docs/frontend/bookmark-surface-policy.md:67`).
+- **Query determinism — latest means `createdAt DESC, id DESC`.** Existing latest-attempt reads use
+  `orderBy(desc(attempts.answeredAt), desc(attempts.id))`
+  (`src/adapters/repositories/drizzle-attempt-repository.ts:282`) and have an integration test for the
+  UUID tie-breaker (`tests/integration/session-attempt-repository.integration.test.ts:293`). Feedback
+  latest-rating hydration must copy that deterministic ordering and index shape.
+
 ### 1. Domain — value objects + entity (`src/domain/`)
 
-**Zero external imports** (the value objects import nothing; the entity `import type`s its three VO
-unions from `../value-objects`, exactly like `attempt.ts`/`question.ts` — that intra-domain import is
-allowed and is not an impurity). Mirror the `src/domain/value-objects/` `const AllX = [...] as const`
+**Zero external imports** (the value objects import nothing; the entity `import type`s the rating /
+category VO unions from `../value-objects`, exactly like `attempt.ts`/`question.ts` — that intra-
+domain import is allowed and is not an impurity). Mirror the `src/domain/value-objects/`
+`const AllX = [...] as const`
 **plus `isValid<Type>` type-predicate guard** idiom: every existing VO (`practice-mode.ts`,
 `question-status.ts`, `tag-kind.ts`, …) ships an `isValid…` guard, and the "Tests First"
 membership/validator tests call them — so each new VO must define one.
@@ -153,60 +190,108 @@ export function isValidQuestionFeedbackKind(
 
 ```typescript
 // src/domain/entities/question-feedback.ts
-export type QuestionFeedback = {
-  readonly id: string;
+export type QuestionFeedbackContext = {
   readonly userId: string;
   readonly questionId: string;
   readonly attemptId: string | null;
   readonly practiceSessionId: string | null;
-  readonly kind: QuestionFeedbackKind;
-  readonly rating: QuestionFeedbackRating | null;   // set when kind='rating'; null = retraction
-  readonly category: QuestionFeedbackCategory | null; // set when kind='report'
-  readonly comment: string | null;
+};
+
+export type PersistedQuestionFeedback = {
+  readonly id: string;
   readonly createdAt: Date;
 };
+
+export type QuestionRatingFeedback = QuestionFeedbackContext &
+  PersistedQuestionFeedback & {
+    readonly kind: 'rating';
+    readonly rating: QuestionFeedbackRating | null; // null = retraction
+    readonly category: null;
+    readonly comment: null;
+  };
+
+export type QuestionReportFeedback = QuestionFeedbackContext &
+  PersistedQuestionFeedback & {
+    readonly kind: 'report';
+    readonly rating: null;
+    readonly category: QuestionFeedbackCategory;
+    readonly comment: string | null;
+  };
+
+export type QuestionFeedback = QuestionRatingFeedback | QuestionReportFeedback;
+export type NewQuestionFeedback =
+  | Omit<QuestionRatingFeedback, keyof PersistedQuestionFeedback>
+  | Omit<QuestionReportFeedback, keyof PersistedQuestionFeedback>;
+
+export function newQuestionRatingFeedback(
+  input: QuestionFeedbackContext & {
+    readonly rating: QuestionFeedbackRating | null;
+  },
+): NewQuestionFeedback {
+  return {
+    ...input,
+    kind: 'rating',
+    category: null,
+    comment: null,
+  };
+}
+
+export function newQuestionReportFeedback(
+  input: QuestionFeedbackContext & {
+    readonly category: QuestionFeedbackCategory;
+    readonly comment: string | null;
+  },
+): NewQuestionFeedback {
+  return {
+    ...input,
+    kind: 'report',
+    rating: null,
+  };
+}
 ```
 
-**Invariant (enforced in use case + DB CHECK):** a `rating` event has `category = null`; a `report`
-event has `category != null` and `rating = null`. This is a deliberate divergence from `Attempt`,
-which enforces its invariant inside a domain `createAttempt()` factory that throws `DomainError`;
-`QuestionFeedback` stays a plain data record (like `Bookmark`/`Subscription`, which have no factory)
-and pushes the invariant to the use case + DB CHECK.
+**Invariant (encoded in type + constructors + DB CHECK):** a `rating` event has
+`category = null` and `comment = null`; a `report` event has `category != null` and `rating = null`.
+Do not pass a raw object literal with `kind`, `rating`, `category`, and `comment` from a use case.
+Use `newQuestionRatingFeedback(...)` / `newQuestionReportFeedback(...)` so impossible shapes are not
+representable in application code; the DB `CHECK` remains defense-in-depth for adapter bugs/manual SQL.
 
-**Test-helper factory:** add `createQuestionFeedback(overrides)` to
-`src/domain/test-helpers/factories.ts` and its `index.ts` barrel, mirroring `createBookmark` /
-`createAttempt` — UUID-emitting defaults via the existing `createUuid()` helper, `createdAt: new
-Date()`, nullable FK ids defaulting to `null`. Use-case, repo, and fake tests build events through it
-so fixture UUID shapes stay valid at the Drizzle/zod boundaries.
+Export the new entity functions/types from `src/domain/entities/index.ts`; export the three new value
+objects from `src/domain/value-objects/index.ts`.
+
+**Test-helper factories:** add `createQuestionRatingFeedback(overrides)` and
+`createQuestionReportFeedback(overrides)` to `src/domain/test-helpers/factories.ts` and its `index.ts`
+barrel. Use UUID-emitting defaults via the existing `createUuid()` helper, `createdAt: new Date()`,
+nullable FK ids defaulting to `null`, and shape-correct defaults (`comment: null` only for reports,
+with ratings always setting `comment: null`). Avoid one permissive
+`createQuestionFeedback({ kind, ... })` factory, because it would recreate the nullable-bag problem
+in tests.
 
 ### 2. Application — port + use cases (`src/application/`)
 
 ```typescript
 // src/application/ports/question-feedback-repository.ts
-export type RecordQuestionFeedbackParams = {
-  userId: string;
-  questionId: string;
-  attemptId: string | null;
-  practiceSessionId: string | null;
-  kind: QuestionFeedbackKind;
-  rating: QuestionFeedbackRating | null;
-  category: QuestionFeedbackCategory | null;
-  comment: string | null;
-};
+import type {
+  NewQuestionFeedback,
+  QuestionFeedback,
+  QuestionRatingFeedback,
+} from '@/src/domain/entities';
 
 export interface QuestionFeedbackRepository {
-  record(params: RecordQuestionFeedbackParams): Promise<QuestionFeedback>;
+  record(event: NewQuestionFeedback): Promise<QuestionFeedback>;
   /** Latest 'rating'-kind event for (user, question); null if none. Drives 👍/👎 hydration. */
   findLatestRatingByUser(
     userId: string,
     questionId: string,
-  ): Promise<QuestionFeedback | null>;
+  ): Promise<QuestionRatingFeedback | null>;
 }
 ```
 
 Re-export via the `src/application/ports/repositories.ts` barrel (matches bookmark port).
 
-**Three small use cases** (constructor injection, `execute()`, throw `ApplicationError`):
+**Three small use cases** (constructor injection, `execute()`, throw `ApplicationError`). Import
+`newQuestionRatingFeedback` / `newQuestionReportFeedback` from the domain entity barrel rather than
+constructing discriminated-union object literals in use-case bodies:
 
 ```typescript
 // src/application/use-cases/rate-question.ts  (Tier 1)
@@ -227,16 +312,15 @@ export class RateQuestionUseCase {
   async execute(input: RateQuestionInput): Promise<RateQuestionOutput> {
     const question = await this.questions.findPublishedById(input.questionId);
     if (!question) throw new ApplicationError('NOT_FOUND', 'Question not found');
-    await this.feedback.record({
-      userId: input.userId,
-      questionId: input.questionId,
-      attemptId: input.attemptId,
-      practiceSessionId: input.practiceSessionId,
-      kind: 'rating',
-      rating: input.rating,
-      category: null,
-      comment: null,
-    });
+    await this.feedback.record(
+      newQuestionRatingFeedback({
+        userId: input.userId,
+        questionId: input.questionId,
+        attemptId: input.attemptId,
+        practiceSessionId: input.practiceSessionId,
+        rating: input.rating,
+      }),
+    );
     return { rating: input.rating };
   }
 }
@@ -278,11 +362,7 @@ export class SubmitQuestionReportUseCase {
   ): Promise<SubmitQuestionReportOutput> {
     const question = await this.questions.findPublishedById(input.questionId);
     if (!question) throw new ApplicationError('NOT_FOUND', 'Question not found');
-    const saved = await this.feedback.record({
-      ...input,
-      kind: 'report',
-      rating: null,
-    });
+    const saved = await this.feedback.record(newQuestionReportFeedback(input));
     return { feedbackId: saved.id };
   }
 }
@@ -292,11 +372,11 @@ export class SubmitQuestionReportUseCase {
 `export class FakeQuestionFeedbackRepository implements QuestionFeedbackRepository`, backed by an
 in-memory array of events. Mirror the bookmark/attempt fake constructor —
 `constructor(seed: readonly QuestionFeedback[] = [], private readonly now: () => Date = () => new Date())`
-— so `findLatestRatingByUser` ordering by `createdAt` is deterministic in hydration tests. `record()`
-pushes (stamping `id`/`createdAt` via the injected `now`); `findLatestRatingByUser()` filters
-`kind === 'rating'`, returns the newest by `createdAt`, else `null`. Register it in `fakes/index.ts`
-as a **named** export in alphabetical position (it sorts before `FakeQuestionRepository`). The fakes
-barrel uses `export { FakeX } from './fake-x'`, not `export *`.
+— so `record()` can stamp `id`/`createdAt` while tests can inject deterministic clocks. `record()`
+pushes the shape-correct `NewQuestionFeedback` plus generated persisted fields. `findLatestRatingByUser()`
+filters `kind === 'rating'`, returns the newest by `createdAt DESC, id DESC`, else `null`. Register it
+in `fakes/index.ts` as a **named** export in alphabetical position (it sorts before
+`FakeQuestionRepository`). The fakes barrel uses `export { FakeX } from './fake-x'`, not `export *`.
 
 Two enforced contract surfaces must also be updated: add `export * from './question-feedback-repository';`
 to the ports barrel `src/application/ports/repositories.ts`, and add the matching re-export assertion
@@ -362,18 +442,22 @@ export const questionFeedback = pgTable(
     questionCreatedAtIdx: index('question_feedback_question_created_at_idx').on(
       t.questionId,
       desc(t.createdAt),
+      desc(t.id),
     ),
-    userQuestionCreatedAtIdx: index(
-      'question_feedback_user_question_created_at_idx',
-    ).on(t.userId, t.questionId, desc(t.createdAt)),
+    ratingUserQuestionCreatedAtIdx: index(
+      'question_feedback_rating_user_question_created_at_idx',
+    )
+      .on(t.userId, t.questionId, desc(t.createdAt), desc(t.id))
+      .where(sql`${t.kind} = 'rating'`),
     kindCreatedAtIdx: index('question_feedback_kind_created_at_idx').on(
       t.kind,
       desc(t.createdAt),
+      desc(t.id),
     ),
-    // Shape invariant: ratings carry no category; reports carry a category and no rating.
+    // Shape invariant: ratings carry no report payload; reports carry a category and no rating.
     kindShapeCheck: check(
       'question_feedback_kind_shape_chk',
-      sql`(${t.kind} = 'rating' AND ${t.category} IS NULL)
+      sql`(${t.kind} = 'rating' AND ${t.category} IS NULL AND ${t.comment} IS NULL)
           OR (${t.kind} = 'report' AND ${t.category} IS NOT NULL AND ${t.rating} IS NULL)`,
     ),
     commentLengthCheck: check(
@@ -425,22 +509,39 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_tes
 > **Schema file-size note:** `db/schema.ts` is already an intentional DEBT-234/DEBT-224 exception
 > and is exempted by `scripts/check-file-size.sh`. Do not split this table out solely to satisfy the
 > 350-line warning; keep the relational schema as the single source of truth.
+>
+> **Index rationale:** the partial latest-rating index is deliberately `WHERE kind = 'rating'` because
+> the hot UI read path filters to one user's current rating for one question. `kindCreatedAtIdx`
+> supports recent-report/recent-feedback export slices; `questionCreatedAtIdx` supports per-question
+> audit/export slices. Do not add a current-rating projection table in v1 unless real query plans show
+> the partial index is insufficient.
 
 #### 3b. Drizzle repo (`src/adapters/repositories/drizzle-question-feedback-repository.ts`)
 
 Constructor-inject `DrizzleDb`. `record()` is a plain `insert(...).returning()` (no upsert —
 append-only). `findLatestRatingByUser()` is `findFirst` filtered to `kind='rating'`, ordered
-`desc(createdAt)`. Map rows → domain via a small `*-mappers.ts` if non-trivial. Throw
-`ApplicationError('INTERNAL_ERROR', ...)` on a missing `returning()` row (bookmark pattern).
+`desc(createdAt), desc(id)` (copy the attempt latest-read tie-breaker). Map rows → the discriminated
+domain union via a small `*-mappers.ts`; the mapper must fail closed with
+`ApplicationError('INTERNAL_ERROR', 'Invalid question feedback row')` if a row violates the union
+shape despite the DB `CHECK`. Throw `ApplicationError('INTERNAL_ERROR', ...)` on a missing
+`returning()` row (bookmark pattern).
 
-#### 3c. Rate limit (`src/adapters/shared/rate-limits.ts`)
+#### 3c. Rate limits (`src/adapters/shared/rate-limits.ts`)
 
 ```typescript
-export const QUESTION_FEEDBACK_RATE_LIMIT = {
-  limit: 30,
+export const QUESTION_RATING_RATE_LIMIT = {
+  limit: 60,
+  windowMs: ONE_MINUTE_MS,
+} as const;
+
+export const QUESTION_REPORT_RATE_LIMIT = {
+  limit: 10,
   windowMs: ONE_MINUTE_MS,
 } as const;
 ```
+
+The split is intentional: rating is as lightweight as bookmark toggling (`BOOKMARK_MUTATION_RATE_LIMIT`
+is 60/min), while reports carry optional free text and should be harder to spam.
 
 #### 3d. zod schemas + controller (`src/adapters/controllers/question-feedback-controller.ts`)
 
@@ -457,7 +558,7 @@ bookmark-controller shape. Non-obvious facts the implementation must honor (veri
   `QuestionFeedbackControllerContainer = { createQuestionFeedbackControllerDeps: () => QuestionFeedbackControllerDeps }`).
 - **`QuestionFeedbackControllerDeps` is defined and exported in this controller file** (mirroring
   `BookmarkControllerDeps`), then imported by `lib/container/types.ts`.
-- Inside `execute`: `requireEntitledUserId(deps, meta)` → `deps.rateLimiter.limit({ key: \`question-feedback:<action>:${userId}\`, ...QUESTION_FEEDBACK_RATE_LIMIT })` → `throw new ApplicationError('RATE_LIMITED', …)` when `!result.success`.
+- Inside `execute`: `requireEntitledUserId(deps, meta)` → `deps.rateLimiter.limit({ key: \`question-feedback:<action>:${userId}\`, ...QUESTION_RATING_RATE_LIMIT })` for `rateQuestion` and `...QUESTION_REPORT_RATE_LIMIT` for `submitQuestionReport` → `throw new ApplicationError('RATE_LIMITED', …)` when `!result.success`.
 - **Writes wrap the use case in `executeIdempotent({ d: deps, userId, idempotencyKey, action, outputSchema, execute })`.** Both `action` (a string label, e.g. `'question-feedback:rateQuestion'`) and `outputSchema` (a zod schema for the use-case output, e.g. `RateQuestionOutputSchema`) are **required**; `execute` is a zero-arg thunk; the idempotency repo/logger/clock are read from `d`. It returns the raw use-case output (not an `ActionResult`) — `createAction` wraps it in `ok(...)`. A missing key short-circuits to a plain call. The read action (`getQuestionRating`) is **not** wrapped (matching `getBookmarks`).
 
 Reuse `zUuid`; add enum schemas (and the output schemas the writes pass to `executeIdempotent`):
@@ -541,16 +642,25 @@ dialog needs different overlay/content classes.
 #### 4b. Tier 1 — rating row `components/question/question-feedback-rating.tsx`
 
 Renders inside the review panel only (after `Feedback`). "Was this helpful?" + two `<Button>` icon
-toggles (`ThumbsUp` / `ThumbsDown` from `lucide-react`), `aria-pressed`, disabled while saving.
+toggles (`ThumbsUp` / `ThumbsDown` from `lucide-react`), `aria-pressed`, descriptive `aria-label`s
+("Mark as helpful", "Mark as not helpful"), disabled while saving. Do not toast on successful rating
+clicks; they are intentionally low-friction. Do expose a compact `aria-live="polite"` status for
+"Saving feedback" / "Feedback saved" / "Could not save feedback" so screen-reader users get the same
+state change without visual noise.
 
 #### 4c. Tier 2 — `components/question/question-report-dialog.tsx`
 
 `Dialog` containing a radio group (the 5 categories via `<Button>`-based or native radio + `label`
-pattern already used by `choice-button.tsx`), an optional `<textarea>` (capped, with live counter),
-Cancel + "Submit feedback". On success show a toast via `useNotification().notify({ message, tone })`
-(the provider exposes `notify`, not a bare `toast()`). Dialog a11y is part of
-the acceptance criteria: focus trap, labelled title/description, Escape close, keyboard-submit path,
-and labelled category controls. Rating thumbs must expose `aria-pressed` plus descriptive labels.
+pattern already used by `choice-button.tsx`), an optional labelled `<textarea name="comment"
+autoComplete="off" maxLength={2000}>` (capped, with live counter), Cancel + "Submit feedback". On
+success show a toast via `useNotification().notify({ message, tone })` (the provider exposes
+`notify`, not a bare `toast()`, and its toast region already uses `aria-live="polite"` in
+`components/ui/notification-provider.tsx:131`). Dialog a11y is part of the acceptance criteria:
+focus trap, labelled title/description, Escape close, focus return to trigger, keyboard-submit path,
+first validation error focus on invalid submit, and labelled category controls. If the form needs
+scrolling on small screens, add a scroll-safe S-4 modal variant to `docs/frontend/pattern-registry.md`
+before code (e.g. max-height + `overflow-y-auto` + overscroll containment); do not invent one-off
+dialog overflow classes.
 
 #### 4d. Client hooks + imperative core
 
@@ -565,7 +675,8 @@ Mirror the bookmark split instead of forcing one hook path:
 
 Each hook hydrates current rating on entering review mode (call `getQuestionRating`) and exposes
 `{ rating, feedbackStatus, onRate, isReportOpen, openReport, submitReport }` with optimistic updates,
-mounted-checks, `withTimeout`, idempotency-key rotation, and error logging.
+rollback on failed rating writes, mounted-checks, `withTimeout`, idempotency-key rotation, and error
+logging. Error logs must include question/action metadata but **never** the free-text report comment.
 
 #### 4e. Wire into the action bar
 
@@ -616,7 +727,7 @@ WITH latest AS (
          user_id, question_id, rating
   FROM question_feedback
   WHERE kind = 'rating'
-  ORDER BY user_id, question_id, created_at DESC
+  ORDER BY user_id, question_id, created_at DESC, id DESC
 )
 SELECT q.slug,
        COUNT(*) FILTER (WHERE rating = 'helpful')     AS helpful,
@@ -631,27 +742,34 @@ ORDER BY not_helpful DESC;
 
 Write in dependency order; each layer red before its implementation.
 
-1. **Domain** — value-object membership/validators (`*.test.ts`).
-2. **Fake repo** — `record()` appends; `findLatestRatingByUser()` returns newest rating, ignores
-   reports, returns null when none.
+1. **Domain** — value-object membership/validators (`*.test.ts`) plus constructor tests:
+   `newQuestionRatingFeedback` always sets `kind='rating'`, `category=null`, `comment=null`;
+   `newQuestionReportFeedback` always sets `kind='report'`, `rating=null`; type-level tests or
+   `expectTypeOf` cover that report-only fields are not accepted by the rating constructor.
+2. **Fake repo** — `record()` appends a persisted event; `findLatestRatingByUser()` returns newest
+   rating, uses `id DESC` as the deterministic tie-breaker for equal `createdAt`, ignores reports,
+   returns null when none.
 3. **Use cases** (fakes): `RateQuestion` (NOT_FOUND when question absent; records `rating` event;
    retraction records `rating=null`), `GetQuestionRating` (latest wins; null when none),
    `SubmitQuestionReport` (NOT_FOUND; records `report` event; returns id).
 4. **Drizzle repo** — unit (mocked db chain) + **integration** (`tests/integration/*.integration.test.ts`):
-   real append, latest-rating query, and the `kind_shape` / `comment_len` CHECK constraints reject
-   bad rows (integration tests self-fixture their users/questions — no seed dependency). Add
-   `'question_feedback'` to the `tests/integration/db.integration.test.ts` table census for coverage;
-   note the census asserts `toContain` per table (additive), so omitting it is a coverage gap, not a
-   guaranteed red.
+   real append, row→union mapping, latest-rating query including equal-`createdAt` tie-breaker, and
+   the `kind_shape` / `comment_len` CHECK constraints reject bad rows (rating with comment, report
+   with rating, report without category, overlong comment). Integration tests self-fixture their
+   users/questions — no seed dependency. Add `'question_feedback'` to the
+   `tests/integration/db.integration.test.ts` table census for coverage; note the census asserts
+   `toContain` per table (additive), so omitting it is a coverage gap, not a guaranteed red.
 5. **Controller** (fakes via DI overrides): validation error, unauthenticated, unsubscribed,
    rate-limited, success, `ActionResult` error mapping via `createAction`, idempotency replay (no
-   double-write), and separate rate-limit keys for rating vs report actions.
+   double-write), separate rate-limit keys for rating vs report actions, and the distinct rating/report
+   limit constants are passed to `RateLimiter.limit`.
 6. **UI** — `renderToStaticMarkup` component tests (`*.test.tsx`) for the rating row + dialog markup;
    **browser specs** (`*.browser.spec.tsx`, `pnpm test:browser`) for the hook (hydrate, optimistic
-   rate, retract) and dialog submit flow. Keep React 19 rules: `// @vitest-environment jsdom` first
-   line in `*.test.tsx`, dynamic imports in `beforeAll`, no `@testing-library/react`, and no per-test
-   timeout overrides. Add a11y assertions for `aria-pressed`, labels, focus return, Escape close, and
-   validation messaging.
+   rate, rollback on failure, retract) and dialog submit flow. Keep React 19 rules:
+   `// @vitest-environment jsdom` first line in `*.test.tsx`, dynamic imports in `beforeAll`, no
+   `@testing-library/react`, and no per-test timeout overrides. Add a11y assertions for
+   `aria-pressed`, icon `aria-label`s, `aria-live` status, labelled textarea/counter, focus return,
+   Escape close, first-invalid-control focus, keyboard submit, and validation messaging.
 7. **E2E (optional)** — open report dialog in review mode, submit, assert toast + DB row.
 8. **Fixture/isolation checks** — UUID-shaped fixture ids across zod/Drizzle boundaries; controller
    tests use fakes via DI overrides; script tests snapshot/restore `process.env` if they mutate
@@ -692,6 +810,8 @@ Vertical slice, layer by layer (each step ends green):
   review** (post-submit), consistent with "post-answer only."
 - **Rating retraction:** clicking the active thumb records a `rating` event with `rating = null`;
   hydration shows no selection.
+- **Equal timestamps:** latest-rating hydration orders by `createdAt DESC, id DESC`, matching the
+  attempt repository's deterministic tie-breaker pattern.
 - **Double-click / retry:** idempotency key dedupes. Append-only does not make duplicate writes
   harmless; duplicates distort analytics even when latest-rating display still works.
 - **Rating retraction as null:** `rating = null` is a deliberate append-only event, not "missing
@@ -700,6 +820,8 @@ Vertical slice, layer by layer (each step ends green):
   `.trim().min(1).optional()`, because a present whitespace string trims to an empty string and fails
   `.min(1)`.
 - **Comment > 2000 chars:** rejected at zod boundary and by DB CHECK (defense in depth).
+- **Comment logging:** do not pass free-text comments to `reportClientError`, controller logs, or
+  idempotency metadata; comments are persisted only in `question_feedback` and explicit raw exports.
 - **Question later archived/deleted:** archived rows keep their FK (feedback persists); a true hard
   delete cascades (rare by policy).
 - **User deleted (GDPR):** feedback cascades away with the user.
@@ -708,8 +830,10 @@ Vertical slice, layer by layer (each step ends green):
 
 - Admin dashboard / in-app browsing of feedback (no role system yet — future spec).
 - Aggregated quality scores surfaced to learners.
-- **Pre-answer** "this question is broken" reporting (the "always available" timing option). Deferred;
-  the append-only model already supports adding it later with no schema change.
+- **Pre-answer** "this question is broken" reporting (the "always available" timing option).
+  Trade-off: it helps when a stem is visibly broken before answering, but it also adds an assessment-
+  mode distraction and bypasses the richer explanation context that usually makes feedback actionable.
+  Defer for v1; the append-only model already supports adding it later with no schema change.
 - Editing or deleting submitted feedback.
 - Notifications/email on new feedback.
 - DEBT-337 explanation-panel enhancements (separate track).

--- a/docs/specs/spec-041-question-feedback.md
+++ b/docs/specs/spec-041-question-feedback.md
@@ -570,9 +570,10 @@ bookmark-controller shape. Non-obvious facts the implementation must honor (veri
 - Inside `execute`: `requireEntitledUserId(deps, meta)` → `deps.rateLimiter.limit({ key: \`question-feedback:<action>:${userId}\`, ...QUESTION_RATING_RATE_LIMIT })` for `rateQuestion` and `...QUESTION_REPORT_RATE_LIMIT` for `submitQuestionReport` → `throw new ApplicationError('RATE_LIMITED', …)` when `!result.success`.
 - **Writes wrap the use case in `executeIdempotent({ d: deps, userId, idempotencyKey, action, outputSchema, execute })`.** Both `action` (a string label, e.g. `'question-feedback:rateQuestion'`) and `outputSchema` (a zod schema for the use-case output, e.g. `RateQuestionOutputSchema`) are **required**; `execute` is a zero-arg thunk; the idempotency repo/logger/clock are read from `d`. It returns the raw use-case output (not an `ActionResult`) — `createAction` wraps it in `ok(...)`. A missing key short-circuits to a plain call. The read action (`getQuestionRating`) is **not** wrapped (matching `getBookmarks`).
 
-Reuse `zUuid` and the domain-owned `AllQuestionFeedbackRatings` /
-`AllQuestionFeedbackCategories` literal arrays; add enum schemas (and the output schemas the writes pass
-to `executeIdempotent`):
+Reuse `zUuid`, the domain-owned `AllQuestionFeedbackRatings` /
+`AllQuestionFeedbackCategories` literal arrays, and
+`MAX_QUESTION_FEEDBACK_COMMENT_LENGTH` from `src/adapters/shared/validation-limits.ts`; add enum schemas
+(and the output schemas the writes pass to `executeIdempotent`):
 
 ```typescript
 const zRating = z.enum(AllQuestionFeedbackRatings);
@@ -580,7 +581,7 @@ const zCategory = z.enum(AllQuestionFeedbackCategories);
 const zOptionalComment = z.preprocess(
   (value) =>
     typeof value === 'string' && value.trim().length === 0 ? undefined : value,
-  z.string().trim().min(1).max(2000).optional(),
+  z.string().trim().min(1).max(MAX_QUESTION_FEEDBACK_COMMENT_LENGTH).optional(),
 );
 
 const RateQuestionInputSchema = z
@@ -692,12 +693,13 @@ hover:bg-foreground/[0.06] dark:hover:border-foreground/50 dark:hover:bg-foregro
 `cursor-not-allowed opacity-50`. If visual review proves the modal needs a denser radio-row variant,
 add that variant to `docs/frontend/pattern-registry.md` with contrast evidence before implementing it.
 
-The optional comment field is `<Textarea name="comment" autoComplete="off" maxLength={2000}>` under
-"Add details (optional)" with a live character counter. The label and legend are `text-sm font-medium
-text-foreground`; the description and normal counter/helper text are `text-sm text-muted-foreground`;
-the near-limit counter (100 chars remaining or fewer) is `text-sm font-medium
-text-warning-foreground`; validation copy is `text-sm text-destructive` with `role="alert"` and the
-field/control wired through `aria-describedby`. Invalid submit (no category) shows "Choose a category
+The optional comment field is `<Textarea name="comment" autoComplete="off"
+maxLength={MAX_QUESTION_FEEDBACK_COMMENT_LENGTH}>` under "Add details (optional)" with a live character
+counter. The label and legend are `text-sm font-medium text-foreground`; the description and normal
+counter/helper text are `text-sm text-muted-foreground`; the near-limit counter (100 chars remaining or
+fewer) is `text-sm font-medium text-warning-foreground`; validation copy is `text-sm text-destructive`
+with `role="alert"` and the field/control wired through `aria-describedby`. Invalid submit (no category)
+shows "Choose a category
 to send your feedback." and focuses the first invalid radio control; invalid textarea state uses the
 `Textarea` primitive's `aria-invalid` destructive ring. The footer uses Button primitives for
 **Cancel** + **"Submit feedback"**.

--- a/docs/specs/spec-041-question-feedback.md
+++ b/docs/specs/spec-041-question-feedback.md
@@ -88,12 +88,14 @@ confusion this spec uses distinct names everywhere:
 3. **Clean Architecture:** domain stays pure (no vendor IDs, no DB imports); port in `application`,
    Drizzle impl in `adapters`; fakes over mocks in tests.
 4. **Design system:** new `Dialog` primitive follows `docs/frontend/standards.md` (canonical focus
-   ring, semantic tokens) and is registered in `docs/frontend/pattern-registry.md` before use. The
-   "Report a problem" trigger uses `<Button variant="outline" className="rounded-full">` to match the
-   Bookmark button.
+   ring, semantic tokens) and either reuses or updates the existing modal pattern
+   (`docs/frontend/pattern-registry.md` S-4) before use. The "Report a problem" trigger uses
+   `<Button variant="outline" className="rounded-full">` to match the Bookmark button.
 5. **Validation:** zod at the boundary, `.strict()`, reusing `zUuid`; comment capped at 2000 chars
    (enforced in zod **and** a DB `CHECK` constraint, matching the `attempts` table idiom).
 6. **Privacy:** `user_id` FK is `ON DELETE CASCADE` — deleting a user removes their feedback (GDPR).
+   Free-text comments are user input that may contain PII/PHI; never log comment bodies, and make
+   the export script local-only with explicit redaction/default-output rules.
 
 ## Design
 
@@ -363,7 +365,8 @@ export const questionFeedbackRelations = relations(
 );
 ```
 
-Generate the migration (never `drizzle-kit push`):
+Generate the migration (never `drizzle-kit push`). `drizzle.config.ts` requires `DATABASE_URL`, so
+prefix `db:generate` and `db:migrate` with the explicit local test database URL:
 
 ```bash
 DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:generate
@@ -373,6 +376,10 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_tes
 > **Question lifecycle note:** questions are **archived** (`question_status='archived'`), not hard-
 > deleted, so the `ON DELETE CASCADE` on `question_id` rarely fires in practice and feedback persists.
 > Keep "archive, don't delete" as content-ops policy so the analytical record stays intact.
+>
+> **Schema file-size note:** `db/schema.ts` is already an intentional DEBT-234/DEBT-224 exception
+> and is exempted by `scripts/check-file-size.sh`. Do not split this table out solely to satisfy the
+> 350-line warning; keep the relational schema as the single source of truth.
 
 #### 3b. Drizzle repo (`src/adapters/repositories/drizzle-question-feedback-repository.ts`)
 
@@ -405,6 +412,11 @@ const zCategory = z.enum([
   'outdated_reference',
   'other',
 ]);
+const zOptionalComment = z.preprocess(
+  (value) =>
+    typeof value === 'string' && value.trim().length === 0 ? undefined : value,
+  z.string().trim().min(1).max(2000).optional(),
+);
 
 const RateQuestionInputSchema = z
   .object({
@@ -422,7 +434,7 @@ const SubmitQuestionReportInputSchema = z
     attemptId: zUuid.nullish(),
     practiceSessionId: zUuid.nullish(),
     category: zCategory,
-    comment: z.string().trim().min(1).max(2000).optional(),
+    comment: zOptionalComment,
     idempotencyKey: zUuid.optional(),
   })
   .strict();
@@ -432,22 +444,31 @@ const GetQuestionRatingInputSchema = z.object({ questionId: zUuid }).strict();
 
 Actions: `rateQuestion`, `getQuestionRating`, `submitQuestionReport`.
 
+Normalize `attemptId`, `practiceSessionId`, and `comment` with `?? null` before calling use cases;
+the use-case inputs are explicit `string | null`, while `.nullish()` and the optional comment schema
+also allow `undefined`. Let `createAction`/`handleError` map `ApplicationError` and `ZodError` to
+`ActionResult`; do not add custom controller try/catch blocks.
+
 #### 3e. DI wiring (`lib/container/*`)
 
 - `repositories.ts`: `createQuestionFeedbackRepository: (db = primitives.db) => new DrizzleQuestionFeedbackRepository(db)`
 - `use-cases.ts`: `createRateQuestionUseCase`, `createGetQuestionRatingUseCase`, `createSubmitQuestionReportUseCase`
 - `controllers.ts`: `createQuestionFeedbackControllerDeps` (authGateway, logger, rateLimiter,
   idempotencyKeyRepository, checkEntitlementUseCase, the three use cases, `now`)
+- `types.ts`: add the new repository, use-case, and controller factory types so DI overrides keep
+  compiling in controller tests.
 
 ### 4. App / UI (`app/`, `components/`)
 
 #### 4a. New design-system primitive — `components/ui/dialog.tsx`
 
-Radix `@radix-ui/react-dialog` (already transitively present via `alert-dialog`/`select`). Model
-the file on `components/ui/alert-dialog.tsx`: `Dialog`, `DialogTrigger`, `DialogContent`,
-`DialogHeader`, `DialogTitle`, `DialogDescription`, `DialogFooter`, `DialogClose`. Use semantic
-tokens and the canonical focus ring. **Add a Pattern Registry entry** in
-`docs/frontend/pattern-registry.md` (overlay/dialog pattern) with rationale before merging UI.
+Use `Dialog as DialogPrimitive` from the existing `radix-ui` dependency, matching
+`components/ui/alert-dialog.tsx`. Do **not** add `@radix-ui/react-dialog` unless the repo intentionally
+changes its Radix package convention. Model the file on `components/ui/alert-dialog.tsx`: `Dialog`,
+`DialogTrigger`, `DialogContent`, `DialogHeader`, `DialogTitle`, `DialogDescription`,
+`DialogFooter`, `DialogClose`. Use semantic tokens and the canonical focus ring. Reuse the existing
+Pattern Registry S-4 modal-dialog surface, or update/add a registry entry first if the non-alert
+dialog needs different overlay/content classes.
 
 #### 4b. Tier 1 — rating row `components/question/question-feedback-rating.tsx`
 
@@ -458,26 +479,50 @@ toggles (`ThumbsUp` / `ThumbsDown` from `lucide-react`), `aria-pressed`, disable
 
 `Dialog` containing a radio group (the 5 categories via `<Button>`-based or native radio + `label`
 pattern already used by `choice-button.tsx`), an optional `<textarea>` (capped, with live counter),
-Cancel + "Submit feedback". On success show a toast via `useNotification()`.
+Cancel + "Submit feedback". On success show a toast via `useNotification()`. Dialog a11y is part of
+the acceptance criteria: focus trap, labelled title/description, Escape close, keyboard-submit path,
+and labelled category controls. Rating thumbs must expose `aria-pressed` plus descriptive labels.
 
-#### 4d. Client hook — `app/(app)/app/shared/use-question-feedback.ts`
+#### 4d. Client hooks + imperative core
 
-Mirror `use-question-page-bookmarks.ts`: hydrate current rating on entering review mode (call
-`getQuestionRating`), expose `{ rating, feedbackStatus, onRate, isReportOpen, openReport, submitReport }`
-with optimistic updates, mounted-checks, `withTimeout`, idempotency-key rotation, and error logging.
-Factor the imperative core into `app/(app)/app/shared/question-feedback-actions.ts` (testable, like
-`bookmark-toggle.ts`).
+Mirror the bookmark split instead of forcing one hook path:
+
+- `app/(app)/app/shared/question-feedback-actions.ts`: imperative core, testable like
+  `bookmark-toggle.ts`.
+- `app/(app)/app/questions/[slug]/use-question-page-feedback.ts`: standalone question/review-page
+  hydration and actions, colocated with `use-question-page-bookmarks.ts`.
+- `app/(app)/app/practice/hooks/use-practice-question-feedback.ts`: practice, quick-practice, and
+  post-exam-review hydration/actions, colocated with `use-practice-question-bookmarks.ts`.
+
+Each hook hydrates current rating on entering review mode (call `getQuestionRating`) and exposes
+`{ rating, feedbackStatus, onRate, isReportOpen, openReport, submitReport }` with optimistic updates,
+mounted-checks, `withTimeout`, idempotency-key rotation, and error logging.
 
 #### 4e. Wire into the action bar
 
 In `app/(app)/app/practice/components/practice-view.tsx`, add a **"Report a problem"** `<Button>` to
 the existing `secondaryGroup` (the `hasBooleanCorrectness(submitResult)` block, right next to
 Bookmark), and render `<QuestionFeedbackRating>` after the `Feedback` panel in
-`components/question/question-surface-body.tsx`. Thread new props
-(`rating`, `feedbackStatus`, `onRate`, `onOpenReport`, …) from the client components
-(`quick-practice-client.tsx`, `practice-page-client.tsx`) exactly as bookmark props are threaded,
-using the `fireAndForget` pattern. Pass best-effort `attemptId`/`practiceSessionId` context from
-`submitResult` / session state (null when unavailable, e.g. Quick Practice has no session).
+`components/question/question-surface-body.tsx`.
+
+Do not stop there. Active question/review surfaces are split across multiple consumers:
+
+- Quick Practice: `app/(app)/app/practice/quick/quick-practice-client.tsx` passes props into
+  `PracticeView` and uses `fireAndForget(...)` for bookmark mutations.
+- Session practice: `app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller.ts`
+  owns active-session hooks; `app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx`
+  passes controller props into `PracticeView`. `practice-page-client.tsx` is only the practice start
+  surface and is not the active-question prop-threading site.
+- Post-exam review: `app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx` imports
+  and renders `Feedback` directly and has its own bottom action bar with Bookmark; add rating/report
+  controls there too.
+- Standalone question review: `app/(app)/app/questions/[slug]/question-page-client.tsx` renders
+  `QuestionSurfaceBody` and owns a review-mode Bookmark button; thread feedback props there too.
+
+Pass best-effort `attemptId`/`practiceSessionId` context from the actual sources: `attemptId` is in
+`submitResult`, but `practiceSessionId` is **not** in `submitResult`; derive it from the session route
+/ session state where available, and pass `null` for Quick Practice and other surfaces without a
+session.
 
 ### 5. Extraction (the "forever maintain & improve" requirement)
 
@@ -487,6 +532,9 @@ No admin UI in v1 (there is no role system yet — out of scope). Two extraction
    helpful-rate per question (latest-rating-per-user), top-reported questions, recent comments.
 2. **Ops export script** `scripts/export-question-feedback.ts` — run locally with `DATABASE_URL`,
    dumps `question_feedback` (joined to question slug) to CSV/JSON. No public surface, no new auth.
+   Default output should include question identifiers/slug, event metadata, category/rating, and
+   redacted user identifiers; include raw `user_id` or free-text comments only behind explicit flags
+   with a console warning that comments may contain PII/PHI.
 
 Example "current helpful-rate per question" (latest rating per user wins):
 
@@ -519,13 +567,21 @@ Write in dependency order; each layer red before its implementation.
    `SubmitQuestionReport` (NOT_FOUND; records `report` event; returns id).
 4. **Drizzle repo** — unit (mocked db chain) + **integration** (`tests/integration/*.integration.test.ts`):
    real append, latest-rating query, and the `kind_shape` / `comment_len` CHECK constraints reject
-   bad rows.
+   bad rows. Update `tests/integration/db.integration.test.ts` table census to include
+   `question_feedback` when the table is added.
 5. **Controller** (fakes via DI overrides): validation error, unauthenticated, unsubscribed,
-   rate-limited, success, idempotency replay (no double-write).
+   rate-limited, success, `ActionResult` error mapping via `createAction`, idempotency replay (no
+   double-write), and separate rate-limit keys for rating vs report actions.
 6. **UI** — `renderToStaticMarkup` component tests (`*.test.tsx`) for the rating row + dialog markup;
    **browser specs** (`*.browser.spec.tsx`, `pnpm test:browser`) for the hook (hydrate, optimistic
-   rate, retract) and dialog submit flow.
+   rate, retract) and dialog submit flow. Keep React 19 rules: `// @vitest-environment jsdom` first
+   line in `*.test.tsx`, dynamic imports in `beforeAll`, no `@testing-library/react`, and no per-test
+   timeout overrides. Add a11y assertions for `aria-pressed`, labels, focus return, Escape close, and
+   validation messaging.
 7. **E2E (optional)** — open report dialog in review mode, submit, assert toast + DB row.
+8. **Fixture/isolation checks** — UUID-shaped fixture ids across zod/Drizzle boundaries; controller
+   tests use fakes via DI overrides; script tests snapshot/restore `process.env` if they mutate
+   `DATABASE_URL` or export flags.
 
 ## Implementation Order
 
@@ -536,9 +592,10 @@ Vertical slice, layer by layer (each step ends green):
 3. Use cases + tests.
 4. Schema + enums + relations → generate & apply migration → Drizzle repo → repo unit + integration tests.
 5. Rate-limit constant + zod schemas + controller + controller tests.
-6. DI wiring in `lib/container/*`.
-7. `Dialog` primitive + Pattern Registry entry + primitive test.
-8. UI: rating row + report dialog + hook + imperative core; wire into `practice-view` + clients;
+6. DI wiring in `lib/container/*`, including `types.ts`.
+7. `Dialog` primitive + Pattern Registry S-4 reuse/update + primitive test.
+8. UI: rating row + report dialog + hooks + imperative core; wire into `practice-view`, active
+   session controller/view, quick-practice client, standalone question client, and post-exam review;
    component tests + browser specs.
 9. Extraction: SQL appendix + `scripts/export-question-feedback.ts`.
 10. Full quality gate, PR, CodeRabbit.
@@ -547,9 +604,10 @@ Vertical slice, layer by layer (each step ends green):
 
 - **PR 1 — Backend slice:** domain → port/fake → use cases → schema/migration → repo → controller →
   DI → all backend tests. Fully functional via tests; no UI yet.
-- **PR 2 — `Dialog` primitive:** `components/ui/dialog.tsx` + Pattern Registry entry + tests.
-- **PR 3 — UI wiring:** rating row + report dialog + hook + `practice-view`/client wiring + component
-  & browser tests.
+- **PR 2 — `Dialog` primitive:** `components/ui/dialog.tsx` + Pattern Registry S-4 reuse/update +
+  tests.
+- **PR 3 — UI wiring:** rating row + report dialog + hooks + all active review-surface wiring +
+  component & browser tests.
 - **PR 4 — Extraction tooling:** export script + SQL docs.
 
 ## Edge Cases
@@ -560,8 +618,13 @@ Vertical slice, layer by layer (each step ends green):
   review** (post-submit), consistent with "post-answer only."
 - **Rating retraction:** clicking the active thumb records a `rating` event with `rating = null`;
   hydration shows no selection.
-- **Double-click / retry:** idempotency key dedupes; append-only means even a slip is harmless.
-- **Empty/whitespace comment:** zod `.trim().min(1)` → treated as absent (optional), not an error.
+- **Double-click / retry:** idempotency key dedupes. Append-only does not make duplicate writes
+  harmless; duplicates distort analytics even when latest-rating display still works.
+- **Rating retraction as null:** `rating = null` is a deliberate append-only event, not "missing
+  input"; it needs idempotency just like helpful/not-helpful clicks.
+- **Empty/whitespace comment:** preprocess to `undefined`, then treat as absent; do not rely on
+  `.trim().min(1).optional()`, because a present whitespace string trims to an empty string and fails
+  `.min(1)`.
 - **Comment > 2000 chars:** rejected at zod boundary and by DB CHECK (defense in depth).
 - **Question later archived/deleted:** archived rows keep their FK (feedback persists); a true hard
   delete cascades (rare by policy).

--- a/docs/specs/spec-041-question-feedback.md
+++ b/docs/specs/spec-041-question-feedback.md
@@ -21,13 +21,15 @@ This spec defines a **two-tier, per-question feedback system**, surfaced in **re
 slice (`toggleBookmark` / `getBookmarks`), which is the closest existing analog: a per-question,
 per-user action that persists to the DB with optimistic UI, rate limiting, and idempotency.
 
-**Tier 1 — Rating (one click).** A lightweight `👍 / 👎` ("Was this helpful?") row inside the
+**Tier 1 — Rating (one click).** A lightweight `👍 / 👎` ("Was this a good question?") row inside the
 review panel. Optimistic, instant, no modal. Captures broad sentiment on every question at scale.
 
-**Tier 2 — Report a problem (modal).** A "Report a problem" button in the action bar (next to
+**Tier 2 — Give feedback (modal).** A "Give feedback" button in the action bar (next to
 Bookmark) opens a focused dialog: a required category (Incorrect answer · Ambiguous wording ·
 Typo / formatting · Outdated reference · Other) plus an optional free-text comment. This is the
-rich, actionable signal for content fixes.
+rich, actionable signal for content fixes. The user-facing label is **"Give feedback"**; the internal
+`kind` stays `report` (a structured report) — and the component/use-case keep their `Report` names —
+to distinguish this tier from a `rating`. UI label ≠ internal domain term, by design.
 
 Both tiers write to a single **append-only event-log table** (`question_feedback`), chosen because
 the primary goal is a long-lived analytical substrate ("forever maintain and improve"): history is
@@ -47,7 +49,7 @@ confusion this spec uses distinct names everywhere:
 | New domain/data type | `QuestionFeedback` |
 | New rating UI (👍/👎 row) | `QuestionFeedbackRating` |
 | New report modal | `QuestionReportDialog` |
-| User-facing copy | "Was this helpful?", "Report a problem" |
+| User-facing copy | "Was this a good question?", "Give feedback" |
 
 ## Relationship to Other Specs
 
@@ -68,7 +70,7 @@ confusion this spec uses distinct names everywhere:
 1. In **review mode** (after an answer is committed and the explanation is visible), a learner can:
    1. Rate the question `helpful` / `not_helpful` with a single click (Tier 1).
    2. Re-click the active rating to **retract** it (back to no rating).
-   3. Open a **Report a problem** modal and submit a **category** (required) + **comment** (optional).
+   3. Open a **Give feedback** modal and submit a **category** (required) + **comment** (optional).
 2. On entering review mode, the UI **hydrates** the learner's current rating for that question
    (filled 👍 or 👎 if they rated it before), matching the bookmark hydration pattern.
 3. Each feedback action persists to `question_feedback` with the user, question, and best-effort
@@ -92,7 +94,7 @@ confusion this spec uses distinct names everywhere:
    Drizzle impl in `adapters`; fakes over mocks in tests.
 4. **Design system:** new `Dialog` primitive follows `docs/frontend/standards.md` (canonical focus
    ring, semantic tokens) and either reuses or updates the existing modal pattern
-   (`docs/frontend/pattern-registry.md` S-4) before use. The "Report a problem" trigger uses
+   (`docs/frontend/pattern-registry.md` S-4) before use. The "Give feedback" trigger uses
    `<Button variant="outline" className="rounded-full">` to match the Bookmark button.
 5. **Validation:** zod at the boundary, `.strict()`, reusing `zUuid`; comment capped at 2000 chars
    (enforced in zod **and** a DB `CHECK` constraint). The CHECK reuses the `check('<table>_<desc>_chk',
@@ -641,21 +643,29 @@ dialog needs different overlay/content classes.
 
 #### 4b. Tier 1 — rating row `components/question/question-feedback-rating.tsx`
 
-Renders inside the review panel only (after `Feedback`). "Was this helpful?" + two `<Button>` icon
-toggles (`ThumbsUp` / `ThumbsDown` from `lucide-react`), `aria-pressed`, descriptive `aria-label`s
-("Mark as helpful", "Mark as not helpful"), disabled while saving. Do not toast on successful rating
-clicks; they are intentionally low-friction. Do expose a compact `aria-live="polite"` status for
-"Saving feedback" / "Feedback saved" / "Could not save feedback" so screen-reader users get the same
-state change without visual noise.
+Renders inside the review panel only (after `Feedback`). Prompt copy is **"Was this a good question?"**
+— it rates the **question**, not the explanation (the analytics + report categories are all about
+question quality). Two `<Button>` icon toggles (`ThumbsUp` / `ThumbsDown` from `lucide-react`),
+`aria-pressed`, descriptive `aria-label`s ("Good question" / "Not a good question"), and a group label
+"Rate this question". Disabled while saving. Do not toast on successful rating clicks; they are
+intentionally low-friction. Do expose a compact `aria-live="polite"` status for "Saving rating" /
+"Rating saved" / "Couldn't save rating" so screen-reader users get the same state change without
+visual noise.
 
 #### 4c. Tier 2 — `components/question/question-report-dialog.tsx`
 
-`Dialog` containing a radio group (the 5 categories via `<Button>`-based or native radio + `label`
-pattern already used by `choice-button.tsx`), an optional labelled `<textarea name="comment"
-autoComplete="off" maxLength={2000}>` (capped, with live counter), Cancel + "Submit feedback". On
-success show a toast via `useNotification().notify({ message, tone })` (the provider exposes
-`notify`, not a bare `toast()`, and its toast region already uses `aria-live="polite"` in
-`components/ui/notification-provider.tsx:131`). Dialog a11y is part of the acceptance criteria:
+`Dialog` titled **"Give feedback"** with a one-line description: "Spotted an issue or have a
+suggestion? This goes to our medical editors and won't affect your score." Contains a **required**
+category radio group under the legend **"What's this about?"** (the 5 categories via `<Button>`-based
+or native radio + `label` pattern already used by `choice-button.tsx`), an optional labelled
+`<textarea name="comment" autoComplete="off" maxLength={2000}>` under "Add details (optional)"
+(capped, with live counter), and a footer with **Cancel** + **"Submit feedback"**. Invalid submit
+(no category) shows "Choose a category to send your feedback." On success show a toast via
+`useNotification().notify({ message, tone })` — success copy "Thanks — our editors will take a look.",
+failure copy "Couldn't send your feedback. Check your connection." with a retry affordance (the
+provider exposes `notify`, not a bare `toast()`, and its toast region already uses
+`aria-live="polite"` in `components/ui/notification-provider.tsx:131`). Dialog a11y is part of the
+acceptance criteria:
 focus trap, labelled title/description, Escape close, focus return to trigger, keyboard-submit path,
 first validation error focus on invalid submit, and labelled category controls. If the form needs
 scrolling on small screens, add a scroll-safe S-4 modal variant to `docs/frontend/pattern-registry.md`
@@ -680,7 +690,7 @@ logging. Error logs must include question/action metadata but **never** the free
 
 #### 4e. Wire into the action bar
 
-In `app/(app)/app/practice/components/practice-view.tsx`, add a **"Report a problem"** `<Button>` to
+In `app/(app)/app/practice/components/practice-view.tsx`, add a **"Give feedback"** `<Button>` to
 the existing `secondaryGroup` (the `hasBooleanCorrectness(submitResult)` block, right next to
 Bookmark), and render `<QuestionFeedbackRating>` after the `Feedback` panel in
 `components/question/question-surface-body.tsx`.

--- a/docs/specs/spec-041-question-feedback.md
+++ b/docs/specs/spec-041-question-feedback.md
@@ -53,7 +53,7 @@ confusion this spec uses distinct names everywhere:
   + fake + Drizzle repo + use case + `createAction` server action + DI wiring + optimistic hook.
 - **SPEC-023 / SPEC-034 (Review Mode)** — feedback controls render only where the review panel is
   visible (tutor immediate review + session review). They never appear mid-exam (no explanation yet).
-- **DEBT-337 (Future Feedback & Practice Session Enhancements)** — adjacent but separate; that item
+- **DEBT-337 (Future feedback & practice enhancements)** — adjacent but separate; that item
   covers explanation-panel content/UX tweaks, not user-submitted feedback. No collision.
 - **DEBT-397 (datetime boundary normalization)** — touches `practice-schemas.ts` only. This feature
   introduces a *new* controller (`question-feedback-controller.ts`); to avoid re-introducing the
@@ -92,7 +92,10 @@ confusion this spec uses distinct names everywhere:
    (`docs/frontend/pattern-registry.md` S-4) before use. The "Report a problem" trigger uses
    `<Button variant="outline" className="rounded-full">` to match the Bookmark button.
 5. **Validation:** zod at the boundary, `.strict()`, reusing `zUuid`; comment capped at 2000 chars
-   (enforced in zod **and** a DB `CHECK` constraint, matching the `attempts` table idiom).
+   (enforced in zod **and** a DB `CHECK` constraint). The CHECK reuses the `check('<table>_<desc>_chk',
+   sql\`…\`)` wrapper idiom from `attempts` (`attempts_*_chk`); note the `char_length(...) <= 2000`
+   length test itself is new — `attempts`' CHECKs are boolean column comparisons only, so the
+   precedent is the wrapper, not the length function.
 6. **Privacy:** `user_id` FK is `ON DELETE CASCADE` — deleting a user removes their feedback (GDPR).
    Free-text comments are user input that may contain PII/PHI; never log comment bodies, and make
    the export script local-only with explicit redaction/default-output rules.
@@ -103,12 +106,22 @@ Dependency direction (inward only): `db` ← `adapters` ← `application` ← `d
 
 ### 1. Domain — value objects + entity (`src/domain/`)
 
-Pure types, no imports. Mirror `src/domain/value-objects/` `const AllX = [...] as const` idiom.
+**Zero external imports** (the value objects import nothing; the entity `import type`s its three VO
+unions from `../value-objects`, exactly like `attempt.ts`/`question.ts` — that intra-domain import is
+allowed and is not an impurity). Mirror the `src/domain/value-objects/` `const AllX = [...] as const`
+**plus `isValid<Type>` type-predicate guard** idiom: every existing VO (`practice-mode.ts`,
+`question-status.ts`, `tag-kind.ts`, …) ships an `isValid…` guard, and the "Tests First"
+membership/validator tests call them — so each new VO must define one.
 
 ```typescript
 // src/domain/value-objects/question-feedback-rating.ts
 export const AllQuestionFeedbackRatings = ['helpful', 'not_helpful'] as const;
 export type QuestionFeedbackRating = (typeof AllQuestionFeedbackRatings)[number];
+export function isValidQuestionFeedbackRating(
+  value: string,
+): value is QuestionFeedbackRating {
+  return AllQuestionFeedbackRatings.includes(value as QuestionFeedbackRating);
+}
 
 // src/domain/value-objects/question-feedback-category.ts
 export const AllQuestionFeedbackCategories = [
@@ -120,10 +133,22 @@ export const AllQuestionFeedbackCategories = [
 ] as const;
 export type QuestionFeedbackCategory =
   (typeof AllQuestionFeedbackCategories)[number];
+export function isValidQuestionFeedbackCategory(
+  value: string,
+): value is QuestionFeedbackCategory {
+  return AllQuestionFeedbackCategories.includes(
+    value as QuestionFeedbackCategory,
+  );
+}
 
 // src/domain/value-objects/question-feedback-kind.ts
 export const AllQuestionFeedbackKinds = ['rating', 'report'] as const;
 export type QuestionFeedbackKind = (typeof AllQuestionFeedbackKinds)[number];
+export function isValidQuestionFeedbackKind(
+  value: string,
+): value is QuestionFeedbackKind {
+  return AllQuestionFeedbackKinds.includes(value as QuestionFeedbackKind);
+}
 ```
 
 ```typescript
@@ -143,7 +168,16 @@ export type QuestionFeedback = {
 ```
 
 **Invariant (enforced in use case + DB CHECK):** a `rating` event has `category = null`; a `report`
-event has `category != null` and `rating = null`.
+event has `category != null` and `rating = null`. This is a deliberate divergence from `Attempt`,
+which enforces its invariant inside a domain `createAttempt()` factory that throws `DomainError`;
+`QuestionFeedback` stays a plain data record (like `Bookmark`/`Subscription`, which have no factory)
+and pushes the invariant to the use case + DB CHECK.
+
+**Test-helper factory:** add `createQuestionFeedback(overrides)` to
+`src/domain/test-helpers/factories.ts` and its `index.ts` barrel, mirroring `createBookmark` /
+`createAttempt` — UUID-emitting defaults via the existing `createUuid()` helper, `createdAt: new
+Date()`, nullable FK ids defaulting to `null`. Use-case, repo, and fake tests build events through it
+so fixture UUID shapes stay valid at the Drizzle/zod boundaries.
 
 ### 2. Application — port + use cases (`src/application/`)
 
@@ -254,9 +288,20 @@ export class SubmitQuestionReportUseCase {
 }
 ```
 
-**Fake** (`src/application/test-helpers/fakes/fake-question-feedback-repository.ts`): in-memory array
-of events; `record()` pushes; `findLatestRatingByUser()` filters `kind==='rating'` and returns the
-newest by `createdAt`. Add to the fakes barrel `index.ts`.
+**Fake** (`src/application/test-helpers/fakes/fake-question-feedback-repository.ts`):
+`export class FakeQuestionFeedbackRepository implements QuestionFeedbackRepository`, backed by an
+in-memory array of events. Mirror the bookmark/attempt fake constructor —
+`constructor(seed: readonly QuestionFeedback[] = [], private readonly now: () => Date = () => new Date())`
+— so `findLatestRatingByUser` ordering by `createdAt` is deterministic in hydration tests. `record()`
+pushes (stamping `id`/`createdAt` via the injected `now`); `findLatestRatingByUser()` filters
+`kind === 'rating'`, returns the newest by `createdAt`, else `null`. Register it in `fakes/index.ts`
+as a **named** export in alphabetical position (it sorts before `FakeQuestionRepository`). The fakes
+barrel uses `export { FakeX } from './fake-x'`, not `export *`.
+
+Two enforced contract surfaces must also be updated: add `export * from './question-feedback-repository';`
+to the ports barrel `src/application/ports/repositories.ts`, and add the matching re-export assertion
+to `src/application/ports/repository-port-modules.test.ts` (it asserts every port is re-exported from
+the barrel — adding the port without it leaves the contract test incomplete).
 
 ### 3. Adapters — schema, migration, Drizzle repo, controller (`src/adapters/`, `db/`)
 
@@ -399,9 +444,23 @@ export const QUESTION_FEEDBACK_RATE_LIMIT = {
 
 #### 3d. zod schemas + controller (`src/adapters/controllers/question-feedback-controller.ts`)
 
-`'use server'`. Three actions built with `createAction({ schema, getDeps, execute })`, each calling
-`requireEntitledUserId`, then `rateLimiter.limit({ key: \`question-feedback:<action>:${userId}\`, ...QUESTION_FEEDBACK_RATE_LIMIT })`,
-then the use case; writes wrapped in `executeIdempotent`. Reuse `zUuid`; add enum schemas:
+`'use server'`. Three actions built with `createAction({ schema, getDeps, execute })` — the exact
+bookmark-controller shape. Non-obvious facts the implementation must honor (verified against
+`bookmark-controller.ts`, `create-action.ts`, `execute-idempotent.ts`, `controller-helpers.ts`):
+
+- **`execute` takes three args: `(input, deps, meta)`.** `meta` (`ActionExecutionMeta = { depsSource }`)
+  is load-bearing — forward it: `await requireEntitledUserId(deps, meta)`. Dropping `meta` compiles but
+  silently breaks entitlement deps-resolution in injected-deps controller tests.
+- **`getDeps` is produced by `createDepsResolver`, not hand-written:**
+  `const getDeps = createDepsResolver<QuestionFeedbackControllerDeps, QuestionFeedbackControllerContainer>((c) => c.createQuestionFeedbackControllerDeps(), loadAppContainer);`
+  (import `createDepsResolver` + `loadAppContainer` from `@/lib/controller-helpers`; declare a local
+  `QuestionFeedbackControllerContainer = { createQuestionFeedbackControllerDeps: () => QuestionFeedbackControllerDeps }`).
+- **`QuestionFeedbackControllerDeps` is defined and exported in this controller file** (mirroring
+  `BookmarkControllerDeps`), then imported by `lib/container/types.ts`.
+- Inside `execute`: `requireEntitledUserId(deps, meta)` → `deps.rateLimiter.limit({ key: \`question-feedback:<action>:${userId}\`, ...QUESTION_FEEDBACK_RATE_LIMIT })` → `throw new ApplicationError('RATE_LIMITED', …)` when `!result.success`.
+- **Writes wrap the use case in `executeIdempotent({ d: deps, userId, idempotencyKey, action, outputSchema, execute })`.** Both `action` (a string label, e.g. `'question-feedback:rateQuestion'`) and `outputSchema` (a zod schema for the use-case output, e.g. `RateQuestionOutputSchema`) are **required**; `execute` is a zero-arg thunk; the idempotency repo/logger/clock are read from `d`. It returns the raw use-case output (not an `ActionResult`) — `createAction` wraps it in `ok(...)`. A missing key short-circuits to a plain call. The read action (`getQuestionRating`) is **not** wrapped (matching `getBookmarks`).
+
+Reuse `zUuid`; add enum schemas (and the output schemas the writes pass to `executeIdempotent`):
 
 ```typescript
 const zRating = z.enum(['helpful', 'not_helpful']);
@@ -451,12 +510,21 @@ also allow `undefined`. Let `createAction`/`handleError` map `ApplicationError` 
 
 #### 3e. DI wiring (`lib/container/*`)
 
-- `repositories.ts`: `createQuestionFeedbackRepository: (db = primitives.db) => new DrizzleQuestionFeedbackRepository(db)`
-- `use-cases.ts`: `createRateQuestionUseCase`, `createGetQuestionRatingUseCase`, `createSubmitQuestionReportUseCase`
-- `controllers.ts`: `createQuestionFeedbackControllerDeps` (authGateway, logger, rateLimiter,
-  idempotencyKeyRepository, checkEntitlementUseCase, the three use cases, `now`)
-- `types.ts`: add the new repository, use-case, and controller factory types so DI overrides keep
-  compiling in controller tests.
+There is **no `index.ts` barrel**; each sub-file exports a `createXFactories(...)` map and
+`lib/container.ts` spreads them under a `satisfies <X>Factories` constraint, so the `types.ts` map and
+the factory object must stay in lockstep.
+
+- `repositories.ts`: `createQuestionFeedbackRepository: (dbOverride = primitives.db) => new DrizzleQuestionFeedbackRepository(dbOverride)` — the param is named **`dbOverride`** (all 13 existing
+  factories use this), not `db`. Also add `DrizzleQuestionFeedbackRepository` to the
+  `@/src/adapters/repositories` barrel and to the import block at the top of `repositories.ts`.
+- `use-cases.ts`: `createRateQuestionUseCase: () => new RateQuestionUseCase(repositories.createQuestionFeedbackRepository(), repositories.createQuestionRepository())`,
+  `createSubmitQuestionReportUseCase` (same two deps), and
+  `createGetQuestionRatingUseCase: () => new GetQuestionRatingUseCase(repositories.createQuestionFeedbackRepository())`
+  (feedback repo only). Import the three classes from `@/src/application/use-cases`.
+- `controllers.ts`: `createQuestionFeedbackControllerDeps: () => ({ authGateway: gateways.createAuthGateway(), logger: primitives.logger, rateLimiter: gateways.createRateLimiter(), idempotencyKeyRepository: repositories.createIdempotencyKeyRepository(), checkEntitlementUseCase: useCases.createCheckEntitlementUseCase(), rateQuestionUseCase: useCases.createRateQuestionUseCase(), getQuestionRatingUseCase: useCases.createGetQuestionRatingUseCase(), submitQuestionReportUseCase: useCases.createSubmitQuestionReportUseCase(), now: primitives.now })`.
+- `types.ts`: extend `RepositoryFactories`, `UseCaseFactories`, and `ControllerFactories` **and their
+  import blocks** with the new factory types, so `ContainerOverrides`-based DI overrides keep compiling
+  in controller tests.
 
 ### 4. App / UI (`app/`, `components/`)
 
@@ -479,7 +547,8 @@ toggles (`ThumbsUp` / `ThumbsDown` from `lucide-react`), `aria-pressed`, disable
 
 `Dialog` containing a radio group (the 5 categories via `<Button>`-based or native radio + `label`
 pattern already used by `choice-button.tsx`), an optional `<textarea>` (capped, with live counter),
-Cancel + "Submit feedback". On success show a toast via `useNotification()`. Dialog a11y is part of
+Cancel + "Submit feedback". On success show a toast via `useNotification().notify({ message, tone })`
+(the provider exposes `notify`, not a bare `toast()`). Dialog a11y is part of
 the acceptance criteria: focus trap, labelled title/description, Escape close, keyboard-submit path,
 and labelled category controls. Rating thumbs must expose `aria-pressed` plus descriptive labels.
 
@@ -530,11 +599,14 @@ No admin UI in v1 (there is no role system yet — out of scope). Two extraction
 
 1. **Documented SQL** (add to this spec's appendix + `docs/dev/`): e.g. report counts by category,
    helpful-rate per question (latest-rating-per-user), top-reported questions, recent comments.
-2. **Ops export script** `scripts/export-question-feedback.ts` — run locally with `DATABASE_URL`,
-   dumps `question_feedback` (joined to question slug) to CSV/JSON. No public surface, no new auth.
-   Default output should include question identifiers/slug, event metadata, category/rating, and
-   redacted user identifiers; include raw `user_id` or free-text comments only behind explicit flags
-   with a console warning that comments may contain PII/PHI.
+2. **Ops export script** `scripts/export-question-feedback.ts` — follow the `scripts/seed.ts`
+   convention exactly: add a `package.json` entry (e.g. `"export:feedback": "tsx scripts/export-question-feedback.ts"`,
+   `tsx` not `ts-node`), load env via `dotenv.config({ path: '.env.local', quiet: true })` then
+   `.env`, read `process.env.DATABASE_URL`, and build the client with `postgres(databaseUrl, { max: 1 })`
+   + `drizzle(sql, { schema })`. Dumps `question_feedback` (joined to question slug) to CSV/JSON. No
+   public surface, no new auth. Default output should include question identifiers/slug, event
+   metadata, category/rating, and redacted user identifiers; include raw `user_id` or free-text
+   comments only behind explicit flags with a console warning that comments may contain PII/PHI.
 
 Example "current helpful-rate per question" (latest rating per user wins):
 
@@ -567,8 +639,10 @@ Write in dependency order; each layer red before its implementation.
    `SubmitQuestionReport` (NOT_FOUND; records `report` event; returns id).
 4. **Drizzle repo** — unit (mocked db chain) + **integration** (`tests/integration/*.integration.test.ts`):
    real append, latest-rating query, and the `kind_shape` / `comment_len` CHECK constraints reject
-   bad rows. Update `tests/integration/db.integration.test.ts` table census to include
-   `question_feedback` when the table is added.
+   bad rows (integration tests self-fixture their users/questions — no seed dependency). Add
+   `'question_feedback'` to the `tests/integration/db.integration.test.ts` table census for coverage;
+   note the census asserts `toContain` per table (additive), so omitting it is a coverage gap, not a
+   guaranteed red.
 5. **Controller** (fakes via DI overrides): validation error, unauthenticated, unsubscribed,
    rate-limited, success, `ActionResult` error mapping via `createAction`, idempotency replay (no
    double-write), and separate rate-limit keys for rating vs report actions.
@@ -644,7 +718,7 @@ Vertical slice, layer by layer (each step ends green):
 
 - Archived **SPEC-014** (Review + Bookmarks) — the architectural template this mirrors.
 - **SPEC-017** (Rate Limiting), **SPEC-016** (Observability) — reused infrastructure.
-- **DEBT-337** (Future Feedback & Practice Session Enhancements) — adjacent, separate.
+- **DEBT-337** (Future feedback & practice enhancements) — adjacent, separate.
 - **DEBT-397** (datetime boundary normalization) — new controller adopts ISO-string boundary to avoid
   re-introducing the issue.
 - `docs/frontend/standards.md`, `docs/frontend/pattern-registry.md` — design-system gates for the new

--- a/docs/specs/spec-041-question-feedback.md
+++ b/docs/specs/spec-041-question-feedback.md
@@ -92,10 +92,12 @@ confusion this spec uses distinct names everywhere:
    reports.
 3. **Clean Architecture:** domain stays pure (no vendor IDs, no DB imports); port in `application`,
    Drizzle impl in `adapters`; fakes over mocks in tests.
-4. **Design system:** new `Dialog` primitive follows `docs/frontend/standards.md` (canonical focus
-   ring, semantic tokens) and either reuses or updates the existing modal pattern
-   (`docs/frontend/pattern-registry.md` S-4) before use. The "Give feedback" trigger uses
-   `<Button variant="outline" className="rounded-full">` to match the Bookmark button.
+4. **Design system:** new `Dialog` and `Textarea` primitives follow
+   `docs/frontend/standards.md` (canonical focus ring, semantic tokens, Button mandate, no raw
+   palette colors, no undocumented opacity tokens). `Dialog` either reuses or updates the existing
+   modal pattern (`docs/frontend/pattern-registry.md` S-4) before use. The "Give feedback" trigger
+   uses `<Button variant="outline" className="rounded-full">` to match the Bookmark button; raw
+   `<button>` is forbidden in `components/question/**` and would fail the DEBT-398 source scan.
 5. **Validation:** zod at the boundary, `.strict()`, reusing `zUuid`; comment capped at 2000 chars
    (enforced in zod **and** a DB `CHECK` constraint). The CHECK reuses the `check('<table>_<desc>_chk',
    sql\`…\`)` wrapper idiom from `attempts` (`attempts_*_chk`); note the `char_length(...) <= 2000`
@@ -631,15 +633,29 @@ the factory object must stay in lockstep.
 
 ### 4. App / UI (`app/`, `components/`)
 
-#### 4a. New design-system primitive — `components/ui/dialog.tsx`
+#### 4a. New design-system primitives — `components/ui/dialog.tsx` and `components/ui/textarea.tsx`
 
 Use `Dialog as DialogPrimitive` from the existing `radix-ui` dependency, matching
 `components/ui/alert-dialog.tsx`. Do **not** add `@radix-ui/react-dialog` unless the repo intentionally
 changes its Radix package convention. Model the file on `components/ui/alert-dialog.tsx`: `Dialog`,
 `DialogTrigger`, `DialogContent`, `DialogHeader`, `DialogTitle`, `DialogDescription`,
-`DialogFooter`, `DialogClose`. Use semantic tokens and the canonical focus ring. Reuse the existing
-Pattern Registry S-4 modal-dialog surface, or update/add a registry entry first if the non-alert
-dialog needs different overlay/content classes.
+`DialogFooter`, `DialogClose`. Use semantic tokens and the canonical focus ring (`buttonVariants` /
+`<Button>` for visible action buttons; `.ring-focus` or the literal canonical ring only for non-Button
+focus targets). Reuse the existing Pattern Registry S-4 modal-dialog overlay/content class strings
+verbatim, or update/add a registry entry first if the non-alert dialog needs different overlay,
+content, close-button, or mobile scroll classes. If a scroll-safe mobile variant is needed, document
+that S-4 variant before code (including max-height, `overflow-y-auto`, overscroll behavior, and any
+new opacity allowlist entry); do not ship one-off dialog overlay/content classes.
+
+Also add `components/ui/textarea.tsx` because the repo has an `Input` primitive but no shared
+textarea primitive. Model it on `components/ui/input.tsx`: semantic `border-input` /
+`dark:border-foreground/40`, `bg-transparent` / `dark:bg-input/30`, `text-base md:text-sm`,
+`placeholder:text-muted-foreground`, `selection:bg-primary selection:text-primary-foreground`,
+`disabled:cursor-not-allowed disabled:opacity-50`, the same `focus-visible:border-ring
+focus-visible:ring-ring/50 focus-visible:ring-[3px]`, and the same
+`aria-invalid:border-destructive aria-invalid:ring-destructive/20
+dark:aria-invalid:ring-destructive/40`. `QuestionReportDialog` imports this `Textarea`; it must not
+hand-roll a raw styled `<textarea>` in `components/question/**`.
 
 #### 4b. Tier 1 — rating row `components/question/question-feedback-rating.tsx`
 
@@ -652,27 +668,58 @@ intentionally low-friction. Do expose a compact `aria-live="polite"` status for 
 "Rating saved" / "Couldn't save rating" so screen-reader users get the same state change without
 visual noise.
 
+Visual contract: the row is an unframed `flex flex-wrap items-center gap-3` control row, not a new
+card-like div. The prompt is `text-sm font-medium text-foreground`; the live status is `text-sm
+text-muted-foreground` except failure, which is `text-sm text-destructive`. The inactive thumbs use
+`<Button variant="outline" size="icon" className="rounded-full">`; the active helpful thumb uses the
+existing `success` Button variant and the active not-helpful thumb uses the existing `destructive`
+Button variant, both still `size="icon"` and `className="rounded-full"`. Do not create custom thumb
+background/border opacity classes unless a Pattern Registry entry exists first.
+
 #### 4c. Tier 2 — `components/question/question-report-dialog.tsx`
 
 `Dialog` titled **"Give feedback"** with a one-line description: "Spotted an issue or have a
 suggestion? This goes to our medical editors and won't affect your score." Contains a **required**
-category radio group under the legend **"What's this about?"** (the 5 categories via `<Button>`-based
-or native radio + `label` pattern already used by `choice-button.tsx`), an optional labelled
-`<textarea name="comment" autoComplete="off" maxLength={2000}>` under "Add details (optional)"
-(capped, with live counter), and a footer with **Cancel** + **"Submit feedback"**. Invalid submit
-(no category) shows "Choose a category to send your feedback." On success show a toast via
-`useNotification().notify({ message, tone })` — success copy "Thanks — our editors will take a look.",
-failure copy "Couldn't send your feedback. Check your connection." with a retry affordance (the
-provider exposes `notify`, not a bare `toast()`, and its toast region already uses
-`aria-live="polite"` in `components/ui/notification-provider.tsx:131`). Dialog a11y is part of the
-acceptance criteria:
-focus trap, labelled title/description, Escape close, focus return to trigger, keyboard-submit path,
-first validation error focus on invalid submit, and labelled category controls. If the form needs
-scrolling on small screens, add a scroll-safe S-4 modal variant to `docs/frontend/pattern-registry.md`
-before code (e.g. max-height + `overflow-y-auto` + overscroll containment); do not invent one-off
-dialog overflow classes.
+category radio group under the legend **"What's this about?"**. The 5 category controls reuse the
+`choice-button.tsx` native radio + `<label>` structure (`input type="radio" className="sr-only"` inside
+a clickable label), not a parallel raw-`<button>` group. Use the Pattern Registry I-3 ChoiceButton
+visual tokens by default: base `rounded-xl border border-foreground/50 bg-background/50 p-4 text-left
+shadow-sm transition-colors focus-within:border-ring ring-focus-within dark:border-foreground/40
+dark:bg-background/50`, hover `cursor-pointer hover:border-foreground/55
+hover:bg-foreground/[0.06] dark:hover:border-foreground/50 dark:hover:bg-foreground/[0.05]`, selected
+`border-ring bg-foreground/[0.08] dark:border-foreground/70 dark:bg-foreground/[0.12]`, disabled
+`cursor-not-allowed opacity-50`. If visual review proves the modal needs a denser radio-row variant,
+add that variant to `docs/frontend/pattern-registry.md` with contrast evidence before implementing it.
 
-#### 4d. Client hooks + imperative core
+The optional comment field is `<Textarea name="comment" autoComplete="off" maxLength={2000}>` under
+"Add details (optional)" with a live character counter. The label and legend are `text-sm font-medium
+text-foreground`; the description and normal counter/helper text are `text-sm text-muted-foreground`;
+the near-limit counter (100 chars remaining or fewer) is `text-sm font-medium
+text-warning-foreground`; validation copy is `text-sm text-destructive` with `role="alert"` and the
+field/control wired through `aria-describedby`. Invalid submit (no category) shows "Choose a category
+to send your feedback." and focuses the first invalid radio control; invalid textarea state uses the
+`Textarea` primitive's `aria-invalid` destructive ring. The footer uses Button primitives for
+**Cancel** + **"Submit feedback"**.
+
+On success call `useNotification().notify({ message: 'Thanks — our editors will take a look.', tone:
+'success' })` and close the dialog. On failure keep the dialog open, leave the **Submit feedback**
+Button available as the retry affordance, and call `useNotification().notify({ message: "Couldn't send
+your feedback. Check your connection.", tone: 'error' })`. Do not add a second toast/action system; the
+provider exposes `notify`, not a bare `toast()`, and its toast region already uses `aria-live="polite"`
+in `components/ui/notification-provider.tsx:131`. Dialog a11y is part of the acceptance criteria:
+focus trap, labelled title/description, Escape close, focus return to trigger, keyboard-submit path,
+first validation error focus on invalid submit, and labelled category controls.
+
+#### 4d. UI source-scan and token acceptance criteria
+
+The UI PR must pass the existing DEBT-398 source scans without exemptions: no raw `<button>` outside
+`components/ui/` and the documented app-shell exception, no raw hex/palette classes, and no opacity
+outside the Pattern Registry / `DOCUMENTED_OPACITY_TOKENS` allowlist. If any new visual state needs a
+new opacity, add the Pattern Registry entry and update the allowlist before using the class in TSX.
+Every new hardcoded UI text node must carry explicit typography per `docs/frontend/typography-policy.md`
+instead of relying on inherited defaults.
+
+#### 4e. Client hooks + imperative core
 
 Mirror the bookmark split instead of forcing one hook path:
 
@@ -688,7 +735,7 @@ Each hook hydrates current rating on entering review mode (call `getQuestionRati
 rollback on failed rating writes, mounted-checks, `withTimeout`, idempotency-key rotation, and error
 logging. Error logs must include question/action metadata but **never** the free-text report comment.
 
-#### 4e. Wire into the action bar
+#### 4f. Wire into the action bar
 
 In `app/(app)/app/practice/components/practice-view.tsx`, add a **"Give feedback"** `<Button>` to
 the existing `secondaryGroup` (the `hasBooleanCorrectness(submitResult)` block, right next to
@@ -773,9 +820,10 @@ Write in dependency order; each layer red before its implementation.
    rate-limited, success, `ActionResult` error mapping via `createAction`, idempotency replay (no
    double-write), separate rate-limit keys for rating vs report actions, and the distinct rating/report
    limit constants are passed to `RateLimiter.limit`.
-6. **UI** — `renderToStaticMarkup` component tests (`*.test.tsx`) for the rating row + dialog markup;
-   **browser specs** (`*.browser.spec.tsx`, `pnpm test:browser`) for the hook (hydrate, optimistic
-   rate, rollback on failure, retract) and dialog submit flow. Keep React 19 rules:
+6. **UI** — primitive tests for `Dialog` and `Textarea`, then `renderToStaticMarkup` component tests
+   (`*.test.tsx`) for the rating row + dialog markup; **browser specs** (`*.browser.spec.tsx`,
+   `pnpm test:browser`) for the hook (hydrate, optimistic rate, rollback on failure, retract) and
+   dialog submit flow. Keep React 19 rules:
    `// @vitest-environment jsdom` first line in `*.test.tsx`, dynamic imports in `beforeAll`, no
    `@testing-library/react`, and no per-test timeout overrides. Add a11y assertions for
    `aria-pressed`, icon `aria-label`s, `aria-live` status, labelled textarea/counter, focus return,
@@ -795,7 +843,7 @@ Vertical slice, layer by layer (each step ends green):
 4. Schema + enums + relations → generate & apply migration → Drizzle repo → repo unit + integration tests.
 5. Rate-limit constant + zod schemas + controller + controller tests.
 6. DI wiring in `lib/container/*`, including `types.ts`.
-7. `Dialog` primitive + Pattern Registry S-4 reuse/update + primitive test.
+7. `Dialog` + `Textarea` primitives + Pattern Registry S-4 reuse/update + primitive tests.
 8. UI: rating row + report dialog + hooks + imperative core; wire into `practice-view`, active
    session controller/view, quick-practice client, standalone question client, and post-exam review;
    component tests + browser specs.
@@ -806,8 +854,8 @@ Vertical slice, layer by layer (each step ends green):
 
 - **PR 1 — Backend slice:** domain → port/fake → use cases → schema/migration → repo → controller →
   DI → all backend tests. Fully functional via tests; no UI yet.
-- **PR 2 — `Dialog` primitive:** `components/ui/dialog.tsx` + Pattern Registry S-4 reuse/update +
-  tests.
+- **PR 2 — UI primitives:** `components/ui/dialog.tsx`, `components/ui/textarea.tsx`, Pattern Registry
+  S-4 reuse/update + primitive tests.
 - **PR 3 — UI wiring:** rating row + report dialog + hooks + all active review-surface wiring +
   component & browser tests.
 - **PR 4 — Extraction tooling:** export script + SQL docs.

--- a/docs/specs/spec-041-question-feedback.md
+++ b/docs/specs/spec-041-question-feedback.md
@@ -333,8 +333,13 @@ export class RateQuestionUseCase {
 ```typescript
 // src/application/use-cases/get-question-rating.ts  (hydration)
 export class GetQuestionRatingUseCase {
-  constructor(private readonly feedback: QuestionFeedbackRepository) {}
+  constructor(
+    private readonly feedback: QuestionFeedbackRepository,
+    private readonly questions: QuestionRepository,
+  ) {}
   async execute(input: { userId: string; questionId: string }) {
+    const question = await this.questions.findPublishedById(input.questionId);
+    if (!question) throw new ApplicationError('NOT_FOUND', 'Question not found');
     const latest = await this.feedback.findLatestRatingByUser(
       input.userId,
       input.questionId,
@@ -565,17 +570,13 @@ bookmark-controller shape. Non-obvious facts the implementation must honor (veri
 - Inside `execute`: `requireEntitledUserId(deps, meta)` → `deps.rateLimiter.limit({ key: \`question-feedback:<action>:${userId}\`, ...QUESTION_RATING_RATE_LIMIT })` for `rateQuestion` and `...QUESTION_REPORT_RATE_LIMIT` for `submitQuestionReport` → `throw new ApplicationError('RATE_LIMITED', …)` when `!result.success`.
 - **Writes wrap the use case in `executeIdempotent({ d: deps, userId, idempotencyKey, action, outputSchema, execute })`.** Both `action` (a string label, e.g. `'question-feedback:rateQuestion'`) and `outputSchema` (a zod schema for the use-case output, e.g. `RateQuestionOutputSchema`) are **required**; `execute` is a zero-arg thunk; the idempotency repo/logger/clock are read from `d`. It returns the raw use-case output (not an `ActionResult`) — `createAction` wraps it in `ok(...)`. A missing key short-circuits to a plain call. The read action (`getQuestionRating`) is **not** wrapped (matching `getBookmarks`).
 
-Reuse `zUuid`; add enum schemas (and the output schemas the writes pass to `executeIdempotent`):
+Reuse `zUuid` and the domain-owned `AllQuestionFeedbackRatings` /
+`AllQuestionFeedbackCategories` literal arrays; add enum schemas (and the output schemas the writes pass
+to `executeIdempotent`):
 
 ```typescript
-const zRating = z.enum(['helpful', 'not_helpful']);
-const zCategory = z.enum([
-  'incorrect_answer',
-  'ambiguous_wording',
-  'typo_formatting',
-  'outdated_reference',
-  'other',
-]);
+const zRating = z.enum(AllQuestionFeedbackRatings);
+const zCategory = z.enum(AllQuestionFeedbackCategories);
 const zOptionalComment = z.preprocess(
   (value) =>
     typeof value === 'string' && value.trim().length === 0 ? undefined : value,
@@ -624,8 +625,8 @@ the factory object must stay in lockstep.
   `@/src/adapters/repositories` barrel and to the import block at the top of `repositories.ts`.
 - `use-cases.ts`: `createRateQuestionUseCase: () => new RateQuestionUseCase(repositories.createQuestionFeedbackRepository(), repositories.createQuestionRepository())`,
   `createSubmitQuestionReportUseCase` (same two deps), and
-  `createGetQuestionRatingUseCase: () => new GetQuestionRatingUseCase(repositories.createQuestionFeedbackRepository())`
-  (feedback repo only). Import the three classes from `@/src/application/use-cases`.
+  `createGetQuestionRatingUseCase: () => new GetQuestionRatingUseCase(repositories.createQuestionFeedbackRepository(), repositories.createQuestionRepository())`.
+  Import the three classes from `@/src/application/use-cases`.
 - `controllers.ts`: `createQuestionFeedbackControllerDeps: () => ({ authGateway: gateways.createAuthGateway(), logger: primitives.logger, rateLimiter: gateways.createRateLimiter(), idempotencyKeyRepository: repositories.createIdempotencyKeyRepository(), checkEntitlementUseCase: useCases.createCheckEntitlementUseCase(), rateQuestionUseCase: useCases.createRateQuestionUseCase(), getQuestionRatingUseCase: useCases.createGetQuestionRatingUseCase(), submitQuestionReportUseCase: useCases.createSubmitQuestionReportUseCase(), now: primitives.now })`.
 - `types.ts`: extend `RepositoryFactories`, `UseCaseFactories`, and `ControllerFactories` **and their
   import blocks** with the new factory types, so `ContainerOverrides`-based DI overrides keep compiling
@@ -807,7 +808,8 @@ Write in dependency order; each layer red before its implementation.
    rating, uses `id DESC` as the deterministic tie-breaker for equal `createdAt`, ignores reports,
    returns null when none.
 3. **Use cases** (fakes): `RateQuestion` (NOT_FOUND when question absent; records `rating` event;
-   retraction records `rating=null`), `GetQuestionRating` (latest wins; null when none),
+   retraction records `rating=null`), `GetQuestionRating` (NOT_FOUND when question absent; latest wins;
+   null when none),
    `SubmitQuestionReport` (NOT_FOUND; records `report` event; returns id).
 4. **Drizzle repo** — unit (mocked db chain) + **integration** (`tests/integration/*.integration.test.ts`):
    real append, row→union mapping, latest-rating query including equal-`createdAt` tie-breaker, and

--- a/docs/specs/spec-041-question-feedback.md
+++ b/docs/specs/spec-041-question-feedback.md
@@ -1,0 +1,588 @@
+# SPEC-041: Question Feedback (Per-Question Ratings & Problem Reports)
+
+> **⚠️ TDD MANDATE:** This spec follows Test-Driven Development (Uncle Bob / Robert C. Martin).
+> Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
+> Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
+
+**Status:** Proposed
+**Layer:** Feature (touches Domain, Application, Adapters, App)
+**Date:** 2026-06-01
+
+---
+
+## Overview
+
+Learners need a frictionless way to tell us when a question is good, bad, or broken — and we
+need that signal to land in our database as a durable, query-able record we can mine forever to
+improve the question bank.
+
+This spec defines a **two-tier, per-question feedback system**, surfaced in **review mode
+(post-answer)** in the practice flow, modeled directly on the existing **Bookmark** vertical
+slice (`toggleBookmark` / `getBookmarks`), which is the closest existing analog: a per-question,
+per-user action that persists to the DB with optimistic UI, rate limiting, and idempotency.
+
+**Tier 1 — Rating (one click).** A lightweight `👍 / 👎` ("Was this helpful?") row inside the
+review panel. Optimistic, instant, no modal. Captures broad sentiment on every question at scale.
+
+**Tier 2 — Report a problem (modal).** A "Report a problem" button in the action bar (next to
+Bookmark) opens a focused dialog: a required category (Incorrect answer · Ambiguous wording ·
+Typo / formatting · Outdated reference · Other) plus an optional free-text comment. This is the
+rich, actionable signal for content fixes.
+
+Both tiers write to a single **append-only event-log table** (`question_feedback`), chosen because
+the primary goal is a long-lived analytical substrate ("forever maintain and improve"): history is
+signal, storage is trivial relative to attempts, and pure-insert is the simplest persistence shape.
+
+### ⚠️ Naming collision (read first)
+
+`components/question/feedback.tsx` **already exists** — it is the **answer-explanation panel**
+(Correct Answer / Why Other Answers Are Wrong / Reference). It is **not** user feedback. To avoid
+confusion this spec uses distinct names everywhere:
+
+| Concept | Name |
+|--------|------|
+| The existing explanation panel | `Feedback` (unchanged — do not repurpose) |
+| New domain/data type | `QuestionFeedback` |
+| New rating UI (👍/👎 row) | `QuestionFeedbackRating` |
+| New report modal | `QuestionReportDialog` |
+| User-facing copy | "Was this helpful?", "Report a problem" |
+
+## Relationship to Other Specs
+
+- **Models the Bookmark slice (archived SPEC-014 "Review + Bookmarks")** — same architecture: port
+  + fake + Drizzle repo + use case + `createAction` server action + DI wiring + optimistic hook.
+- **SPEC-023 / SPEC-034 (Review Mode)** — feedback controls render only where the review panel is
+  visible (tutor immediate review + session review). They never appear mid-exam (no explanation yet).
+- **DEBT-337 (Future Feedback & Practice Session Enhancements)** — adjacent but separate; that item
+  covers explanation-panel content/UX tweaks, not user-submitted feedback. No collision.
+- **DEBT-397 (datetime boundary normalization)** — touches `practice-schemas.ts` only. This feature
+  introduces a *new* controller (`question-feedback-controller.ts`); to avoid re-introducing the
+  DEBT-397 problem, its boundary uses **ISO strings** for any datetime in/out from day one.
+
+## Requirements
+
+### Functional
+
+1. In **review mode** (after an answer is committed and the explanation is visible), a learner can:
+   1. Rate the question `helpful` / `not_helpful` with a single click (Tier 1).
+   2. Re-click the active rating to **retract** it (back to no rating).
+   3. Open a **Report a problem** modal and submit a **category** (required) + **comment** (optional).
+2. On entering review mode, the UI **hydrates** the learner's current rating for that question
+   (filled 👍 or 👎 if they rated it before), matching the bookmark hydration pattern.
+3. Each feedback action persists to `question_feedback` with the user, question, and best-effort
+   context (attempt id, practice-session id) so we can correlate feedback with whether the learner
+   got the question right and in which mode.
+4. Submitting feedback is **idempotent** (client-supplied idempotency key), reusing the existing
+   `executeIdempotent` wrapper so retries/double-clicks never double-write.
+5. Feedback is **immutable** once written (append-only). A rating "change" is a new event; latest
+   event per `(user, question)` wins for display.
+6. We can **extract** all feedback for offline analysis via (a) documented SQL queries and (b) an
+   ops export script (`scripts/export-question-feedback.ts`) run locally with `DATABASE_URL`.
+
+### Non-Functional
+
+1. **Auth + entitlement:** all actions go through `requireEntitledUserId` (authenticated + subscribed),
+   identical to bookmark/practice controllers.
+2. **Rate limited:** per-user limit via the existing `RateLimiter` gateway and a new
+   `QUESTION_FEEDBACK_RATE_LIMIT` constant.
+3. **Clean Architecture:** domain stays pure (no vendor IDs, no DB imports); port in `application`,
+   Drizzle impl in `adapters`; fakes over mocks in tests.
+4. **Design system:** new `Dialog` primitive follows `docs/frontend/standards.md` (canonical focus
+   ring, semantic tokens) and is registered in `docs/frontend/pattern-registry.md` before use. The
+   "Report a problem" trigger uses `<Button variant="outline" className="rounded-full">` to match the
+   Bookmark button.
+5. **Validation:** zod at the boundary, `.strict()`, reusing `zUuid`; comment capped at 2000 chars
+   (enforced in zod **and** a DB `CHECK` constraint, matching the `attempts` table idiom).
+6. **Privacy:** `user_id` FK is `ON DELETE CASCADE` — deleting a user removes their feedback (GDPR).
+
+## Design
+
+Dependency direction (inward only): `db` ← `adapters` ← `application` ← `domain`.
+
+### 1. Domain — value objects + entity (`src/domain/`)
+
+Pure types, no imports. Mirror `src/domain/value-objects/` `const AllX = [...] as const` idiom.
+
+```typescript
+// src/domain/value-objects/question-feedback-rating.ts
+export const AllQuestionFeedbackRatings = ['helpful', 'not_helpful'] as const;
+export type QuestionFeedbackRating = (typeof AllQuestionFeedbackRatings)[number];
+
+// src/domain/value-objects/question-feedback-category.ts
+export const AllQuestionFeedbackCategories = [
+  'incorrect_answer',
+  'ambiguous_wording',
+  'typo_formatting',
+  'outdated_reference',
+  'other',
+] as const;
+export type QuestionFeedbackCategory =
+  (typeof AllQuestionFeedbackCategories)[number];
+
+// src/domain/value-objects/question-feedback-kind.ts
+export const AllQuestionFeedbackKinds = ['rating', 'report'] as const;
+export type QuestionFeedbackKind = (typeof AllQuestionFeedbackKinds)[number];
+```
+
+```typescript
+// src/domain/entities/question-feedback.ts
+export type QuestionFeedback = {
+  readonly id: string;
+  readonly userId: string;
+  readonly questionId: string;
+  readonly attemptId: string | null;
+  readonly practiceSessionId: string | null;
+  readonly kind: QuestionFeedbackKind;
+  readonly rating: QuestionFeedbackRating | null;   // set when kind='rating'; null = retraction
+  readonly category: QuestionFeedbackCategory | null; // set when kind='report'
+  readonly comment: string | null;
+  readonly createdAt: Date;
+};
+```
+
+**Invariant (enforced in use case + DB CHECK):** a `rating` event has `category = null`; a `report`
+event has `category != null` and `rating = null`.
+
+### 2. Application — port + use cases (`src/application/`)
+
+```typescript
+// src/application/ports/question-feedback-repository.ts
+export type RecordQuestionFeedbackParams = {
+  userId: string;
+  questionId: string;
+  attemptId: string | null;
+  practiceSessionId: string | null;
+  kind: QuestionFeedbackKind;
+  rating: QuestionFeedbackRating | null;
+  category: QuestionFeedbackCategory | null;
+  comment: string | null;
+};
+
+export interface QuestionFeedbackRepository {
+  record(params: RecordQuestionFeedbackParams): Promise<QuestionFeedback>;
+  /** Latest 'rating'-kind event for (user, question); null if none. Drives 👍/👎 hydration. */
+  findLatestRatingByUser(
+    userId: string,
+    questionId: string,
+  ): Promise<QuestionFeedback | null>;
+}
+```
+
+Re-export via the `src/application/ports/repositories.ts` barrel (matches bookmark port).
+
+**Three small use cases** (constructor injection, `execute()`, throw `ApplicationError`):
+
+```typescript
+// src/application/use-cases/rate-question.ts  (Tier 1)
+export type RateQuestionInput = {
+  userId: string;
+  questionId: string;
+  attemptId: string | null;
+  practiceSessionId: string | null;
+  rating: QuestionFeedbackRating | null; // null = retract
+};
+export type RateQuestionOutput = { rating: QuestionFeedbackRating | null };
+
+export class RateQuestionUseCase {
+  constructor(
+    private readonly feedback: QuestionFeedbackRepository,
+    private readonly questions: QuestionRepository,
+  ) {}
+  async execute(input: RateQuestionInput): Promise<RateQuestionOutput> {
+    const question = await this.questions.findPublishedById(input.questionId);
+    if (!question) throw new ApplicationError('NOT_FOUND', 'Question not found');
+    await this.feedback.record({
+      userId: input.userId,
+      questionId: input.questionId,
+      attemptId: input.attemptId,
+      practiceSessionId: input.practiceSessionId,
+      kind: 'rating',
+      rating: input.rating,
+      category: null,
+      comment: null,
+    });
+    return { rating: input.rating };
+  }
+}
+```
+
+```typescript
+// src/application/use-cases/get-question-rating.ts  (hydration)
+export class GetQuestionRatingUseCase {
+  constructor(private readonly feedback: QuestionFeedbackRepository) {}
+  async execute(input: { userId: string; questionId: string }) {
+    const latest = await this.feedback.findLatestRatingByUser(
+      input.userId,
+      input.questionId,
+    );
+    return { rating: latest?.rating ?? null };
+  }
+}
+```
+
+```typescript
+// src/application/use-cases/submit-question-report.ts  (Tier 2)
+export type SubmitQuestionReportInput = {
+  userId: string;
+  questionId: string;
+  attemptId: string | null;
+  practiceSessionId: string | null;
+  category: QuestionFeedbackCategory;
+  comment: string | null;
+};
+export type SubmitQuestionReportOutput = { feedbackId: string };
+
+export class SubmitQuestionReportUseCase {
+  constructor(
+    private readonly feedback: QuestionFeedbackRepository,
+    private readonly questions: QuestionRepository,
+  ) {}
+  async execute(
+    input: SubmitQuestionReportInput,
+  ): Promise<SubmitQuestionReportOutput> {
+    const question = await this.questions.findPublishedById(input.questionId);
+    if (!question) throw new ApplicationError('NOT_FOUND', 'Question not found');
+    const saved = await this.feedback.record({
+      ...input,
+      kind: 'report',
+      rating: null,
+    });
+    return { feedbackId: saved.id };
+  }
+}
+```
+
+**Fake** (`src/application/test-helpers/fakes/fake-question-feedback-repository.ts`): in-memory array
+of events; `record()` pushes; `findLatestRatingByUser()` filters `kind==='rating'` and returns the
+newest by `createdAt`. Add to the fakes barrel `index.ts`.
+
+### 3. Adapters — schema, migration, Drizzle repo, controller (`src/adapters/`, `db/`)
+
+#### 3a. Schema (`db/schema.ts`)
+
+Add enums near the other `pgEnum` declarations:
+
+```typescript
+export const questionFeedbackKindEnum = pgEnum('question_feedback_kind', [
+  'rating',
+  'report',
+]);
+export const questionFeedbackRatingEnum = pgEnum('question_feedback_rating', [
+  'helpful',
+  'not_helpful',
+]);
+export const questionFeedbackCategoryEnum = pgEnum(
+  'question_feedback_category',
+  [
+    'incorrect_answer',
+    'ambiguous_wording',
+    'typo_formatting',
+    'outdated_reference',
+    'other',
+  ],
+);
+```
+
+Add the table (append-only; single UUID PK like `attempts`):
+
+```typescript
+export const questionFeedback = pgTable(
+  'question_feedback',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    questionId: uuid('question_id')
+      .notNull()
+      .references(() => questions.id, { onDelete: 'cascade' }),
+    attemptId: uuid('attempt_id').references(() => attempts.id, {
+      onDelete: 'set null',
+    }),
+    practiceSessionId: uuid('practice_session_id').references(
+      () => practiceSessions.id,
+      { onDelete: 'set null' },
+    ),
+    kind: questionFeedbackKindEnum('kind').notNull(),
+    rating: questionFeedbackRatingEnum('rating'),
+    category: questionFeedbackCategoryEnum('category'),
+    comment: text('comment'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    questionCreatedAtIdx: index('question_feedback_question_created_at_idx').on(
+      t.questionId,
+      desc(t.createdAt),
+    ),
+    userQuestionCreatedAtIdx: index(
+      'question_feedback_user_question_created_at_idx',
+    ).on(t.userId, t.questionId, desc(t.createdAt)),
+    kindCreatedAtIdx: index('question_feedback_kind_created_at_idx').on(
+      t.kind,
+      desc(t.createdAt),
+    ),
+    // Shape invariant: ratings carry no category; reports carry a category and no rating.
+    kindShapeCheck: check(
+      'question_feedback_kind_shape_chk',
+      sql`(${t.kind} = 'rating' AND ${t.category} IS NULL)
+          OR (${t.kind} = 'report' AND ${t.category} IS NOT NULL AND ${t.rating} IS NULL)`,
+    ),
+    commentLengthCheck: check(
+      'question_feedback_comment_len_chk',
+      sql`${t.comment} IS NULL OR char_length(${t.comment}) <= 2000`,
+    ),
+  }),
+);
+```
+
+Add relations (and `feedback: many(questionFeedback)` to `usersRelations` and `questionsRelations`):
+
+```typescript
+export const questionFeedbackRelations = relations(
+  questionFeedback,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [questionFeedback.userId],
+      references: [users.id],
+    }),
+    question: one(questions, {
+      fields: [questionFeedback.questionId],
+      references: [questions.id],
+    }),
+    attempt: one(attempts, {
+      fields: [questionFeedback.attemptId],
+      references: [attempts.id],
+    }),
+    practiceSession: one(practiceSessions, {
+      fields: [questionFeedback.practiceSessionId],
+      references: [practiceSessions.id],
+    }),
+  }),
+);
+```
+
+Generate the migration (never `drizzle-kit push`):
+
+```bash
+DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:generate
+DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:migrate
+```
+
+> **Question lifecycle note:** questions are **archived** (`question_status='archived'`), not hard-
+> deleted, so the `ON DELETE CASCADE` on `question_id` rarely fires in practice and feedback persists.
+> Keep "archive, don't delete" as content-ops policy so the analytical record stays intact.
+
+#### 3b. Drizzle repo (`src/adapters/repositories/drizzle-question-feedback-repository.ts`)
+
+Constructor-inject `DrizzleDb`. `record()` is a plain `insert(...).returning()` (no upsert —
+append-only). `findLatestRatingByUser()` is `findFirst` filtered to `kind='rating'`, ordered
+`desc(createdAt)`. Map rows → domain via a small `*-mappers.ts` if non-trivial. Throw
+`ApplicationError('INTERNAL_ERROR', ...)` on a missing `returning()` row (bookmark pattern).
+
+#### 3c. Rate limit (`src/adapters/shared/rate-limits.ts`)
+
+```typescript
+export const QUESTION_FEEDBACK_RATE_LIMIT = {
+  limit: 30,
+  windowMs: ONE_MINUTE_MS,
+} as const;
+```
+
+#### 3d. zod schemas + controller (`src/adapters/controllers/question-feedback-controller.ts`)
+
+`'use server'`. Three actions built with `createAction({ schema, getDeps, execute })`, each calling
+`requireEntitledUserId`, then `rateLimiter.limit({ key: \`question-feedback:<action>:${userId}\`, ...QUESTION_FEEDBACK_RATE_LIMIT })`,
+then the use case; writes wrapped in `executeIdempotent`. Reuse `zUuid`; add enum schemas:
+
+```typescript
+const zRating = z.enum(['helpful', 'not_helpful']);
+const zCategory = z.enum([
+  'incorrect_answer',
+  'ambiguous_wording',
+  'typo_formatting',
+  'outdated_reference',
+  'other',
+]);
+
+const RateQuestionInputSchema = z
+  .object({
+    questionId: zUuid,
+    attemptId: zUuid.nullish(),
+    practiceSessionId: zUuid.nullish(),
+    rating: zRating.nullable(), // null = retract
+    idempotencyKey: zUuid.optional(),
+  })
+  .strict();
+
+const SubmitQuestionReportInputSchema = z
+  .object({
+    questionId: zUuid,
+    attemptId: zUuid.nullish(),
+    practiceSessionId: zUuid.nullish(),
+    category: zCategory,
+    comment: z.string().trim().min(1).max(2000).optional(),
+    idempotencyKey: zUuid.optional(),
+  })
+  .strict();
+
+const GetQuestionRatingInputSchema = z.object({ questionId: zUuid }).strict();
+```
+
+Actions: `rateQuestion`, `getQuestionRating`, `submitQuestionReport`.
+
+#### 3e. DI wiring (`lib/container/*`)
+
+- `repositories.ts`: `createQuestionFeedbackRepository: (db = primitives.db) => new DrizzleQuestionFeedbackRepository(db)`
+- `use-cases.ts`: `createRateQuestionUseCase`, `createGetQuestionRatingUseCase`, `createSubmitQuestionReportUseCase`
+- `controllers.ts`: `createQuestionFeedbackControllerDeps` (authGateway, logger, rateLimiter,
+  idempotencyKeyRepository, checkEntitlementUseCase, the three use cases, `now`)
+
+### 4. App / UI (`app/`, `components/`)
+
+#### 4a. New design-system primitive — `components/ui/dialog.tsx`
+
+Radix `@radix-ui/react-dialog` (already transitively present via `alert-dialog`/`select`). Model
+the file on `components/ui/alert-dialog.tsx`: `Dialog`, `DialogTrigger`, `DialogContent`,
+`DialogHeader`, `DialogTitle`, `DialogDescription`, `DialogFooter`, `DialogClose`. Use semantic
+tokens and the canonical focus ring. **Add a Pattern Registry entry** in
+`docs/frontend/pattern-registry.md` (overlay/dialog pattern) with rationale before merging UI.
+
+#### 4b. Tier 1 — rating row `components/question/question-feedback-rating.tsx`
+
+Renders inside the review panel only (after `Feedback`). "Was this helpful?" + two `<Button>` icon
+toggles (`ThumbsUp` / `ThumbsDown` from `lucide-react`), `aria-pressed`, disabled while saving.
+
+#### 4c. Tier 2 — `components/question/question-report-dialog.tsx`
+
+`Dialog` containing a radio group (the 5 categories via `<Button>`-based or native radio + `label`
+pattern already used by `choice-button.tsx`), an optional `<textarea>` (capped, with live counter),
+Cancel + "Submit feedback". On success show a toast via `useNotification()`.
+
+#### 4d. Client hook — `app/(app)/app/shared/use-question-feedback.ts`
+
+Mirror `use-question-page-bookmarks.ts`: hydrate current rating on entering review mode (call
+`getQuestionRating`), expose `{ rating, feedbackStatus, onRate, isReportOpen, openReport, submitReport }`
+with optimistic updates, mounted-checks, `withTimeout`, idempotency-key rotation, and error logging.
+Factor the imperative core into `app/(app)/app/shared/question-feedback-actions.ts` (testable, like
+`bookmark-toggle.ts`).
+
+#### 4e. Wire into the action bar
+
+In `app/(app)/app/practice/components/practice-view.tsx`, add a **"Report a problem"** `<Button>` to
+the existing `secondaryGroup` (the `hasBooleanCorrectness(submitResult)` block, right next to
+Bookmark), and render `<QuestionFeedbackRating>` after the `Feedback` panel in
+`components/question/question-surface-body.tsx`. Thread new props
+(`rating`, `feedbackStatus`, `onRate`, `onOpenReport`, …) from the client components
+(`quick-practice-client.tsx`, `practice-page-client.tsx`) exactly as bookmark props are threaded,
+using the `fireAndForget` pattern. Pass best-effort `attemptId`/`practiceSessionId` context from
+`submitResult` / session state (null when unavailable, e.g. Quick Practice has no session).
+
+### 5. Extraction (the "forever maintain & improve" requirement)
+
+No admin UI in v1 (there is no role system yet — out of scope). Two extraction paths:
+
+1. **Documented SQL** (add to this spec's appendix + `docs/dev/`): e.g. report counts by category,
+   helpful-rate per question (latest-rating-per-user), top-reported questions, recent comments.
+2. **Ops export script** `scripts/export-question-feedback.ts` — run locally with `DATABASE_URL`,
+   dumps `question_feedback` (joined to question slug) to CSV/JSON. No public surface, no new auth.
+
+Example "current helpful-rate per question" (latest rating per user wins):
+
+```sql
+WITH latest AS (
+  SELECT DISTINCT ON (user_id, question_id)
+         user_id, question_id, rating
+  FROM question_feedback
+  WHERE kind = 'rating'
+  ORDER BY user_id, question_id, created_at DESC
+)
+SELECT q.slug,
+       COUNT(*) FILTER (WHERE rating = 'helpful')     AS helpful,
+       COUNT(*) FILTER (WHERE rating = 'not_helpful') AS not_helpful
+FROM latest l JOIN questions q ON q.id = l.question_id
+WHERE l.rating IS NOT NULL
+GROUP BY q.slug
+ORDER BY not_helpful DESC;
+```
+
+## Tests First
+
+Write in dependency order; each layer red before its implementation.
+
+1. **Domain** — value-object membership/validators (`*.test.ts`).
+2. **Fake repo** — `record()` appends; `findLatestRatingByUser()` returns newest rating, ignores
+   reports, returns null when none.
+3. **Use cases** (fakes): `RateQuestion` (NOT_FOUND when question absent; records `rating` event;
+   retraction records `rating=null`), `GetQuestionRating` (latest wins; null when none),
+   `SubmitQuestionReport` (NOT_FOUND; records `report` event; returns id).
+4. **Drizzle repo** — unit (mocked db chain) + **integration** (`tests/integration/*.integration.test.ts`):
+   real append, latest-rating query, and the `kind_shape` / `comment_len` CHECK constraints reject
+   bad rows.
+5. **Controller** (fakes via DI overrides): validation error, unauthenticated, unsubscribed,
+   rate-limited, success, idempotency replay (no double-write).
+6. **UI** — `renderToStaticMarkup` component tests (`*.test.tsx`) for the rating row + dialog markup;
+   **browser specs** (`*.browser.spec.tsx`, `pnpm test:browser`) for the hook (hydrate, optimistic
+   rate, retract) and dialog submit flow.
+7. **E2E (optional)** — open report dialog in review mode, submit, assert toast + DB row.
+
+## Implementation Order
+
+Vertical slice, layer by layer (each step ends green):
+
+1. Domain value objects + entity + tests.
+2. Port + Fake + fake test; add to barrels.
+3. Use cases + tests.
+4. Schema + enums + relations → generate & apply migration → Drizzle repo → repo unit + integration tests.
+5. Rate-limit constant + zod schemas + controller + controller tests.
+6. DI wiring in `lib/container/*`.
+7. `Dialog` primitive + Pattern Registry entry + primitive test.
+8. UI: rating row + report dialog + hook + imperative core; wire into `practice-view` + clients;
+   component tests + browser specs.
+9. Extraction: SQL appendix + `scripts/export-question-feedback.ts`.
+10. Full quality gate, PR, CodeRabbit.
+
+### Suggested PR breakdown (keep each reviewable)
+
+- **PR 1 — Backend slice:** domain → port/fake → use cases → schema/migration → repo → controller →
+  DI → all backend tests. Fully functional via tests; no UI yet.
+- **PR 2 — `Dialog` primitive:** `components/ui/dialog.tsx` + Pattern Registry entry + tests.
+- **PR 3 — UI wiring:** rating row + report dialog + hook + `practice-view`/client wiring + component
+  & browser tests.
+- **PR 4 — Extraction tooling:** export script + SQL docs.
+
+## Edge Cases
+
+- **Quick Practice** has no session → `practiceSessionId = null`.
+- **Attempt id unavailable** client-side → `attemptId = null` (context is best-effort, not required).
+- **Exam mode mid-block:** no explanation shown → no feedback controls; they appear in **session
+  review** (post-submit), consistent with "post-answer only."
+- **Rating retraction:** clicking the active thumb records a `rating` event with `rating = null`;
+  hydration shows no selection.
+- **Double-click / retry:** idempotency key dedupes; append-only means even a slip is harmless.
+- **Empty/whitespace comment:** zod `.trim().min(1)` → treated as absent (optional), not an error.
+- **Comment > 2000 chars:** rejected at zod boundary and by DB CHECK (defense in depth).
+- **Question later archived/deleted:** archived rows keep their FK (feedback persists); a true hard
+  delete cascades (rare by policy).
+- **User deleted (GDPR):** feedback cascades away with the user.
+
+## Out of Scope (v1)
+
+- Admin dashboard / in-app browsing of feedback (no role system yet — future spec).
+- Aggregated quality scores surfaced to learners.
+- **Pre-answer** "this question is broken" reporting (the "always available" timing option). Deferred;
+  the append-only model already supports adding it later with no schema change.
+- Editing or deleting submitted feedback.
+- Notifications/email on new feedback.
+- DEBT-337 explanation-panel enhancements (separate track).
+
+## Related
+
+- Archived **SPEC-014** (Review + Bookmarks) — the architectural template this mirrors.
+- **SPEC-017** (Rate Limiting), **SPEC-016** (Observability) — reused infrastructure.
+- **DEBT-337** (Future Feedback & Practice Session Enhancements) — adjacent, separate.
+- **DEBT-397** (datetime boundary normalization) — new controller adopts ISO-string boundary to avoid
+  re-introducing the issue.
+- `docs/frontend/standards.md`, `docs/frontend/pattern-registry.md` — design-system gates for the new
+  `Dialog` primitive and the action-bar button.

--- a/docs/specs/spec-041-question-feedback.md
+++ b/docs/specs/spec-041-question-feedback.md
@@ -380,10 +380,12 @@ export class SubmitQuestionReportUseCase {
 **Fake** (`src/application/test-helpers/fakes/fake-question-feedback-repository.ts`):
 `export class FakeQuestionFeedbackRepository implements QuestionFeedbackRepository`, backed by an
 in-memory array of events. Mirror the bookmark/attempt fake constructor —
-`constructor(seed: readonly QuestionFeedback[] = [], private readonly now: () => Date = () => new Date())`
-— so `record()` can stamp `id`/`createdAt` while tests can inject deterministic clocks. `record()`
-pushes the shape-correct `NewQuestionFeedback` plus generated persisted fields. `findLatestRatingByUser()`
-filters `kind === 'rating'`, returns the newest by `createdAt DESC, id DESC`, else `null`. Register it
+`constructor(seed: readonly QuestionFeedback[] = [], private readonly now: () => Date = () => new Date(),
+private readonly randomUuid: () => string = () => crypto.randomUUID())`
+— so `record()` can stamp `id`/`createdAt` while tests can inject deterministic clocks and ids.
+`record()` pushes the shape-correct `NewQuestionFeedback` plus generated persisted fields.
+`findLatestRatingByUser()` filters `kind === 'rating'`, returns the newest by `createdAt DESC, id DESC`,
+else `null`. Register it
 in `fakes/index.ts` as a **named** export in alphabetical position (it sorts before
 `FakeQuestionRepository`). The fakes barrel uses `export { FakeX } from './fake-x'`, not `export *`.
 
@@ -448,11 +450,24 @@ export const questionFeedback = pgTable(
       .defaultNow(),
   },
   (t) => ({
+    userCreatedAtIdx: index('question_feedback_user_created_at_idx').on(
+      t.userId,
+      desc(t.createdAt),
+      desc(t.id),
+    ),
     questionCreatedAtIdx: index('question_feedback_question_created_at_idx').on(
       t.questionId,
       desc(t.createdAt),
       desc(t.id),
     ),
+    attemptCreatedAtIdx: index('question_feedback_attempt_created_at_idx').on(
+      t.attemptId,
+      desc(t.createdAt),
+      desc(t.id),
+    ),
+    practiceSessionCreatedAtIdx: index(
+      'question_feedback_practice_session_created_at_idx',
+    ).on(t.practiceSessionId, desc(t.createdAt), desc(t.id)),
     ratingUserQuestionCreatedAtIdx: index(
       'question_feedback_rating_user_question_created_at_idx',
     )
@@ -522,8 +537,9 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_tes
 > **Index rationale:** the partial latest-rating index is deliberately `WHERE kind = 'rating'` because
 > the hot UI read path filters to one user's current rating for one question. `kindCreatedAtIdx`
 > supports recent-report/recent-feedback export slices; `questionCreatedAtIdx` supports per-question
-> audit/export slices. Do not add a current-rating projection table in v1 unless real query plans show
-> the partial index is insufficient.
+> audit/export slices. The `user`/`attempt`/`practiceSession` indexes support parent-side FK
+> cascade/set-null maintenance and future audit slices by context. Do not add a current-rating
+> projection table in v1 unless real query plans show the partial index is insufficient.
 
 #### 3b. Drizzle repo (`src/adapters/repositories/drizzle-question-feedback-repository.ts`)
 
@@ -533,7 +549,8 @@ append-only). `findLatestRatingByUser()` is `findFirst` filtered to `kind='ratin
 domain union via a small `*-mappers.ts`; the mapper must fail closed with
 `ApplicationError('INTERNAL_ERROR', 'Invalid question feedback row')` if a row violates the union
 shape despite the DB `CHECK`. Throw `ApplicationError('INTERNAL_ERROR', ...)` on a missing
-`returning()` row (bookmark pattern).
+`returning()` row (bookmark pattern) and wrap unexpected latest-rating read failures as
+`ApplicationError('INTERNAL_ERROR', 'Failed to load latest question rating', undefined, { cause })`.
 
 #### 3c. Rate limits (`src/adapters/shared/rate-limits.ts`)
 
@@ -806,20 +823,21 @@ Write in dependency order; each layer red before its implementation.
    `newQuestionRatingFeedback` always sets `kind='rating'`, `category=null`, `comment=null`;
    `newQuestionReportFeedback` always sets `kind='report'`, `rating=null`; type-level tests or
    `expectTypeOf` cover that report-only fields are not accepted by the rating constructor.
-2. **Fake repo** — `record()` appends a persisted event; `findLatestRatingByUser()` returns newest
-   rating, uses `id DESC` as the deterministic tie-breaker for equal `createdAt`, ignores reports,
-   returns null when none.
+2. **Fake repo** — `record()` appends a persisted event with injectable clock + id generator;
+   `findLatestRatingByUser()` returns newest rating, uses `id DESC` as the deterministic tie-breaker
+   for equal `createdAt`, ignores reports, returns null when none.
 3. **Use cases** (fakes): `RateQuestion` (NOT_FOUND when question absent; records `rating` event;
    retraction records `rating=null`), `GetQuestionRating` (NOT_FOUND when question absent; latest wins;
    null when none),
    `SubmitQuestionReport` (NOT_FOUND; records `report` event; returns id).
 4. **Drizzle repo** — unit (mocked db chain) + **integration** (`tests/integration/*.integration.test.ts`):
-   real append, row→union mapping, latest-rating query including equal-`createdAt` tie-breaker, and
-   the `kind_shape` / `comment_len` CHECK constraints reject bad rows (rating with comment, report
-   with rating, report without category, overlong comment). Integration tests self-fixture their
-   users/questions — no seed dependency. Add `'question_feedback'` to the
-   `tests/integration/db.integration.test.ts` table census for coverage; note the census asserts
-   `toContain` per table (additive), so omitting it is a coverage gap, not a guaranteed red.
+   real append, row→union mapping, latest-rating query including equal-`createdAt` tie-breaker, read
+   failure wrapping, and the `kind_shape` / `comment_len` CHECK constraints reject bad rows (rating
+   with comment, report with rating, report without category, overlong comment). Integration tests
+   self-fixture their users/questions — no seed dependency. Add `'question_feedback'` to the
+   `tests/integration/db.integration.test.ts` table census and assert the feedback FK-support indexes
+   exist for coverage; note the census asserts `toContain` per table (additive), so omitting it is a
+   coverage gap, not a guaranteed red.
 5. **Controller** (fakes via DI overrides): validation error, unauthenticated, unsubscribed,
    rate-limited, success, `ActionResult` error mapping via `createAction`, idempotency replay (no
    double-write), separate rate-limit keys for rating vs report actions, and the distinct rating/report

--- a/lib/container.test.ts
+++ b/lib/container.test.ts
@@ -13,6 +13,7 @@ import {
   DrizzleIdempotencyKeyRepository,
   DrizzlePendingStripeCancellationRepository,
   DrizzlePracticeSessionRepository,
+  DrizzleQuestionFeedbackRepository,
   DrizzleQuestionRepository,
   DrizzleStripeCustomerRepository,
   DrizzleStripeEventRepository,
@@ -35,9 +36,12 @@ import {
   GetNextQuestionUseCase,
   GetPracticeSessionSummaryUseCase,
   GetPreviousAttemptUseCase,
+  GetQuestionRatingUseCase,
   GetUserStatsUseCase,
+  RateQuestionUseCase,
   StartPracticeSessionUseCase,
   SubmitAnswerUseCase,
+  SubmitQuestionReportUseCase,
   ToggleBookmarkUseCase,
 } from '@/src/application/use-cases';
 import {
@@ -104,6 +108,7 @@ describe('container factories', () => {
       'function',
     );
     expect(typeof container.createPracticeSessionRepository).toBe('function');
+    expect(typeof container.createQuestionFeedbackRepository).toBe('function');
     expect(typeof container.createQuestionRepository).toBe('function');
     expect(typeof container.createTagRepository).toBe('function');
     expect(typeof container.createSubscriptionRepository).toBe('function');
@@ -118,6 +123,9 @@ describe('container factories', () => {
     expect(typeof container.createCheckEntitlementUseCase).toBe('function');
     expect(typeof container.createGetNextQuestionUseCase).toBe('function');
     expect(typeof container.createGetPreviousAttemptUseCase).toBe('function');
+    expect(typeof container.createGetQuestionRatingUseCase).toBe('function');
+    expect(typeof container.createRateQuestionUseCase).toBe('function');
+    expect(typeof container.createSubmitQuestionReportUseCase).toBe('function');
     expect(
       typeof container.createGetCompletedSessionQuestionsWithFeedbackUseCase,
     ).toBe('function');
@@ -137,6 +145,9 @@ describe('container factories', () => {
     expect(typeof container.createQuestionViewControllerDeps).toBe('function');
     expect(typeof container.createBillingControllerDeps).toBe('function');
     expect(typeof container.createBookmarkControllerDeps).toBe('function');
+    expect(typeof container.createQuestionFeedbackControllerDeps).toBe(
+      'function',
+    );
     expect(typeof container.createPracticeControllerDeps).toBe('function');
     expect(typeof container.createReviewControllerDeps).toBe('function');
     expect(typeof container.createStatsControllerDeps).toBe('function');
@@ -180,6 +191,9 @@ describe('container factories', () => {
     ).toBeInstanceOf(DrizzlePendingStripeCancellationRepository);
     expect(container.createPracticeSessionRepository()).toBeInstanceOf(
       DrizzlePracticeSessionRepository,
+    );
+    expect(container.createQuestionFeedbackRepository()).toBeInstanceOf(
+      DrizzleQuestionFeedbackRepository,
     );
     expect(container.createQuestionRepository()).toBeInstanceOf(
       DrizzleQuestionRepository,
@@ -226,6 +240,15 @@ describe('container factories', () => {
     );
     expect(container.createGetBookmarksUseCase()).toBeInstanceOf(
       GetBookmarksUseCase,
+    );
+    expect(container.createGetQuestionRatingUseCase()).toBeInstanceOf(
+      GetQuestionRatingUseCase,
+    );
+    expect(container.createRateQuestionUseCase()).toBeInstanceOf(
+      RateQuestionUseCase,
+    );
+    expect(container.createSubmitQuestionReportUseCase()).toBeInstanceOf(
+      SubmitQuestionReportUseCase,
     );
     expect(
       container.createGetIncompletePracticeSessionUseCase(),
@@ -312,6 +335,27 @@ describe('container factories', () => {
     expect(bookmarkDeps.getBookmarksUseCase).toBeInstanceOf(
       GetBookmarksUseCase,
     );
+
+    const questionFeedbackDeps =
+      container.createQuestionFeedbackControllerDeps();
+    expect(questionFeedbackDeps.authGateway).toBeInstanceOf(ClerkAuthGateway);
+    expect(typeof questionFeedbackDeps.rateLimiter.limit).toBe('function');
+    expect(questionFeedbackDeps.idempotencyKeyRepository).toBeInstanceOf(
+      DrizzleIdempotencyKeyRepository,
+    );
+    expect(questionFeedbackDeps.checkEntitlementUseCase).toBeInstanceOf(
+      CheckEntitlementUseCase,
+    );
+    expect(questionFeedbackDeps.rateQuestionUseCase).toBeInstanceOf(
+      RateQuestionUseCase,
+    );
+    expect(questionFeedbackDeps.getQuestionRatingUseCase).toBeInstanceOf(
+      GetQuestionRatingUseCase,
+    );
+    expect(questionFeedbackDeps.submitQuestionReportUseCase).toBeInstanceOf(
+      SubmitQuestionReportUseCase,
+    );
+    expect(typeof questionFeedbackDeps.now).toBe('function');
 
     const practiceDeps = container.createPracticeControllerDeps();
     expect(practiceDeps.authGateway).toBeInstanceOf(ClerkAuthGateway);

--- a/lib/container/controllers.ts
+++ b/lib/container/controllers.ts
@@ -68,6 +68,17 @@ export function createControllerFactories(input: {
       getBookmarksUseCase: useCases.createGetBookmarksUseCase(),
       now: primitives.now,
     }),
+    createQuestionFeedbackControllerDeps: () => ({
+      authGateway: gateways.createAuthGateway(),
+      logger: primitives.logger,
+      rateLimiter: gateways.createRateLimiter(),
+      idempotencyKeyRepository: repositories.createIdempotencyKeyRepository(),
+      checkEntitlementUseCase: useCases.createCheckEntitlementUseCase(),
+      rateQuestionUseCase: useCases.createRateQuestionUseCase(),
+      getQuestionRatingUseCase: useCases.createGetQuestionRatingUseCase(),
+      submitQuestionReportUseCase: useCases.createSubmitQuestionReportUseCase(),
+      now: primitives.now,
+    }),
     createPracticeControllerDeps: () => ({
       authGateway: gateways.createAuthGateway(),
       logger: primitives.logger,

--- a/lib/container/repositories.ts
+++ b/lib/container/repositories.ts
@@ -6,6 +6,7 @@ import {
   DrizzleIdempotencyKeyRepository,
   DrizzlePendingStripeCancellationRepository,
   DrizzlePracticeSessionRepository,
+  DrizzleQuestionFeedbackRepository,
   DrizzleQuestionRepository,
   DrizzleStripeCustomerRepository,
   DrizzleStripeEventRepository,
@@ -38,6 +39,8 @@ export function createRepositoryFactories(
       new DrizzlePendingStripeCancellationRepository(dbOverride),
     createPracticeSessionRepository: (dbOverride = primitives.db) =>
       new DrizzlePracticeSessionRepository(dbOverride, primitives.now),
+    createQuestionFeedbackRepository: (dbOverride = primitives.db) =>
+      new DrizzleQuestionFeedbackRepository(dbOverride),
     createQuestionRepository: (dbOverride = primitives.db) =>
       new DrizzleQuestionRepository(dbOverride),
     createTagRepository: (dbOverride = primitives.db) =>

--- a/lib/container/types.ts
+++ b/lib/container/types.ts
@@ -2,6 +2,7 @@ import type { BillingControllerDeps } from '@/src/adapters/controllers/billing-c
 import type { BookmarkControllerDeps } from '@/src/adapters/controllers/bookmark-controller';
 import type { PracticeControllerDeps } from '@/src/adapters/controllers/practice-controller';
 import type { QuestionControllerDeps } from '@/src/adapters/controllers/question-controller';
+import type { QuestionFeedbackControllerDeps } from '@/src/adapters/controllers/question-feedback-controller';
 import type { QuestionViewControllerDeps } from '@/src/adapters/controllers/question-view-controller';
 import type { ReviewControllerDeps } from '@/src/adapters/controllers/review-controller';
 import type { StatsControllerDeps } from '@/src/adapters/controllers/stats-controller';
@@ -21,6 +22,7 @@ import type {
   IdempotencyKeyRepository,
   PendingStripeCancellationRepository,
   PracticeSessionRepository,
+  QuestionFeedbackRepository,
   QuestionRepository,
   StripeCustomerRepository,
   StripeEventRepository,
@@ -43,12 +45,15 @@ import type {
   GetPracticeSessionReviewUseCase,
   GetPracticeSessionSummaryUseCase,
   GetPreviousAttemptUseCase,
+  GetQuestionRatingUseCase,
   GetSessionHistoryUseCase,
   GetUserStatsUseCase,
+  RateQuestionUseCase,
   SaveExamDraftAnswerUseCase,
   SetPracticeSessionQuestionMarkUseCase,
   StartPracticeSessionUseCase,
   SubmitAnswerUseCase,
+  SubmitQuestionReportUseCase,
   ToggleBookmarkUseCase,
 } from '@/src/application/use-cases';
 import type { env } from '../env';
@@ -84,6 +89,9 @@ export type RepositoryFactories = {
   createPracticeSessionRepository: (
     dbOverride?: DrizzleDb,
   ) => PracticeSessionRepository;
+  createQuestionFeedbackRepository: (
+    dbOverride?: DrizzleDb,
+  ) => QuestionFeedbackRepository;
   createQuestionRepository: (dbOverride?: DrizzleDb) => QuestionRepository;
   createTagRepository: (dbOverride?: DrizzleDb) => TagRepository;
   createSubscriptionRepository: (
@@ -114,6 +122,9 @@ export type UseCaseFactories = {
   createSaveExamDraftAnswerUseCase: () => SaveExamDraftAnswerUseCase;
   createGetNextQuestionUseCase: () => GetNextQuestionUseCase;
   createGetPreviousAttemptUseCase: () => GetPreviousAttemptUseCase;
+  createGetQuestionRatingUseCase: () => GetQuestionRatingUseCase;
+  createRateQuestionUseCase: () => RateQuestionUseCase;
+  createSubmitQuestionReportUseCase: () => SubmitQuestionReportUseCase;
   createGetBookmarksUseCase: () => GetBookmarksUseCase;
   createGetAttemptedQuestionsUseCase: () => GetAttemptedQuestionsUseCase;
   createGetIncompletePracticeSessionUseCase: () => GetIncompletePracticeSessionUseCase;
@@ -134,6 +145,7 @@ export type ControllerFactories = {
   createQuestionViewControllerDeps: () => QuestionViewControllerDeps;
   createBillingControllerDeps: () => BillingControllerDeps;
   createBookmarkControllerDeps: () => BookmarkControllerDeps;
+  createQuestionFeedbackControllerDeps: () => QuestionFeedbackControllerDeps;
   createPracticeControllerDeps: () => PracticeControllerDeps;
   createReviewControllerDeps: () => ReviewControllerDeps;
   createStatsControllerDeps: () => StatsControllerDeps;

--- a/lib/container/use-cases.ts
+++ b/lib/container/use-cases.ts
@@ -13,12 +13,15 @@ import {
   GetPracticeSessionReviewUseCase,
   GetPracticeSessionSummaryUseCase,
   GetPreviousAttemptUseCase,
+  GetQuestionRatingUseCase,
   GetSessionHistoryUseCase,
   GetUserStatsUseCase,
+  RateQuestionUseCase,
   SaveExamDraftAnswerUseCase,
   SetPracticeSessionQuestionMarkUseCase,
   StartPracticeSessionUseCase,
   SubmitAnswerUseCase,
+  SubmitQuestionReportUseCase,
   ToggleBookmarkUseCase,
 } from '@/src/application/use-cases';
 import type {
@@ -105,6 +108,20 @@ export function createUseCaseFactories(input: {
         repositories.createBookmarkRepository(),
         repositories.createQuestionRepository(),
         primitives.logger,
+      ),
+    createGetQuestionRatingUseCase: () =>
+      new GetQuestionRatingUseCase(
+        repositories.createQuestionFeedbackRepository(),
+      ),
+    createRateQuestionUseCase: () =>
+      new RateQuestionUseCase(
+        repositories.createQuestionFeedbackRepository(),
+        repositories.createQuestionRepository(),
+      ),
+    createSubmitQuestionReportUseCase: () =>
+      new SubmitQuestionReportUseCase(
+        repositories.createQuestionFeedbackRepository(),
+        repositories.createQuestionRepository(),
       ),
     createGetIncompletePracticeSessionUseCase: () =>
       new GetIncompletePracticeSessionUseCase(

--- a/lib/container/use-cases.ts
+++ b/lib/container/use-cases.ts
@@ -112,6 +112,7 @@ export function createUseCaseFactories(input: {
     createGetQuestionRatingUseCase: () =>
       new GetQuestionRatingUseCase(
         repositories.createQuestionFeedbackRepository(),
+        repositories.createQuestionRepository(),
       ),
     createRateQuestionUseCase: () =>
       new RateQuestionUseCase(

--- a/src/adapters/controllers/index.test.ts
+++ b/src/adapters/controllers/index.test.ts
@@ -3,10 +3,13 @@ import {
   createCheckoutSession,
   getNextQuestion,
   getQuestionBySlug,
+  getQuestionRating,
   getTags,
   getUserStats,
   processStripeWebhook,
+  rateQuestion,
   submitAnswer,
+  submitQuestionReport,
   toggleBookmark,
 } from '@/src/adapters/controllers';
 
@@ -15,7 +18,10 @@ describe('controllers exports', () => {
     expect(createCheckoutSession).toBeTypeOf('function');
     expect(getNextQuestion).toBeTypeOf('function');
     expect(getQuestionBySlug).toBeTypeOf('function');
+    expect(getQuestionRating).toBeTypeOf('function');
     expect(submitAnswer).toBeTypeOf('function');
+    expect(rateQuestion).toBeTypeOf('function');
+    expect(submitQuestionReport).toBeTypeOf('function');
     expect(toggleBookmark).toBeTypeOf('function');
     expect(getUserStats).toBeTypeOf('function');
     expect(processStripeWebhook).toBeTypeOf('function');

--- a/src/adapters/controllers/index.ts
+++ b/src/adapters/controllers/index.ts
@@ -4,6 +4,7 @@ export * from './billing-controller';
 export * from './bookmark-controller';
 export * from './practice-controller';
 export * from './question-controller';
+export * from './question-feedback-controller';
 export * from './question-view-controller';
 export * from './review-controller';
 export * from './stats-controller';

--- a/src/adapters/controllers/question-feedback-controller.test.ts
+++ b/src/adapters/controllers/question-feedback-controller.test.ts
@@ -1,0 +1,394 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { ApplicationError } from '@/src/application/errors';
+import {
+  FakeAuthGateway,
+  FakeGetQuestionRatingUseCase,
+  FakeIdempotencyKeyRepository,
+  FakeLogger,
+  FakeRateLimiter,
+  FakeRateQuestionUseCase,
+  FakeSubmitQuestionReportUseCase,
+  FakeSubscriptionRepository,
+} from '@/src/application/test-helpers/fakes';
+import type {
+  GetQuestionRatingOutput,
+  RateQuestionOutput,
+  SubmitQuestionReportOutput,
+} from '@/src/application/use-cases';
+import { CheckEntitlementUseCase } from '@/src/application/use-cases/check-entitlement';
+import type { User } from '@/src/domain/entities';
+import { createSubscription, createUser } from '@/src/domain/test-helpers';
+import {
+  getQuestionRating,
+  type QuestionFeedbackControllerDeps,
+  rateQuestion,
+  submitQuestionReport,
+} from './question-feedback-controller';
+
+const questionId = '11111111-1111-1111-1111-111111111111';
+const attemptId = '22222222-2222-2222-2222-222222222222';
+const practiceSessionId = '33333333-3333-3333-3333-333333333333';
+const idempotencyKey = '44444444-4444-4444-4444-444444444444';
+const feedbackId = '55555555-5555-5555-5555-555555555555';
+
+type QuestionFeedbackControllerTestDeps = QuestionFeedbackControllerDeps & {
+  rateQuestionUseCase: FakeRateQuestionUseCase;
+  getQuestionRatingUseCase: FakeGetQuestionRatingUseCase;
+  submitQuestionReportUseCase: FakeSubmitQuestionReportUseCase;
+  rateLimiter: FakeRateLimiter;
+  _fixtures: {
+    userId: string;
+  };
+};
+
+function createDeps(overrides?: {
+  user?: User | null;
+  isEntitled?: boolean;
+  rateLimitResult?: ConstructorParameters<typeof FakeRateLimiter>[0];
+  rateQuestionOutput?: RateQuestionOutput;
+  rateQuestionThrows?: unknown;
+  getQuestionRatingOutput?: GetQuestionRatingOutput;
+  getQuestionRatingThrows?: unknown;
+  submitQuestionReportOutput?: SubmitQuestionReportOutput;
+  submitQuestionReportThrows?: unknown;
+}): QuestionFeedbackControllerTestDeps {
+  const user =
+    overrides?.user === undefined
+      ? createUser({
+          email: 'user@example.com',
+          createdAt: new Date('2026-02-01T00:00:00Z'),
+          updatedAt: new Date('2026-02-01T00:00:00Z'),
+        })
+      : overrides.user;
+  const userId = user?.id ?? crypto.randomUUID();
+  const now = new Date('2026-02-01T00:00:00Z');
+
+  const subscriptionRepository = new FakeSubscriptionRepository(
+    overrides?.isEntitled === false
+      ? []
+      : [
+          createSubscription({
+            userId,
+            status: 'active',
+            currentPeriodEnd: new Date('2026-12-31T00:00:00Z'),
+          }),
+        ],
+  );
+
+  const rateQuestionUseCase = new FakeRateQuestionUseCase(
+    overrides?.rateQuestionOutput ?? { rating: 'helpful' },
+    overrides?.rateQuestionThrows,
+  );
+  const getQuestionRatingUseCase = new FakeGetQuestionRatingUseCase(
+    overrides?.getQuestionRatingOutput ?? { rating: null },
+    overrides?.getQuestionRatingThrows,
+  );
+  const submitQuestionReportUseCase = new FakeSubmitQuestionReportUseCase(
+    overrides?.submitQuestionReportOutput ?? { feedbackId },
+    overrides?.submitQuestionReportThrows,
+  );
+
+  return {
+    authGateway: new FakeAuthGateway(user),
+    logger: new FakeLogger(),
+    rateLimiter: new FakeRateLimiter(overrides?.rateLimitResult),
+    idempotencyKeyRepository: new FakeIdempotencyKeyRepository(() => now),
+    checkEntitlementUseCase: new CheckEntitlementUseCase(
+      subscriptionRepository,
+      () => now,
+    ),
+    rateQuestionUseCase,
+    getQuestionRatingUseCase,
+    submitQuestionReportUseCase,
+    now: () => now,
+    _fixtures: {
+      userId,
+    },
+  };
+}
+
+describe('question-feedback-controller', () => {
+  describe('rateQuestion', () => {
+    it('returns VALIDATION_ERROR when input is invalid', async () => {
+      const deps = createDeps();
+
+      const result = await rateQuestion({ questionId: 'not-a-uuid' }, deps);
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          fieldErrors: { questionId: expect.any(Array) },
+        },
+      });
+      expect(deps.rateQuestionUseCase.inputs).toEqual([]);
+    });
+
+    it('returns UNAUTHENTICATED when unauthenticated', async () => {
+      const deps = createDeps({ user: null });
+
+      const result = await rateQuestion(
+        { questionId, rating: 'helpful' },
+        deps,
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: 'UNAUTHENTICATED' },
+      });
+      expect(deps.rateQuestionUseCase.inputs).toEqual([]);
+    });
+
+    it('returns UNSUBSCRIBED when not entitled', async () => {
+      const deps = createDeps({ isEntitled: false });
+
+      const result = await rateQuestion(
+        { questionId, rating: 'helpful' },
+        deps,
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: 'UNSUBSCRIBED' },
+      });
+      expect(deps.rateQuestionUseCase.inputs).toEqual([]);
+    });
+
+    it('returns ok and normalizes nullish context ids', async () => {
+      const deps = createDeps({
+        rateQuestionOutput: { rating: 'not_helpful' },
+      });
+
+      const result = await rateQuestion(
+        { questionId, rating: 'not_helpful' },
+        deps,
+      );
+
+      expect(result).toEqual({ ok: true, data: { rating: 'not_helpful' } });
+      expect(deps.rateQuestionUseCase.inputs).toEqual([
+        {
+          userId: deps._fixtures.userId,
+          questionId,
+          attemptId: null,
+          practiceSessionId: null,
+          rating: 'not_helpful',
+        },
+      ]);
+      expect(deps.rateLimiter.inputs).toEqual([
+        {
+          key: `question-feedback:rateQuestion:${deps._fixtures.userId}`,
+          limit: 60,
+          windowMs: 60_000,
+        },
+      ]);
+    });
+
+    it('returns the cached rating result when idempotencyKey is reused', async () => {
+      const deps = createDeps({ rateQuestionOutput: { rating: null } });
+      const input = { questionId, rating: null, idempotencyKey } as const;
+
+      const first = await rateQuestion(input, deps);
+      const second = await rateQuestion(input, deps);
+
+      expect(first).toEqual({ ok: true, data: { rating: null } });
+      expect(second).toEqual(first);
+      expect(deps.rateQuestionUseCase.inputs).toHaveLength(1);
+      expect(deps.rateLimiter.inputs).toHaveLength(1);
+    });
+
+    it('returns RATE_LIMITED when rating limit denies request', async () => {
+      const deps = createDeps({
+        rateLimitResult: {
+          success: false,
+          limit: 60,
+          remaining: 0,
+          retryAfterSeconds: 30,
+        },
+      });
+
+      const result = await rateQuestion(
+        { questionId, rating: 'helpful' },
+        deps,
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: 'RATE_LIMITED' },
+      });
+      expect(deps.rateQuestionUseCase.inputs).toEqual([]);
+      expect(deps.rateLimiter.inputs).toEqual([
+        {
+          key: `question-feedback:rateQuestion:${deps._fixtures.userId}`,
+          limit: 60,
+          windowMs: 60_000,
+        },
+      ]);
+    });
+
+    it('returns NOT_FOUND when the use case throws ApplicationError', async () => {
+      const deps = createDeps({
+        rateQuestionThrows: new ApplicationError(
+          'NOT_FOUND',
+          'Question not found',
+        ),
+      });
+
+      const result = await rateQuestion(
+        { questionId, rating: 'helpful' },
+        deps,
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        error: { code: 'NOT_FOUND', message: 'Question not found' },
+      });
+    });
+
+    it('returns ok when deps are loaded from the container', async () => {
+      const deps = createDeps({ rateQuestionOutput: { rating: 'helpful' } });
+
+      const result = await rateQuestion(
+        { questionId, rating: 'helpful' },
+        undefined,
+        {
+          loadContainer: async () => ({
+            createQuestionFeedbackControllerDeps: () => deps,
+          }),
+        },
+      );
+
+      expect(result).toEqual({ ok: true, data: { rating: 'helpful' } });
+    });
+  });
+
+  describe('getQuestionRating', () => {
+    it('returns current rating without rate limiting', async () => {
+      const deps = createDeps({
+        getQuestionRatingOutput: { rating: 'helpful' },
+      });
+
+      const result = await getQuestionRating({ questionId }, deps);
+
+      expect(result).toEqual({ ok: true, data: { rating: 'helpful' } });
+      expect(deps.getQuestionRatingUseCase.inputs).toEqual([
+        {
+          userId: deps._fixtures.userId,
+          questionId,
+        },
+      ]);
+      expect(deps.rateLimiter.inputs).toEqual([]);
+    });
+
+    it('returns VALIDATION_ERROR when questionId is invalid', async () => {
+      const deps = createDeps();
+
+      const result = await getQuestionRating({ questionId: 'bad' }, deps);
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: 'VALIDATION_ERROR' },
+      });
+      expect(deps.getQuestionRatingUseCase.inputs).toEqual([]);
+    });
+  });
+
+  describe('submitQuestionReport', () => {
+    it('returns VALIDATION_ERROR when category is missing', async () => {
+      const deps = createDeps();
+
+      const result = await submitQuestionReport({ questionId }, deps);
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: 'VALIDATION_ERROR' },
+      });
+      expect(deps.submitQuestionReportUseCase.inputs).toEqual([]);
+    });
+
+    it('returns ok and normalizes blank comments to null', async () => {
+      const deps = createDeps({
+        submitQuestionReportOutput: { feedbackId },
+      });
+
+      const result = await submitQuestionReport(
+        {
+          questionId,
+          attemptId,
+          practiceSessionId,
+          category: 'ambiguous_wording',
+          comment: '   ',
+        },
+        deps,
+      );
+
+      expect(result).toEqual({ ok: true, data: { feedbackId } });
+      expect(deps.submitQuestionReportUseCase.inputs).toEqual([
+        {
+          userId: deps._fixtures.userId,
+          questionId,
+          attemptId,
+          practiceSessionId,
+          category: 'ambiguous_wording',
+          comment: null,
+        },
+      ]);
+      expect(deps.rateLimiter.inputs).toEqual([
+        {
+          key: `question-feedback:submitQuestionReport:${deps._fixtures.userId}`,
+          limit: 10,
+          windowMs: 60_000,
+        },
+      ]);
+    });
+
+    it('returns the cached report result when idempotencyKey is reused', async () => {
+      const deps = createDeps({
+        submitQuestionReportOutput: { feedbackId },
+      });
+      const input = {
+        questionId,
+        category: 'other',
+        comment: 'Looks stale.',
+        idempotencyKey,
+      } as const;
+
+      const first = await submitQuestionReport(input, deps);
+      const second = await submitQuestionReport(input, deps);
+
+      expect(first).toEqual({ ok: true, data: { feedbackId } });
+      expect(second).toEqual(first);
+      expect(deps.submitQuestionReportUseCase.inputs).toHaveLength(1);
+      expect(deps.rateLimiter.inputs).toHaveLength(1);
+    });
+
+    it('returns RATE_LIMITED when report limit denies request', async () => {
+      const deps = createDeps({
+        rateLimitResult: {
+          success: false,
+          limit: 10,
+          remaining: 0,
+          retryAfterSeconds: 30,
+        },
+      });
+
+      const result = await submitQuestionReport(
+        { questionId, category: 'other' },
+        deps,
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: 'RATE_LIMITED' },
+      });
+      expect(deps.submitQuestionReportUseCase.inputs).toEqual([]);
+      expect(deps.rateLimiter.inputs).toEqual([
+        {
+          key: `question-feedback:submitQuestionReport:${deps._fixtures.userId}`,
+          limit: 10,
+          windowMs: 60_000,
+        },
+      ]);
+    });
+  });
+});

--- a/src/adapters/controllers/question-feedback-controller.test.ts
+++ b/src/adapters/controllers/question-feedback-controller.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { MAX_QUESTION_FEEDBACK_COMMENT_LENGTH } from '@/src/adapters/shared/validation-limits';
 import { ApplicationError } from '@/src/application/errors';
 import {
   FakeAuthGateway,
@@ -301,6 +302,28 @@ describe('question-feedback-controller', () => {
       expect(result).toMatchObject({
         ok: false,
         error: { code: 'VALIDATION_ERROR' },
+      });
+      expect(deps.submitQuestionReportUseCase.inputs).toEqual([]);
+    });
+
+    it('returns VALIDATION_ERROR when comment exceeds the feedback comment limit', async () => {
+      const deps = createDeps();
+
+      const result = await submitQuestionReport(
+        {
+          questionId,
+          category: 'other',
+          comment: 'a'.repeat(MAX_QUESTION_FEEDBACK_COMMENT_LENGTH + 1),
+        },
+        deps,
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          fieldErrors: { comment: expect.any(Array) },
+        },
       });
       expect(deps.submitQuestionReportUseCase.inputs).toEqual([]);
     });

--- a/src/adapters/controllers/question-feedback-controller.test.ts
+++ b/src/adapters/controllers/question-feedback-controller.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 import { ApplicationError } from '@/src/application/errors';
 import {

--- a/src/adapters/controllers/question-feedback-controller.ts
+++ b/src/adapters/controllers/question-feedback-controller.ts
@@ -22,19 +22,17 @@ import type {
   SubmitQuestionReportInput,
   SubmitQuestionReportOutput,
 } from '@/src/application/use-cases';
+import {
+  AllQuestionFeedbackCategories,
+  AllQuestionFeedbackRatings,
+} from '@/src/domain/value-objects';
 import { createAction } from './create-action';
 import type { CheckEntitlementUseCase } from './require-entitled-user-id';
 import { requireEntitledUserId } from './require-entitled-user-id';
 import { executeIdempotent } from './shared/execute-idempotent';
 
-const zRating = z.enum(['helpful', 'not_helpful']);
-const zCategory = z.enum([
-  'incorrect_answer',
-  'ambiguous_wording',
-  'typo_formatting',
-  'outdated_reference',
-  'other',
-]);
+const zRating = z.enum(AllQuestionFeedbackRatings);
+const zCategory = z.enum(AllQuestionFeedbackCategories);
 const zOptionalComment = z.preprocess(
   (value) =>
     typeof value === 'string' && value.trim().length === 0 ? undefined : value,

--- a/src/adapters/controllers/question-feedback-controller.ts
+++ b/src/adapters/controllers/question-feedback-controller.ts
@@ -6,6 +6,7 @@ import {
   QUESTION_RATING_RATE_LIMIT,
   QUESTION_REPORT_RATE_LIMIT,
 } from '@/src/adapters/shared/rate-limits';
+import { MAX_QUESTION_FEEDBACK_COMMENT_LENGTH } from '@/src/adapters/shared/validation-limits';
 import { zUuid } from '@/src/adapters/shared/zod-schemas';
 import { ApplicationError } from '@/src/application/errors';
 import type {
@@ -36,7 +37,7 @@ const zCategory = z.enum(AllQuestionFeedbackCategories);
 const zOptionalComment = z.preprocess(
   (value) =>
     typeof value === 'string' && value.trim().length === 0 ? undefined : value,
-  z.string().trim().min(1).max(2000).optional(),
+  z.string().trim().min(1).max(MAX_QUESTION_FEEDBACK_COMMENT_LENGTH).optional(),
 );
 
 const RateQuestionInputSchema = z

--- a/src/adapters/controllers/question-feedback-controller.ts
+++ b/src/adapters/controllers/question-feedback-controller.ts
@@ -1,0 +1,215 @@
+'use server';
+
+import { z } from 'zod';
+import { createDepsResolver, loadAppContainer } from '@/lib/controller-helpers';
+import {
+  QUESTION_RATING_RATE_LIMIT,
+  QUESTION_REPORT_RATE_LIMIT,
+} from '@/src/adapters/shared/rate-limits';
+import { zUuid } from '@/src/adapters/shared/zod-schemas';
+import { ApplicationError } from '@/src/application/errors';
+import type {
+  AuthGateway,
+  RateLimiter,
+} from '@/src/application/ports/gateways';
+import type { Logger } from '@/src/application/ports/logger';
+import type { IdempotencyKeyRepository } from '@/src/application/ports/repositories';
+import type {
+  GetQuestionRatingInput,
+  GetQuestionRatingOutput,
+  RateQuestionInput,
+  RateQuestionOutput,
+  SubmitQuestionReportInput,
+  SubmitQuestionReportOutput,
+} from '@/src/application/use-cases';
+import { createAction } from './create-action';
+import type { CheckEntitlementUseCase } from './require-entitled-user-id';
+import { requireEntitledUserId } from './require-entitled-user-id';
+import { executeIdempotent } from './shared/execute-idempotent';
+
+const zRating = z.enum(['helpful', 'not_helpful']);
+const zCategory = z.enum([
+  'incorrect_answer',
+  'ambiguous_wording',
+  'typo_formatting',
+  'outdated_reference',
+  'other',
+]);
+const zOptionalComment = z.preprocess(
+  (value) =>
+    typeof value === 'string' && value.trim().length === 0 ? undefined : value,
+  z.string().trim().min(1).max(2000).optional(),
+);
+
+const RateQuestionInputSchema = z
+  .object({
+    questionId: zUuid,
+    attemptId: zUuid.nullish(),
+    practiceSessionId: zUuid.nullish(),
+    rating: zRating.nullable(),
+    idempotencyKey: zUuid.optional(),
+  })
+  .strict();
+
+const GetQuestionRatingInputSchema = z
+  .object({
+    questionId: zUuid,
+  })
+  .strict();
+
+const SubmitQuestionReportInputSchema = z
+  .object({
+    questionId: zUuid,
+    attemptId: zUuid.nullish(),
+    practiceSessionId: zUuid.nullish(),
+    category: zCategory,
+    comment: zOptionalComment,
+    idempotencyKey: zUuid.optional(),
+  })
+  .strict();
+
+const RateQuestionOutputSchema = z
+  .object({
+    rating: zRating.nullable(),
+  })
+  .strict();
+
+const GetQuestionRatingOutputSchema = RateQuestionOutputSchema;
+
+const SubmitQuestionReportOutputSchema = z
+  .object({
+    feedbackId: zUuid,
+  })
+  .strict();
+
+export type {
+  GetQuestionRatingOutput,
+  RateQuestionOutput,
+  SubmitQuestionReportOutput,
+} from '@/src/application/use-cases';
+
+export type QuestionFeedbackControllerDeps = {
+  authGateway: AuthGateway;
+  logger: Logger;
+  rateLimiter: RateLimiter;
+  idempotencyKeyRepository: IdempotencyKeyRepository;
+  checkEntitlementUseCase: CheckEntitlementUseCase;
+  rateQuestionUseCase: {
+    execute: (input: RateQuestionInput) => Promise<RateQuestionOutput>;
+  };
+  getQuestionRatingUseCase: {
+    execute: (
+      input: GetQuestionRatingInput,
+    ) => Promise<GetQuestionRatingOutput>;
+  };
+  submitQuestionReportUseCase: {
+    execute: (
+      input: SubmitQuestionReportInput,
+    ) => Promise<SubmitQuestionReportOutput>;
+  };
+  now: () => Date;
+};
+
+type QuestionFeedbackControllerContainer = {
+  createQuestionFeedbackControllerDeps: () => QuestionFeedbackControllerDeps;
+};
+
+const getDeps = createDepsResolver<
+  QuestionFeedbackControllerDeps,
+  QuestionFeedbackControllerContainer
+>(
+  (container) => container.createQuestionFeedbackControllerDeps(),
+  loadAppContainer,
+);
+
+export const rateQuestion = createAction({
+  schema: RateQuestionInputSchema,
+  getDeps,
+  execute: async (input, d, meta) => {
+    const userId = await requireEntitledUserId(d, meta);
+    const { idempotencyKey } = input;
+
+    async function rate(): Promise<RateQuestionOutput> {
+      const rateLimit = await d.rateLimiter.limit({
+        key: `question-feedback:rateQuestion:${userId}`,
+        ...QUESTION_RATING_RATE_LIMIT,
+      });
+      if (!rateLimit.success) {
+        throw new ApplicationError(
+          'RATE_LIMITED',
+          `Too many question ratings. Try again in ${rateLimit.retryAfterSeconds}s.`,
+        );
+      }
+
+      return d.rateQuestionUseCase.execute({
+        userId,
+        questionId: input.questionId,
+        attemptId: input.attemptId ?? null,
+        practiceSessionId: input.practiceSessionId ?? null,
+        rating: input.rating,
+      });
+    }
+
+    return executeIdempotent({
+      d,
+      userId,
+      action: 'question-feedback:rateQuestion',
+      idempotencyKey,
+      outputSchema: RateQuestionOutputSchema,
+      execute: rate,
+    });
+  },
+});
+
+export const getQuestionRating = createAction({
+  schema: GetQuestionRatingInputSchema,
+  getDeps,
+  execute: async (input, d, meta) => {
+    const userId = await requireEntitledUserId(d, meta);
+    const output = await d.getQuestionRatingUseCase.execute({
+      userId,
+      questionId: input.questionId,
+    });
+    return GetQuestionRatingOutputSchema.parse(output);
+  },
+});
+
+export const submitQuestionReport = createAction({
+  schema: SubmitQuestionReportInputSchema,
+  getDeps,
+  execute: async (input, d, meta) => {
+    const userId = await requireEntitledUserId(d, meta);
+    const { idempotencyKey } = input;
+
+    async function submit(): Promise<SubmitQuestionReportOutput> {
+      const rateLimit = await d.rateLimiter.limit({
+        key: `question-feedback:submitQuestionReport:${userId}`,
+        ...QUESTION_REPORT_RATE_LIMIT,
+      });
+      if (!rateLimit.success) {
+        throw new ApplicationError(
+          'RATE_LIMITED',
+          `Too many question reports. Try again in ${rateLimit.retryAfterSeconds}s.`,
+        );
+      }
+
+      return d.submitQuestionReportUseCase.execute({
+        userId,
+        questionId: input.questionId,
+        attemptId: input.attemptId ?? null,
+        practiceSessionId: input.practiceSessionId ?? null,
+        category: input.category,
+        comment: input.comment ?? null,
+      });
+    }
+
+    return executeIdempotent({
+      d,
+      userId,
+      action: 'question-feedback:submitQuestionReport',
+      idempotencyKey,
+      outputSchema: SubmitQuestionReportOutputSchema,
+      execute: submit,
+    });
+  },
+});

--- a/src/adapters/repositories/drizzle-question-feedback-repository.test.ts
+++ b/src/adapters/repositories/drizzle-question-feedback-repository.test.ts
@@ -1,0 +1,221 @@
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { describe, expect, it, vi } from 'vitest';
+import { ApplicationError } from '@/src/application/errors';
+import {
+  newQuestionRatingFeedback,
+  newQuestionReportFeedback,
+} from '@/src/domain/entities';
+import { DrizzleQuestionFeedbackRepository } from './drizzle-question-feedback-repository';
+
+type RepoDb = ConstructorParameters<
+  typeof DrizzleQuestionFeedbackRepository
+>[0];
+
+const userId = crypto.randomUUID();
+const questionId = crypto.randomUUID();
+
+function createDbMock() {
+  const insertReturning = vi.fn();
+  const insertValues = vi.fn(() => ({ returning: insertReturning }));
+  const insert = vi.fn(() => ({ values: insertValues }));
+  const queryFindFirst = vi.fn();
+
+  return {
+    insert,
+    query: {
+      questionFeedback: {
+        findFirst: queryFindFirst,
+      },
+    },
+    _mocks: {
+      insertReturning,
+      insertValues,
+      queryFindFirst,
+    },
+  } as const;
+}
+
+describe('DrizzleQuestionFeedbackRepository', () => {
+  describe('record', () => {
+    it('inserts and maps a rating event', async () => {
+      const db = createDbMock();
+      const createdAt = new Date('2026-02-10T00:00:00.000Z');
+      db._mocks.insertReturning.mockResolvedValue([
+        {
+          id: 'feedback-1',
+          userId,
+          questionId,
+          attemptId: 'attempt-1',
+          practiceSessionId: 'session-1',
+          kind: 'rating',
+          rating: 'helpful',
+          category: null,
+          comment: null,
+          createdAt,
+        },
+      ]);
+      const repo = new DrizzleQuestionFeedbackRepository(
+        db as unknown as RepoDb,
+      );
+
+      await expect(
+        repo.record(
+          newQuestionRatingFeedback({
+            userId,
+            questionId,
+            attemptId: 'attempt-1',
+            practiceSessionId: 'session-1',
+            rating: 'helpful',
+          }),
+        ),
+      ).resolves.toEqual({
+        id: 'feedback-1',
+        userId,
+        questionId,
+        attemptId: 'attempt-1',
+        practiceSessionId: 'session-1',
+        kind: 'rating',
+        rating: 'helpful',
+        category: null,
+        comment: null,
+        createdAt,
+      });
+      expect(db._mocks.insertValues).toHaveBeenCalledWith({
+        userId,
+        questionId,
+        attemptId: 'attempt-1',
+        practiceSessionId: 'session-1',
+        kind: 'rating',
+        rating: 'helpful',
+        category: null,
+        comment: null,
+      });
+    });
+
+    it('inserts and maps a report event', async () => {
+      const db = createDbMock();
+      const createdAt = new Date('2026-02-10T00:00:00.000Z');
+      db._mocks.insertReturning.mockResolvedValue([
+        {
+          id: 'feedback-1',
+          userId,
+          questionId,
+          attemptId: null,
+          practiceSessionId: null,
+          kind: 'report',
+          rating: null,
+          category: 'incorrect_answer',
+          comment: 'The keyed answer appears wrong.',
+          createdAt,
+        },
+      ]);
+      const repo = new DrizzleQuestionFeedbackRepository(
+        db as unknown as RepoDb,
+      );
+
+      await expect(
+        repo.record(
+          newQuestionReportFeedback({
+            userId,
+            questionId,
+            attemptId: null,
+            practiceSessionId: null,
+            category: 'incorrect_answer',
+            comment: 'The keyed answer appears wrong.',
+          }),
+        ),
+      ).resolves.toEqual({
+        id: 'feedback-1',
+        userId,
+        questionId,
+        attemptId: null,
+        practiceSessionId: null,
+        kind: 'report',
+        rating: null,
+        category: 'incorrect_answer',
+        comment: 'The keyed answer appears wrong.',
+        createdAt,
+      });
+    });
+
+    it('throws INTERNAL_ERROR when insert returns no rows', async () => {
+      const db = createDbMock();
+      db._mocks.insertReturning.mockResolvedValue([]);
+      const repo = new DrizzleQuestionFeedbackRepository(
+        db as unknown as RepoDb,
+      );
+
+      const promise = repo.record(
+        newQuestionRatingFeedback({
+          userId,
+          questionId,
+          attemptId: null,
+          practiceSessionId: null,
+          rating: 'helpful',
+        }),
+      );
+
+      await expect(promise).rejects.toBeInstanceOf(ApplicationError);
+      await expect(promise).rejects.toMatchObject({ code: 'INTERNAL_ERROR' });
+    });
+  });
+
+  describe('findLatestRatingByUser', () => {
+    it('returns null when no rating exists', async () => {
+      const db = createDbMock();
+      db._mocks.queryFindFirst.mockResolvedValue(null);
+      const repo = new DrizzleQuestionFeedbackRepository(
+        db as unknown as RepoDb,
+      );
+
+      await expect(
+        repo.findLatestRatingByUser(userId, questionId),
+      ).resolves.toBeNull();
+    });
+
+    it('maps the latest rating row and orders by createdAt then id descending', async () => {
+      const db = createDbMock();
+      const createdAt = new Date('2026-02-10T00:00:00.000Z');
+      db._mocks.queryFindFirst.mockResolvedValue({
+        id: 'feedback-1',
+        userId,
+        questionId,
+        attemptId: null,
+        practiceSessionId: null,
+        kind: 'rating',
+        rating: null,
+        category: null,
+        comment: null,
+        createdAt,
+      });
+      const repo = new DrizzleQuestionFeedbackRepository(
+        db as unknown as RepoDb,
+      );
+
+      await expect(
+        repo.findLatestRatingByUser(userId, questionId),
+      ).resolves.toEqual({
+        id: 'feedback-1',
+        userId,
+        questionId,
+        attemptId: null,
+        practiceSessionId: null,
+        kind: 'rating',
+        rating: null,
+        category: null,
+        comment: null,
+        createdAt,
+      });
+
+      const queryArgs = db._mocks.queryFindFirst.mock.calls[0]?.[0];
+      const orderBy = queryArgs?.orderBy;
+      expect(orderBy).toHaveLength(2);
+      const orderSql = (orderBy as SQL[]).map(
+        (clause) => new PgDialect().sqlToQuery(clause).sql,
+      );
+      expect(orderSql[0]).toMatch(/"question_feedback"\."created_at"\s+desc/i);
+      expect(orderSql[1]).toMatch(/"question_feedback"\."id"\s+desc/i);
+    });
+  });
+});

--- a/src/adapters/repositories/drizzle-question-feedback-repository.test.ts
+++ b/src/adapters/repositories/drizzle-question-feedback-repository.test.ts
@@ -217,5 +217,23 @@ describe('DrizzleQuestionFeedbackRepository', () => {
       expect(orderSql[0]).toMatch(/"question_feedback"\."created_at"\s+desc/i);
       expect(orderSql[1]).toMatch(/"question_feedback"\."id"\s+desc/i);
     });
+
+    it('throws INTERNAL_ERROR when the latest-rating read fails', async () => {
+      const db = createDbMock();
+      const dbError = new Error('db down');
+      db._mocks.queryFindFirst.mockRejectedValue(dbError);
+      const repo = new DrizzleQuestionFeedbackRepository(
+        db as unknown as RepoDb,
+      );
+
+      const promise = repo.findLatestRatingByUser(userId, questionId);
+
+      await expect(promise).rejects.toBeInstanceOf(ApplicationError);
+      await expect(promise).rejects.toMatchObject({
+        code: 'INTERNAL_ERROR',
+        message: 'Failed to load latest question rating',
+        cause: dbError,
+      });
+    });
   });
 });

--- a/src/adapters/repositories/drizzle-question-feedback-repository.ts
+++ b/src/adapters/repositories/drizzle-question-feedback-repository.ts
@@ -53,14 +53,24 @@ export class DrizzleQuestionFeedbackRepository
     userId: string,
     questionId: string,
   ): Promise<QuestionRatingFeedback | null> {
-    const row = await this.db.query.questionFeedback.findFirst({
-      where: and(
-        eq(questionFeedback.userId, userId),
-        eq(questionFeedback.questionId, questionId),
-        eq(questionFeedback.kind, 'rating'),
-      ),
-      orderBy: [desc(questionFeedback.createdAt), desc(questionFeedback.id)],
-    });
+    let row: (typeof questionFeedback)['$inferSelect'] | undefined;
+    try {
+      row = await this.db.query.questionFeedback.findFirst({
+        where: and(
+          eq(questionFeedback.userId, userId),
+          eq(questionFeedback.questionId, questionId),
+          eq(questionFeedback.kind, 'rating'),
+        ),
+        orderBy: [desc(questionFeedback.createdAt), desc(questionFeedback.id)],
+      });
+    } catch (error) {
+      throw new ApplicationError(
+        'INTERNAL_ERROR',
+        'Failed to load latest question rating',
+        undefined,
+        { cause: error },
+      );
+    }
 
     if (!row) return null;
 

--- a/src/adapters/repositories/drizzle-question-feedback-repository.ts
+++ b/src/adapters/repositories/drizzle-question-feedback-repository.ts
@@ -1,0 +1,77 @@
+import { and, desc, eq } from 'drizzle-orm';
+import { questionFeedback } from '@/db/schema';
+import { ApplicationError } from '@/src/application/errors';
+import type { QuestionFeedbackRepository } from '@/src/application/ports/repositories';
+import type {
+  NewQuestionFeedback,
+  QuestionRatingFeedback,
+} from '@/src/domain/entities';
+import type { DrizzleDb } from '../shared/database-types';
+import { toQuestionFeedbackDomain } from './question-feedback-row-mappers';
+
+export class DrizzleQuestionFeedbackRepository
+  implements QuestionFeedbackRepository
+{
+  constructor(private readonly db: DrizzleDb) {}
+
+  async record(event: NewQuestionFeedback) {
+    let row: (typeof questionFeedback)['$inferSelect'] | undefined;
+    try {
+      [row] = await this.db
+        .insert(questionFeedback)
+        .values({
+          userId: event.userId,
+          questionId: event.questionId,
+          attemptId: event.attemptId,
+          practiceSessionId: event.practiceSessionId,
+          kind: event.kind,
+          rating: event.rating,
+          category: event.category,
+          comment: event.comment,
+        })
+        .returning();
+    } catch (error) {
+      throw new ApplicationError(
+        'INTERNAL_ERROR',
+        'Failed to insert question feedback',
+        undefined,
+        { cause: error },
+      );
+    }
+
+    if (!row) {
+      throw new ApplicationError(
+        'INTERNAL_ERROR',
+        'Failed to insert question feedback',
+      );
+    }
+
+    return toQuestionFeedbackDomain(row);
+  }
+
+  async findLatestRatingByUser(
+    userId: string,
+    questionId: string,
+  ): Promise<QuestionRatingFeedback | null> {
+    const row = await this.db.query.questionFeedback.findFirst({
+      where: and(
+        eq(questionFeedback.userId, userId),
+        eq(questionFeedback.questionId, questionId),
+        eq(questionFeedback.kind, 'rating'),
+      ),
+      orderBy: [desc(questionFeedback.createdAt), desc(questionFeedback.id)],
+    });
+
+    if (!row) return null;
+
+    const mapped = toQuestionFeedbackDomain(row);
+    if (mapped.kind !== 'rating') {
+      throw new ApplicationError(
+        'INTERNAL_ERROR',
+        'Invalid question feedback row',
+      );
+    }
+
+    return mapped;
+  }
+}

--- a/src/adapters/repositories/index.test.ts
+++ b/src/adapters/repositories/index.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { DrizzleUserRepository } from '@/src/adapters/repositories';
+import {
+  DrizzleQuestionFeedbackRepository,
+  DrizzleUserRepository,
+} from '@/src/adapters/repositories';
 
 describe('repositories exports', () => {
-  it('exports DrizzleUserRepository from the barrel', () => {
+  it('exports repositories from the barrel', () => {
+    expect(DrizzleQuestionFeedbackRepository).toBeTypeOf('function');
     expect(DrizzleUserRepository).toBeTypeOf('function');
   });
 });

--- a/src/adapters/repositories/index.ts
+++ b/src/adapters/repositories/index.ts
@@ -5,6 +5,7 @@ export { DrizzleDeletedClerkUserRepository } from './drizzle-deleted-clerk-user-
 export { DrizzleIdempotencyKeyRepository } from './drizzle-idempotency-key-repository';
 export { DrizzlePendingStripeCancellationRepository } from './drizzle-pending-stripe-cancellation-repository';
 export { DrizzlePracticeSessionRepository } from './drizzle-practice-session-repository';
+export { DrizzleQuestionFeedbackRepository } from './drizzle-question-feedback-repository';
 export { DrizzleQuestionRepository } from './drizzle-question-repository';
 export { DrizzleStripeCustomerRepository } from './drizzle-stripe-customer-repository';
 export { DrizzleStripeEventRepository } from './drizzle-stripe-event-repository';

--- a/src/adapters/repositories/question-feedback-row-mappers.ts
+++ b/src/adapters/repositories/question-feedback-row-mappers.ts
@@ -1,0 +1,54 @@
+import type { QuestionFeedback as QuestionFeedbackRow } from '@/db/schema';
+import { ApplicationError } from '@/src/application/errors';
+import type {
+  QuestionFeedback,
+  QuestionRatingFeedback,
+  QuestionReportFeedback,
+} from '@/src/domain/entities';
+
+export function toQuestionFeedbackDomain(
+  row: QuestionFeedbackRow,
+): QuestionFeedback {
+  if (row.kind === 'rating') {
+    if (row.category !== null || row.comment !== null) {
+      throw invalidQuestionFeedbackRow();
+    }
+
+    return {
+      id: row.id,
+      userId: row.userId,
+      questionId: row.questionId,
+      attemptId: row.attemptId,
+      practiceSessionId: row.practiceSessionId,
+      kind: 'rating',
+      rating: row.rating,
+      category: null,
+      comment: null,
+      createdAt: row.createdAt,
+    } satisfies QuestionRatingFeedback;
+  }
+
+  if (row.rating !== null || row.category === null) {
+    throw invalidQuestionFeedbackRow();
+  }
+
+  return {
+    id: row.id,
+    userId: row.userId,
+    questionId: row.questionId,
+    attemptId: row.attemptId,
+    practiceSessionId: row.practiceSessionId,
+    kind: 'report',
+    rating: null,
+    category: row.category,
+    comment: row.comment,
+    createdAt: row.createdAt,
+  } satisfies QuestionReportFeedback;
+}
+
+function invalidQuestionFeedbackRow(): ApplicationError {
+  return new ApplicationError(
+    'INTERNAL_ERROR',
+    'Invalid question feedback row',
+  );
+}

--- a/src/adapters/shared/rate-limits.test.ts
+++ b/src/adapters/shared/rate-limits.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ONE_MINUTE_MS,
+  QUESTION_RATING_RATE_LIMIT,
+  QUESTION_REPORT_RATE_LIMIT,
+} from './rate-limits';
+
+describe('question feedback rate limits', () => {
+  it('allows lightweight rating actions at bookmark-toggle scale', () => {
+    expect(QUESTION_RATING_RATE_LIMIT).toEqual({
+      limit: 60,
+      windowMs: ONE_MINUTE_MS,
+    });
+  });
+
+  it('uses a tighter limit for free-text reports', () => {
+    expect(QUESTION_REPORT_RATE_LIMIT).toEqual({
+      limit: 10,
+      windowMs: ONE_MINUTE_MS,
+    });
+  });
+});

--- a/src/adapters/shared/rate-limits.ts
+++ b/src/adapters/shared/rate-limits.ts
@@ -44,6 +44,16 @@ export const BOOKMARK_MUTATION_RATE_LIMIT = {
   windowMs: ONE_MINUTE_MS,
 } as const;
 
+export const QUESTION_RATING_RATE_LIMIT = {
+  limit: 60,
+  windowMs: ONE_MINUTE_MS,
+} as const;
+
+export const QUESTION_REPORT_RATE_LIMIT = {
+  limit: 10,
+  windowMs: ONE_MINUTE_MS,
+} as const;
+
 export const HEALTH_CHECK_RATE_LIMIT = {
   limit: 600,
   windowMs: ONE_MINUTE_MS,

--- a/src/adapters/shared/validation-limits.ts
+++ b/src/adapters/shared/validation-limits.ts
@@ -39,5 +39,8 @@ export const MAX_PRACTICE_SESSION_TAG_FILTERS = 50;
 /** Max length for tag slugs (matches db/schema.ts tags.slug varchar length). */
 export const MAX_TAG_SLUG_LENGTH = 255;
 
+/** Max length for question feedback report comments (matches db/schema.ts CHECK). */
+export const MAX_QUESTION_FEEDBACK_COMMENT_LENGTH = 2_000;
+
 /** Max difficulty filters per practice session (easy/medium/hard). */
 export const MAX_PRACTICE_SESSION_DIFFICULTY_FILTERS = 3;

--- a/src/application/ports/question-feedback-repository.ts
+++ b/src/application/ports/question-feedback-repository.ts
@@ -1,0 +1,17 @@
+import type {
+  NewQuestionFeedback,
+  QuestionFeedback,
+  QuestionRatingFeedback,
+} from '@/src/domain/entities';
+
+export interface QuestionFeedbackRepository {
+  record(event: NewQuestionFeedback): Promise<QuestionFeedback>;
+  /**
+   * Latest rating-kind event for (user, question); null if none.
+   * Drives thumbs-up/thumbs-down hydration.
+   */
+  findLatestRatingByUser(
+    userId: string,
+    questionId: string,
+  ): Promise<QuestionRatingFeedback | null>;
+}

--- a/src/application/ports/repositories.ts
+++ b/src/application/ports/repositories.ts
@@ -5,6 +5,7 @@ export * from './deleted-clerk-user-repository';
 export * from './idempotency-key-repository';
 export * from './pending-stripe-cancellation-repository';
 export * from './practice-session-repository';
+export * from './question-feedback-repository';
 export * from './question-repository';
 export * from './stripe-customer-repository';
 export * from './stripe-event-repository';

--- a/src/application/ports/repository-port-modules.test.ts
+++ b/src/application/ports/repository-port-modules.test.ts
@@ -6,6 +6,7 @@ import type { DeletedClerkUserRepository } from './deleted-clerk-user-repository
 import type { IdempotencyKeyRepository } from './idempotency-key-repository';
 import type { PendingStripeCancellationRepository } from './pending-stripe-cancellation-repository';
 import type { PracticeSessionRepository } from './practice-session-repository';
+import type { QuestionFeedbackRepository } from './question-feedback-repository';
 import type { QuestionRepository } from './question-repository';
 import type {
   AttemptRepository as AttemptRepositoryFromBarrel,
@@ -15,6 +16,7 @@ import type {
   IdempotencyKeyRepository as IdempotencyKeyRepositoryFromBarrel,
   PendingStripeCancellationRepository as PendingStripeCancellationRepositoryFromBarrel,
   PracticeSessionRepository as PracticeSessionRepositoryFromBarrel,
+  QuestionFeedbackRepository as QuestionFeedbackRepositoryFromBarrel,
   QuestionRepository as QuestionRepositoryFromBarrel,
   StripeCustomerRepository as StripeCustomerRepositoryFromBarrel,
   StripeEventRepository as StripeEventRepositoryFromBarrel,
@@ -38,6 +40,7 @@ describe('repository port modules', () => {
     expectTypeOf<DeletedClerkUserRepositoryFromBarrel>().toEqualTypeOf<DeletedClerkUserRepository>();
     expectTypeOf<PendingStripeCancellationRepositoryFromBarrel>().toEqualTypeOf<PendingStripeCancellationRepository>();
     expectTypeOf<TagRepositoryFromBarrel>().toEqualTypeOf<TagRepository>();
+    expectTypeOf<QuestionFeedbackRepositoryFromBarrel>().toEqualTypeOf<QuestionFeedbackRepository>();
     expectTypeOf<SubscriptionRepositoryFromBarrel>().toEqualTypeOf<SubscriptionRepository>();
     expectTypeOf<StripeCustomerRepositoryFromBarrel>().toEqualTypeOf<StripeCustomerRepository>();
     expectTypeOf<StripeEventRepositoryFromBarrel>().toEqualTypeOf<StripeEventRepository>();

--- a/src/application/test-helpers/fakes/fake-question-feedback-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-question-feedback-repository.test.ts
@@ -36,6 +36,38 @@ describe('FakeQuestionFeedbackRepository', () => {
       });
     });
 
+    it('uses the injected id generator for persisted events', async () => {
+      const createdAt = new Date('2026-02-10T00:00:00.000Z');
+      const ids = ['feedback-1', 'feedback-2'];
+      const repo = new FakeQuestionFeedbackRepository(
+        [],
+        () => createdAt,
+        () => ids.shift() ?? 'feedback-fallback',
+      );
+
+      const first = await repo.record(
+        newQuestionRatingFeedback({
+          userId: 'user-1',
+          questionId: 'question-1',
+          attemptId: null,
+          practiceSessionId: null,
+          rating: 'helpful',
+        }),
+      );
+      const second = await repo.record(
+        newQuestionRatingFeedback({
+          userId: 'user-1',
+          questionId: 'question-1',
+          attemptId: null,
+          practiceSessionId: null,
+          rating: 'not_helpful',
+        }),
+      );
+
+      expect(first.id).toBe('feedback-1');
+      expect(second.id).toBe('feedback-2');
+    });
+
     it('appends a new event for each call', async () => {
       const times = [
         new Date('2026-02-10T00:00:00.000Z'),

--- a/src/application/test-helpers/fakes/fake-question-feedback-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-question-feedback-repository.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import { newQuestionRatingFeedback } from '@/src/domain/entities';
+import {
+  createQuestionRatingFeedback,
+  createQuestionReportFeedback,
+} from '@/src/domain/test-helpers';
+import { FakeQuestionFeedbackRepository } from './fake-question-feedback-repository';
+
+describe('FakeQuestionFeedbackRepository', () => {
+  describe('record', () => {
+    it('appends a persisted rating event', async () => {
+      const createdAt = new Date('2026-02-10T00:00:00.000Z');
+      const repo = new FakeQuestionFeedbackRepository([], () => createdAt);
+
+      const result = await repo.record(
+        newQuestionRatingFeedback({
+          userId: 'user-1',
+          questionId: 'question-1',
+          attemptId: 'attempt-1',
+          practiceSessionId: 'session-1',
+          rating: 'helpful',
+        }),
+      );
+
+      expect(result).toEqual({
+        id: expect.any(String),
+        userId: 'user-1',
+        questionId: 'question-1',
+        attemptId: 'attempt-1',
+        practiceSessionId: 'session-1',
+        kind: 'rating',
+        rating: 'helpful',
+        category: null,
+        comment: null,
+        createdAt,
+      });
+    });
+
+    it('appends a new event for each call', async () => {
+      const times = [
+        new Date('2026-02-10T00:00:00.000Z'),
+        new Date('2026-02-11T00:00:00.000Z'),
+      ];
+      const repo = new FakeQuestionFeedbackRepository(
+        [],
+        () => times.shift() ?? new Date('2026-02-11T00:00:00.000Z'),
+      );
+
+      const first = await repo.record(
+        newQuestionRatingFeedback({
+          userId: 'user-1',
+          questionId: 'question-1',
+          attemptId: null,
+          practiceSessionId: null,
+          rating: 'helpful',
+        }),
+      );
+      const second = await repo.record(
+        newQuestionRatingFeedback({
+          userId: 'user-1',
+          questionId: 'question-1',
+          attemptId: null,
+          practiceSessionId: null,
+          rating: 'not_helpful',
+        }),
+      );
+
+      expect(second.id).not.toBe(first.id);
+      await expect(
+        repo.findLatestRatingByUser('user-1', 'question-1'),
+      ).resolves.toMatchObject({
+        id: second.id,
+        rating: 'not_helpful',
+      });
+    });
+  });
+
+  describe('findLatestRatingByUser', () => {
+    it('returns null when no rating exists', async () => {
+      const repo = new FakeQuestionFeedbackRepository();
+
+      const result = await repo.findLatestRatingByUser('user-1', 'question-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('ignores report events', async () => {
+      const repo = new FakeQuestionFeedbackRepository([
+        createQuestionReportFeedback({
+          userId: 'user-1',
+          questionId: 'question-1',
+          createdAt: new Date('2026-02-10T00:00:00.000Z'),
+        }),
+      ]);
+
+      const result = await repo.findLatestRatingByUser('user-1', 'question-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('filters by user and question', async () => {
+      const repo = new FakeQuestionFeedbackRepository([
+        createQuestionRatingFeedback({
+          id: 'feedback-1',
+          userId: 'user-1',
+          questionId: 'question-2',
+          rating: 'helpful',
+        }),
+        createQuestionRatingFeedback({
+          id: 'feedback-2',
+          userId: 'user-2',
+          questionId: 'question-1',
+          rating: 'not_helpful',
+        }),
+        createQuestionRatingFeedback({
+          id: 'feedback-3',
+          userId: 'user-1',
+          questionId: 'question-1',
+          rating: null,
+        }),
+      ]);
+
+      const result = await repo.findLatestRatingByUser('user-1', 'question-1');
+
+      expect(result).toMatchObject({
+        id: 'feedback-3',
+        rating: null,
+      });
+    });
+
+    it('returns the newest rating by createdAt descending', async () => {
+      const repo = new FakeQuestionFeedbackRepository([
+        createQuestionRatingFeedback({
+          id: 'feedback-old',
+          userId: 'user-1',
+          questionId: 'question-1',
+          rating: 'helpful',
+          createdAt: new Date('2026-02-10T00:00:00.000Z'),
+        }),
+        createQuestionRatingFeedback({
+          id: 'feedback-new',
+          userId: 'user-1',
+          questionId: 'question-1',
+          rating: 'not_helpful',
+          createdAt: new Date('2026-02-11T00:00:00.000Z'),
+        }),
+      ]);
+
+      const result = await repo.findLatestRatingByUser('user-1', 'question-1');
+
+      expect(result).toMatchObject({
+        id: 'feedback-new',
+        rating: 'not_helpful',
+      });
+    });
+
+    it('uses id descending as the deterministic tie-breaker', async () => {
+      const createdAt = new Date('2026-02-10T00:00:00.000Z');
+      const repo = new FakeQuestionFeedbackRepository([
+        createQuestionRatingFeedback({
+          id: '00000000-0000-4000-8000-000000000001',
+          userId: 'user-1',
+          questionId: 'question-1',
+          rating: 'helpful',
+          createdAt,
+        }),
+        createQuestionRatingFeedback({
+          id: '00000000-0000-4000-8000-000000000002',
+          userId: 'user-1',
+          questionId: 'question-1',
+          rating: 'not_helpful',
+          createdAt,
+        }),
+      ]);
+
+      const result = await repo.findLatestRatingByUser('user-1', 'question-1');
+
+      expect(result).toMatchObject({
+        id: '00000000-0000-4000-8000-000000000002',
+        rating: 'not_helpful',
+      });
+    });
+  });
+});

--- a/src/application/test-helpers/fakes/fake-question-feedback-repository.ts
+++ b/src/application/test-helpers/fakes/fake-question-feedback-repository.ts
@@ -15,6 +15,7 @@ export class FakeQuestionFeedbackRepository
   constructor(
     seed: readonly QuestionFeedback[] = [],
     private readonly now: () => Date = () => new Date(),
+    private readonly randomUuid: () => string = () => crypto.randomUUID(),
   ) {
     this.events = [...seed];
   }
@@ -55,7 +56,7 @@ export class FakeQuestionFeedbackRepository
   ): QuestionRatingFeedback {
     return {
       ...event,
-      id: crypto.randomUUID(),
+      id: this.randomUuid(),
       createdAt: this.now(),
     };
   }
@@ -65,7 +66,7 @@ export class FakeQuestionFeedbackRepository
   ): QuestionReportFeedback {
     return {
       ...event,
-      id: crypto.randomUUID(),
+      id: this.randomUuid(),
       createdAt: this.now(),
     };
   }

--- a/src/application/test-helpers/fakes/fake-question-feedback-repository.ts
+++ b/src/application/test-helpers/fakes/fake-question-feedback-repository.ts
@@ -1,0 +1,72 @@
+import type { QuestionFeedbackRepository } from '@/src/application/ports/repositories';
+import type {
+  NewQuestionFeedback,
+  QuestionFeedback,
+  QuestionRatingFeedback,
+  QuestionReportFeedback,
+} from '@/src/domain/entities';
+
+export class FakeQuestionFeedbackRepository
+  implements QuestionFeedbackRepository
+{
+  readonly recordCalls: NewQuestionFeedback[] = [];
+  private events: QuestionFeedback[];
+
+  constructor(
+    seed: readonly QuestionFeedback[] = [],
+    private readonly now: () => Date = () => new Date(),
+  ) {
+    this.events = [...seed];
+  }
+
+  async record(event: NewQuestionFeedback): Promise<QuestionFeedback> {
+    this.recordCalls.push(event);
+
+    const persisted =
+      event.kind === 'rating'
+        ? this.persistRating(event)
+        : this.persistReport(event);
+
+    this.events = [...this.events, persisted];
+    return persisted;
+  }
+
+  async findLatestRatingByUser(
+    userId: string,
+    questionId: string,
+  ): Promise<QuestionRatingFeedback | null> {
+    const matching = this.events.filter(
+      (event): event is QuestionRatingFeedback =>
+        event.kind === 'rating' &&
+        event.userId === userId &&
+        event.questionId === questionId,
+    );
+    if (matching.length === 0) return null;
+
+    return matching.slice().sort((a, b) => {
+      const byDate = b.createdAt.getTime() - a.createdAt.getTime();
+      if (byDate !== 0) return byDate;
+      return b.id.localeCompare(a.id);
+    })[0];
+  }
+
+  private persistRating(
+    event: Extract<NewQuestionFeedback, { kind: 'rating' }>,
+  ): QuestionRatingFeedback {
+    return {
+      ...event,
+      id: crypto.randomUUID(),
+      createdAt: this.now(),
+    };
+  }
+
+  private persistReport(
+    event: Extract<NewQuestionFeedback, { kind: 'report' }>,
+  ): QuestionReportFeedback {
+    return {
+      ...event,
+      id: crypto.randomUUID(),
+      createdAt: this.now(),
+    };
+  }
+}

--- a/src/application/test-helpers/fakes/fake-use-cases.ts
+++ b/src/application/test-helpers/fakes/fake-use-cases.ts
@@ -20,6 +20,18 @@ export class FakeToggleBookmarkUseCase extends FakeUseCase<
   U.ToggleBookmarkInput,
   U.ToggleBookmarkOutput
 > {}
+export class FakeRateQuestionUseCase extends FakeUseCase<
+  U.RateQuestionInput,
+  U.RateQuestionOutput
+> {}
+export class FakeGetQuestionRatingUseCase extends FakeUseCase<
+  U.GetQuestionRatingInput,
+  U.GetQuestionRatingOutput
+> {}
+export class FakeSubmitQuestionReportUseCase extends FakeUseCase<
+  U.SubmitQuestionReportInput,
+  U.SubmitQuestionReportOutput
+> {}
 export class FakeGetBookmarksUseCase extends FakeUseCase<
   U.GetBookmarksInput,
   U.GetBookmarksOutput

--- a/src/application/test-helpers/fakes/index.ts
+++ b/src/application/test-helpers/fakes/index.ts
@@ -11,6 +11,7 @@ export { FakeIdempotencyKeyRepository } from './fake-idempotency-key-repository'
 export { FakeLogger } from './fake-logger';
 export { FakePendingStripeCancellationRepository } from './fake-pending-stripe-cancellation-repository';
 export { FakePracticeSessionRepository } from './fake-practice-session-repository';
+export { FakeQuestionFeedbackRepository } from './fake-question-feedback-repository';
 export { FakeQuestionRepository } from './fake-question-repository';
 export { FakeStripeCustomerRepository } from './fake-stripe-customer-repository';
 export { FakeStripeEventRepository } from './fake-stripe-event-repository';
@@ -30,12 +31,15 @@ export {
   FakeGetNextQuestionUseCase,
   FakeGetPracticeSessionReviewUseCase,
   FakeGetPracticeSessionSummaryUseCase,
+  FakeGetQuestionRatingUseCase,
   FakeGetSessionHistoryUseCase,
   FakeGetUserStatsUseCase,
+  FakeRateQuestionUseCase,
   FakeSaveExamDraftAnswerUseCase,
   FakeSetPracticeSessionQuestionMarkUseCase,
   FakeStartPracticeSessionUseCase,
   FakeSubmitAnswerUseCase,
+  FakeSubmitQuestionReportUseCase,
   FakeToggleBookmarkUseCase,
 } from './fake-use-cases';
 export { FakeUserRepository } from './fake-user-repository';

--- a/src/application/use-cases/get-question-rating.test.ts
+++ b/src/application/use-cases/get-question-rating.test.ts
@@ -1,12 +1,33 @@
 import { describe, expect, it } from 'vitest';
-import { FakeQuestionFeedbackRepository } from '@/src/application/test-helpers/fakes';
-import { createQuestionRatingFeedback } from '@/src/domain/test-helpers';
+import { ApplicationError } from '@/src/application/errors';
+import {
+  FakeQuestionFeedbackRepository,
+  FakeQuestionRepository,
+} from '@/src/application/test-helpers/fakes';
+import {
+  createQuestion,
+  createQuestionRatingFeedback,
+} from '@/src/domain/test-helpers';
 import { GetQuestionRatingUseCase } from './get-question-rating';
 
 describe('GetQuestionRatingUseCase', () => {
+  it('returns NOT_FOUND when the question is missing', async () => {
+    const useCase = new GetQuestionRatingUseCase(
+      new FakeQuestionFeedbackRepository(),
+      new FakeQuestionRepository([]),
+    );
+
+    await expect(
+      useCase.execute({ userId: 'user-1', questionId: 'missing' }),
+    ).rejects.toEqual(new ApplicationError('NOT_FOUND', 'Question not found'));
+  });
+
   it('returns null when no rating exists', async () => {
     const useCase = new GetQuestionRatingUseCase(
       new FakeQuestionFeedbackRepository(),
+      new FakeQuestionRepository([
+        createQuestion({ id: 'question-1', status: 'published' }),
+      ]),
     );
 
     await expect(
@@ -30,6 +51,9 @@ describe('GetQuestionRatingUseCase', () => {
           createdAt: new Date('2026-02-11T00:00:00.000Z'),
         }),
       ]),
+      new FakeQuestionRepository([
+        createQuestion({ id: 'question-1', status: 'published' }),
+      ]),
     );
 
     await expect(
@@ -52,6 +76,9 @@ describe('GetQuestionRatingUseCase', () => {
           rating: null,
           createdAt: new Date('2026-02-11T00:00:00.000Z'),
         }),
+      ]),
+      new FakeQuestionRepository([
+        createQuestion({ id: 'question-1', status: 'published' }),
       ]),
     );
 

--- a/src/application/use-cases/get-question-rating.test.ts
+++ b/src/application/use-cases/get-question-rating.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { FakeQuestionFeedbackRepository } from '@/src/application/test-helpers/fakes';
+import { createQuestionRatingFeedback } from '@/src/domain/test-helpers';
+import { GetQuestionRatingUseCase } from './get-question-rating';
+
+describe('GetQuestionRatingUseCase', () => {
+  it('returns null when no rating exists', async () => {
+    const useCase = new GetQuestionRatingUseCase(
+      new FakeQuestionFeedbackRepository(),
+    );
+
+    await expect(
+      useCase.execute({ userId: 'user-1', questionId: 'question-1' }),
+    ).resolves.toEqual({ rating: null });
+  });
+
+  it('returns the latest rating for the user and question', async () => {
+    const useCase = new GetQuestionRatingUseCase(
+      new FakeQuestionFeedbackRepository([
+        createQuestionRatingFeedback({
+          userId: 'user-1',
+          questionId: 'question-1',
+          rating: 'helpful',
+          createdAt: new Date('2026-02-10T00:00:00.000Z'),
+        }),
+        createQuestionRatingFeedback({
+          userId: 'user-1',
+          questionId: 'question-1',
+          rating: 'not_helpful',
+          createdAt: new Date('2026-02-11T00:00:00.000Z'),
+        }),
+      ]),
+    );
+
+    await expect(
+      useCase.execute({ userId: 'user-1', questionId: 'question-1' }),
+    ).resolves.toEqual({ rating: 'not_helpful' });
+  });
+
+  it('returns null when the latest rating is a retraction', async () => {
+    const useCase = new GetQuestionRatingUseCase(
+      new FakeQuestionFeedbackRepository([
+        createQuestionRatingFeedback({
+          userId: 'user-1',
+          questionId: 'question-1',
+          rating: 'helpful',
+          createdAt: new Date('2026-02-10T00:00:00.000Z'),
+        }),
+        createQuestionRatingFeedback({
+          userId: 'user-1',
+          questionId: 'question-1',
+          rating: null,
+          createdAt: new Date('2026-02-11T00:00:00.000Z'),
+        }),
+      ]),
+    );
+
+    await expect(
+      useCase.execute({ userId: 'user-1', questionId: 'question-1' }),
+    ).resolves.toEqual({ rating: null });
+  });
+});

--- a/src/application/use-cases/get-question-rating.ts
+++ b/src/application/use-cases/get-question-rating.ts
@@ -1,0 +1,26 @@
+import type { QuestionFeedbackRepository } from '@/src/application/ports/repositories';
+import type { QuestionFeedbackRating } from '@/src/domain/value-objects';
+
+export type GetQuestionRatingInput = {
+  userId: string;
+  questionId: string;
+};
+
+export type GetQuestionRatingOutput = {
+  rating: QuestionFeedbackRating | null;
+};
+
+export class GetQuestionRatingUseCase {
+  constructor(private readonly feedback: QuestionFeedbackRepository) {}
+
+  async execute(
+    input: GetQuestionRatingInput,
+  ): Promise<GetQuestionRatingOutput> {
+    const latest = await this.feedback.findLatestRatingByUser(
+      input.userId,
+      input.questionId,
+    );
+
+    return { rating: latest?.rating ?? null };
+  }
+}

--- a/src/application/use-cases/get-question-rating.ts
+++ b/src/application/use-cases/get-question-rating.ts
@@ -1,4 +1,8 @@
-import type { QuestionFeedbackRepository } from '@/src/application/ports/repositories';
+import { ApplicationError } from '@/src/application/errors';
+import type {
+  QuestionFeedbackRepository,
+  QuestionRepository,
+} from '@/src/application/ports/repositories';
 import type { QuestionFeedbackRating } from '@/src/domain/value-objects';
 
 export type GetQuestionRatingInput = {
@@ -11,11 +15,19 @@ export type GetQuestionRatingOutput = {
 };
 
 export class GetQuestionRatingUseCase {
-  constructor(private readonly feedback: QuestionFeedbackRepository) {}
+  constructor(
+    private readonly feedback: QuestionFeedbackRepository,
+    private readonly questions: QuestionRepository,
+  ) {}
 
   async execute(
     input: GetQuestionRatingInput,
   ): Promise<GetQuestionRatingOutput> {
+    const question = await this.questions.findPublishedById(input.questionId);
+    if (!question) {
+      throw new ApplicationError('NOT_FOUND', 'Question not found');
+    }
+
     const latest = await this.feedback.findLatestRatingByUser(
       input.userId,
       input.questionId,

--- a/src/application/use-cases/index.ts
+++ b/src/application/use-cases/index.ts
@@ -76,6 +76,11 @@ export {
   GetPreviousAttemptUseCase,
 } from './get-previous-attempt';
 export {
+  type GetQuestionRatingInput,
+  type GetQuestionRatingOutput,
+  GetQuestionRatingUseCase,
+} from './get-question-rating';
+export {
   type GetSessionHistoryInput,
   type GetSessionHistoryOutput,
   GetSessionHistoryUseCase,
@@ -86,6 +91,11 @@ export {
   GetUserStatsUseCase,
   type UserStatsOutput,
 } from './get-user-stats';
+export {
+  type RateQuestionInput,
+  type RateQuestionOutput,
+  RateQuestionUseCase,
+} from './rate-question';
 export {
   type SaveExamDraftAnswerInput,
   type SaveExamDraftAnswerOutput,
@@ -106,6 +116,11 @@ export {
   type SubmitAnswerOutput,
   SubmitAnswerUseCase,
 } from './submit-answer';
+export {
+  type SubmitQuestionReportInput,
+  type SubmitQuestionReportOutput,
+  SubmitQuestionReportUseCase,
+} from './submit-question-report';
 
 export {
   type ToggleBookmarkInput,

--- a/src/application/use-cases/rate-question.test.ts
+++ b/src/application/use-cases/rate-question.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { ApplicationError } from '@/src/application/errors';
+import {
+  FakeQuestionFeedbackRepository,
+  FakeQuestionRepository,
+} from '@/src/application/test-helpers/fakes';
+import { createQuestion } from '@/src/domain/test-helpers';
+import { RateQuestionUseCase } from './rate-question';
+
+describe('RateQuestionUseCase', () => {
+  it('returns NOT_FOUND when the question is missing', async () => {
+    const feedback = new FakeQuestionFeedbackRepository();
+    const useCase = new RateQuestionUseCase(
+      feedback,
+      new FakeQuestionRepository([]),
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        questionId: 'missing',
+        attemptId: null,
+        practiceSessionId: null,
+        rating: 'helpful',
+      }),
+    ).rejects.toEqual(new ApplicationError('NOT_FOUND', 'Question not found'));
+    expect(feedback.recordCalls).toEqual([]);
+  });
+
+  it('records a rating event and returns the rating', async () => {
+    const feedback = new FakeQuestionFeedbackRepository();
+    const useCase = new RateQuestionUseCase(
+      feedback,
+      new FakeQuestionRepository([
+        createQuestion({ id: 'question-1', status: 'published' }),
+      ]),
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        questionId: 'question-1',
+        attemptId: 'attempt-1',
+        practiceSessionId: 'session-1',
+        rating: 'not_helpful',
+      }),
+    ).resolves.toEqual({ rating: 'not_helpful' });
+
+    expect(feedback.recordCalls).toEqual([
+      {
+        userId: 'user-1',
+        questionId: 'question-1',
+        attemptId: 'attempt-1',
+        practiceSessionId: 'session-1',
+        kind: 'rating',
+        rating: 'not_helpful',
+        category: null,
+        comment: null,
+      },
+    ]);
+    await expect(
+      feedback.findLatestRatingByUser('user-1', 'question-1'),
+    ).resolves.toMatchObject({ rating: 'not_helpful' });
+  });
+
+  it('records a null rating event for retraction', async () => {
+    const feedback = new FakeQuestionFeedbackRepository();
+    const useCase = new RateQuestionUseCase(
+      feedback,
+      new FakeQuestionRepository([
+        createQuestion({ id: 'question-1', status: 'published' }),
+      ]),
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        questionId: 'question-1',
+        attemptId: null,
+        practiceSessionId: null,
+        rating: null,
+      }),
+    ).resolves.toEqual({ rating: null });
+
+    expect(feedback.recordCalls).toEqual([
+      {
+        userId: 'user-1',
+        questionId: 'question-1',
+        attemptId: null,
+        practiceSessionId: null,
+        kind: 'rating',
+        rating: null,
+        category: null,
+        comment: null,
+      },
+    ]);
+  });
+});

--- a/src/application/use-cases/rate-question.ts
+++ b/src/application/use-cases/rate-question.ts
@@ -1,0 +1,45 @@
+import { ApplicationError } from '@/src/application/errors';
+import type {
+  QuestionFeedbackRepository,
+  QuestionRepository,
+} from '@/src/application/ports/repositories';
+import { newQuestionRatingFeedback } from '@/src/domain/entities';
+import type { QuestionFeedbackRating } from '@/src/domain/value-objects';
+
+export type RateQuestionInput = {
+  userId: string;
+  questionId: string;
+  attemptId: string | null;
+  practiceSessionId: string | null;
+  rating: QuestionFeedbackRating | null;
+};
+
+export type RateQuestionOutput = {
+  rating: QuestionFeedbackRating | null;
+};
+
+export class RateQuestionUseCase {
+  constructor(
+    private readonly feedback: QuestionFeedbackRepository,
+    private readonly questions: QuestionRepository,
+  ) {}
+
+  async execute(input: RateQuestionInput): Promise<RateQuestionOutput> {
+    const question = await this.questions.findPublishedById(input.questionId);
+    if (!question) {
+      throw new ApplicationError('NOT_FOUND', 'Question not found');
+    }
+
+    await this.feedback.record(
+      newQuestionRatingFeedback({
+        userId: input.userId,
+        questionId: input.questionId,
+        attemptId: input.attemptId,
+        practiceSessionId: input.practiceSessionId,
+        rating: input.rating,
+      }),
+    );
+
+    return { rating: input.rating };
+  }
+}

--- a/src/application/use-cases/submit-question-report.test.ts
+++ b/src/application/use-cases/submit-question-report.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { ApplicationError } from '@/src/application/errors';
+import {
+  FakeQuestionFeedbackRepository,
+  FakeQuestionRepository,
+} from '@/src/application/test-helpers/fakes';
+import { createQuestion } from '@/src/domain/test-helpers';
+import { SubmitQuestionReportUseCase } from './submit-question-report';
+
+describe('SubmitQuestionReportUseCase', () => {
+  it('returns NOT_FOUND when the question is missing', async () => {
+    const feedback = new FakeQuestionFeedbackRepository();
+    const useCase = new SubmitQuestionReportUseCase(
+      feedback,
+      new FakeQuestionRepository([]),
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        questionId: 'missing',
+        attemptId: null,
+        practiceSessionId: null,
+        category: 'incorrect_answer',
+        comment: null,
+      }),
+    ).rejects.toEqual(new ApplicationError('NOT_FOUND', 'Question not found'));
+    expect(feedback.recordCalls).toEqual([]);
+  });
+
+  it('records a report event and returns its feedback id', async () => {
+    const feedback = new FakeQuestionFeedbackRepository();
+    const useCase = new SubmitQuestionReportUseCase(
+      feedback,
+      new FakeQuestionRepository([
+        createQuestion({ id: 'question-1', status: 'published' }),
+      ]),
+    );
+
+    const result = await useCase.execute({
+      userId: 'user-1',
+      questionId: 'question-1',
+      attemptId: 'attempt-1',
+      practiceSessionId: 'session-1',
+      category: 'ambiguous_wording',
+      comment: 'Two answers could be correct.',
+    });
+
+    expect(result.feedbackId).toEqual(expect.any(String));
+    expect(feedback.recordCalls).toEqual([
+      {
+        userId: 'user-1',
+        questionId: 'question-1',
+        attemptId: 'attempt-1',
+        practiceSessionId: 'session-1',
+        kind: 'report',
+        rating: null,
+        category: 'ambiguous_wording',
+        comment: 'Two answers could be correct.',
+      },
+    ]);
+  });
+});

--- a/src/application/use-cases/submit-question-report.ts
+++ b/src/application/use-cases/submit-question-report.ts
@@ -1,0 +1,39 @@
+import { ApplicationError } from '@/src/application/errors';
+import type {
+  QuestionFeedbackRepository,
+  QuestionRepository,
+} from '@/src/application/ports/repositories';
+import { newQuestionReportFeedback } from '@/src/domain/entities';
+import type { QuestionFeedbackCategory } from '@/src/domain/value-objects';
+
+export type SubmitQuestionReportInput = {
+  userId: string;
+  questionId: string;
+  attemptId: string | null;
+  practiceSessionId: string | null;
+  category: QuestionFeedbackCategory;
+  comment: string | null;
+};
+
+export type SubmitQuestionReportOutput = {
+  feedbackId: string;
+};
+
+export class SubmitQuestionReportUseCase {
+  constructor(
+    private readonly feedback: QuestionFeedbackRepository,
+    private readonly questions: QuestionRepository,
+  ) {}
+
+  async execute(
+    input: SubmitQuestionReportInput,
+  ): Promise<SubmitQuestionReportOutput> {
+    const question = await this.questions.findPublishedById(input.questionId);
+    if (!question) {
+      throw new ApplicationError('NOT_FOUND', 'Question not found');
+    }
+
+    const saved = await this.feedback.record(newQuestionReportFeedback(input));
+    return { feedbackId: saved.id };
+  }
+}

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -12,6 +12,16 @@ export type {
   PracticeSessionQuestionState,
 } from './practice-session';
 export type { Question } from './question';
+export {
+  type NewQuestionFeedback,
+  newQuestionRatingFeedback,
+  newQuestionReportFeedback,
+  type PersistedQuestionFeedback,
+  type QuestionFeedback,
+  type QuestionFeedbackContext,
+  type QuestionRatingFeedback,
+  type QuestionReportFeedback,
+} from './question-feedback';
 export type { Subscription } from './subscription';
 export type { Tag } from './tag';
 export type { User } from './user';

--- a/src/domain/entities/question-feedback.test.ts
+++ b/src/domain/entities/question-feedback.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type {
+  NewQuestionFeedback,
+  QuestionFeedback,
+  QuestionRatingFeedback,
+  QuestionReportFeedback,
+} from './question-feedback';
+import {
+  newQuestionRatingFeedback,
+  newQuestionReportFeedback,
+} from './question-feedback';
+
+describe('QuestionFeedback entity constructors', () => {
+  const context = {
+    userId: 'user-1',
+    questionId: 'question-1',
+    attemptId: 'attempt-1',
+    practiceSessionId: 'session-1',
+  } as const;
+
+  it('creates rating feedback with report-only fields cleared', () => {
+    expect(
+      newQuestionRatingFeedback({
+        ...context,
+        rating: 'helpful',
+      }),
+    ).toEqual({
+      ...context,
+      kind: 'rating',
+      rating: 'helpful',
+      category: null,
+      comment: null,
+    });
+  });
+
+  it('creates rating retractions with null rating', () => {
+    expect(
+      newQuestionRatingFeedback({
+        ...context,
+        rating: null,
+      }),
+    ).toMatchObject({
+      kind: 'rating',
+      rating: null,
+      category: null,
+      comment: null,
+    });
+  });
+
+  it('creates report feedback with rating cleared', () => {
+    expect(
+      newQuestionReportFeedback({
+        ...context,
+        category: 'ambiguous_wording',
+        comment: 'The stem has two plausible answers.',
+      }),
+    ).toEqual({
+      ...context,
+      kind: 'report',
+      rating: null,
+      category: 'ambiguous_wording',
+      comment: 'The stem has two plausible answers.',
+    });
+  });
+
+  it('creates report feedback with a null optional comment', () => {
+    expect(
+      newQuestionReportFeedback({
+        ...context,
+        category: 'other',
+        comment: null,
+      }),
+    ).toMatchObject({
+      kind: 'report',
+      rating: null,
+      category: 'other',
+      comment: null,
+    });
+  });
+
+  it('types persisted rating and report feedback as the feedback union', () => {
+    expectTypeOf<QuestionRatingFeedback>().toMatchTypeOf<QuestionFeedback>();
+    expectTypeOf<QuestionReportFeedback>().toMatchTypeOf<QuestionFeedback>();
+    expectTypeOf<
+      ReturnType<typeof newQuestionRatingFeedback>
+    >().toMatchTypeOf<NewQuestionFeedback>();
+    expectTypeOf<
+      ReturnType<typeof newQuestionReportFeedback>
+    >().toMatchTypeOf<NewQuestionFeedback>();
+  });
+
+  it('rejects report-only fields on rating constructor input at compile time', () => {
+    type RatingInput = Parameters<typeof newQuestionRatingFeedback>[0];
+
+    const invalidRatingInput = {
+      ...context,
+      rating: 'helpful',
+      // @ts-expect-error rating feedback cannot accept report categories.
+      category: 'other',
+    } satisfies RatingInput;
+
+    expect(invalidRatingInput.category).toBe('other');
+  });
+
+  it('rejects rating-only fields on report constructor input at compile time', () => {
+    type ReportInput = Parameters<typeof newQuestionReportFeedback>[0];
+
+    const invalidReportInput = {
+      ...context,
+      category: 'incorrect_answer',
+      comment: null,
+      // @ts-expect-error report feedback cannot accept ratings.
+      rating: 'not_helpful',
+    } satisfies ReportInput;
+
+    expect(invalidReportInput.rating).toBe('not_helpful');
+  });
+});

--- a/src/domain/entities/question-feedback.test.ts
+++ b/src/domain/entities/question-feedback.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+  createAttempt,
+  createPracticeSession,
+  createQuestion,
+  createUser,
+} from '../test-helpers';
 import type {
   NewQuestionFeedback,
   QuestionFeedback,
@@ -11,11 +17,18 @@ import {
 } from './question-feedback';
 
 describe('QuestionFeedback entity constructors', () => {
+  const user = createUser();
+  const question = createQuestion();
+  const attempt = createAttempt({ userId: user.id, questionId: question.id });
+  const practiceSession = createPracticeSession({
+    userId: user.id,
+    questionIds: [question.id],
+  });
   const context = {
-    userId: 'user-1',
-    questionId: 'question-1',
-    attemptId: 'attempt-1',
-    practiceSessionId: 'session-1',
+    userId: user.id,
+    questionId: question.id,
+    attemptId: attempt.id,
+    practiceSessionId: practiceSession.id,
   } as const;
 
   it('creates rating feedback with report-only fields cleared', () => {

--- a/src/domain/entities/question-feedback.ts
+++ b/src/domain/entities/question-feedback.ts
@@ -1,0 +1,64 @@
+import type {
+  QuestionFeedbackCategory,
+  QuestionFeedbackRating,
+} from '../value-objects';
+
+export type QuestionFeedbackContext = {
+  readonly userId: string;
+  readonly questionId: string;
+  readonly attemptId: string | null;
+  readonly practiceSessionId: string | null;
+};
+
+export type PersistedQuestionFeedback = {
+  readonly id: string;
+  readonly createdAt: Date;
+};
+
+export type QuestionRatingFeedback = QuestionFeedbackContext &
+  PersistedQuestionFeedback & {
+    readonly kind: 'rating';
+    readonly rating: QuestionFeedbackRating | null;
+    readonly category: null;
+    readonly comment: null;
+  };
+
+export type QuestionReportFeedback = QuestionFeedbackContext &
+  PersistedQuestionFeedback & {
+    readonly kind: 'report';
+    readonly rating: null;
+    readonly category: QuestionFeedbackCategory;
+    readonly comment: string | null;
+  };
+
+export type QuestionFeedback = QuestionRatingFeedback | QuestionReportFeedback;
+
+export type NewQuestionFeedback =
+  | Omit<QuestionRatingFeedback, keyof PersistedQuestionFeedback>
+  | Omit<QuestionReportFeedback, keyof PersistedQuestionFeedback>;
+
+export function newQuestionRatingFeedback(
+  input: QuestionFeedbackContext & {
+    readonly rating: QuestionFeedbackRating | null;
+  },
+): NewQuestionFeedback {
+  return {
+    ...input,
+    kind: 'rating',
+    category: null,
+    comment: null,
+  };
+}
+
+export function newQuestionReportFeedback(
+  input: QuestionFeedbackContext & {
+    readonly category: QuestionFeedbackCategory;
+    readonly comment: string | null;
+  },
+): NewQuestionFeedback {
+  return {
+    ...input,
+    kind: 'report',
+    rating: null,
+  };
+}

--- a/src/domain/test-helpers/factories.test.ts
+++ b/src/domain/test-helpers/factories.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { createBookmark, createPracticeSession } from './index';
+import {
+  createBookmark,
+  createPracticeSession,
+  createQuestionRatingFeedback,
+  createQuestionReportFeedback,
+} from './index';
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 describe('createBookmark', () => {
   afterEach(() => {
@@ -65,5 +73,112 @@ describe('createPracticeSession', () => {
         draftCumulativeMs: 0,
       },
     ]);
+  });
+});
+
+describe('createQuestionRatingFeedback', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns shape-correct rating feedback defaults', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-09T12:00:00.000Z'));
+
+    const feedback = createQuestionRatingFeedback();
+
+    expect(feedback).toEqual({
+      id: expect.stringMatching(UUID_PATTERN),
+      userId: expect.stringMatching(UUID_PATTERN),
+      questionId: expect.stringMatching(UUID_PATTERN),
+      attemptId: null,
+      practiceSessionId: null,
+      kind: 'rating',
+      rating: 'helpful',
+      category: null,
+      comment: null,
+      createdAt: new Date('2026-02-09T12:00:00.000Z'),
+    });
+  });
+
+  it('applies rating feedback overrides', () => {
+    const createdAt = new Date('2026-02-10T00:00:00.000Z');
+
+    const feedback = createQuestionRatingFeedback({
+      id: 'feedback-1',
+      userId: 'user-1',
+      questionId: 'question-1',
+      attemptId: 'attempt-1',
+      practiceSessionId: 'session-1',
+      rating: null,
+      createdAt,
+    });
+
+    expect(feedback).toEqual({
+      id: 'feedback-1',
+      userId: 'user-1',
+      questionId: 'question-1',
+      attemptId: 'attempt-1',
+      practiceSessionId: 'session-1',
+      kind: 'rating',
+      rating: null,
+      category: null,
+      comment: null,
+      createdAt,
+    });
+  });
+});
+
+describe('createQuestionReportFeedback', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns shape-correct report feedback defaults', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-09T12:00:00.000Z'));
+
+    const feedback = createQuestionReportFeedback();
+
+    expect(feedback).toEqual({
+      id: expect.stringMatching(UUID_PATTERN),
+      userId: expect.stringMatching(UUID_PATTERN),
+      questionId: expect.stringMatching(UUID_PATTERN),
+      attemptId: null,
+      practiceSessionId: null,
+      kind: 'report',
+      rating: null,
+      category: 'other',
+      comment: null,
+      createdAt: new Date('2026-02-09T12:00:00.000Z'),
+    });
+  });
+
+  it('applies report feedback overrides', () => {
+    const createdAt = new Date('2026-02-10T00:00:00.000Z');
+
+    const feedback = createQuestionReportFeedback({
+      id: 'feedback-1',
+      userId: 'user-1',
+      questionId: 'question-1',
+      attemptId: 'attempt-1',
+      practiceSessionId: 'session-1',
+      category: 'incorrect_answer',
+      comment: 'The keyed answer appears wrong.',
+      createdAt,
+    });
+
+    expect(feedback).toEqual({
+      id: 'feedback-1',
+      userId: 'user-1',
+      questionId: 'question-1',
+      attemptId: 'attempt-1',
+      practiceSessionId: 'session-1',
+      kind: 'report',
+      rating: null,
+      category: 'incorrect_answer',
+      comment: 'The keyed answer appears wrong.',
+      createdAt,
+    });
   });
 });

--- a/src/domain/test-helpers/factories.test.ts
+++ b/src/domain/test-helpers/factories.test.ts
@@ -127,6 +127,29 @@ describe('createQuestionRatingFeedback', () => {
       createdAt,
     });
   });
+
+  it('rejects report-only overrides at compile time', () => {
+    // @ts-expect-error rating feedback fixtures cannot accept report categories
+    createQuestionRatingFeedback({ category: 'other' });
+    // @ts-expect-error rating feedback fixtures cannot accept free-text comments
+    createQuestionRatingFeedback({ comment: 'Question wording is unclear.' });
+    // @ts-expect-error rating feedback fixtures cannot change the discriminant
+    createQuestionRatingFeedback({ kind: 'report' });
+  });
+
+  it('reasserts rating invariants after unsafe overrides', () => {
+    const feedback = createQuestionRatingFeedback({
+      kind: 'report',
+      category: 'other',
+      comment: 'Question wording is unclear.',
+    } as unknown as Parameters<typeof createQuestionRatingFeedback>[0]);
+
+    expect(feedback).toMatchObject({
+      kind: 'rating',
+      category: null,
+      comment: null,
+    });
+  });
 });
 
 describe('createQuestionReportFeedback', () => {
@@ -179,6 +202,25 @@ describe('createQuestionReportFeedback', () => {
       category: 'incorrect_answer',
       comment: 'The keyed answer appears wrong.',
       createdAt,
+    });
+  });
+
+  it('rejects rating-only overrides at compile time', () => {
+    // @ts-expect-error report feedback fixtures cannot accept ratings
+    createQuestionReportFeedback({ rating: 'helpful' });
+    // @ts-expect-error report feedback fixtures cannot change the discriminant
+    createQuestionReportFeedback({ kind: 'rating' });
+  });
+
+  it('reasserts report invariants after unsafe overrides', () => {
+    const feedback = createQuestionReportFeedback({
+      kind: 'rating',
+      rating: 'helpful',
+    } as unknown as Parameters<typeof createQuestionReportFeedback>[0]);
+
+    expect(feedback).toMatchObject({
+      kind: 'report',
+      rating: null,
     });
   });
 });

--- a/src/domain/test-helpers/factories.ts
+++ b/src/domain/test-helpers/factories.ts
@@ -6,6 +6,10 @@ import type {
   PracticeSessionQuestionState,
 } from '../entities/practice-session';
 import type { Question } from '../entities/question';
+import type {
+  QuestionRatingFeedback,
+  QuestionReportFeedback,
+} from '../entities/question-feedback';
 import type { Subscription } from '../entities/subscription';
 import type { Tag } from '../entities/tag';
 import type { User } from '../entities/user';
@@ -75,6 +79,46 @@ export function createBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
   return {
     userId: createUuid(),
     questionId: createUuid(),
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+export function createQuestionRatingFeedback(
+  overrides: Partial<QuestionRatingFeedback> = {},
+): QuestionRatingFeedback {
+  const now = new Date();
+
+  return {
+    id: createUuid(),
+    userId: createUuid(),
+    questionId: createUuid(),
+    attemptId: null,
+    practiceSessionId: null,
+    kind: 'rating',
+    rating: 'helpful',
+    category: null,
+    comment: null,
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+export function createQuestionReportFeedback(
+  overrides: Partial<QuestionReportFeedback> = {},
+): QuestionReportFeedback {
+  const now = new Date();
+
+  return {
+    id: createUuid(),
+    userId: createUuid(),
+    questionId: createUuid(),
+    attemptId: null,
+    practiceSessionId: null,
+    kind: 'report',
+    rating: null,
+    category: 'other',
+    comment: null,
     createdAt: now,
     ...overrides,
   };

--- a/src/domain/test-helpers/factories.ts
+++ b/src/domain/test-helpers/factories.ts
@@ -85,9 +85,12 @@ export function createBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
 }
 
 export function createQuestionRatingFeedback(
-  overrides: Partial<QuestionRatingFeedback> = {},
+  overrides: Partial<
+    Omit<QuestionRatingFeedback, 'kind' | 'category' | 'comment'>
+  > = {},
 ): QuestionRatingFeedback {
   const now = new Date();
+  const { rating = 'helpful', ...rest } = overrides;
 
   return {
     id: createUuid(),
@@ -95,19 +98,20 @@ export function createQuestionRatingFeedback(
     questionId: createUuid(),
     attemptId: null,
     practiceSessionId: null,
+    createdAt: now,
+    ...rest,
     kind: 'rating',
-    rating: 'helpful',
+    rating,
     category: null,
     comment: null,
-    createdAt: now,
-    ...overrides,
   };
 }
 
 export function createQuestionReportFeedback(
-  overrides: Partial<QuestionReportFeedback> = {},
+  overrides: Partial<Omit<QuestionReportFeedback, 'kind' | 'rating'>> = {},
 ): QuestionReportFeedback {
   const now = new Date();
+  const { category = 'other', comment = null, ...rest } = overrides;
 
   return {
     id: createUuid(),
@@ -115,12 +119,12 @@ export function createQuestionReportFeedback(
     questionId: createUuid(),
     attemptId: null,
     practiceSessionId: null,
+    createdAt: now,
+    ...rest,
     kind: 'report',
     rating: null,
-    category: 'other',
-    comment: null,
-    createdAt: now,
-    ...overrides,
+    category,
+    comment,
   };
 }
 

--- a/src/domain/test-helpers/index.ts
+++ b/src/domain/test-helpers/index.ts
@@ -4,6 +4,8 @@ export {
   createChoice,
   createPracticeSession,
   createQuestion,
+  createQuestionRatingFeedback,
+  createQuestionReportFeedback,
   createSubscription,
   createTag,
   createUser,

--- a/src/domain/value-objects/index.ts
+++ b/src/domain/value-objects/index.ts
@@ -22,7 +22,21 @@ export {
   isValidDifficulty,
   type QuestionDifficulty,
 } from './question-difficulty';
-
+export {
+  AllQuestionFeedbackCategories,
+  isValidQuestionFeedbackCategory,
+  type QuestionFeedbackCategory,
+} from './question-feedback-category';
+export {
+  AllQuestionFeedbackKinds,
+  isValidQuestionFeedbackKind,
+  type QuestionFeedbackKind,
+} from './question-feedback-kind';
+export {
+  AllQuestionFeedbackRatings,
+  isValidQuestionFeedbackRating,
+  type QuestionFeedbackRating,
+} from './question-feedback-rating';
 export {
   AllQuestionProgressStatuses,
   isValidQuestionProgressStatus,

--- a/src/domain/value-objects/question-feedback-category.test.ts
+++ b/src/domain/value-objects/question-feedback-category.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AllQuestionFeedbackCategories,
+  isValidQuestionFeedbackCategory,
+} from './question-feedback-category';
+
+describe('QuestionFeedbackCategory', () => {
+  it('defines the supported feedback categories', () => {
+    expect(AllQuestionFeedbackCategories).toEqual([
+      'incorrect_answer',
+      'ambiguous_wording',
+      'typo_formatting',
+      'outdated_reference',
+      'other',
+    ]);
+  });
+
+  it('validates known feedback categories', () => {
+    expect(isValidQuestionFeedbackCategory('incorrect_answer')).toBe(true);
+    expect(isValidQuestionFeedbackCategory('ambiguous_wording')).toBe(true);
+    expect(isValidQuestionFeedbackCategory('typo_formatting')).toBe(true);
+    expect(isValidQuestionFeedbackCategory('outdated_reference')).toBe(true);
+    expect(isValidQuestionFeedbackCategory('other')).toBe(true);
+  });
+
+  it('rejects unknown feedback categories', () => {
+    expect(isValidQuestionFeedbackCategory('bad_reference')).toBe(false);
+  });
+});

--- a/src/domain/value-objects/question-feedback-category.ts
+++ b/src/domain/value-objects/question-feedback-category.ts
@@ -1,0 +1,21 @@
+/**
+ * Question feedback report category values.
+ */
+export const AllQuestionFeedbackCategories = [
+  'incorrect_answer',
+  'ambiguous_wording',
+  'typo_formatting',
+  'outdated_reference',
+  'other',
+] as const;
+
+export type QuestionFeedbackCategory =
+  (typeof AllQuestionFeedbackCategories)[number];
+
+export function isValidQuestionFeedbackCategory(
+  value: string,
+): value is QuestionFeedbackCategory {
+  return AllQuestionFeedbackCategories.includes(
+    value as QuestionFeedbackCategory,
+  );
+}

--- a/src/domain/value-objects/question-feedback-kind.test.ts
+++ b/src/domain/value-objects/question-feedback-kind.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AllQuestionFeedbackKinds,
+  isValidQuestionFeedbackKind,
+} from './question-feedback-kind';
+
+describe('QuestionFeedbackKind', () => {
+  it('defines the supported feedback kinds', () => {
+    expect(AllQuestionFeedbackKinds).toEqual(['rating', 'report']);
+  });
+
+  it('validates known feedback kinds', () => {
+    expect(isValidQuestionFeedbackKind('rating')).toBe(true);
+    expect(isValidQuestionFeedbackKind('report')).toBe(true);
+  });
+
+  it('rejects unknown feedback kinds', () => {
+    expect(isValidQuestionFeedbackKind('comment')).toBe(false);
+  });
+});

--- a/src/domain/value-objects/question-feedback-kind.ts
+++ b/src/domain/value-objects/question-feedback-kind.ts
@@ -1,0 +1,12 @@
+/**
+ * Question feedback event kind values.
+ */
+export const AllQuestionFeedbackKinds = ['rating', 'report'] as const;
+
+export type QuestionFeedbackKind = (typeof AllQuestionFeedbackKinds)[number];
+
+export function isValidQuestionFeedbackKind(
+  value: string,
+): value is QuestionFeedbackKind {
+  return AllQuestionFeedbackKinds.includes(value as QuestionFeedbackKind);
+}

--- a/src/domain/value-objects/question-feedback-rating.test.ts
+++ b/src/domain/value-objects/question-feedback-rating.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AllQuestionFeedbackRatings,
+  isValidQuestionFeedbackRating,
+} from './question-feedback-rating';
+
+describe('QuestionFeedbackRating', () => {
+  it('defines the supported feedback ratings', () => {
+    expect(AllQuestionFeedbackRatings).toEqual(['helpful', 'not_helpful']);
+  });
+
+  it('validates known feedback ratings', () => {
+    expect(isValidQuestionFeedbackRating('helpful')).toBe(true);
+    expect(isValidQuestionFeedbackRating('not_helpful')).toBe(true);
+  });
+
+  it('rejects unknown feedback ratings', () => {
+    expect(isValidQuestionFeedbackRating('neutral')).toBe(false);
+  });
+});

--- a/src/domain/value-objects/question-feedback-rating.ts
+++ b/src/domain/value-objects/question-feedback-rating.ts
@@ -1,0 +1,13 @@
+/**
+ * Question feedback rating values.
+ */
+export const AllQuestionFeedbackRatings = ['helpful', 'not_helpful'] as const;
+
+export type QuestionFeedbackRating =
+  (typeof AllQuestionFeedbackRatings)[number];
+
+export function isValidQuestionFeedbackRating(
+  value: string,
+): value is QuestionFeedbackRating {
+  return AllQuestionFeedbackRatings.includes(value as QuestionFeedbackRating);
+}

--- a/tests/integration/db.integration.test.ts
+++ b/tests/integration/db.integration.test.ts
@@ -52,6 +52,7 @@ describe('database migrations', () => {
       'practice_sessions',
       'attempts',
       'bookmarks',
+      'question_feedback',
     ] as const;
 
     for (const table of expectedTables) {

--- a/tests/integration/db.integration.test.ts
+++ b/tests/integration/db.integration.test.ts
@@ -60,6 +60,22 @@ describe('database migrations', () => {
     }
   });
 
+  it('creates question feedback foreign-key support indexes', async () => {
+    const rows = await sql<{ indexname: string }[]>`
+      select indexname
+      from pg_indexes
+      where schemaname = 'public'
+        and tablename = 'question_feedback'
+    `;
+    const indexes = new Set(rows.map((row) => row.indexname));
+
+    expect(indexes).toContain('question_feedback_user_created_at_idx');
+    expect(indexes).toContain('question_feedback_attempt_created_at_idx');
+    expect(indexes).toContain(
+      'question_feedback_practice_session_created_at_idx',
+    );
+  });
+
   it('allows attempts.selected_choice_id to be nullable for omitted attempts', async () => {
     const rows = await sql<{ is_nullable: string }[]>`
       select is_nullable

--- a/tests/integration/question-feedback-repository.integration.test.ts
+++ b/tests/integration/question-feedback-repository.integration.test.ts
@@ -1,0 +1,180 @@
+import { randomUUID } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import * as schema from '@/db/schema';
+import { DrizzleQuestionFeedbackRepository } from '@/src/adapters/repositories/drizzle-question-feedback-repository';
+import {
+  newQuestionRatingFeedback,
+  newQuestionReportFeedback,
+} from '@/src/domain/entities';
+import {
+  cleanupAfterEach,
+  closeConnection,
+  createCleanupState,
+  createIntegrationDb,
+  createQuestion,
+  createUser,
+} from './helpers';
+
+const { db, sql } = createIntegrationDb();
+const cleanup = createCleanupState();
+
+afterEach(async () => {
+  await cleanupAfterEach(db, cleanup);
+});
+
+afterAll(async () => {
+  await closeConnection(sql);
+});
+
+describe('DrizzleQuestionFeedbackRepository', () => {
+  it('records rating and report events', async () => {
+    const user = await createUser(db, cleanup);
+    const question = await createQuestion(db, cleanup, {
+      slug: `it-feedback-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const repo = new DrizzleQuestionFeedbackRepository(db);
+
+    await expect(
+      repo.record(
+        newQuestionRatingFeedback({
+          userId: user.id,
+          questionId: question.id,
+          attemptId: null,
+          practiceSessionId: null,
+          rating: 'helpful',
+        }),
+      ),
+    ).resolves.toMatchObject({
+      userId: user.id,
+      questionId: question.id,
+      kind: 'rating',
+      rating: 'helpful',
+      category: null,
+      comment: null,
+    });
+
+    await expect(
+      repo.record(
+        newQuestionReportFeedback({
+          userId: user.id,
+          questionId: question.id,
+          attemptId: null,
+          practiceSessionId: null,
+          category: 'incorrect_answer',
+          comment: 'The keyed answer appears wrong.',
+        }),
+      ),
+    ).resolves.toMatchObject({
+      userId: user.id,
+      questionId: question.id,
+      kind: 'report',
+      rating: null,
+      category: 'incorrect_answer',
+      comment: 'The keyed answer appears wrong.',
+    });
+  });
+
+  it('returns latest rating by createdAt and id descending while ignoring reports', async () => {
+    const user = await createUser(db, cleanup);
+    const question = await createQuestion(db, cleanup, {
+      slug: `it-feedback-latest-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const lowerId = '00000000-0000-4000-8000-000000000001';
+    const higherId = 'ffffffff-ffff-4fff-bfff-ffffffffffff';
+    const tieCreatedAt = new Date('2026-02-10T00:00:00.000Z');
+
+    await db.insert(schema.questionFeedback).values([
+      {
+        id: lowerId,
+        userId: user.id,
+        questionId: question.id,
+        kind: 'rating',
+        rating: 'helpful',
+        createdAt: tieCreatedAt,
+      },
+      {
+        id: higherId,
+        userId: user.id,
+        questionId: question.id,
+        kind: 'rating',
+        rating: 'not_helpful',
+        createdAt: tieCreatedAt,
+      },
+      {
+        userId: user.id,
+        questionId: question.id,
+        kind: 'report',
+        category: 'other',
+        comment: 'Newer report should not affect rating hydration.',
+        createdAt: new Date('2026-02-11T00:00:00.000Z'),
+      },
+    ]);
+
+    const repo = new DrizzleQuestionFeedbackRepository(db);
+    await expect(
+      repo.findLatestRatingByUser(user.id, question.id),
+    ).resolves.toMatchObject({
+      id: higherId,
+      rating: 'not_helpful',
+    });
+  });
+
+  it('rejects invalid feedback shapes at the database boundary', async () => {
+    const user = await createUser(db, cleanup);
+    const question = await createQuestion(db, cleanup, {
+      slug: `it-feedback-check-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+
+    await expect(
+      db.insert(schema.questionFeedback).values({
+        userId: user.id,
+        questionId: question.id,
+        kind: 'rating',
+        rating: 'helpful',
+        comment: 'Rating events cannot carry comments.',
+      }),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    await expect(
+      db.insert(schema.questionFeedback).values({
+        userId: user.id,
+        questionId: question.id,
+        kind: 'report',
+        rating: 'not_helpful',
+        category: 'other',
+      }),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    await expect(
+      db.insert(schema.questionFeedback).values({
+        userId: user.id,
+        questionId: question.id,
+        kind: 'report',
+        category: null,
+      }),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    await expect(
+      db.insert(schema.questionFeedback).values({
+        userId: user.id,
+        questionId: question.id,
+        kind: 'report',
+        category: 'other',
+        comment: 'x'.repeat(2001),
+      }),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    const rows = await db
+      .select({ id: schema.questionFeedback.id })
+      .from(schema.questionFeedback)
+      .where(eq(schema.questionFeedback.userId, user.id));
+    expect(rows).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add the SPEC-041 backend slice for append-only question feedback events.
- Add pure domain value objects/entities, test-helper factories, repository port/fake, and rate/report/hydration use cases.
- Add Drizzle schema, migration, repository, row mapper, controller actions, rate limits, DI wiring, and integration coverage.

## Validation
- pnpm typecheck
- pnpm lint (passes with the existing nursery file-size warnings)
- pnpm test --run (323 files, 2,582 tests)
- pnpm test:browser (50 files, 271 tests)
- DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm test:integration (19 files, 107 tests)
- pnpm build

## Notes
- Migration was generated and applied only against the explicit local Docker test DB at localhost:5434.
- This PR intentionally contains no UI; PR2 starts the Dialog/Textarea primitive slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-question feedback: one-click helpful/not-helpful ratings and a “Give feedback” report modal (category + optional comment)
  * Public endpoints to submit ratings, fetch a user’s latest rating, and submit reports
  * Append-only feedback storage with deterministic latest-rating hydration; comments capped at 2000 chars; per-action rate limits and idempotency

* **Documentation**
  * Full spec added detailing UX, validation, persistence, rate limits, and implementation plan

* **Tests**
  * Unit and integration tests for feedback flows, repository behavior, and DB constraints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->