### PR TITLE
SPEC-041 PR2: add Dialog primitive

### DIFF
--- a/components/ui/dialog.browser.spec.tsx
+++ b/components/ui/dialog.browser.spec.tsx
@@ -1,0 +1,80 @@
+import { expect, test } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { Button } from './button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './dialog';
+
+function DialogProbe() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">Open dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Give feedback</DialogTitle>
+          <DialogDescription>
+            Spotted an issue or have a suggestion?
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose>Close dialog</DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+test('opens, traps focus, closes on Escape, and returns focus to the trigger', async () => {
+  const screen = await render(<DialogProbe />);
+  const trigger = screen.getByRole('button', { name: 'Open dialog' });
+
+  await trigger.click();
+
+  await expect
+    .element(screen.getByRole('dialog', { name: 'Give feedback' }))
+    .toBeVisible();
+  await expect
+    .poll(() => {
+      const dialog = document.querySelector('[role="dialog"]');
+      const title = document.querySelector('[data-slot="dialog-title"]');
+      const description = document.querySelector(
+        '[data-slot="dialog-description"]',
+      );
+
+      return (
+        dialog?.getAttribute('aria-modal') === 'true' &&
+        dialog?.getAttribute('aria-labelledby') === title?.id &&
+        dialog?.getAttribute('aria-describedby') === description?.id
+      );
+    })
+    .toBe(true);
+  await expect
+    .poll(() => document.activeElement?.closest('[role="dialog"]') !== null)
+    .toBe(true);
+
+  await userEvent.keyboard('{Escape}');
+
+  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+  await expect.element(trigger).toHaveFocus();
+});
+
+test('closes from DialogClose and returns focus to the trigger', async () => {
+  const screen = await render(<DialogProbe />);
+  const trigger = screen.getByRole('button', { name: 'Open dialog' });
+
+  await trigger.click();
+  await screen.getByRole('button', { name: 'Close dialog' }).click();
+
+  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+  await expect.element(trigger).toHaveFocus();
+});

--- a/components/ui/dialog.test.tsx
+++ b/components/ui/dialog.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+let Dialog: typeof import('./dialog').Dialog;
+let DialogClose: typeof import('./dialog').DialogClose;
+let DialogDescription: typeof import('./dialog').DialogDescription;
+let DialogFooter: typeof import('./dialog').DialogFooter;
+let DialogHeader: typeof import('./dialog').DialogHeader;
+let DialogTitle: typeof import('./dialog').DialogTitle;
+let DialogTrigger: typeof import('./dialog').DialogTrigger;
+
+const DIALOG_SOURCE = readFileSync(
+  resolve(process.cwd(), 'components/ui/dialog.tsx'),
+  'utf-8',
+);
+
+const S4_OVERLAY_CLASSES =
+  'fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0';
+
+const S4_CONTENT_CLASSES =
+  'fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-2xl border border-border bg-card p-6 text-foreground shadow-lg outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:w-full';
+
+beforeAll(async () => {
+  ({
+    Dialog,
+    DialogClose,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+  } = await import('./dialog'));
+});
+
+function getClassTokens(element: Element | null): Set<string> {
+  return new Set(element?.getAttribute('class')?.split(/\s+/) ?? []);
+}
+
+function renderOpenDialog() {
+  const html = renderToStaticMarkup(
+    <Dialog defaultOpen>
+      <DialogTrigger>Open dialog</DialogTrigger>
+      <DialogHeader>
+        <DialogTitle>Give feedback</DialogTitle>
+        <DialogDescription>
+          Spotted an issue or have a suggestion?
+        </DialogDescription>
+      </DialogHeader>
+      <DialogFooter>
+        <DialogClose>Close dialog</DialogClose>
+      </DialogFooter>
+    </Dialog>,
+  );
+
+  return new DOMParser().parseFromString(html, 'text/html');
+}
+
+describe('components/ui/dialog', () => {
+  it('renders named structural slots for the exported dialog pieces', () => {
+    const doc = renderOpenDialog();
+    const title = doc.querySelector('[data-slot="dialog-title"]');
+    const description = doc.querySelector('[data-slot="dialog-description"]');
+
+    expect(doc.querySelector('[data-slot="dialog-trigger"]')).not.toBeNull();
+    expect(doc.querySelector('[data-slot="dialog-header"]')).not.toBeNull();
+    expect(doc.querySelector('[data-slot="dialog-footer"]')).not.toBeNull();
+    expect(title?.textContent).toBe('Give feedback');
+    expect(title?.getAttribute('id')).toBeTruthy();
+    expect(description?.textContent).toBe(
+      'Spotted an issue or have a suggestion?',
+    );
+    expect(description?.getAttribute('id')).toBeTruthy();
+  });
+
+  it('uses the registered S-4 modal surface classes and button-variant focus ring for close actions', () => {
+    const doc = renderOpenDialog();
+    const closeClasses = getClassTokens(
+      doc.querySelector('[data-slot="dialog-close"]'),
+    );
+
+    expect(DIALOG_SOURCE).toContain(
+      "import { Dialog as DialogPrimitive } from 'radix-ui';",
+    );
+    expect(DIALOG_SOURCE).toContain(S4_OVERLAY_CLASSES);
+    expect(DIALOG_SOURCE).toContain(S4_CONTENT_CLASSES);
+    expect(closeClasses.has('focus-visible:ring-ring/50')).toBe(true);
+    expect(closeClasses.has('focus-visible:ring-[3px]')).toBe(true);
+    expect(doc.querySelector('[data-slot="dialog-close"]')?.textContent).toBe(
+      'Close dialog',
+    );
+  });
+});

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import type { VariantProps } from 'class-variance-authority';
+import { Dialog as DialogPrimitive } from 'radix-ui';
+import type * as React from 'react';
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-2xl border border-border bg-card p-6 text-foreground shadow-lg outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:w-full',
+          className,
+        )}
+        aria-modal="true"
+        {...props}
+      />
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-lg font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogClose({
+  className,
+  variant = 'outline',
+  size,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close> &
+  VariantProps<typeof buttonVariants>) {
+  return (
+    <DialogPrimitive.Close
+      data-slot="dialog-close"
+      className={cn(buttonVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/docs/frontend/pattern-registry.md
+++ b/docs/frontend/pattern-registry.md
@@ -250,7 +250,11 @@ fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-i
 fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-2xl border border-border bg-card p-6 text-foreground shadow-lg outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:w-full
 ```
 
-**Source:** `components/ui/alert-dialog.tsx`
+**Sources:** `components/ui/alert-dialog.tsx`, `components/ui/dialog.tsx`
+
+General-purpose dialogs reuse the same overlay and card class strings as alert dialogs. If a dialog
+needs a scroll-safe mobile variant or any other overlay/card change, document the S-4 variant here
+before adding new production UI classes.
 
 Action buttons inside dialogs use `buttonVariants` from `components/ui/button.tsx` (not ad-hoc dialog button styles).
 

--- a/docs/specs/spec-041-question-feedback.md
+++ b/docs/specs/spec-041-question-feedback.md
@@ -267,7 +267,10 @@ objects from `src/domain/value-objects/index.ts`.
 `createQuestionReportFeedback(overrides)` to `src/domain/test-helpers/factories.ts` and its `index.ts`
 barrel. Use UUID-emitting defaults via the existing `createUuid()` helper, `createdAt: new Date()`,
 nullable FK ids defaulting to `null`, and shape-correct defaults (`comment: null` only for reports,
-with ratings always setting `comment: null`). Avoid one permissive
+with ratings always setting `comment: null`). **Lock the discriminant fields against override:** type
+the param as `Partial<Omit<QuestionRatingFeedback, 'kind' | 'category' | 'comment'>>` (and the report
+analog `Omit<…, 'kind' | 'rating'>`) and hard-set `kind`/`category`/`rating`/`comment` *after* the
+`...overrides` spread, so callers can't produce an invalid-but-typed entity. Avoid one permissive
 `createQuestionFeedback({ kind, ... })` factory, because it would recreate the nullable-bag problem
 in tests.
 
@@ -544,13 +547,16 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_tes
 #### 3b. Drizzle repo (`src/adapters/repositories/drizzle-question-feedback-repository.ts`)
 
 Constructor-inject `DrizzleDb`. `record()` is a plain `insert(...).returning()` (no upsert —
-append-only). `findLatestRatingByUser()` is `findFirst` filtered to `kind='rating'`, ordered
-`desc(createdAt), desc(id)` (copy the attempt latest-read tie-breaker). Map rows → the discriminated
+append-only); wrap the insert call in try/catch and throw `ApplicationError('INTERNAL_ERROR',
+'Failed to insert question feedback', undefined, { cause })` on a driver failure, plus
+`ApplicationError('INTERNAL_ERROR', ...)` on a missing `returning()` row (bookmark pattern).
+`findLatestRatingByUser()` is `findFirst` filtered to `kind='rating'`, ordered `desc(createdAt),
+desc(id)` (copy the attempt latest-read tie-breaker); wrap unexpected read failures as
+`ApplicationError('INTERNAL_ERROR', 'Failed to load latest question rating', undefined, { cause })`,
+and after mapping re-assert `kind === 'rating'` (fail closed otherwise). Map rows → the discriminated
 domain union via a small `*-mappers.ts`; the mapper must fail closed with
 `ApplicationError('INTERNAL_ERROR', 'Invalid question feedback row')` if a row violates the union
-shape despite the DB `CHECK`. Throw `ApplicationError('INTERNAL_ERROR', ...)` on a missing
-`returning()` row (bookmark pattern) and wrap unexpected latest-rating read failures as
-`ApplicationError('INTERNAL_ERROR', 'Failed to load latest question rating', undefined, { cause })`.
+shape despite the DB `CHECK`.
 
 #### 3c. Rate limits (`src/adapters/shared/rate-limits.ts`)
 

--- a/docs/specs/spec-041-question-feedback.md
+++ b/docs/specs/spec-041-question-feedback.md
@@ -267,12 +267,15 @@ objects from `src/domain/value-objects/index.ts`.
 `createQuestionReportFeedback(overrides)` to `src/domain/test-helpers/factories.ts` and its `index.ts`
 barrel. Use UUID-emitting defaults via the existing `createUuid()` helper, `createdAt: new Date()`,
 nullable FK ids defaulting to `null`, and shape-correct defaults (`comment: null` only for reports,
-with ratings always setting `comment: null`). **Lock the discriminant fields against override:** type
-the param as `Partial<Omit<QuestionRatingFeedback, 'kind' | 'category' | 'comment'>>` (and the report
-analog `Omit<…, 'kind' | 'rating'>`) and hard-set `kind`/`category`/`rating`/`comment` *after* the
-`...overrides` spread, so callers can't produce an invalid-but-typed entity. Avoid one permissive
-`createQuestionFeedback({ kind, ... })` factory, because it would recreate the nullable-bag problem
-in tests.
+with ratings always setting `comment: null`). **Lock persisted and discriminant fields against
+override:** type the rating param as
+`Partial<Omit<QuestionRatingFeedback, keyof PersistedQuestionFeedback | 'kind' | 'category' | 'comment'>>`
+(and the report analog
+`Partial<Omit<QuestionReportFeedback, keyof PersistedQuestionFeedback | 'kind' | 'rating'>>`) and
+hard-set `id`/`createdAt`/`kind`/`category`/`rating`/`comment` *after* the `...overrides` spread, so
+callers can't produce an invalid-but-typed entity or override persisted defaults. Avoid one permissive
+`createQuestionFeedback({ kind, ... })` factory, because it would recreate the nullable-bag problem in
+tests.
 
 ### 2. Application — port + use cases (`src/application/`)
 


### PR DESCRIPTION
## Summary
- add the `components/ui/dialog.tsx` design-system primitive using the existing unscoped `radix-ui` Dialog namespace
- reuse the registered S-4 modal overlay/card classes and document `components/ui/dialog.tsx` as an S-4 source
- add jsdom structural tests plus browser tests for title/description wiring, focus containment, Escape close, DialogClose, and focus return

## Verification
- `pnpm typecheck`
- `pnpm lint` (19 pre-existing nursery file-size warnings)
- `pnpm test --run`
- `pnpm test:browser`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable Dialog component with trigger, overlay, content, header, footer, title, description, and close controls for modal interactions.

* **Tests**
  * Added browser and unit tests validating dialog open/close behavior, focus trapping, escape/close actions, and accessibility attributes.

* **Documentation**
  * Updated pattern guidance to include the new Dialog and require reuse of established overlay/card styling and variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->