### PR TITLE
SPEC-041 PR3: add question feedback UI

### DIFF
--- a/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx
@@ -36,6 +36,9 @@ function renderView(input?: {
   row?: GetCompletedSessionQuestionsWithFeedbackOutput['rows'][number];
   currentQuestionId?: string | null;
   isBookmarked?: boolean;
+  questionFeedback?: Parameters<
+    typeof PostExamReviewView
+  >[0]['questionFeedback'];
 }) {
   const rows = input?.rows ?? [input?.row ?? createReviewRow()];
   const answered = rows.filter((row) => row.isAnswered).length;
@@ -60,6 +63,7 @@ function renderView(input?: {
       controlledPanelId="practice-question-panel"
       bookmarkStatus="idle"
       isBookmarked={input?.isBookmarked ?? false}
+      questionFeedback={input?.questionFeedback ?? null}
       onToggleBookmark={() => undefined}
       onNavigateQuestion={() => undefined}
       onViewSummary={() => undefined}
@@ -247,6 +251,50 @@ describe('PostExamReviewView', () => {
     });
 
     expect(getReviewActionLabels(doc)).toEqual(['Next', 'Bookmark']);
+  });
+
+  it('renders Give feedback as a post-exam review action sibling', () => {
+    const doc = renderView({
+      questionFeedback: {
+        rating: null,
+        feedbackStatus: 'idle',
+        onRate: () => undefined,
+        isReportOpen: false,
+        openReport: () => undefined,
+        submitReport: async () => true,
+      },
+    });
+
+    expect(getReviewActionLabels(doc)).toEqual([
+      'View Summary',
+      'Bookmark',
+      'Give feedback',
+    ]);
+  });
+
+  it('renders question feedback rating controls after the explanation', () => {
+    const doc = renderView({
+      row: createReviewRow({
+        isAnswered: true,
+        isCorrect: true,
+        selectedChoiceId: fixtureChoiceBId,
+        explanationMd: 'Post-exam explanation.',
+      }),
+      questionFeedback: {
+        rating: 'helpful',
+        feedbackStatus: 'saved',
+        onRate: () => undefined,
+        isReportOpen: false,
+        openReport: () => undefined,
+        submitReport: async () => true,
+      },
+    });
+    const html = doc.body.innerHTML;
+
+    expect(html).toContain('Was this a good question?');
+    expect(html.indexOf('Post-exam explanation.')).toBeLessThan(
+      html.indexOf('Was this a good question?'),
+    );
   });
 
   it('renders the last-question action bar with view summary before bookmark', () => {

--- a/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import type { PracticeViewProps } from '@/app/(app)/app/practice/components/practice-view';
 import { Feedback } from '@/components/question/feedback';
 import { QuestionCard } from '@/components/question/question-card';
+import { QuestionFeedbackRating } from '@/components/question/question-feedback-rating';
+import { QuestionReportDialog } from '@/components/question/question-report-dialog';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import type {
@@ -19,6 +22,7 @@ type PostExamReviewViewProps = {
   controlledPanelId: string;
   bookmarkStatus: 'idle' | 'loading' | 'error';
   isBookmarked: boolean;
+  questionFeedback?: PracticeViewProps['questionFeedback'];
   onToggleBookmark: () => void;
   onNavigateQuestion: (questionId: string) => void;
   onViewSummary: () => void;
@@ -31,6 +35,7 @@ export function PostExamReviewView({
   controlledPanelId,
   bookmarkStatus,
   isBookmarked,
+  questionFeedback = null,
   onToggleBookmark,
   onNavigateQuestion,
   onViewSummary,
@@ -148,6 +153,13 @@ export function PostExamReviewView({
                 choiceExplanations={currentRow.choiceExplanations}
                 selectedChoiceId={currentRow.selectedChoiceId}
               />
+              {questionFeedback ? (
+                <QuestionFeedbackRating
+                  rating={questionFeedback.rating}
+                  feedbackStatus={questionFeedback.feedbackStatus}
+                  onRate={questionFeedback.onRate}
+                />
+              ) : null}
             </>
           ) : (
             <Card className="gap-0 rounded-2xl p-6 text-sm text-muted-foreground shadow-sm">
@@ -205,6 +217,13 @@ export function PostExamReviewView({
           >
             {isBookmarked ? 'Remove bookmark' : 'Bookmark'}
           </Button>
+        ) : null}
+        {currentRow?.isAvailable && questionFeedback ? (
+          <QuestionReportDialog
+            open={questionFeedback.isReportOpen}
+            onOpenChange={questionFeedback.openReport}
+            submitReport={questionFeedback.submitReport}
+          />
         ) : null}
       </div>
     </div>

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-exam-results-renderer.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-exam-results-renderer.tsx
@@ -5,6 +5,7 @@ import { Card } from '@/components/ui/card';
 import type { EndPracticeSessionOutput } from '@/src/adapters/controllers/practice-controller';
 import type { GetCompletedSessionQuestionsWithFeedbackOutput } from '@/src/application/use-cases';
 import type { GetPracticeSessionReviewOutput } from '@/src/application/use-cases/get-practice-session-review';
+import type { PracticeViewProps } from '../../components/practice-view';
 import type { LoadState } from '../../practice-page-logic';
 import type { ExamResultsSubstage } from '../hooks/use-practice-session-review-stage';
 import { PostExamReviewView } from './post-exam-review-view';
@@ -22,6 +23,7 @@ type PracticeSessionExamResultsRendererInput = {
   questionPanelId: string;
   bookmarkStatus: 'idle' | 'loading' | 'error';
   isBookmarked: boolean;
+  questionFeedback?: PracticeViewProps['questionFeedback'];
   onToggleBookmark: () => void;
   onRetryPostExamReview?: () => void;
   onNavigatePostExamReviewQuestion?: (questionId: string) => void;
@@ -117,6 +119,7 @@ export function renderPracticeSessionExamResults(
       controlledPanelId={input.questionPanelId}
       bookmarkStatus={input.bookmarkStatus}
       isBookmarked={input.isBookmarked}
+      questionFeedback={input.questionFeedback ?? null}
       onToggleBookmark={input.onToggleBookmark}
       onNavigateQuestion={
         input.onNavigatePostExamReviewQuestion ?? (() => undefined)

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx
@@ -6,7 +6,10 @@ import {
   useMemo,
   useRef,
 } from 'react';
-import { PracticeView } from '@/app/(app)/app/practice/components/practice-view';
+import {
+  PracticeView,
+  type PracticeViewProps,
+} from '@/app/(app)/app/practice/components/practice-view';
 import {
   fireAndForget,
   logUnhandledAsyncError,
@@ -51,6 +54,7 @@ export type PracticeSessionPageViewProps = {
   isMarkingForReview?: boolean;
   bookmarkMessage?: string | null;
   bookmarkMessageVersion?: number;
+  questionFeedback?: PracticeViewProps['questionFeedback'];
   onEndSession: () => void;
   onRetryReview?: () => void;
   onRetryPostExamReview?: () => void;
@@ -150,6 +154,7 @@ export function PracticeSessionPageView(props: PracticeSessionPageViewProps) {
     questionPanelId,
     bookmarkStatus: props.bookmarkStatus,
     isBookmarked: props.isBookmarked,
+    questionFeedback: props.questionFeedback ?? null,
     onToggleBookmark: props.onToggleBookmark,
     onRetryPostExamReview: props.onRetryPostExamReview,
     onNavigatePostExamReviewQuestion: props.onNavigatePostExamReviewQuestion,
@@ -270,6 +275,7 @@ export function PracticeSessionPageView(props: PracticeSessionPageViewProps) {
       isMarkingForReview={props.isMarkingForReview}
       bookmarkMessage={props.bookmarkMessage}
       bookmarkMessageVersion={props.bookmarkMessageVersion}
+      questionFeedback={props.questionFeedback ?? null}
       endSessionLabel={mode === 'exam' ? 'Review & Submit' : 'End session'}
       onEndSession={props.onEndSession}
       onTryAgain={onTryAgainResolved}

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller.test.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller.test.tsx
@@ -25,6 +25,9 @@ describe('usePracticeSessionPageController', () => {
     expect(output.isMarkingForReview).toBe(false);
     expect(output.bookmarkMessage).toBeNull();
     expect(output.bookmarkMessageVersion).toBe(0);
+    expect(output.questionFeedback.rating).toBeNull();
+    expect(output.questionFeedback.feedbackStatus).toBe('idle');
+    expect(output.questionFeedback.isReportOpen).toBe(false);
     expect(output.canSubmit).toBe(false);
     expect(output.summary).toBeNull();
     expect(output.examResultsSubstage).toBeNull();
@@ -38,6 +41,9 @@ describe('usePracticeSessionPageController', () => {
     expect(typeof output.onRetryNavigator).toBe('function');
     expect(typeof output.onTryAgain).toBe('function');
     expect(typeof output.onToggleBookmark).toBe('function');
+    expect(typeof output.questionFeedback.onRate).toBe('function');
+    expect(typeof output.questionFeedback.openReport).toBe('function');
+    expect(typeof output.questionFeedback.submitReport).toBe('function');
     expect(typeof output.onToggleMarkForReview).toBe('function');
     expect(typeof output.onSelectChoice).toBe('function');
     expect(typeof output.onSubmit).toBe('function');

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-controller.ts
@@ -13,6 +13,7 @@ import { usePracticeSessionQuestionFlow } from '@/app/(app)/app/practice/[sessio
 import { usePracticeSessionReviewStage } from '@/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage';
 import { ExamTimer } from '@/app/(app)/app/practice/components/exam-timer';
 import { usePracticeQuestionBookmarks } from '@/app/(app)/app/practice/hooks/use-practice-question-bookmarks';
+import { usePracticeQuestionFeedback } from '@/app/(app)/app/practice/hooks/use-practice-question-feedback';
 import {
   getActionResultErrorMessage,
   getThrownErrorMessage,
@@ -37,7 +38,13 @@ import {
 
 const BOOTSTRAP_SUMMARY_TIMEOUT_MS = STANDARD_READ_TIMEOUT_MS;
 
-type PracticeSessionPageControllerOutput = PracticeSessionPageViewProps & {
+type PracticeSessionPageControllerOutput = Omit<
+  PracticeSessionPageViewProps,
+  'questionFeedback'
+> & {
+  questionFeedback: NonNullable<
+    PracticeSessionPageViewProps['questionFeedback']
+  >;
   canSubmit: boolean;
   onSubmit: () => void;
 };
@@ -90,9 +97,56 @@ export function usePracticeSessionPageController(
     if (!currentRow?.isAvailable) return null;
     return { questionId: currentRow.questionId };
   }, [reviewStage.postExamReview, reviewStage.postExamReviewCurrentQuestionId]);
+  const currentPostExamFeedbackQuestion = useMemo(() => {
+    const currentRow =
+      reviewStage.postExamReview?.rows.find(
+        (row) => row.questionId === reviewStage.postExamReviewCurrentQuestionId,
+      ) ??
+      reviewStage.postExamReview?.rows[0] ??
+      null;
+
+    if (!currentRow?.isAvailable) return null;
+    return {
+      questionId: currentRow.questionId,
+      attemptId: null,
+      practiceSessionId: sessionId,
+    };
+  }, [
+    reviewStage.postExamReview,
+    reviewStage.postExamReviewCurrentQuestionId,
+    sessionId,
+  ]);
+  const activeQuestionFeedbackQuestion = useMemo(() => {
+    if (questionFlow.sessionMode === 'exam') return null;
+    if (!questionFlow.question) return null;
+    if (
+      questionFlow.submitResult === null ||
+      typeof questionFlow.submitResult.isCorrect !== 'boolean'
+    ) {
+      return null;
+    }
+
+    return {
+      questionId: questionFlow.question.questionId,
+      attemptId: questionFlow.submitResult.attemptId,
+      practiceSessionId: sessionId,
+    };
+  }, [
+    questionFlow.question,
+    questionFlow.sessionMode,
+    questionFlow.submitResult,
+    sessionId,
+  ]);
 
   const bookmarks = usePracticeQuestionBookmarks({
     question: currentPostExamBookmarkQuestion ?? questionFlow.question,
+    isMounted,
+  });
+  const currentFeedbackQuestion =
+    currentPostExamFeedbackQuestion ?? activeQuestionFeedbackQuestion;
+  const questionFeedback = usePracticeQuestionFeedback({
+    question: currentFeedbackQuestion,
+    isReviewMode: currentFeedbackQuestion !== null,
     isMounted,
   });
 
@@ -256,6 +310,7 @@ export function usePracticeSessionPageController(
     isMarkingForReview,
     bookmarkMessage: bookmarks.bookmarkMessage,
     bookmarkMessageVersion: bookmarks.bookmarkMessageVersion,
+    questionFeedback,
     canSubmit: questionFlow.canSubmit,
     onEndSession: reviewStage.onEndSession,
     onRetryReview: reviewStage.onRetryReview,

--- a/app/(app)/app/practice/components/practice-view-answer-feedback.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-answer-feedback.test.tsx
@@ -222,6 +222,51 @@ describe('PracticeView answer feedback', () => {
     expect(nextButton?.getAttribute('data-variant')).toBe('default');
   });
 
+  it('threads question feedback rating controls after the answer feedback panel', () => {
+    const question = createQuestionProps();
+    const selectedChoice = question.choices[0];
+    if (!selectedChoice) {
+      throw new Error('Expected at least one choice');
+    }
+
+    const html = renderToStaticMarkup(
+      <PracticeView
+        loadState={{ status: 'ready' }}
+        question={question}
+        selectedChoiceId={selectedChoice.id}
+        isAnswered={true}
+        submitResult={{
+          attemptId: fixtureAttempt1Id,
+          isCorrect: true,
+          correctChoiceId: selectedChoice.id,
+          explanationMd: 'Because.',
+          referenceMd: null,
+          choiceExplanations: [],
+        }}
+        isPending={false}
+        bookmarkStatus="idle"
+        isBookmarked={false}
+        questionFeedback={{
+          rating: 'helpful',
+          feedbackStatus: 'saved',
+          onRate: () => undefined,
+          isReportOpen: false,
+          openReport: () => undefined,
+          submitReport: async () => true,
+        }}
+        onTryAgain={() => undefined}
+        onToggleBookmark={() => undefined}
+        onSelectChoice={() => undefined}
+        onNextQuestion={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('Was this a good question?');
+    expect(html.indexOf('Because.')).toBeLessThan(
+      html.indexOf('Was this a good question?'),
+    );
+  });
+
   it('does not render Review answers for tutor mode after answer commit', () => {
     const question = createQuestionProps();
     const selectedChoice = question.choices[0];

--- a/app/(app)/app/practice/components/practice-view-bookmarks.test.tsx
+++ b/app/(app)/app/practice/components/practice-view-bookmarks.test.tsx
@@ -192,6 +192,65 @@ describe('PracticeView bookmarks', () => {
     expect(html).toContain('>Bookmark<');
   });
 
+  it('renders Give feedback as a review action sibling after feedback is visible', () => {
+    const question = createQuestionProps();
+    const selectedChoice = question.choices[0];
+    if (!selectedChoice) {
+      throw new Error('Expected at least one choice');
+    }
+
+    const html = renderToStaticMarkup(
+      <PracticeView
+        sessionInfo={{
+          sessionId: fixtureSession1Id,
+          mode: 'tutor',
+
+          deadlineAt: null,
+
+          index: 0,
+          total: 10,
+          isMarkedForReview: false,
+        }}
+        loadState={{ status: 'ready' }}
+        question={question}
+        selectedChoiceId={selectedChoice.id}
+        isAnswered={true}
+        submitResult={{
+          attemptId: fixtureAttempt1Id,
+          isCorrect: true,
+          correctChoiceId: selectedChoice.id,
+          explanationMd: 'Because.',
+          referenceMd: null,
+          choiceExplanations: [],
+        }}
+        isPending={false}
+        bookmarkStatus="idle"
+        isBookmarked={false}
+        questionFeedback={{
+          rating: null,
+          feedbackStatus: 'idle',
+          onRate: () => undefined,
+          isReportOpen: false,
+          openReport: () => undefined,
+          submitReport: async () => true,
+        }}
+        onTryAgain={() => undefined}
+        onToggleBookmark={() => undefined}
+        onToggleMarkForReview={() => undefined}
+        onSelectChoice={() => undefined}
+        onNextQuestion={() => undefined}
+      />,
+    );
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const actionBar = doc.querySelector('[data-testid="bottom-action-bar"]');
+    const labels = Array.from(actionBar?.querySelectorAll('button') ?? []).map(
+      (button) => button.textContent?.trim(),
+    );
+
+    expect(labels).toContain('Bookmark');
+    expect(labels).toContain('Give feedback');
+  });
+
   it('disables the tutor bookmark button when bookmarks are unavailable', () => {
     const question = createQuestionProps();
     const selectedChoice = question.choices[0];

--- a/app/(app)/app/practice/components/practice-view.tsx
+++ b/app/(app)/app/practice/components/practice-view.tsx
@@ -4,6 +4,11 @@ import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { useEffect, useId, useRef } from 'react';
 import { ErrorCard } from '@/components/error-card';
+import type { QuestionFeedbackRatingProps } from '@/components/question/question-feedback-rating';
+import {
+  QuestionReportDialog,
+  type QuestionReportDialogProps,
+} from '@/components/question/question-report-dialog';
 import { QuestionSurfaceBody } from '@/components/question/question-surface-body';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -36,6 +41,13 @@ export type PracticeViewProps = {
   isMarkingForReview?: boolean;
   bookmarkMessage?: string | null;
   bookmarkMessageVersion?: number;
+  questionFeedback?:
+    | (QuestionFeedbackRatingProps & {
+        isReportOpen: boolean;
+        openReport: (open?: boolean) => void;
+        submitReport: QuestionReportDialogProps['submitReport'];
+      })
+    | null;
   endSessionLabel?: string;
   questionPanelId?: string;
   questionAreaRef?: React.RefObject<HTMLElement | null>;
@@ -98,6 +110,7 @@ type TutorActionBarProps = Pick<
   | 'onNextQuestion'
   | 'onPreviousQuestion'
   | 'onToggleBookmark'
+  | 'questionFeedback'
   | 'submitResult'
 >;
 
@@ -181,6 +194,14 @@ function TutorActionBar(props: TutorActionBarProps) {
       >
         {props.isBookmarked ? 'Remove bookmark' : 'Bookmark'}
       </Button>
+      {props.questionFeedback ? (
+        <QuestionReportDialog
+          open={props.questionFeedback.isReportOpen}
+          onOpenChange={props.questionFeedback.openReport}
+          submitReport={props.questionFeedback.submitReport}
+          disabled={isActionBarDisabled}
+        />
+      ) : null}
     </div>
   ) : null;
 
@@ -345,6 +366,7 @@ export function PracticeView(props: PracticeViewProps) {
           onPreviousQuestion={props.onPreviousQuestion}
           onEndSession={props.onEndSession}
           onToggleBookmark={props.onToggleBookmark}
+          questionFeedback={props.questionFeedback ?? null}
           submitResult={props.submitResult}
         />
       )}
@@ -498,6 +520,15 @@ export function PracticeView(props: PracticeViewProps) {
             }
             onSelectChoice={props.onSelectChoice}
             feedback={feedbackResult}
+            questionFeedbackRating={
+              props.questionFeedback
+                ? {
+                    rating: props.questionFeedback.rating,
+                    feedbackStatus: props.questionFeedback.feedbackStatus,
+                    onRate: props.questionFeedback.onRate,
+                  }
+                : null
+            }
             feedbackRef={feedbackRef}
           />
         ) : null}

--- a/app/(app)/app/practice/hooks/use-practice-question-feedback.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-question-feedback.browser.spec.tsx
@@ -1,0 +1,214 @@
+import { useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import * as questionFeedbackController from '@/src/adapters/controllers/question-feedback-controller';
+import { ok } from '@/tests/test-helpers/ok';
+import { usePracticeQuestionFeedback } from './use-practice-question-feedback';
+
+vi.mock('@/src/adapters/controllers/question-feedback-controller', {
+  spy: true,
+});
+vi.mock('@/lib/report-client-error', { spy: true });
+
+const getQuestionRating = vi.mocked(
+  questionFeedbackController.getQuestionRating,
+);
+const rateQuestion = vi.mocked(questionFeedbackController.rateQuestion);
+const submitQuestionReport = vi.mocked(
+  questionFeedbackController.submitQuestionReport,
+);
+
+const questionId = '11111111-1111-4111-8111-111111111111';
+const attemptId = '22222222-2222-4222-8222-222222222222';
+const practiceSessionId = '33333333-3333-4333-8333-333333333333';
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function Probe({ initialReviewMode = true }: { initialReviewMode?: boolean }) {
+  const [isReviewMode, setIsReviewMode] = useState(initialReviewMode);
+  const output = usePracticeQuestionFeedback({
+    question: {
+      questionId,
+      attemptId,
+      practiceSessionId,
+    },
+    isReviewMode,
+    isMounted: () => true,
+  });
+
+  return (
+    <>
+      <div data-testid="feedback-status">{output.feedbackStatus}</div>
+      <div data-testid="rating">{output.rating ?? 'none'}</div>
+      <div data-testid="is-report-open">
+        {output.isReportOpen ? 'true' : 'false'}
+      </div>
+      <button type="button" onClick={() => output.onRate('helpful')}>
+        rate-helpful
+      </button>
+      <button type="button" onClick={() => output.onRate(null)}>
+        retract
+      </button>
+      <button type="button" onClick={() => output.openReport()}>
+        open-report
+      </button>
+      <button type="button" onClick={() => output.openReport(false)}>
+        close-report
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void output.submitReport({
+            category: 'ambiguous_wording',
+            comment: 'Needs a clearer stem.',
+          });
+        }}
+      >
+        submit-report
+      </button>
+      <button type="button" onClick={() => setIsReviewMode(false)}>
+        leave-review
+      </button>
+    </>
+  );
+}
+
+describe('usePracticeQuestionFeedback (browser)', () => {
+  beforeEach(() => {
+    getQuestionRating.mockResolvedValue(ok({ rating: null }));
+    rateQuestion.mockResolvedValue(ok({ rating: null }));
+    submitQuestionReport.mockResolvedValue(
+      ok({ feedbackId: crypto.randomUUID() }),
+    );
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('hydrates the current rating when review feedback is visible', async () => {
+    getQuestionRating.mockResolvedValue(ok({ rating: 'helpful' }));
+
+    const screen = await render(<Probe />);
+
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('idle');
+    await expect
+      .element(screen.getByTestId('rating'))
+      .toHaveTextContent('helpful');
+    expect(getQuestionRating).toHaveBeenCalledWith({ questionId });
+  });
+
+  it('optimistically applies a rating before the write resolves', async () => {
+    const deferred = createDeferred<Awaited<ReturnType<typeof rateQuestion>>>();
+    rateQuestion.mockReturnValue(deferred.promise);
+
+    const screen = await render(<Probe />);
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'rate-helpful' }).click();
+
+    await expect
+      .element(screen.getByTestId('rating'))
+      .toHaveTextContent('helpful');
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('saving');
+
+    deferred.resolve(ok({ rating: 'helpful' }));
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('saved');
+    expect(rateQuestion).toHaveBeenCalledWith({
+      questionId,
+      attemptId,
+      practiceSessionId,
+      rating: 'helpful',
+      idempotencyKey: expect.any(String),
+    });
+  });
+
+  it('rolls back a retraction when the write fails', async () => {
+    getQuestionRating.mockResolvedValue(ok({ rating: 'not_helpful' }));
+    rateQuestion.mockResolvedValue({
+      ok: false,
+      error: { code: 'INTERNAL_ERROR', message: 'Nope' },
+    });
+
+    const screen = await render(<Probe />);
+    await expect
+      .element(screen.getByTestId('rating'))
+      .toHaveTextContent('not_helpful');
+
+    await screen.getByRole('button', { name: 'retract' }).click();
+
+    await expect
+      .element(screen.getByTestId('rating'))
+      .toHaveTextContent('not_helpful');
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('error');
+    expect(rateQuestion).toHaveBeenCalledWith({
+      questionId,
+      attemptId,
+      practiceSessionId,
+      rating: null,
+      idempotencyKey: expect.any(String),
+    });
+  });
+
+  it('opens and closes the report dialog state and submits report context', async () => {
+    const screen = await render(<Probe />);
+    await expect
+      .element(screen.getByTestId('is-report-open'))
+      .toHaveTextContent('false');
+
+    await screen.getByRole('button', { name: 'open-report' }).click();
+    await expect
+      .element(screen.getByTestId('is-report-open'))
+      .toHaveTextContent('true');
+
+    await screen.getByRole('button', { name: 'submit-report' }).click();
+    await expect.poll(() => submitQuestionReport.mock.calls.length).toBe(1);
+    expect(submitQuestionReport).toHaveBeenCalledWith({
+      questionId,
+      attemptId,
+      practiceSessionId,
+      category: 'ambiguous_wording',
+      comment: 'Needs a clearer stem.',
+      idempotencyKey: expect.any(String),
+    });
+
+    await screen.getByRole('button', { name: 'close-report' }).click();
+    await expect
+      .element(screen.getByTestId('is-report-open'))
+      .toHaveTextContent('false');
+  });
+
+  it('resets rating state when leaving review mode', async () => {
+    getQuestionRating.mockResolvedValue(ok({ rating: 'helpful' }));
+
+    const screen = await render(<Probe />);
+    await expect
+      .element(screen.getByTestId('rating'))
+      .toHaveTextContent('helpful');
+
+    await screen.getByRole('button', { name: 'leave-review' }).click();
+
+    await expect
+      .element(screen.getByTestId('rating'))
+      .toHaveTextContent('none');
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('idle');
+  });
+});

--- a/app/(app)/app/practice/hooks/use-practice-question-feedback.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-question-feedback.browser.spec.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
+import * as clientError from '@/lib/report-client-error';
 import * as questionFeedbackController from '@/src/adapters/controllers/question-feedback-controller';
 import { ok } from '@/tests/test-helpers/ok';
 import { usePracticeQuestionFeedback } from './use-practice-question-feedback';
@@ -17,6 +18,7 @@ const rateQuestion = vi.mocked(questionFeedbackController.rateQuestion);
 const submitQuestionReport = vi.mocked(
   questionFeedbackController.submitQuestionReport,
 );
+const reportClientError = vi.mocked(clientError.reportClientError);
 
 const questionId = '11111111-1111-4111-8111-111111111111';
 const attemptId = '22222222-2222-4222-8222-222222222222';
@@ -30,7 +32,13 @@ function createDeferred<T>() {
   return { promise, resolve };
 }
 
-function Probe({ initialReviewMode = true }: { initialReviewMode?: boolean }) {
+function Probe({
+  initialReviewMode = true,
+  isMounted = () => true,
+}: {
+  initialReviewMode?: boolean;
+  isMounted?: () => boolean;
+}) {
   const [isReviewMode, setIsReviewMode] = useState(initialReviewMode);
   const output = usePracticeQuestionFeedback({
     question: {
@@ -39,7 +47,7 @@ function Probe({ initialReviewMode = true }: { initialReviewMode?: boolean }) {
       practiceSessionId,
     },
     isReviewMode,
-    isMounted: () => true,
+    isMounted,
   });
 
   return (
@@ -104,6 +112,54 @@ describe('usePracticeQuestionFeedback (browser)', () => {
       .element(screen.getByTestId('rating'))
       .toHaveTextContent('helpful');
     expect(getQuestionRating).toHaveBeenCalledWith({ questionId });
+  });
+
+  it('reports hydration action errors and enters an error state', async () => {
+    getQuestionRating.mockResolvedValue({
+      ok: false,
+      error: { code: 'INTERNAL_ERROR', message: 'Nope' },
+    });
+
+    const screen = await render(<Probe />);
+
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('error');
+    expect(reportClientError).toHaveBeenCalledWith(
+      { code: 'INTERNAL_ERROR', message: 'Nope' },
+      {
+        component: 'UsePracticeQuestionFeedback',
+        action: 'loadQuestionRating',
+      },
+    );
+  });
+
+  it('reports thrown hydration errors and enters an error state', async () => {
+    const error = new Error('Network down');
+    getQuestionRating.mockRejectedValue(error);
+
+    const screen = await render(<Probe />);
+
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('error');
+    expect(reportClientError).toHaveBeenCalledWith(error, {
+      component: 'UsePracticeQuestionFeedback',
+      action: 'loadQuestionRating',
+    });
+  });
+
+  it('ignores hydration results after unmount', async () => {
+    getQuestionRating.mockResolvedValue(ok({ rating: 'helpful' }));
+
+    const screen = await render(<Probe isMounted={() => false} />);
+
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('loading');
+    await expect
+      .element(screen.getByTestId('rating'))
+      .toHaveTextContent('none');
   });
 
   it('optimistically applies a rating before the write resolves', async () => {
@@ -194,6 +250,50 @@ describe('usePracticeQuestionFeedback (browser)', () => {
       .toHaveTextContent('false');
   });
 
+  it('reports submit-report failures through the client error reporter', async () => {
+    submitQuestionReport.mockResolvedValue({
+      ok: false,
+      error: { code: 'INTERNAL_ERROR', message: 'Nope' },
+    });
+
+    const screen = await render(<Probe />);
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'submit-report' }).click();
+
+    await expect.poll(() => submitQuestionReport.mock.calls.length).toBe(1);
+    expect(reportClientError).toHaveBeenCalledWith(
+      {
+        code: 'INTERNAL_ERROR',
+        message: 'Nope',
+        questionId,
+        category: 'ambiguous_wording',
+      },
+      {
+        component: 'UsePracticeQuestionFeedback',
+        action: 'submitQuestionReport',
+      },
+    );
+  });
+
+  it('ignores rating state updates after unmount', async () => {
+    rateQuestion.mockResolvedValue(ok({ rating: 'helpful' }));
+
+    const screen = await render(<Probe isMounted={() => false} />);
+
+    await screen.getByRole('button', { name: 'rate-helpful' }).click();
+
+    await expect.poll(() => rateQuestion.mock.calls.length).toBe(1);
+    await expect
+      .element(screen.getByTestId('rating'))
+      .toHaveTextContent('none');
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('loading');
+  });
+
   it('resets rating state when leaving review mode', async () => {
     getQuestionRating.mockResolvedValue(ok({ rating: 'helpful' }));
 
@@ -210,5 +310,19 @@ describe('usePracticeQuestionFeedback (browser)', () => {
     await expect
       .element(screen.getByTestId('feedback-status'))
       .toHaveTextContent('idle');
+  });
+
+  it('ignores rate and report commands after leaving review mode', async () => {
+    const screen = await render(<Probe />);
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'leave-review' }).click();
+    await screen.getByRole('button', { name: 'rate-helpful' }).click();
+    await screen.getByRole('button', { name: 'submit-report' }).click();
+
+    expect(rateQuestion).not.toHaveBeenCalled();
+    expect(submitQuestionReport).not.toHaveBeenCalled();
   });
 });

--- a/app/(app)/app/practice/hooks/use-practice-question-feedback.ts
+++ b/app/(app)/app/practice/hooks/use-practice-question-feedback.ts
@@ -1,0 +1,218 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type FeedbackQuestionContext,
+  rateQuestionForQuestion,
+  submitReportForQuestion,
+} from '@/app/(app)/app/shared/question-feedback-actions';
+import { STANDARD_READ_TIMEOUT_MS } from '@/app/(app)/app/shared/timeout-tiers';
+import {
+  reportClientError,
+  shouldReportClientError,
+} from '@/lib/report-client-error';
+import { withTimeout } from '@/lib/with-timeout';
+import {
+  getQuestionRating,
+  rateQuestion,
+  submitQuestionReport,
+} from '@/src/adapters/controllers/question-feedback-controller';
+import type {
+  QuestionFeedbackCategory,
+  QuestionFeedbackRating,
+} from '@/src/domain/value-objects';
+
+const QUESTION_RATING_LOOKUP_TIMEOUT_MS = STANDARD_READ_TIMEOUT_MS;
+
+export type PracticeQuestionFeedbackStatus =
+  | 'idle'
+  | 'loading'
+  | 'saving'
+  | 'saved'
+  | 'error';
+
+export type UsePracticeQuestionFeedbackInput = {
+  question: FeedbackQuestionContext | null;
+  isReviewMode: boolean;
+  isMounted: () => boolean;
+};
+
+export type UsePracticeQuestionFeedbackOutput = {
+  rating: QuestionFeedbackRating | null;
+  feedbackStatus: PracticeQuestionFeedbackStatus;
+  onRate: (rating: QuestionFeedbackRating | null) => void;
+  isReportOpen: boolean;
+  openReport: (open?: boolean) => void;
+  submitReport: (input: {
+    category: QuestionFeedbackCategory;
+    comment: string | null;
+  }) => Promise<boolean>;
+};
+
+export function usePracticeQuestionFeedback(
+  input: UsePracticeQuestionFeedbackInput,
+): UsePracticeQuestionFeedbackOutput {
+  const [rating, setRating] = useState<QuestionFeedbackRating | null>(null);
+  const [feedbackStatus, setFeedbackStatus] =
+    useState<PracticeQuestionFeedbackStatus>('idle');
+  const [isReportOpen, setIsReportOpen] = useState(false);
+  const latestRatingLookupRequestId = useRef(0);
+  const feedbackStateVersionRef = useRef(0);
+  const ratingIdempotencyKeysRef = useRef<Map<string, string>>(new Map());
+  const reportIdempotencyKeysRef = useRef<Map<string, string>>(new Map());
+  const isMountedRef = useRef(input.isMounted);
+  isMountedRef.current = input.isMounted;
+  const questionId = input.question?.questionId ?? null;
+  const attemptId = input.question?.attemptId ?? null;
+  const practiceSessionId = input.question?.practiceSessionId ?? null;
+
+  const questionContext = useMemo<FeedbackQuestionContext | null>(() => {
+    if (!input.isReviewMode || !questionId) return null;
+
+    return {
+      questionId,
+      attemptId,
+      practiceSessionId,
+    };
+  }, [input.isReviewMode, questionId, attemptId, practiceSessionId]);
+
+  useEffect(() => {
+    const isMounted = () => isMountedRef.current();
+
+    if (!questionContext) {
+      latestRatingLookupRequestId.current += 1;
+      feedbackStateVersionRef.current += 1;
+      setRating(null);
+      setFeedbackStatus('idle');
+      setIsReportOpen(false);
+      return;
+    }
+
+    latestRatingLookupRequestId.current += 1;
+    const requestId = latestRatingLookupRequestId.current;
+    feedbackStateVersionRef.current += 1;
+    const stateVersion = feedbackStateVersionRef.current;
+    const questionId = questionContext.questionId;
+
+    setRating(null);
+    setFeedbackStatus('loading');
+
+    void withTimeout(
+      getQuestionRating({ questionId }),
+      QUESTION_RATING_LOOKUP_TIMEOUT_MS,
+    )
+      .then((result) => {
+        if (!isMounted()) return;
+        if (latestRatingLookupRequestId.current !== requestId) return;
+        if (feedbackStateVersionRef.current !== stateVersion) return;
+
+        if (!result.ok) {
+          if (shouldReportClientError(result.error)) {
+            reportClientError(result.error, {
+              component: 'UsePracticeQuestionFeedback',
+              action: 'loadQuestionRating',
+            });
+          }
+          setFeedbackStatus('error');
+          return;
+        }
+
+        setRating(result.data.rating);
+        setFeedbackStatus('idle');
+      })
+      .catch((error: unknown) => {
+        if (!isMounted()) return;
+        if (latestRatingLookupRequestId.current !== requestId) return;
+        if (feedbackStateVersionRef.current !== stateVersion) return;
+
+        reportClientError(error, {
+          component: 'UsePracticeQuestionFeedback',
+          action: 'loadQuestionRating',
+        });
+        setFeedbackStatus('error');
+      });
+  }, [questionContext]);
+
+  const onRate = useCallback(
+    (nextRating: QuestionFeedbackRating | null) => {
+      if (!questionContext) return;
+
+      feedbackStateVersionRef.current += 1;
+      const stateVersion = feedbackStateVersionRef.current;
+      const questionId = questionContext.questionId;
+
+      void rateQuestionForQuestion({
+        question: questionContext,
+        currentRating: rating,
+        nextRating,
+        ratingIdempotencyKey:
+          ratingIdempotencyKeysRef.current.get(questionId) ?? null,
+        createIdempotencyKey: () => crypto.randomUUID(),
+        setRatingIdempotencyKey: (key) => {
+          ratingIdempotencyKeysRef.current.set(questionId, key);
+        },
+        rateQuestionFn: rateQuestion,
+        setRating: (nextRatingState) => {
+          if (!isMountedRef.current()) return;
+          if (feedbackStateVersionRef.current !== stateVersion) return;
+          setRating(nextRatingState);
+        },
+        setFeedbackStatus: (status) => {
+          if (!isMountedRef.current()) return;
+          if (feedbackStateVersionRef.current !== stateVersion) return;
+          setFeedbackStatus(status);
+        },
+        logError: (_message, error) => {
+          reportClientError(error, {
+            component: 'UsePracticeQuestionFeedback',
+            action: 'rateQuestion',
+          });
+        },
+        isMounted: () => isMountedRef.current(),
+      });
+    },
+    [questionContext, rating],
+  );
+
+  const openReport = useCallback((open = true) => {
+    setIsReportOpen(open);
+  }, []);
+
+  const submitReport = useCallback(
+    async (report: {
+      category: QuestionFeedbackCategory;
+      comment: string | null;
+    }): Promise<boolean> => {
+      if (!questionContext) return false;
+
+      const questionId = questionContext.questionId;
+      return submitReportForQuestion({
+        question: questionContext,
+        category: report.category,
+        comment: report.comment,
+        reportIdempotencyKey:
+          reportIdempotencyKeysRef.current.get(questionId) ?? null,
+        createIdempotencyKey: () => crypto.randomUUID(),
+        setReportIdempotencyKey: (key) => {
+          reportIdempotencyKeysRef.current.set(questionId, key);
+        },
+        submitQuestionReportFn: submitQuestionReport,
+        logError: (_message, context) => {
+          reportClientError(context, {
+            component: 'UsePracticeQuestionFeedback',
+            action: 'submitQuestionReport',
+          });
+        },
+        isMounted: () => isMountedRef.current(),
+      });
+    },
+    [questionContext],
+  );
+
+  return {
+    rating,
+    feedbackStatus,
+    onRate,
+    isReportOpen,
+    openReport,
+    submitReport,
+  };
+}

--- a/app/(app)/app/practice/hooks/use-practice-question-flow.test.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-question-flow.test.tsx
@@ -29,9 +29,15 @@ describe('usePracticeQuestionFlow', () => {
     expect(output.bookmarkMessageVersion).toBe(0);
     expect(output.canSubmit).toBe(false);
     expect(output.isBookmarked).toBe(false);
+    expect(output.questionFeedback.rating).toBeNull();
+    expect(output.questionFeedback.feedbackStatus).toBe('idle');
+    expect(output.questionFeedback.isReportOpen).toBe(false);
     expect(output.questionAreaRef).toBeDefined();
     expect(typeof output.onTryAgain).toBe('function');
     expect(typeof output.onToggleBookmark).toBe('function');
+    expect(typeof output.questionFeedback.onRate).toBe('function');
+    expect(typeof output.questionFeedback.openReport).toBe('function');
+    expect(typeof output.questionFeedback.submitReport).toBe('function');
     expect(typeof output.onSelectChoice).toBe('function');
     expect(typeof output.onSubmit).toBe('function');
     expect(typeof output.onNextQuestion).toBe('function');

--- a/app/(app)/app/practice/hooks/use-practice-question-flow.ts
+++ b/app/(app)/app/practice/hooks/use-practice-question-flow.ts
@@ -3,6 +3,10 @@ import {
   usePracticeQuestionAnswerFlow,
 } from '@/app/(app)/app/practice/hooks/use-practice-question-answer-flow';
 import { usePracticeQuestionBookmarks } from '@/app/(app)/app/practice/hooks/use-practice-question-bookmarks';
+import {
+  type UsePracticeQuestionFeedbackOutput,
+  usePracticeQuestionFeedback,
+} from '@/app/(app)/app/practice/hooks/use-practice-question-feedback';
 import type { PracticeFilters } from '@/app/(app)/app/practice/practice-page-logic';
 import { useIsMounted } from '@/lib/use-is-mounted';
 import {
@@ -26,6 +30,7 @@ export type UsePracticeQuestionFlowOutput = {
   bookmarkStatus: 'idle' | 'loading' | 'error';
   bookmarkMessage: string | null;
   bookmarkMessageVersion: number;
+  questionFeedback: UsePracticeQuestionFeedbackOutput;
   canSubmit: boolean;
   isBookmarked: boolean;
   questionAreaRef: React.RefObject<HTMLElement | null>;
@@ -55,9 +60,23 @@ export function usePracticeQuestionFlow(
     question: answerFlow.question,
     isMounted,
   });
+  const questionFeedback = usePracticeQuestionFeedback({
+    question: answerFlow.question
+      ? {
+          questionId: answerFlow.question.questionId,
+          attemptId: answerFlow.submitResult?.attemptId ?? null,
+          practiceSessionId: null,
+        }
+      : null,
+    isReviewMode:
+      answerFlow.submitResult !== null &&
+      typeof answerFlow.submitResult.isCorrect === 'boolean',
+    isMounted,
+  });
 
   return {
     ...answerFlow,
     ...bookmarks,
+    questionFeedback,
   };
 }

--- a/app/(app)/app/practice/quick/quick-practice-client.tsx
+++ b/app/(app)/app/practice/quick/quick-practice-client.tsx
@@ -106,6 +106,7 @@ export default function QuickPracticeClient() {
       isPending={questionFlow.isPending}
       bookmarkStatus={questionFlow.bookmarkStatus}
       isBookmarked={questionFlow.isBookmarked}
+      questionFeedback={questionFlow.questionFeedback}
       // Mark-for-review is session-only; ad-hoc practice doesn't support it yet.
       isMarkingForReview={false}
       bookmarkMessage={questionFlow.bookmarkMessage}

--- a/app/(app)/app/questions/[slug]/question-page-client.test.tsx
+++ b/app/(app)/app/questions/[slug]/question-page-client.test.tsx
@@ -61,7 +61,7 @@ describe('QuestionView', () => {
     );
   }
 
-  // Uses shadcn's data-slot="button" to capture both <button> and asChild <a> elements.
+  // Uses shadcn/Radix slots to capture buttons, asChild links, and Dialog triggers.
   // If shadcn removes data-slot, fall back to 'button, a' combined selector.
   function getBottomActionLabels(doc: Document): string[] {
     const bottomBar = getBottomActionBar(doc);
@@ -69,9 +69,11 @@ describe('QuestionView', () => {
       throw new Error('Expected bottom action bar');
     }
 
-    return Array.from(bottomBar.querySelectorAll('[data-slot="button"]')).map(
-      (element) => (element.textContent ?? '').trim(),
-    );
+    return Array.from(
+      bottomBar.querySelectorAll(
+        '[data-slot="button"], [data-slot="dialog-trigger"]',
+      ),
+    ).map((element) => (element.textContent ?? '').trim());
   }
 
   const sharedSessionNavigation = {
@@ -944,6 +946,120 @@ describe('QuestionView', () => {
 
     expect(bookmarkButton).not.toBeNull();
     expect(bookmarkButton?.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('renders Give feedback as a review action sibling', () => {
+    const html = renderToStaticMarkup(
+      <QuestionView
+        {...createBaseProps()}
+        mode="review"
+        origin="history"
+        question={{
+          questionId: fixtureQuestion1Id2,
+          slug: 'q1',
+          stemMd: 'Question stem',
+          difficulty: 'easy',
+          choices: [{ id: 'c1', label: 'A', textMd: 'Choice A' }],
+        }}
+        submitResult={{
+          attemptId: fixtureAttempt1Id,
+          isCorrect: true,
+          correctChoiceId: 'c1',
+          explanationMd: 'Explanation',
+          referenceMd: null,
+          choiceExplanations: [],
+        }}
+        isBookmarked={false}
+        isBookmarkHydrated={true}
+        bookmarkStatus="idle"
+        questionFeedback={{
+          rating: null,
+          feedbackStatus: 'idle',
+          onRate: () => undefined,
+          isReportOpen: false,
+          openReport: () => undefined,
+          submitReport: async () => true,
+        }}
+        onToggleBookmark={() => undefined}
+      />,
+    );
+
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    expect(getBottomActionLabels(doc)).toContain('Bookmark');
+    expect(getBottomActionLabels(doc)).toContain('Give feedback');
+  });
+
+  it('renders question feedback rating controls after standalone review feedback', () => {
+    const html = renderToStaticMarkup(
+      <QuestionView
+        {...createBaseProps()}
+        mode="review"
+        origin="history"
+        question={{
+          questionId: fixtureQuestion1Id2,
+          slug: 'q1',
+          stemMd: 'Question stem',
+          difficulty: 'easy',
+          choices: [{ id: 'c1', label: 'A', textMd: 'Choice A' }],
+        }}
+        submitResult={{
+          attemptId: fixtureAttempt1Id,
+          isCorrect: true,
+          correctChoiceId: 'c1',
+          explanationMd: 'Standalone explanation',
+          referenceMd: null,
+          choiceExplanations: [],
+        }}
+        questionFeedback={{
+          rating: 'helpful',
+          feedbackStatus: 'saved',
+          onRate: () => undefined,
+          isReportOpen: false,
+          openReport: () => undefined,
+          submitReport: async () => true,
+        }}
+      />,
+    );
+
+    expect(html).toContain('Was this a good question?');
+    expect(html.indexOf('Standalone explanation')).toBeLessThan(
+      html.indexOf('Was this a good question?'),
+    );
+  });
+
+  it('does not render standalone rating controls outside review mode', () => {
+    const html = renderToStaticMarkup(
+      <QuestionView
+        {...createBaseProps()}
+        question={{
+          questionId: fixtureQuestion1Id2,
+          slug: 'q1',
+          stemMd: 'Question stem',
+          difficulty: 'easy',
+          choices: [{ id: 'c1', label: 'A', textMd: 'Choice A' }],
+        }}
+        submitResult={{
+          attemptId: fixtureAttempt1Id,
+          isCorrect: true,
+          correctChoiceId: 'c1',
+          explanationMd: 'Standalone explanation',
+          referenceMd: null,
+          choiceExplanations: [],
+        }}
+        questionFeedback={{
+          rating: 'helpful',
+          feedbackStatus: 'saved',
+          onRate: () => undefined,
+          isReportOpen: false,
+          openReport: () => undefined,
+          submitReport: async () => true,
+        }}
+      />,
+    );
+
+    expect(html).toContain('Standalone explanation');
+    expect(html).not.toContain('Was this a good question?');
+    expect(html).not.toContain('Give feedback');
   });
 
   it('hides the bookmark toggle while bookmark state is still hydrating', () => {

--- a/app/(app)/app/questions/[slug]/question-page-client.tsx
+++ b/app/(app)/app/questions/[slug]/question-page-client.tsx
@@ -4,6 +4,11 @@ import Link from 'next/link';
 import { useMemo } from 'react';
 import { ReviewQuestionNavigator } from '@/app/(app)/app/questions/[slug]/components/review-question-navigator';
 import { ErrorCard } from '@/components/error-card';
+import type { QuestionFeedbackRatingProps } from '@/components/question/question-feedback-rating';
+import {
+  QuestionReportDialog,
+  type QuestionReportDialogProps,
+} from '@/components/question/question-report-dialog';
 import { QuestionSurfaceBody } from '@/components/question/question-surface-body';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -158,6 +163,13 @@ export type QuestionViewProps = {
   bookmarkStatus?: QuestionPageBookmarkStatus;
   isBookmarkHydrated?: boolean;
   isBookmarked?: boolean;
+  questionFeedback?:
+    | (QuestionFeedbackRatingProps & {
+        isReportOpen: boolean;
+        openReport: (open?: boolean) => void;
+        submitReport: QuestionReportDialogProps['submitReport'];
+      })
+    | null;
   mode?: QuestionMode | null;
   origin?: QuestionOrigin | null;
   sessionId?: string;
@@ -216,6 +228,7 @@ export function QuestionView(props: QuestionViewProps) {
   const isBookmarkHydrated = props.isBookmarkHydrated ?? false;
   const isBookmarked = props.isBookmarked ?? false;
   const onToggleBookmark = props.onToggleBookmark ?? (() => undefined);
+  const questionFeedback = props.questionFeedback ?? null;
   const questionSurfaceQuestion =
     props.question && !props.isLoadingPreviousAttempt && !isReviewHydrationError
       ? props.question
@@ -353,6 +366,15 @@ export function QuestionView(props: QuestionViewProps) {
           }
           onSelectChoice={props.onSelectChoice}
           feedback={questionSurfaceFeedback}
+          questionFeedbackRating={
+            isReviewMode && questionFeedback
+              ? {
+                  rating: questionFeedback.rating,
+                  feedbackStatus: questionFeedback.feedbackStatus,
+                  onRate: questionFeedback.onRate,
+                }
+              : null
+          }
           beforeQuestionCard={
             isSessionReviewUnansweredReveal ? (
               <Card
@@ -432,6 +454,15 @@ export function QuestionView(props: QuestionViewProps) {
             >
               {isBookmarked ? 'Remove bookmark' : 'Bookmark'}
             </Button>
+          ) : null}
+
+          {isReviewMode && props.question && questionFeedback ? (
+            <QuestionReportDialog
+              open={questionFeedback.isReportOpen}
+              onOpenChange={questionFeedback.openReport}
+              submitReport={questionFeedback.submitReport}
+              disabled={props.isPending}
+            />
           ) : null}
 
           {props.sessionNavigation ? (

--- a/app/(app)/app/questions/[slug]/use-question-page-controller-feedback.browser.spec.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-controller-feedback.browser.spec.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { ok } from '@/tests/test-helpers/ok';
+import {
+  getPreviousAttempt,
+  getQuestionBySlug,
+  getQuestionRating,
+  Probe,
+  QUESTION_PAGE_ATTEMPT_1_ID,
+  QUESTION_PAGE_CHOICE_1_ID,
+  QUESTION_PAGE_QUESTION_1_ID,
+  rateQuestion,
+  setupQuestionPageControllerBrowserSpec,
+  submitQuestionReport,
+} from './use-question-page-controller-test-helpers';
+
+setupQuestionPageControllerBrowserSpec();
+
+describe('useQuestionPageController feedback wiring (browser)', () => {
+  it('hydrates and rates feedback for a standalone review question', async () => {
+    getQuestionBySlug.mockResolvedValue(
+      ok({
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
+        slug: 'q-1',
+        stemMd: 'Stem',
+        difficulty: 'easy',
+        choices: [
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+        ],
+      }),
+    );
+    getPreviousAttempt.mockResolvedValue(
+      ok({
+        kind: 'attempt',
+        sessionMode: null,
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_1_ID,
+        isOmitted: false,
+        isCorrect: true,
+        correctChoiceId: QUESTION_PAGE_CHOICE_1_ID,
+        explanationMd: 'Because.',
+        referenceMd: null,
+        choiceExplanations: [],
+        answeredAt: '2026-02-01T00:00:00.000Z',
+      }),
+    );
+    getQuestionRating.mockResolvedValue(ok({ rating: 'not_helpful' }));
+    rateQuestion.mockResolvedValue(ok({ rating: 'helpful' }));
+
+    const screen = await render(
+      <Probe mode="review" attemptId={QUESTION_PAGE_ATTEMPT_1_ID} />,
+    );
+
+    await expect
+      .element(screen.getByTestId('question-rating'))
+      .toHaveTextContent('not_helpful');
+    expect(getQuestionRating).toHaveBeenCalledWith({
+      questionId: QUESTION_PAGE_QUESTION_1_ID,
+    });
+
+    await screen.getByTestId('trigger-rate-good').click();
+
+    await expect.poll(() => rateQuestion.mock.calls.length).toBe(1);
+    expect(rateQuestion).toHaveBeenCalledWith({
+      questionId: QUESTION_PAGE_QUESTION_1_ID,
+      attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+      practiceSessionId: null,
+      rating: 'helpful',
+      idempotencyKey: expect.any(String),
+    });
+    await expect
+      .element(screen.getByTestId('question-rating'))
+      .toHaveTextContent('helpful');
+  });
+
+  it('submits report context for a standalone review question', async () => {
+    getQuestionBySlug.mockResolvedValue(
+      ok({
+        questionId: QUESTION_PAGE_QUESTION_1_ID,
+        slug: 'q-1',
+        stemMd: 'Stem',
+        difficulty: 'easy',
+        choices: [
+          { id: QUESTION_PAGE_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+        ],
+      }),
+    );
+    getPreviousAttempt.mockResolvedValue(
+      ok({
+        kind: 'attempt',
+        sessionMode: null,
+        attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+        selectedChoiceId: QUESTION_PAGE_CHOICE_1_ID,
+        isOmitted: false,
+        isCorrect: true,
+        correctChoiceId: QUESTION_PAGE_CHOICE_1_ID,
+        explanationMd: 'Because.',
+        referenceMd: null,
+        choiceExplanations: [],
+        answeredAt: '2026-02-01T00:00:00.000Z',
+      }),
+    );
+
+    const screen = await render(
+      <Probe mode="review" attemptId={QUESTION_PAGE_ATTEMPT_1_ID} />,
+    );
+
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByTestId('trigger-submit-report').click();
+
+    await expect.poll(() => submitQuestionReport.mock.calls.length).toBe(1);
+    expect(submitQuestionReport).toHaveBeenCalledWith({
+      questionId: QUESTION_PAGE_QUESTION_1_ID,
+      attemptId: QUESTION_PAGE_ATTEMPT_1_ID,
+      practiceSessionId: null,
+      category: 'ambiguous_wording',
+      comment: 'Needs source',
+      idempotencyKey: expect.any(String),
+    });
+  });
+});

--- a/app/(app)/app/questions/[slug]/use-question-page-controller-test-helpers.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-controller-test-helpers.tsx
@@ -4,6 +4,7 @@ import type { QuestionOrigin } from '@/lib/routes';
 import * as bookmarkController from '@/src/adapters/controllers/bookmark-controller';
 import * as practiceController from '@/src/adapters/controllers/practice-controller';
 import * as questionController from '@/src/adapters/controllers/question-controller';
+import * as questionFeedbackController from '@/src/adapters/controllers/question-feedback-controller';
 import * as questionViewController from '@/src/adapters/controllers/question-view-controller';
 import type { GetBookmarksOutput } from '@/src/application/ports/bookmarks';
 import { ok } from '@/tests/test-helpers/ok';
@@ -26,6 +27,9 @@ vi.mock('@/src/adapters/controllers/question-view-controller', { spy: true });
 vi.mock('@/src/adapters/controllers/question-controller', { spy: true });
 vi.mock('@/src/adapters/controllers/practice-controller', { spy: true });
 vi.mock('@/src/adapters/controllers/bookmark-controller', { spy: true });
+vi.mock('@/src/adapters/controllers/question-feedback-controller', {
+  spy: true,
+});
 vi.mock('@/lib/report-client-error', { spy: true });
 
 export const getQuestionBySlug = vi.mocked(
@@ -40,6 +44,13 @@ export const getPracticeSessionReview = vi.mocked(
 );
 export const getBookmarks = vi.mocked(bookmarkController.getBookmarks);
 export const toggleBookmark = vi.mocked(bookmarkController.toggleBookmark);
+export const getQuestionRating = vi.mocked(
+  questionFeedbackController.getQuestionRating,
+);
+export const rateQuestion = vi.mocked(questionFeedbackController.rateQuestion);
+export const submitQuestionReport = vi.mocked(
+  questionFeedbackController.submitQuestionReport,
+);
 export const reportClientErrorSpy = vi.mocked(
   reportClientError.reportClientError,
 );
@@ -54,6 +65,11 @@ export function setupQuestionPageControllerBrowserSpec() {
   beforeEach(() => {
     getBookmarks.mockResolvedValue(emptyBookmarksResult);
     toggleBookmark.mockResolvedValue(ok({ bookmarked: false }));
+    getQuestionRating.mockResolvedValue(ok({ rating: null }));
+    rateQuestion.mockResolvedValue(ok({ rating: null }));
+    submitQuestionReport.mockResolvedValue(
+      ok({ feedbackId: crypto.randomUUID() }),
+    );
   });
 
   afterEach(() => {
@@ -144,6 +160,15 @@ export function Probe({
       <div data-testid="is-bookmarked">
         {output.isBookmarked ? 'true' : 'false'}
       </div>
+      <div data-testid="feedback-status">
+        {output.questionFeedback.feedbackStatus}
+      </div>
+      <div data-testid="question-rating">
+        {output.questionFeedback.rating ?? 'none'}
+      </div>
+      <div data-testid="is-report-open">
+        {output.questionFeedback.isReportOpen ? 'true' : 'false'}
+      </div>
       <button
         type="button"
         data-testid="select-choice-1"
@@ -178,6 +203,32 @@ export function Probe({
         onClick={() => void output.onToggleBookmark()}
       >
         Trigger toggle bookmark
+      </button>
+      <button
+        type="button"
+        data-testid="trigger-rate-good"
+        onClick={() => void output.questionFeedback.onRate('helpful')}
+      >
+        Trigger rate good
+      </button>
+      <button
+        type="button"
+        data-testid="trigger-open-report"
+        onClick={() => output.questionFeedback.openReport()}
+      >
+        Trigger open report
+      </button>
+      <button
+        type="button"
+        data-testid="trigger-submit-report"
+        onClick={() =>
+          void output.questionFeedback.submitReport({
+            category: 'ambiguous_wording',
+            comment: 'Needs source',
+          })
+        }
+      >
+        Trigger submit report
       </button>
     </>
   );

--- a/app/(app)/app/questions/[slug]/use-question-page-controller.ts
+++ b/app/(app)/app/questions/[slug]/use-question-page-controller.ts
@@ -28,10 +28,15 @@ import {
   type QuestionPageBookmarkStatus,
   useQuestionPageBookmarks,
 } from './use-question-page-bookmarks';
+import {
+  type UseQuestionPageFeedbackOutput,
+  useQuestionPageFeedback,
+} from './use-question-page-feedback';
 import { useQuestionPagePreviousAttempt } from './use-question-page-previous-attempt';
 import { useQuestionPageSessionNavigation } from './use-question-page-session-navigation';
 
 export type { QuestionPageBookmarkStatus } from './use-question-page-bookmarks';
+export type { QuestionPageFeedbackStatus } from './use-question-page-feedback';
 
 function resolveRetryOrigin(input: {
   mode?: QuestionMode | null;
@@ -70,6 +75,7 @@ export type UseQuestionPageControllerOutput = {
   bookmarkStatus: QuestionPageBookmarkStatus;
   isBookmarkHydrated: boolean;
   isBookmarked: boolean;
+  questionFeedback: UseQuestionPageFeedbackOutput;
   onTryAgain: () => void;
   onToggleBookmark: () => void;
   onSelectChoice: (choiceId: string) => void;
@@ -173,6 +179,13 @@ export function useQuestionPageController(
       question,
       isMounted,
     });
+  const questionFeedback = useQuestionPageFeedback({
+    mode: input.mode,
+    question,
+    attemptId: submitResult?.attemptId ?? normalizedAttemptId ?? null,
+    practiceSessionId: normalizedSessionId ?? null,
+    isMounted,
+  });
   const { sessionNavigation, markCurrentQuestionRetried } =
     useQuestionPageSessionNavigation({
       slug: input.slug,
@@ -348,6 +361,7 @@ export function useQuestionPageController(
     bookmarkStatus,
     isBookmarkHydrated,
     isBookmarked,
+    questionFeedback,
     onTryAgain: loadQuestion,
     onToggleBookmark,
     onSelectChoice,

--- a/app/(app)/app/questions/[slug]/use-question-page-feedback.browser.spec.tsx
+++ b/app/(app)/app/questions/[slug]/use-question-page-feedback.browser.spec.tsx
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import * as questionFeedbackController from '@/src/adapters/controllers/question-feedback-controller';
+import type { GetQuestionBySlugOutput } from '@/src/adapters/controllers/question-view-controller';
+import { ok } from '@/tests/test-helpers/ok';
+import { useQuestionPageFeedback } from './use-question-page-feedback';
+
+vi.mock('@/src/adapters/controllers/question-feedback-controller', {
+  spy: true,
+});
+vi.mock('@/lib/report-client-error', { spy: true });
+
+const getQuestionRating = vi.mocked(
+  questionFeedbackController.getQuestionRating,
+);
+const submitQuestionReport = vi.mocked(
+  questionFeedbackController.submitQuestionReport,
+);
+
+const questionId = '11111111-1111-4111-8111-111111111111';
+const attemptId = '22222222-2222-4222-8222-222222222222';
+const practiceSessionId = '33333333-3333-4333-8333-333333333333';
+
+function createQuestion(): GetQuestionBySlugOutput {
+  return {
+    questionId,
+    slug: 'question-1',
+    stemMd: 'Stem',
+    difficulty: 'easy',
+    choices: [],
+  };
+}
+
+function Probe({ mode = 'review' }: { mode?: 'review' | null }) {
+  const output = useQuestionPageFeedback({
+    mode,
+    question: createQuestion(),
+    attemptId,
+    practiceSessionId,
+    isMounted: () => true,
+  });
+
+  return (
+    <>
+      <div data-testid="feedback-status">{output.feedbackStatus}</div>
+      <div data-testid="rating">{output.rating ?? 'none'}</div>
+      <button
+        type="button"
+        onClick={() => {
+          void output.submitReport({
+            category: 'outdated_reference',
+            comment: null,
+          });
+        }}
+      >
+        submit-report
+      </button>
+    </>
+  );
+}
+
+describe('useQuestionPageFeedback (browser)', () => {
+  beforeEach(() => {
+    getQuestionRating.mockResolvedValue(ok({ rating: null }));
+    submitQuestionReport.mockResolvedValue(
+      ok({ feedbackId: crypto.randomUUID() }),
+    );
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('hydrates rating state in standalone review mode', async () => {
+    getQuestionRating.mockResolvedValue(ok({ rating: 'not_helpful' }));
+
+    const screen = await render(<Probe />);
+
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('idle');
+    await expect
+      .element(screen.getByTestId('rating'))
+      .toHaveTextContent('not_helpful');
+    expect(getQuestionRating).toHaveBeenCalledWith({ questionId });
+  });
+
+  it('does not hydrate outside review mode', async () => {
+    const screen = await render(<Probe mode={null} />);
+
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('idle');
+    await expect
+      .element(screen.getByTestId('rating'))
+      .toHaveTextContent('none');
+    expect(getQuestionRating).not.toHaveBeenCalled();
+  });
+
+  it('submits report context from the review route', async () => {
+    const screen = await render(<Probe />);
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'submit-report' }).click();
+
+    await expect.poll(() => submitQuestionReport.mock.calls.length).toBe(1);
+    expect(submitQuestionReport).toHaveBeenCalledWith({
+      questionId,
+      attemptId,
+      practiceSessionId,
+      category: 'outdated_reference',
+      comment: null,
+      idempotencyKey: expect.any(String),
+    });
+  });
+});

--- a/app/(app)/app/questions/[slug]/use-question-page-feedback.ts
+++ b/app/(app)/app/questions/[slug]/use-question-page-feedback.ts
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import {
+  type PracticeQuestionFeedbackStatus,
+  usePracticeQuestionFeedback,
+} from '@/app/(app)/app/practice/hooks/use-practice-question-feedback';
+import type { QuestionMode } from '@/lib/routes';
+import type { GetQuestionBySlugOutput } from '@/src/adapters/controllers/question-view-controller';
+import type {
+  QuestionFeedbackCategory,
+  QuestionFeedbackRating,
+} from '@/src/domain/value-objects';
+
+export type QuestionPageFeedbackStatus = PracticeQuestionFeedbackStatus;
+
+export type UseQuestionPageFeedbackInput = {
+  mode?: QuestionMode | null;
+  question: Pick<GetQuestionBySlugOutput, 'questionId'> | null;
+  attemptId?: string | null;
+  practiceSessionId?: string | null;
+  isMounted: () => boolean;
+};
+
+export type UseQuestionPageFeedbackOutput = {
+  rating: QuestionFeedbackRating | null;
+  feedbackStatus: QuestionPageFeedbackStatus;
+  onRate: (rating: QuestionFeedbackRating | null) => void;
+  isReportOpen: boolean;
+  openReport: (open?: boolean) => void;
+  submitReport: (input: {
+    category: QuestionFeedbackCategory;
+    comment: string | null;
+  }) => Promise<boolean>;
+};
+
+export function useQuestionPageFeedback(
+  input: UseQuestionPageFeedbackInput,
+): UseQuestionPageFeedbackOutput {
+  const isReviewMode = input.mode === 'review';
+  const questionId = input.question?.questionId ?? null;
+  const question = useMemo(() => {
+    if (!isReviewMode || !questionId) return null;
+
+    return {
+      questionId,
+      attemptId: input.attemptId ?? null,
+      practiceSessionId: input.practiceSessionId ?? null,
+    };
+  }, [isReviewMode, questionId, input.attemptId, input.practiceSessionId]);
+
+  return usePracticeQuestionFeedback({
+    question,
+    isReviewMode,
+    isMounted: input.isMounted,
+  });
+}

--- a/app/(app)/app/shared/question-feedback-actions.test.ts
+++ b/app/(app)/app/shared/question-feedback-actions.test.ts
@@ -50,6 +50,34 @@ describe('question-feedback-actions', () => {
     expect(setRatingKey).toHaveBeenCalledWith(secondIdempotencyKey);
   });
 
+  it('initializes a rating idempotency key before the first rating write', async () => {
+    const setRatingKey = vi.fn();
+    const rateQuestionFn = vi
+      .fn<(input: unknown) => Promise<ActionResult<RateQuestionOutput>>>()
+      .mockResolvedValue(ok({ rating: 'helpful' }));
+
+    await rateQuestionForQuestion({
+      question: { questionId, attemptId: null, practiceSessionId: null },
+      currentRating: null,
+      nextRating: 'helpful',
+      ratingIdempotencyKey: null,
+      createIdempotencyKey: () => firstIdempotencyKey,
+      setRatingIdempotencyKey: setRatingKey,
+      rateQuestionFn,
+      setRating: vi.fn(),
+      setFeedbackStatus: vi.fn(),
+    });
+
+    expect(setRatingKey).toHaveBeenCalledWith(firstIdempotencyKey);
+    expect(rateQuestionFn).toHaveBeenCalledWith({
+      questionId,
+      attemptId: null,
+      practiceSessionId: null,
+      rating: 'helpful',
+      idempotencyKey: firstIdempotencyKey,
+    });
+  });
+
   it('rolls back the optimistic rating when the write fails', async () => {
     const statuses: string[] = [];
     const ratings: Array<QuestionFeedbackRating | null> = [];
@@ -77,6 +105,46 @@ describe('question-feedback-actions', () => {
       code: 'INTERNAL_ERROR',
       message: 'Nope',
     });
+  });
+
+  it('rolls back thrown rating errors even when the reporter fails', async () => {
+    const statuses: string[] = [];
+    const ratings: Array<QuestionFeedbackRating | null> = [];
+
+    await rateQuestionForQuestion({
+      question: { questionId, attemptId: null, practiceSessionId: null },
+      currentRating: 'not_helpful',
+      nextRating: 'helpful',
+      ratingIdempotencyKey: firstIdempotencyKey,
+      rateQuestionFn: vi.fn().mockRejectedValue(new Error('Network down')),
+      setRating: (rating) => ratings.push(rating),
+      setFeedbackStatus: (status) => statuses.push(status),
+      logError: () => {
+        throw new Error('Reporter down');
+      },
+    });
+
+    expect(ratings).toEqual(['helpful', 'not_helpful']);
+    expect(statuses).toEqual(['saving', 'error']);
+  });
+
+  it('does not roll back a failed rating after unmount', async () => {
+    const statuses: string[] = [];
+    const ratings: Array<QuestionFeedbackRating | null> = [];
+
+    await rateQuestionForQuestion({
+      question: { questionId, attemptId: null, practiceSessionId: null },
+      currentRating: 'not_helpful',
+      nextRating: null,
+      ratingIdempotencyKey: firstIdempotencyKey,
+      rateQuestionFn: vi.fn().mockRejectedValue(new Error('Network down')),
+      setRating: (rating) => ratings.push(rating),
+      setFeedbackStatus: (status) => statuses.push(status),
+      isMounted: () => false,
+    });
+
+    expect(ratings).toEqual([null]);
+    expect(statuses).toEqual(['saving']);
   });
 
   it('submits report context and rotates its idempotency key only after success', async () => {
@@ -109,6 +177,36 @@ describe('question-feedback-actions', () => {
     expect(setReportKey).toHaveBeenCalledWith(secondIdempotencyKey);
   });
 
+  it('initializes a report idempotency key before the first submit', async () => {
+    const setReportKey = vi.fn();
+    const submitQuestionReportFn = vi
+      .fn<
+        (input: unknown) => Promise<ActionResult<SubmitQuestionReportOutput>>
+      >()
+      .mockResolvedValue(ok({ feedbackId: crypto.randomUUID() }));
+
+    const didSubmit = await submitReportForQuestion({
+      question: { questionId, attemptId: null, practiceSessionId: null },
+      category: 'incorrect_answer',
+      comment: null,
+      reportIdempotencyKey: null,
+      createIdempotencyKey: () => firstIdempotencyKey,
+      setReportIdempotencyKey: setReportKey,
+      submitQuestionReportFn,
+    });
+
+    expect(didSubmit).toBe(true);
+    expect(setReportKey).toHaveBeenCalledWith(firstIdempotencyKey);
+    expect(submitQuestionReportFn).toHaveBeenCalledWith({
+      questionId,
+      attemptId: null,
+      practiceSessionId: null,
+      category: 'incorrect_answer',
+      comment: null,
+      idempotencyKey: firstIdempotencyKey,
+    });
+  });
+
   it('does not include free-text report comments in error log context', async () => {
     const logError = vi.fn();
 
@@ -136,5 +234,22 @@ describe('question-feedback-actions', () => {
     expect(JSON.stringify(logError.mock.calls)).not.toContain(
       'Sensitive free text',
     );
+  });
+
+  it('returns false for thrown report errors even when the reporter fails', async () => {
+    const didSubmit = await submitReportForQuestion({
+      question: { questionId, attemptId: null, practiceSessionId: null },
+      category: 'other',
+      comment: 'Sensitive free text',
+      reportIdempotencyKey: firstIdempotencyKey,
+      submitQuestionReportFn: vi
+        .fn()
+        .mockRejectedValue(new Error('Network down')),
+      logError: () => {
+        throw new Error('Reporter down');
+      },
+    });
+
+    expect(didSubmit).toBe(false);
   });
 });

--- a/app/(app)/app/shared/question-feedback-actions.test.ts
+++ b/app/(app)/app/shared/question-feedback-actions.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ActionResult } from '@/src/adapters/controllers/action-result';
+import type {
+  RateQuestionOutput,
+  SubmitQuestionReportOutput,
+} from '@/src/adapters/controllers/question-feedback-controller';
+import type { QuestionFeedbackRating } from '@/src/domain/value-objects';
+import { ok } from '@/tests/test-helpers/ok';
+import {
+  rateQuestionForQuestion,
+  submitReportForQuestion,
+} from './question-feedback-actions';
+
+const questionId = '11111111-1111-4111-8111-111111111111';
+const attemptId = '22222222-2222-4222-8222-222222222222';
+const practiceSessionId = '33333333-3333-4333-8333-333333333333';
+const firstIdempotencyKey = '44444444-4444-4444-8444-444444444444';
+const secondIdempotencyKey = '55555555-5555-4555-8555-555555555555';
+
+describe('question-feedback-actions', () => {
+  it('optimistically records a rating and rotates the idempotency key after success', async () => {
+    const statuses: string[] = [];
+    const ratings: Array<QuestionFeedbackRating | null> = [];
+    const setRatingKey = vi.fn();
+    const rateQuestionFn = vi
+      .fn<(input: unknown) => Promise<ActionResult<RateQuestionOutput>>>()
+      .mockResolvedValue(ok({ rating: 'helpful' }));
+
+    await rateQuestionForQuestion({
+      question: { questionId, attemptId, practiceSessionId },
+      currentRating: null,
+      nextRating: 'helpful',
+      ratingIdempotencyKey: firstIdempotencyKey,
+      createIdempotencyKey: () => secondIdempotencyKey,
+      setRatingIdempotencyKey: setRatingKey,
+      rateQuestionFn,
+      setRating: (rating) => ratings.push(rating),
+      setFeedbackStatus: (status) => statuses.push(status),
+    });
+
+    expect(rateQuestionFn).toHaveBeenCalledWith({
+      questionId,
+      attemptId,
+      practiceSessionId,
+      rating: 'helpful',
+      idempotencyKey: firstIdempotencyKey,
+    });
+    expect(ratings).toEqual(['helpful', 'helpful']);
+    expect(statuses).toEqual(['saving', 'saved']);
+    expect(setRatingKey).toHaveBeenCalledWith(secondIdempotencyKey);
+  });
+
+  it('rolls back the optimistic rating when the write fails', async () => {
+    const statuses: string[] = [];
+    const ratings: Array<QuestionFeedbackRating | null> = [];
+    const logError = vi.fn();
+
+    await rateQuestionForQuestion({
+      question: { questionId, attemptId: null, practiceSessionId: null },
+      currentRating: 'not_helpful',
+      nextRating: null,
+      ratingIdempotencyKey: firstIdempotencyKey,
+      createIdempotencyKey: () => secondIdempotencyKey,
+      setRatingIdempotencyKey: vi.fn(),
+      rateQuestionFn: vi.fn().mockResolvedValue({
+        ok: false,
+        error: { code: 'INTERNAL_ERROR', message: 'Nope' },
+      }),
+      setRating: (rating) => ratings.push(rating),
+      setFeedbackStatus: (status) => statuses.push(status),
+      logError,
+    });
+
+    expect(ratings).toEqual([null, 'not_helpful']);
+    expect(statuses).toEqual(['saving', 'error']);
+    expect(logError).toHaveBeenCalledWith('Failed to rate question', {
+      code: 'INTERNAL_ERROR',
+      message: 'Nope',
+    });
+  });
+
+  it('submits report context and rotates its idempotency key only after success', async () => {
+    const setReportKey = vi.fn();
+    const submitQuestionReportFn = vi
+      .fn<
+        (input: unknown) => Promise<ActionResult<SubmitQuestionReportOutput>>
+      >()
+      .mockResolvedValue(ok({ feedbackId: crypto.randomUUID() }));
+
+    const didSubmit = await submitReportForQuestion({
+      question: { questionId, attemptId, practiceSessionId },
+      category: 'ambiguous_wording',
+      comment: 'Needs a clearer stem.',
+      reportIdempotencyKey: firstIdempotencyKey,
+      createIdempotencyKey: () => secondIdempotencyKey,
+      setReportIdempotencyKey: setReportKey,
+      submitQuestionReportFn,
+    });
+
+    expect(didSubmit).toBe(true);
+    expect(submitQuestionReportFn).toHaveBeenCalledWith({
+      questionId,
+      attemptId,
+      practiceSessionId,
+      category: 'ambiguous_wording',
+      comment: 'Needs a clearer stem.',
+      idempotencyKey: firstIdempotencyKey,
+    });
+    expect(setReportKey).toHaveBeenCalledWith(secondIdempotencyKey);
+  });
+
+  it('does not include free-text report comments in error log context', async () => {
+    const logError = vi.fn();
+
+    const didSubmit = await submitReportForQuestion({
+      question: { questionId, attemptId: null, practiceSessionId: null },
+      category: 'other',
+      comment: 'Sensitive free text',
+      reportIdempotencyKey: firstIdempotencyKey,
+      createIdempotencyKey: () => secondIdempotencyKey,
+      setReportIdempotencyKey: vi.fn(),
+      submitQuestionReportFn: vi.fn().mockResolvedValue({
+        ok: false,
+        error: { code: 'INTERNAL_ERROR', message: 'Nope' },
+      }),
+      logError,
+    });
+
+    expect(didSubmit).toBe(false);
+    expect(logError).toHaveBeenCalledWith('Failed to submit question report', {
+      code: 'INTERNAL_ERROR',
+      message: 'Nope',
+      questionId,
+      category: 'other',
+    });
+    expect(JSON.stringify(logError.mock.calls)).not.toContain(
+      'Sensitive free text',
+    );
+  });
+});

--- a/app/(app)/app/shared/question-feedback-actions.ts
+++ b/app/(app)/app/shared/question-feedback-actions.ts
@@ -1,0 +1,167 @@
+import { shouldReportClientError } from '@/lib/report-client-error';
+import { withTimeout } from '@/lib/with-timeout';
+import type { ActionResult } from '@/src/adapters/controllers/action-result';
+import type {
+  RateQuestionOutput,
+  SubmitQuestionReportOutput,
+} from '@/src/adapters/controllers/question-feedback-controller';
+import type {
+  QuestionFeedbackCategory,
+  QuestionFeedbackRating,
+} from '@/src/domain/value-objects';
+import { STANDARD_MUTATION_TIMEOUT_MS } from './timeout-tiers';
+
+const QUESTION_FEEDBACK_MUTATION_TIMEOUT_MS = STANDARD_MUTATION_TIMEOUT_MS;
+
+export type FeedbackQuestionContext = {
+  questionId: string;
+  attemptId?: string | null;
+  practiceSessionId?: string | null;
+};
+
+export async function rateQuestionForQuestion(input: {
+  question: FeedbackQuestionContext | null;
+  currentRating: QuestionFeedbackRating | null;
+  nextRating: QuestionFeedbackRating | null;
+  ratingIdempotencyKey?: string | null;
+  createIdempotencyKey?: () => string;
+  setRatingIdempotencyKey?: (key: string) => void;
+  rateQuestionFn: (input: unknown) => Promise<ActionResult<RateQuestionOutput>>;
+  setRating: (rating: QuestionFeedbackRating | null) => void;
+  setFeedbackStatus: (
+    status: 'idle' | 'loading' | 'saving' | 'saved' | 'error',
+  ) => void;
+  logError?: (message: string, context: unknown) => void;
+  isMounted?: () => boolean;
+}): Promise<void> {
+  if (!input.question) return;
+
+  const isMounted = input.isMounted ?? (() => true);
+  const requestIdempotencyKey =
+    input.ratingIdempotencyKey ?? input.createIdempotencyKey?.();
+
+  if (!input.ratingIdempotencyKey && requestIdempotencyKey) {
+    input.setRatingIdempotencyKey?.(requestIdempotencyKey);
+  }
+
+  input.setFeedbackStatus('saving');
+  input.setRating(input.nextRating);
+
+  let result: ActionResult<RateQuestionOutput>;
+  try {
+    result = await withTimeout(
+      input.rateQuestionFn({
+        questionId: input.question.questionId,
+        attemptId: input.question.attemptId ?? null,
+        practiceSessionId: input.question.practiceSessionId ?? null,
+        rating: input.nextRating,
+        idempotencyKey: requestIdempotencyKey ?? undefined,
+      }),
+      QUESTION_FEEDBACK_MUTATION_TIMEOUT_MS,
+    );
+  } catch (error) {
+    try {
+      input.logError?.('Failed to rate question', error);
+    } catch {
+      // Reporter failures must not block the primary error path.
+    }
+    if (!isMounted()) return;
+    input.setRating(input.currentRating);
+    input.setFeedbackStatus('error');
+    return;
+  }
+
+  if (!result.ok) {
+    if (shouldReportClientError(result.error)) {
+      try {
+        input.logError?.('Failed to rate question', result.error);
+      } catch {
+        // Reporter failures must not block the primary error path.
+      }
+    }
+    if (!isMounted()) return;
+    input.setRating(input.currentRating);
+    input.setFeedbackStatus('error');
+    return;
+  }
+
+  if (!isMounted()) return;
+
+  input.setRating(result.data.rating);
+  if (input.setRatingIdempotencyKey && input.createIdempotencyKey) {
+    input.setRatingIdempotencyKey(input.createIdempotencyKey());
+  }
+  input.setFeedbackStatus('saved');
+}
+
+export async function submitReportForQuestion(input: {
+  question: FeedbackQuestionContext | null;
+  category: QuestionFeedbackCategory;
+  comment: string | null;
+  reportIdempotencyKey?: string | null;
+  createIdempotencyKey?: () => string;
+  setReportIdempotencyKey?: (key: string) => void;
+  submitQuestionReportFn: (
+    input: unknown,
+  ) => Promise<ActionResult<SubmitQuestionReportOutput>>;
+  logError?: (message: string, context: unknown) => void;
+  isMounted?: () => boolean;
+}): Promise<boolean> {
+  if (!input.question) return false;
+
+  const isMounted = input.isMounted ?? (() => true);
+  const requestIdempotencyKey =
+    input.reportIdempotencyKey ?? input.createIdempotencyKey?.();
+
+  if (!input.reportIdempotencyKey && requestIdempotencyKey) {
+    input.setReportIdempotencyKey?.(requestIdempotencyKey);
+  }
+
+  let result: ActionResult<SubmitQuestionReportOutput>;
+  try {
+    result = await withTimeout(
+      input.submitQuestionReportFn({
+        questionId: input.question.questionId,
+        attemptId: input.question.attemptId ?? null,
+        practiceSessionId: input.question.practiceSessionId ?? null,
+        category: input.category,
+        comment: input.comment,
+        idempotencyKey: requestIdempotencyKey ?? undefined,
+      }),
+      QUESTION_FEEDBACK_MUTATION_TIMEOUT_MS,
+    );
+  } catch (error) {
+    try {
+      input.logError?.('Failed to submit question report', {
+        error,
+        questionId: input.question.questionId,
+        category: input.category,
+      });
+    } catch {
+      // Reporter failures must not block the primary error path.
+    }
+    return false;
+  }
+
+  if (!result.ok) {
+    if (shouldReportClientError(result.error)) {
+      try {
+        input.logError?.('Failed to submit question report', {
+          ...result.error,
+          questionId: input.question.questionId,
+          category: input.category,
+        });
+      } catch {
+        // Reporter failures must not block the primary error path.
+      }
+    }
+    return false;
+  }
+
+  if (!isMounted()) return false;
+
+  if (input.setReportIdempotencyKey && input.createIdempotencyKey) {
+    input.setReportIdempotencyKey(input.createIdempotencyKey());
+  }
+  return true;
+}

--- a/components/question/question-feedback-rating.browser.spec.tsx
+++ b/components/question/question-feedback-rating.browser.spec.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import {
+  QuestionFeedbackRating,
+  type QuestionFeedbackRatingProps,
+} from './question-feedback-rating';
+
+function RatingProbe({
+  initialRating = null,
+  onRate = () => undefined,
+}: {
+  initialRating?: QuestionFeedbackRatingProps['rating'];
+  onRate?: QuestionFeedbackRatingProps['onRate'];
+}) {
+  const [rating, setRating] =
+    useState<QuestionFeedbackRatingProps['rating']>(initialRating);
+
+  return (
+    <QuestionFeedbackRating
+      rating={rating}
+      feedbackStatus="idle"
+      onRate={(nextRating) => {
+        onRate(nextRating);
+        setRating(nextRating);
+      }}
+    />
+  );
+}
+
+test('selects and retracts the helpful rating', async () => {
+  const onRate = vi.fn();
+  const screen = await render(<RatingProbe onRate={onRate} />);
+  const goodButton = screen.getByRole('button', { name: /^Good question$/ });
+
+  await goodButton.click();
+
+  expect(onRate).toHaveBeenCalledWith('helpful');
+  await expect.element(goodButton).toHaveAttribute('aria-pressed', 'true');
+
+  await goodButton.click();
+
+  expect(onRate).toHaveBeenLastCalledWith(null);
+  await expect.element(goodButton).toHaveAttribute('aria-pressed', 'false');
+});
+
+test('selects and retracts the not-good rating', async () => {
+  const onRate = vi.fn();
+  const screen = await render(
+    <RatingProbe initialRating="not_helpful" onRate={onRate} />,
+  );
+  const notGoodButton = screen.getByRole('button', {
+    name: /^Not a good question$/,
+  });
+
+  await expect.element(notGoodButton).toHaveAttribute('aria-pressed', 'true');
+
+  await notGoodButton.click();
+
+  expect(onRate).toHaveBeenCalledWith(null);
+  await expect.element(notGoodButton).toHaveAttribute('aria-pressed', 'false');
+});

--- a/components/question/question-feedback-rating.test.tsx
+++ b/components/question/question-feedback-rating.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+type QuestionFeedbackRatingModule = typeof import('./question-feedback-rating');
+
+let QuestionFeedbackRating: QuestionFeedbackRatingModule['QuestionFeedbackRating'];
+
+beforeAll(async () => {
+  ({ QuestionFeedbackRating } = await import('./question-feedback-rating'));
+});
+
+function renderRating(
+  overrides: Partial<Parameters<typeof QuestionFeedbackRating>[0]> = {},
+) {
+  const html = renderToStaticMarkup(
+    <QuestionFeedbackRating
+      rating={null}
+      feedbackStatus="idle"
+      onRate={() => undefined}
+      {...overrides}
+    />,
+  );
+
+  return {
+    html,
+    doc: new DOMParser().parseFromString(html, 'text/html'),
+  };
+}
+
+describe('QuestionFeedbackRating', () => {
+  it('renders the rating row with a labelled group and icon buttons', () => {
+    const { html, doc } = renderRating();
+    const group = doc.querySelector('fieldset');
+    const legend = group?.querySelector('legend');
+    const goodButton = doc.querySelector('button[aria-label="Good question"]');
+    const notGoodButton = doc.querySelector(
+      'button[aria-label="Not a good question"]',
+    );
+
+    expect(html).toContain('Was this a good question?');
+    expect(legend?.textContent?.trim()).toBe('Rate this question');
+    expect(legend?.getAttribute('class')).toContain('sr-only');
+    expect(goodButton?.getAttribute('data-slot')).toBe('button');
+    expect(notGoodButton?.getAttribute('data-slot')).toBe('button');
+    expect(goodButton?.getAttribute('aria-pressed')).toBe('false');
+    expect(notGoodButton?.getAttribute('aria-pressed')).toBe('false');
+    expect(goodButton?.getAttribute('data-variant')).toBe('outline');
+    expect(notGoodButton?.getAttribute('data-variant')).toBe('outline');
+  });
+
+  it('marks the active helpful rating and exposes polite save status text', () => {
+    const { doc } = renderRating({
+      rating: 'helpful',
+      feedbackStatus: 'saved',
+    });
+    const goodButton = doc.querySelector('button[aria-label="Good question"]');
+    const status = doc.querySelector('[aria-live="polite"]');
+
+    expect(goodButton?.getAttribute('aria-pressed')).toBe('true');
+    expect(goodButton?.getAttribute('data-variant')).toBe('success');
+    expect(status?.textContent?.trim()).toBe('Rating saved');
+    expect(status?.getAttribute('class')).toContain('text-muted-foreground');
+  });
+
+  it('marks the active not-helpful rating and renders the failure state accessibly', () => {
+    const { doc } = renderRating({
+      rating: 'not_helpful',
+      feedbackStatus: 'error',
+    });
+    const notGoodButton = doc.querySelector(
+      'button[aria-label="Not a good question"]',
+    );
+    const status = doc.querySelector('[aria-live="polite"]');
+
+    expect(notGoodButton?.getAttribute('aria-pressed')).toBe('true');
+    expect(notGoodButton?.getAttribute('data-variant')).toBe('destructive');
+    expect(status?.textContent?.trim()).toBe("Couldn't save rating");
+    expect(status?.getAttribute('class')).toContain('text-destructive');
+  });
+
+  it('disables both thumbs while saving', () => {
+    const { doc } = renderRating({ feedbackStatus: 'saving' });
+    const buttons = Array.from(doc.querySelectorAll('button'));
+    const status = doc.querySelector('[aria-live="polite"]');
+
+    expect(buttons).toHaveLength(2);
+    expect(buttons.every((button) => button.hasAttribute('disabled'))).toBe(
+      true,
+    );
+    expect(status?.textContent?.trim()).toBe('Saving rating');
+  });
+});

--- a/components/question/question-feedback-rating.tsx
+++ b/components/question/question-feedback-rating.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { ThumbsDown, ThumbsUp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { QuestionFeedbackRating as QuestionFeedbackRatingValue } from '@/src/domain/value-objects';
+
+export type QuestionFeedbackStatus =
+  | 'idle'
+  | 'loading'
+  | 'saving'
+  | 'saved'
+  | 'error';
+
+export type QuestionFeedbackRatingProps = {
+  rating: QuestionFeedbackRatingValue | null;
+  feedbackStatus: QuestionFeedbackStatus;
+  onRate: (rating: QuestionFeedbackRatingValue | null) => void;
+};
+
+function getStatusMessage(status: QuestionFeedbackStatus): string {
+  if (status === 'saving') return 'Saving rating';
+  if (status === 'saved') return 'Rating saved';
+  if (status === 'error') return "Couldn't save rating";
+  return '';
+}
+
+export function QuestionFeedbackRating({
+  rating,
+  feedbackStatus,
+  onRate,
+}: QuestionFeedbackRatingProps) {
+  const isSaving = feedbackStatus === 'saving';
+  const statusMessage = getStatusMessage(feedbackStatus);
+  const statusClassName = cn(
+    'text-sm',
+    feedbackStatus === 'error' ? 'text-destructive' : 'text-muted-foreground',
+  );
+
+  function selectRating(nextRating: QuestionFeedbackRatingValue) {
+    onRate(rating === nextRating ? null : nextRating);
+  }
+
+  return (
+    <fieldset className="flex flex-wrap items-center gap-3">
+      <legend className="sr-only">Rate this question</legend>
+      <p className="text-sm font-medium text-foreground">
+        Was this a good question?
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant={rating === 'helpful' ? 'success' : 'outline'}
+          size="icon"
+          className="rounded-full"
+          aria-label="Good question"
+          aria-pressed={rating === 'helpful'}
+          disabled={isSaving}
+          onClick={() => selectRating('helpful')}
+        >
+          <ThumbsUp aria-hidden="true" />
+        </Button>
+        <Button
+          type="button"
+          variant={rating === 'not_helpful' ? 'destructive' : 'outline'}
+          size="icon"
+          className="rounded-full"
+          aria-label="Not a good question"
+          aria-pressed={rating === 'not_helpful'}
+          disabled={isSaving}
+          onClick={() => selectRating('not_helpful')}
+        >
+          <ThumbsDown aria-hidden="true" />
+        </Button>
+      </div>
+      <output aria-live="polite" className={statusClassName}>
+        {statusMessage}
+      </output>
+    </fieldset>
+  );
+}

--- a/components/question/question-report-dialog.browser.spec.tsx
+++ b/components/question/question-report-dialog.browser.spec.tsx
@@ -80,3 +80,43 @@ test('keeps the dialog open on submit failure and closes on Escape with focus re
   await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
   await expect.element(trigger).toHaveFocus();
 });
+
+test('cancels, resets the form, and returns focus to the trigger', async () => {
+  const screen = await render(<DialogProbe />);
+  const trigger = screen.getByRole('button', { name: 'Give feedback' });
+
+  await trigger.click();
+  await screen.getByRole('radio', { name: 'Other' }).click();
+  await screen.getByRole('textbox', { name: 'Add details (optional)' }).click();
+  await userEvent.keyboard('Temporary note');
+  await screen.getByRole('button', { name: 'Cancel' }).click();
+
+  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+  await expect.element(trigger).toHaveFocus();
+
+  await trigger.click();
+
+  await expect
+    .element(screen.getByRole('textbox', { name: 'Add details (optional)' }))
+    .toHaveValue('');
+  await expect
+    .element(screen.getByRole('radio', { name: 'Other' }))
+    .not.toBeChecked();
+});
+
+test('keeps the dialog open when submit throws', async () => {
+  const submitReport = vi.fn().mockRejectedValue(new Error('Network down'));
+  const screen = await render(<DialogProbe submitReport={submitReport} />);
+
+  await screen.getByRole('button', { name: 'Give feedback' }).click();
+  await screen.getByRole('radio', { name: 'Other' }).click();
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+
+  await expect.poll(() => submitReport.mock.calls.length).toBe(1);
+  await expect
+    .element(
+      screen.getByText("Couldn't send your feedback. Check your connection."),
+    )
+    .toBeVisible();
+  await expect.element(screen.getByRole('dialog')).toBeVisible();
+});

--- a/components/question/question-report-dialog.browser.spec.tsx
+++ b/components/question/question-report-dialog.browser.spec.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { expect, test, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { QuestionReportDialog } from '@/components/question/question-report-dialog';
+import { NotificationProvider } from '@/components/ui/notification-provider';
+
+function DialogProbe({
+  submitReport = async () => true,
+}: {
+  submitReport?: Parameters<typeof QuestionReportDialog>[0]['submitReport'];
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <NotificationProvider>
+      <QuestionReportDialog
+        open={open}
+        onOpenChange={setOpen}
+        submitReport={submitReport}
+      />
+    </NotificationProvider>
+  );
+}
+
+test('validates category, submits selected feedback, closes, and returns focus', async () => {
+  const submitReport = vi.fn().mockResolvedValue(true);
+  const screen = await render(<DialogProbe submitReport={submitReport} />);
+  const trigger = screen.getByRole('button', { name: 'Give feedback' });
+
+  await trigger.click();
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+
+  await expect
+    .element(screen.getByRole('alert'))
+    .toHaveTextContent('Choose a category to send your feedback.');
+  await expect
+    .poll(() => document.activeElement?.getAttribute('value'))
+    .toBe('incorrect_answer');
+
+  await screen.getByRole('radio', { name: 'Ambiguous wording' }).click();
+  await screen.getByRole('textbox', { name: 'Add details (optional)' }).click();
+  await userEvent.keyboard('Needs a clearer stem.');
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+
+  await expect.poll(() => submitReport.mock.calls.length).toBe(1);
+  expect(submitReport).toHaveBeenCalledWith({
+    category: 'ambiguous_wording',
+    comment: 'Needs a clearer stem.',
+  });
+  await expect
+    .element(screen.getByText('Thanks — our editors will take a look.'))
+    .toBeVisible();
+  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+  await expect.element(trigger).toHaveFocus();
+});
+
+test('keeps the dialog open on submit failure and closes on Escape with focus return', async () => {
+  const submitReport = vi.fn().mockResolvedValue(false);
+  const screen = await render(<DialogProbe submitReport={submitReport} />);
+  const trigger = screen.getByRole('button', { name: 'Give feedback' });
+
+  await trigger.click();
+  await screen.getByRole('radio', { name: 'Other' }).click();
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+
+  await expect.poll(() => submitReport.mock.calls.length).toBe(1);
+  await expect
+    .element(
+      screen.getByText("Couldn't send your feedback. Check your connection."),
+    )
+    .toBeVisible();
+  await expect.element(screen.getByRole('dialog')).toBeVisible();
+  await expect
+    .element(screen.getByRole('heading', { name: 'Give feedback' }))
+    .toBeVisible();
+
+  await userEvent.keyboard('{Escape}');
+
+  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+  await expect.element(trigger).toHaveFocus();
+});

--- a/components/question/question-report-dialog.test.tsx
+++ b/components/question/question-report-dialog.test.tsx
@@ -76,6 +76,7 @@ describe('QuestionReportDialog', () => {
     const description = doc.querySelector('[data-slot="dialog-description"]');
     const legend = doc.querySelector('legend');
     const radios = Array.from(doc.querySelectorAll('input[type="radio"]'));
+    const firstCategoryLabel = radios[0]?.closest('label');
     const textarea = doc.querySelector('[data-slot="textarea"]');
     const counter = doc.querySelector(
       '[data-testid="question-report-counter"]',
@@ -95,6 +96,15 @@ describe('QuestionReportDialog', () => {
     ]);
     expect(radios.every((radio) => radio.classList.contains('sr-only'))).toBe(
       true,
+    );
+    expect(firstCategoryLabel?.getAttribute('class')).toContain(
+      'focus-within:ring-ring/50',
+    );
+    expect(firstCategoryLabel?.getAttribute('class')).toContain(
+      'focus-within:ring-[3px]',
+    );
+    expect(firstCategoryLabel?.getAttribute('class')).not.toContain(
+      'ring-focus-within',
     );
     expect(html).toContain('Add details (optional)');
     expect(textarea?.getAttribute('name')).toBe('comment');

--- a/components/question/question-report-dialog.test.tsx
+++ b/components/question/question-report-dialog.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { MAX_QUESTION_FEEDBACK_COMMENT_LENGTH } from '@/src/adapters/shared/validation-limits';
+
+type QuestionReportDialogModule = typeof import('./question-report-dialog');
+
+let QuestionReportDialog: QuestionReportDialogModule['QuestionReportDialog'];
+let QuestionReportDialogForm: QuestionReportDialogModule['QuestionReportDialogForm'];
+let Dialog: typeof import('@/components/ui/dialog').Dialog;
+
+beforeAll(async () => {
+  ({ QuestionReportDialog, QuestionReportDialogForm } = await import(
+    './question-report-dialog'
+  ));
+  ({ Dialog } = await import('@/components/ui/dialog'));
+});
+
+function renderDialog(
+  overrides: Partial<Parameters<typeof QuestionReportDialog>[0]> = {},
+) {
+  const html = renderToStaticMarkup(
+    <QuestionReportDialog
+      open={false}
+      onOpenChange={() => undefined}
+      submitReport={async () => true}
+      {...overrides}
+    />,
+  );
+
+  return {
+    html,
+    doc: new DOMParser().parseFromString(html, 'text/html'),
+  };
+}
+
+function renderForm(
+  overrides: Partial<Parameters<typeof QuestionReportDialogForm>[0]> = {},
+) {
+  const html = renderToStaticMarkup(
+    <Dialog open>
+      <QuestionReportDialogForm
+        category={null}
+        comment=""
+        validationError={null}
+        isSubmitting={false}
+        onCancel={() => undefined}
+        onCategoryChange={() => undefined}
+        onCommentChange={() => undefined}
+        onSubmit={() => undefined}
+        {...overrides}
+      />
+    </Dialog>,
+  );
+
+  return {
+    html,
+    doc: new DOMParser().parseFromString(html, 'text/html'),
+  };
+}
+
+describe('QuestionReportDialog', () => {
+  it('renders the Give feedback trigger as a Button sibling for review action bars', () => {
+    const { doc } = renderDialog();
+    const trigger = doc.querySelector('button');
+
+    expect(trigger?.getAttribute('data-slot')).toBe('dialog-trigger');
+    expect(trigger?.getAttribute('data-variant')).toBe('outline');
+    expect(trigger?.getAttribute('class')).toContain('rounded-full');
+    expect(trigger?.textContent?.trim()).toBe('Give feedback');
+  });
+
+  it('renders the modal title, description, category radios, textarea, and footer actions', () => {
+    const { html, doc } = renderForm();
+    const title = doc.querySelector('[data-slot="dialog-title"]');
+    const description = doc.querySelector('[data-slot="dialog-description"]');
+    const legend = doc.querySelector('legend');
+    const radios = Array.from(doc.querySelectorAll('input[type="radio"]'));
+    const textarea = doc.querySelector('[data-slot="textarea"]');
+    const counter = doc.querySelector(
+      '[data-testid="question-report-counter"]',
+    );
+
+    expect(title?.textContent?.trim()).toBe('Give feedback');
+    expect(description?.textContent).toContain(
+      "This goes to our medical editors and won't affect your score.",
+    );
+    expect(legend?.textContent?.trim()).toBe("What's this about?");
+    expect(radios.map((radio) => radio.getAttribute('value'))).toEqual([
+      'incorrect_answer',
+      'ambiguous_wording',
+      'typo_formatting',
+      'outdated_reference',
+      'other',
+    ]);
+    expect(radios.every((radio) => radio.classList.contains('sr-only'))).toBe(
+      true,
+    );
+    expect(html).toContain('Add details (optional)');
+    expect(textarea?.getAttribute('name')).toBe('comment');
+    expect(textarea?.getAttribute('autoComplete')).toBe('off');
+    expect(textarea?.getAttribute('maxLength')).toBe(
+      String(MAX_QUESTION_FEEDBACK_COMMENT_LENGTH),
+    );
+    expect(counter?.getAttribute('aria-live')).toBe('polite');
+    expect(counter?.textContent?.trim()).toBe('0 / 2000');
+    expect(html).toContain('Cancel');
+    expect(html).toContain('Submit feedback');
+  });
+
+  it('wires category validation messaging to the radio group', () => {
+    const { doc } = renderForm({
+      validationError: 'Choose a category to send your feedback.',
+    });
+    const fieldset = doc.querySelector('fieldset');
+    const error = doc.querySelector('[role="alert"]');
+
+    expect(error?.textContent?.trim()).toBe(
+      'Choose a category to send your feedback.',
+    );
+    expect(fieldset?.getAttribute('aria-describedby')).toBe(
+      error?.getAttribute('id'),
+    );
+    expect(error?.getAttribute('class')).toContain('text-destructive');
+  });
+
+  it('uses the warning foreground token when the comment is near the limit', () => {
+    const { doc } = renderForm({
+      comment: 'x'.repeat(MAX_QUESTION_FEEDBACK_COMMENT_LENGTH - 50),
+    });
+    const counter = doc.querySelector(
+      '[data-testid="question-report-counter"]',
+    );
+
+    expect(counter?.getAttribute('class')).toContain('text-warning-foreground');
+  });
+});

--- a/components/question/question-report-dialog.tsx
+++ b/components/question/question-report-dialog.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import type * as React from 'react';
+import { useId, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { useNotification } from '@/components/ui/notification-provider';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+import { MAX_QUESTION_FEEDBACK_COMMENT_LENGTH } from '@/src/adapters/shared/validation-limits';
+import {
+  AllQuestionFeedbackCategories,
+  type QuestionFeedbackCategory,
+} from '@/src/domain/value-objects';
+
+const CATEGORY_LABELS: Record<QuestionFeedbackCategory, string> = {
+  incorrect_answer: 'Incorrect answer',
+  ambiguous_wording: 'Ambiguous wording',
+  typo_formatting: 'Typo or formatting',
+  outdated_reference: 'Outdated reference',
+  other: 'Other',
+};
+
+const CATEGORY_VALIDATION_MESSAGE = 'Choose a category to send your feedback.';
+const NEAR_LIMIT_REMAINING_COUNT = 100;
+
+export type QuestionReportSubmitInput = {
+  category: QuestionFeedbackCategory;
+  comment: string | null;
+};
+
+export type QuestionReportDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  submitReport: (input: QuestionReportSubmitInput) => Promise<boolean>;
+  disabled?: boolean;
+};
+
+export type QuestionReportDialogFormProps = {
+  category: QuestionFeedbackCategory | null;
+  comment: string;
+  validationError: string | null;
+  isSubmitting: boolean;
+  onCancel: () => void;
+  onCategoryChange: (category: QuestionFeedbackCategory) => void;
+  onCommentChange: (comment: string) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  firstCategoryInputRef?: React.Ref<HTMLInputElement>;
+};
+
+export function QuestionReportDialogForm({
+  category,
+  comment,
+  validationError,
+  isSubmitting,
+  onCancel,
+  onCategoryChange,
+  onCommentChange,
+  onSubmit,
+  firstCategoryInputRef,
+}: QuestionReportDialogFormProps) {
+  const errorId = useId();
+  const counterId = useId();
+  const remainingCharacters =
+    MAX_QUESTION_FEEDBACK_COMMENT_LENGTH - comment.length;
+  const isNearLimit = remainingCharacters <= NEAR_LIMIT_REMAINING_COUNT;
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Give feedback</DialogTitle>
+        <DialogDescription>
+          Spotted an issue or have a suggestion? This goes to our medical
+          editors and won't affect your score.
+        </DialogDescription>
+      </DialogHeader>
+      <form className="space-y-4" onSubmit={onSubmit}>
+        <fieldset
+          className="space-y-2"
+          aria-describedby={validationError ? errorId : undefined}
+        >
+          <legend className="text-sm font-medium text-foreground">
+            What's this about?
+          </legend>
+          <div className="grid gap-2">
+            {AllQuestionFeedbackCategories.map((option, index) => {
+              const selected = category === option;
+
+              return (
+                <label
+                  key={option}
+                  className={cn(
+                    'block w-full rounded-xl border border-foreground/50 bg-background/50 p-4 text-left shadow-sm transition-colors focus-within:border-ring ring-focus-within dark:border-foreground/40 dark:bg-background/50',
+                    !selected &&
+                      !isSubmitting &&
+                      'cursor-pointer hover:border-foreground/55 hover:bg-foreground/[0.06] dark:hover:border-foreground/50 dark:hover:bg-foreground/[0.05]',
+                    selected &&
+                      'border-ring bg-foreground/[0.08] dark:border-foreground/70 dark:bg-foreground/[0.12]',
+                    isSubmitting && 'cursor-not-allowed opacity-50',
+                  )}
+                >
+                  <input
+                    ref={index === 0 ? firstCategoryInputRef : undefined}
+                    type="radio"
+                    name="category"
+                    value={option}
+                    checked={selected}
+                    disabled={isSubmitting}
+                    onChange={() => onCategoryChange(option)}
+                    className="sr-only"
+                  />
+                  <span className="text-base text-foreground">
+                    {CATEGORY_LABELS[option]}
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+          {validationError ? (
+            <p id={errorId} role="alert" className="text-sm text-destructive">
+              {validationError}
+            </p>
+          ) : null}
+        </fieldset>
+
+        <div className="space-y-2">
+          <label
+            htmlFor="question-report-comment"
+            className="text-sm font-medium text-foreground"
+          >
+            Add details (optional)
+          </label>
+          <Textarea
+            id="question-report-comment"
+            name="comment"
+            autoComplete="off"
+            maxLength={MAX_QUESTION_FEEDBACK_COMMENT_LENGTH}
+            value={comment}
+            disabled={isSubmitting}
+            aria-describedby={counterId}
+            onChange={(event) => onCommentChange(event.currentTarget.value)}
+          />
+          <p
+            id={counterId}
+            data-testid="question-report-counter"
+            aria-live="polite"
+            className={cn(
+              'text-sm text-muted-foreground',
+              isNearLimit && 'font-medium text-warning-foreground',
+            )}
+          >
+            {comment.length} / {MAX_QUESTION_FEEDBACK_COMMENT_LENGTH}
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isSubmitting}
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            Submit feedback
+          </Button>
+        </DialogFooter>
+      </form>
+    </>
+  );
+}
+
+export function QuestionReportDialog({
+  open,
+  onOpenChange,
+  submitReport,
+  disabled = false,
+}: QuestionReportDialogProps) {
+  const { notify } = useNotification();
+  const [category, setCategory] = useState<QuestionFeedbackCategory | null>(
+    null,
+  );
+  const [comment, setComment] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const firstCategoryInputRef = useRef<HTMLInputElement>(null);
+
+  function resetForm() {
+    setCategory(null);
+    setComment('');
+    setValidationError(null);
+    setIsSubmitting(false);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) resetForm();
+    onOpenChange(nextOpen);
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!category) {
+      setValidationError(CATEGORY_VALIDATION_MESSAGE);
+      firstCategoryInputRef.current?.focus();
+      return;
+    }
+
+    setValidationError(null);
+    setIsSubmitting(true);
+
+    const trimmedComment = comment.trim();
+    try {
+      const didSubmit = await submitReport({
+        category,
+        comment: trimmedComment.length > 0 ? trimmedComment : null,
+      });
+
+      if (!didSubmit) {
+        notify({
+          message: "Couldn't send your feedback. Check your connection.",
+          tone: 'error',
+        });
+        setIsSubmitting(false);
+        return;
+      }
+
+      notify({
+        message: 'Thanks — our editors will take a look.',
+        tone: 'success',
+      });
+      resetForm();
+      onOpenChange(false);
+    } catch {
+      notify({
+        message: "Couldn't send your feedback. Check your connection.",
+        tone: 'error',
+      });
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          className="rounded-full"
+          disabled={disabled}
+        >
+          Give feedback
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <QuestionReportDialogForm
+          category={category}
+          comment={comment}
+          validationError={validationError}
+          isSubmitting={isSubmitting}
+          onCancel={() => handleOpenChange(false)}
+          onCategoryChange={(nextCategory) => {
+            setCategory(nextCategory);
+            setValidationError(null);
+          }}
+          onCommentChange={setComment}
+          onSubmit={handleSubmit}
+          firstCategoryInputRef={firstCategoryInputRef}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/question/question-report-dialog.tsx
+++ b/components/question/question-report-dialog.tsx
@@ -98,7 +98,7 @@ export function QuestionReportDialogForm({
                 <label
                   key={option}
                   className={cn(
-                    'block w-full rounded-xl border border-foreground/50 bg-background/50 p-4 text-left shadow-sm transition-colors focus-within:border-ring ring-focus-within dark:border-foreground/40 dark:bg-background/50',
+                    'block w-full rounded-xl border border-foreground/50 bg-background/50 p-4 text-left shadow-sm transition-colors focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px] dark:border-foreground/40 dark:bg-background/50',
                     !selected &&
                       !isSubmitting &&
                       'cursor-pointer hover:border-foreground/55 hover:bg-foreground/[0.06] dark:hover:border-foreground/50 dark:hover:bg-foreground/[0.05]',

--- a/components/question/question-surface-body.test.tsx
+++ b/components/question/question-surface-body.test.tsx
@@ -101,6 +101,27 @@ describe('QuestionSurfaceBody', () => {
     expect(html).toContain('Reference text');
   });
 
+  it('renders question feedback rating controls after the answer feedback panel', () => {
+    const { html } = renderQuestionSurfaceBody({
+      feedback: {
+        isCorrect: true,
+        explanationMd: 'Overall explanation',
+        referenceMd: null,
+        choiceExplanations: [],
+      },
+      questionFeedbackRating: {
+        rating: null,
+        feedbackStatus: 'idle',
+        onRate: () => undefined,
+      },
+    });
+
+    expect(html).toContain('Was this a good question?');
+    expect(html.indexOf('Overall explanation')).toBeLessThan(
+      html.indexOf('Was this a good question?'),
+    );
+  });
+
   it('does not render feedback when feedback is null', () => {
     const { html, doc } = renderQuestionSurfaceBody({ feedback: null });
 

--- a/components/question/question-surface-body.tsx
+++ b/components/question/question-surface-body.tsx
@@ -3,6 +3,10 @@
 import type { ReactNode, RefObject } from 'react';
 import { Feedback, type FeedbackProps } from './feedback';
 import { QuestionCard, type QuestionCardChoice } from './question-card';
+import {
+  QuestionFeedbackRating,
+  type QuestionFeedbackRatingProps,
+} from './question-feedback-rating';
 
 type QuestionSurfaceBodyQuestion = {
   stemMd: string;
@@ -16,6 +20,7 @@ export type QuestionSurfaceBodyProps = {
   disabled: boolean;
   onSelectChoice: (choiceId: string) => void;
   feedback?: FeedbackProps | null;
+  questionFeedbackRating?: QuestionFeedbackRatingProps | null;
   feedbackRef?: RefObject<HTMLDivElement | null>;
   beforeQuestionCard?: ReactNode;
 };
@@ -27,6 +32,7 @@ export function QuestionSurfaceBody({
   disabled,
   onSelectChoice,
   feedback = null,
+  questionFeedbackRating = null,
   feedbackRef,
   beforeQuestionCard,
 }: QuestionSurfaceBodyProps) {
@@ -46,7 +52,12 @@ export function QuestionSurfaceBody({
   ) : null;
 
   const feedbackCard = feedback ? (
-    <Feedback {...feedback} selectedChoiceId={selectedChoiceId} />
+    <>
+      <Feedback {...feedback} selectedChoiceId={selectedChoiceId} />
+      {questionFeedbackRating ? (
+        <QuestionFeedbackRating {...questionFeedbackRating} />
+      ) : null}
+    </>
   ) : null;
 
   return (

--- a/components/ui/textarea.test.tsx
+++ b/components/ui/textarea.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+let Textarea: typeof import('./textarea').Textarea;
+
+beforeAll(async () => {
+  ({ Textarea } = await import('./textarea'));
+});
+
+function getClassTokens(className: string): Set<string> {
+  return new Set(className.split(/\s+/).filter(Boolean));
+}
+
+describe('components/ui/textarea', () => {
+  it('renders a textarea with the shared form-control tokens', () => {
+    const html = renderToStaticMarkup(
+      <Textarea
+        name="comment"
+        placeholder="Add details"
+        maxLength={2000}
+        aria-invalid="true"
+      />,
+    );
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const textarea = doc.querySelector('[data-slot="textarea"]');
+    const classTokens = getClassTokens(textarea?.getAttribute('class') ?? '');
+
+    expect(textarea).not.toBeNull();
+    expect(textarea?.getAttribute('name')).toBe('comment');
+    expect(textarea?.getAttribute('placeholder')).toBe('Add details');
+    expect(textarea?.getAttribute('maxLength')).toBe('2000');
+    expect(textarea?.getAttribute('aria-invalid')).toBe('true');
+    expect(classTokens.has('border-input')).toBe(true);
+    expect(classTokens.has('dark:border-foreground/40')).toBe(true);
+    expect(classTokens.has('focus-visible:ring-ring/50')).toBe(true);
+    expect(classTokens.has('focus-visible:ring-[3px]')).toBe(true);
+    expect(classTokens.has('aria-invalid:border-destructive')).toBe(true);
+    expect(classTokens.has('disabled:opacity-50')).toBe(true);
+  });
+});

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input dark:border-foreground/40 flex min-h-24 w-full min-w-0 rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };


### PR DESCRIPTION
## Summary
- Add feedback rating row, report dialog, and textarea primitive with design-system compliant controls.
- Add feedback action core and hooks mirroring the bookmark optimistic/idempotency pattern.
- Wire feedback into quick practice, active/session review, post-exam review, and standalone question review surfaces.

## Tests
- pnpm typecheck
- pnpm lint (19 existing nursery file-size warnings)
- pnpm test --run (2,617 passed)
- pnpm test:browser (285 passed)
- pnpm build

SPEC-041 PR3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can rate questions ("helpful" / "not helpful") and see live status (saving / saved / error).
  * "Give feedback" action added to bottom action bars in practice, exam review, and question review views.
  * A feedback dialog lets users choose a category, add optional comments, and submit reports; rating controls appear after answer explanations where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->