### PR TITLE
SPEC-041 PR4: add feedback export tooling

### DIFF
--- a/docs/dev/question-feedback-analytics.md
+++ b/docs/dev/question-feedback-analytics.md
@@ -1,0 +1,91 @@
+# Question Feedback Analytics
+
+Question feedback is exported through a local-only, read-only script:
+
+```bash
+DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm --silent export:feedback > question-feedback.csv
+DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm --silent export:feedback -- --format json > question-feedback.json
+```
+
+Default exports redact `user_id` and exclude free-text comments. Raw user identifiers and comment
+bodies require explicit opt-in flags and should only be used for local editorial analysis:
+
+```bash
+DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm --silent export:feedback -- --include-user-id > question-feedback-raw-users.csv
+DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm --silent export:feedback -- --include-comments > question-feedback-comments.csv
+```
+
+Never run the export against a production database unless the output location and retention policy
+are approved for possible PII/PHI.
+
+## Current Helpful Rate Per Question
+
+Latest rating per user/question wins. A null latest rating is a retraction and is excluded from the
+helpful/not-helpful denominator.
+
+```sql
+WITH latest AS (
+  SELECT DISTINCT ON (user_id, question_id)
+         user_id, question_id, rating
+  FROM question_feedback
+  WHERE kind = 'rating'
+  ORDER BY user_id, question_id, created_at DESC, id DESC
+)
+SELECT q.slug,
+       COUNT(*) FILTER (WHERE latest.rating = 'helpful')     AS helpful,
+       COUNT(*) FILTER (WHERE latest.rating = 'not_helpful') AS not_helpful,
+       COUNT(*)                                             AS total_ratings,
+       ROUND(
+         COUNT(*) FILTER (WHERE latest.rating = 'helpful')::numeric
+         / NULLIF(COUNT(*), 0),
+         4
+       ) AS helpful_rate
+FROM latest
+JOIN questions q ON q.id = latest.question_id
+WHERE latest.rating IS NOT NULL
+GROUP BY q.slug
+ORDER BY not_helpful DESC, total_ratings DESC, q.slug;
+```
+
+## Top Reported Questions
+
+```sql
+SELECT q.slug,
+       COUNT(*)                 AS report_count,
+       MAX(qf.created_at)       AS most_recent_report_at
+FROM question_feedback qf
+JOIN questions q ON q.id = qf.question_id
+WHERE qf.kind = 'report'
+GROUP BY q.slug
+ORDER BY report_count DESC, most_recent_report_at DESC, q.slug;
+```
+
+## Counts By Report Category
+
+```sql
+SELECT qf.category,
+       COUNT(*) AS report_count
+FROM question_feedback qf
+WHERE qf.kind = 'report'
+GROUP BY qf.category
+ORDER BY report_count DESC, qf.category;
+```
+
+## Recent Comments
+
+Comments are free text and may contain PII/PHI. Use this query only in approved local analysis
+contexts; do not paste the result into logs, issue trackers, or PR comments.
+
+```sql
+SELECT qf.created_at,
+       q.slug,
+       qf.category,
+       qf.comment
+FROM question_feedback qf
+JOIN questions q ON q.id = qf.question_id
+WHERE qf.kind = 'report'
+  AND qf.comment IS NOT NULL
+  AND char_length(trim(qf.comment)) > 0
+ORDER BY qf.created_at DESC, qf.id DESC
+LIMIT 100;
+```

--- a/docs/specs/spec-041-question-feedback.md
+++ b/docs/specs/spec-041-question-feedback.md
@@ -796,6 +796,9 @@ No admin UI in v1 (there is no role system yet — out of scope). Two extraction
 
 1. **Documented SQL** (add to this spec's appendix + `docs/dev/`): e.g. report counts by category,
    helpful-rate per question (latest-rating-per-user), top-reported questions, recent comments.
+   The operational appendix lives in `docs/dev/question-feedback-analytics.md`; it includes the
+   verified current-helpful-rate query, top-reported-question query, category counts, and a
+   privacy-warning recent-comments query.
 2. **Ops export script** `scripts/export-question-feedback.ts` — follow the `scripts/seed.ts`
    convention exactly: add a `package.json` entry (e.g. `"export:feedback": "tsx scripts/export-question-feedback.ts"`,
    `tsx` not `ts-node`), load env via `dotenv.config({ path: '.env.local', quiet: true })` then

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:seed": "tsx scripts/seed.ts",
     "db:studio": "drizzle-kit studio",
+    "export:feedback": "tsx scripts/export-question-feedback.ts",
     "db:test:up": "docker compose up -d --wait",
     "db:test:down": "docker compose down",
     "db:test:reset": "docker compose down -v && docker compose up -d --wait",

--- a/scripts/export-question-feedback.test.ts
+++ b/scripts/export-question-feedback.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  restoreProcessEnv,
+  snapshotProcessEnv,
+} from '../tests/shared/process-env';
+import {
+  formatQuestionFeedbackExport,
+  getQuestionFeedbackExportPrivacyWarnings,
+  parseQuestionFeedbackExportArgs,
+  type QuestionFeedbackExportRow,
+  runExportQuestionFeedback,
+} from './export-question-feedback';
+
+const ORIGINAL_ENV = snapshotProcessEnv();
+
+afterEach(() => {
+  restoreProcessEnv(ORIGINAL_ENV);
+});
+
+const BASE_ROW: QuestionFeedbackExportRow = {
+  id: 'feedback-1',
+  userId: 'user-1',
+  questionId: 'question-1',
+  questionSlug: 'question-slug-1',
+  attemptId: 'attempt-1',
+  practiceSessionId: null,
+  kind: 'report',
+  rating: null,
+  category: 'ambiguous_wording',
+  comment: 'Contains comma, newline\nand private details',
+  createdAt: new Date('2026-06-03T12:00:00.000Z'),
+};
+
+describe('formatQuestionFeedbackExport', () => {
+  it('formats CSV with redacted user ids and excluded comments by default', () => {
+    const csv = formatQuestionFeedbackExport([BASE_ROW], {
+      format: 'csv',
+      includeUserId: false,
+      includeComments: false,
+    });
+
+    expect(csv).toBe(
+      [
+        'feedback_id,question_id,question_slug,attempt_id,practice_session_id,kind,rating,category,created_at,user_id,has_comment',
+        'feedback-1,question-1,question-slug-1,attempt-1,,report,,ambiguous_wording,2026-06-03T12:00:00.000Z,[redacted],true',
+        '',
+      ].join('\n'),
+    );
+    expect(csv).not.toContain('user-1');
+    expect(csv).not.toContain('private details');
+  });
+
+  it('adds raw user ids and comments only when explicit options allow them', () => {
+    const csv = formatQuestionFeedbackExport([BASE_ROW], {
+      format: 'csv',
+      includeUserId: true,
+      includeComments: true,
+    });
+
+    expect(csv).toBe(
+      [
+        'feedback_id,question_id,question_slug,attempt_id,practice_session_id,kind,rating,category,created_at,user_id,has_comment,comment',
+        'feedback-1,question-1,question-slug-1,attempt-1,,report,,ambiguous_wording,2026-06-03T12:00:00.000Z,user-1,true,"Contains comma, newline\nand private details"',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('formats JSON with ISO timestamps and omits comment bodies by default', () => {
+    const json = formatQuestionFeedbackExport([BASE_ROW], {
+      format: 'json',
+      includeUserId: false,
+      includeComments: false,
+    });
+
+    expect(JSON.parse(json)).toEqual([
+      {
+        feedbackId: 'feedback-1',
+        questionId: 'question-1',
+        questionSlug: 'question-slug-1',
+        attemptId: 'attempt-1',
+        practiceSessionId: null,
+        kind: 'report',
+        rating: null,
+        category: 'ambiguous_wording',
+        createdAt: '2026-06-03T12:00:00.000Z',
+        userId: '[redacted]',
+        hasComment: true,
+      },
+    ]);
+  });
+});
+
+describe('parseQuestionFeedbackExportArgs', () => {
+  it('defaults to CSV with privacy-preserving output', () => {
+    expect(parseQuestionFeedbackExportArgs([])).toEqual({
+      format: 'csv',
+      includeUserId: false,
+      includeComments: false,
+    });
+  });
+
+  it('parses format and raw-data opt-in flags', () => {
+    expect(
+      parseQuestionFeedbackExportArgs([
+        '--format',
+        'json',
+        '--include-user-id',
+        '--include-comments',
+      ]),
+    ).toEqual({
+      format: 'json',
+      includeUserId: true,
+      includeComments: true,
+    });
+  });
+
+  it('rejects unsupported formats', () => {
+    expect(() => parseQuestionFeedbackExportArgs(['--format', 'xml'])).toThrow(
+      /Invalid --format/,
+    );
+  });
+});
+
+describe('getQuestionFeedbackExportPrivacyWarnings', () => {
+  it('returns explicit PII/PHI warnings for raw export flags', () => {
+    expect(
+      getQuestionFeedbackExportPrivacyWarnings({
+        format: 'csv',
+        includeUserId: true,
+        includeComments: true,
+      }),
+    ).toEqual([
+      'WARNING: --include-user-id exports raw user identifiers and may contain PII.',
+      'WARNING: --include-comments exports free-text comments that may contain PII/PHI.',
+    ]);
+  });
+});
+
+describe('runExportQuestionFeedback', () => {
+  it('requires DATABASE_URL before opening the read-only database client', async () => {
+    delete process.env.DATABASE_URL;
+
+    await expect(runExportQuestionFeedback([])).rejects.toThrow(
+      /DATABASE_URL environment variable is required/,
+    );
+  });
+});

--- a/scripts/export-question-feedback.test.ts
+++ b/scripts/export-question-feedback.test.ts
@@ -17,6 +17,10 @@ const ORIGINAL_ENV = snapshotProcessEnv();
 
 afterEach(() => {
   restoreProcessEnv(ORIGINAL_ENV);
+  vi.doUnmock('postgres');
+  vi.doUnmock('drizzle-orm/postgres-js');
+  vi.resetModules();
+  vi.restoreAllMocks();
 });
 
 const BASE_ROW: QuestionFeedbackExportRow = {
@@ -212,44 +216,52 @@ describe('runExportQuestionFeedback', () => {
     );
     expect(sql.end).toHaveBeenCalledWith({ timeout: 5 });
   });
+
+  it('uses the seed-style postgres and drizzle defaults when dependencies are omitted', async () => {
+    vi.resetModules();
+    process.env.DATABASE_URL =
+      'postgresql://postgres:postgres@localhost:5434/addiction_boards_test';
+    const output = createWritableSink();
+    const sql = {
+      end: vi.fn().mockResolvedValue(undefined),
+    };
+    const fakeDb = createQuestionFeedbackSelectDb([BASE_ROW], {
+      assertTableIdentity: false,
+    });
+    const postgresMock = vi.fn(() => sql);
+    const drizzleMock = vi.fn(() => fakeDb);
+
+    vi.doMock('postgres', () => ({ default: postgresMock }));
+    vi.doMock('drizzle-orm/postgres-js', () => ({
+      drizzle: drizzleMock,
+    }));
+    const imported = await import('./export-question-feedback');
+
+    await imported.runExportQuestionFeedback([], output, createWritableSink());
+
+    expect(postgresMock).toHaveBeenCalledWith(process.env.DATABASE_URL, {
+      max: 1,
+    });
+    expect(drizzleMock).toHaveBeenCalledWith(
+      sql,
+      expect.objectContaining({ schema: expect.any(Object) }),
+    );
+    expect(output.text()).toContain('question-slug-1');
+    expect(sql.end).toHaveBeenCalledWith({ timeout: 5 });
+  });
 });
 
 describe('readQuestionFeedbackRows', () => {
   it('selects feedback rows joined to question slugs in newest-first order', async () => {
-    const calls: string[] = [];
     const selectedRows = [BASE_ROW];
-    const fakeDb = {
-      select(selection: Record<string, unknown>) {
-        calls.push(`select:${Object.keys(selection).join(',')}`);
-        return {
-          from(table: unknown) {
-            expect(table).toBe(schema.questionFeedback);
-            calls.push('from:questionFeedback');
-            return {
-              innerJoin(tableToJoin: unknown, condition: unknown) {
-                expect(tableToJoin).toBe(schema.questions);
-                expect(condition).toBeDefined();
-                calls.push('innerJoin:questions');
-                return {
-                  orderBy(...orderings: unknown[]) {
-                    expect(orderings).toHaveLength(2);
-                    calls.push('orderBy:createdAt,id');
-                    return Promise.resolve(selectedRows);
-                  },
-                };
-              },
-            };
-          },
-        };
-      },
-    };
+    const fakeDb = createQuestionFeedbackSelectDb(selectedRows);
 
     const rows = await readQuestionFeedbackRows(
       fakeDb as unknown as Parameters<typeof readQuestionFeedbackRows>[0],
     );
 
     expect(rows).toEqual(selectedRows);
-    expect(calls).toEqual([
+    expect(fakeDb.calls).toEqual([
       'select:id,userId,questionId,questionSlug,attemptId,practiceSessionId,kind,rating,category,comment,createdAt',
       'from:questionFeedback',
       'innerJoin:questions',
@@ -270,4 +282,46 @@ function createWritableSink(): NodeJS.WritableStream & { text(): string } {
       return value;
     },
   } as NodeJS.WritableStream & { text(): string };
+}
+
+function createQuestionFeedbackSelectDb(
+  rows: QuestionFeedbackExportRow[],
+  options = { assertTableIdentity: true },
+) {
+  const calls: string[] = [];
+
+  return {
+    calls,
+    select(selection: Record<string, unknown>) {
+      calls.push(`select:${Object.keys(selection).join(',')}`);
+      return {
+        from(table: unknown) {
+          if (options.assertTableIdentity) {
+            expect(table).toBe(schema.questionFeedback);
+          } else {
+            expect(table).toBeDefined();
+          }
+          calls.push('from:questionFeedback');
+          return {
+            innerJoin(tableToJoin: unknown, condition: unknown) {
+              if (options.assertTableIdentity) {
+                expect(tableToJoin).toBe(schema.questions);
+              } else {
+                expect(tableToJoin).toBeDefined();
+              }
+              expect(condition).toBeDefined();
+              calls.push('innerJoin:questions');
+              return {
+                orderBy(...orderings: unknown[]) {
+                  expect(orderings).toHaveLength(2);
+                  calls.push('orderBy:createdAt,id');
+                  return Promise.resolve(rows);
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
 }

--- a/scripts/export-question-feedback.test.ts
+++ b/scripts/export-question-feedback.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../db/schema';
 import {
   restoreProcessEnv,
   snapshotProcessEnv,
@@ -8,6 +9,7 @@ import {
   getQuestionFeedbackExportPrivacyWarnings,
   parseQuestionFeedbackExportArgs,
   type QuestionFeedbackExportRow,
+  readQuestionFeedbackRows,
   runExportQuestionFeedback,
 } from './export-question-feedback';
 
@@ -115,9 +117,22 @@ describe('parseQuestionFeedbackExportArgs', () => {
     });
   });
 
+  it('supports CSV and JSON aliases', () => {
+    expect(parseQuestionFeedbackExportArgs(['--json']).format).toBe('json');
+    expect(parseQuestionFeedbackExportArgs(['--json', '--csv']).format).toBe(
+      'csv',
+    );
+  });
+
   it('rejects unsupported formats', () => {
     expect(() => parseQuestionFeedbackExportArgs(['--format', 'xml'])).toThrow(
       /Invalid --format/,
+    );
+  });
+
+  it('rejects unknown flags', () => {
+    expect(() => parseQuestionFeedbackExportArgs(['--wat'])).toThrow(
+      /Unknown export flag: --wat/,
     );
   });
 });
@@ -145,4 +160,114 @@ describe('runExportQuestionFeedback', () => {
       /DATABASE_URL environment variable is required/,
     );
   });
+
+  it('writes formatted output, privacy warnings, and closes the database client', async () => {
+    process.env.DATABASE_URL =
+      'postgresql://postgres:postgres@localhost:5434/addiction_boards_test';
+    const output = createWritableSink();
+    const errorOutput = createWritableSink();
+    const sql = {
+      end: vi.fn().mockResolvedValue(undefined),
+    };
+    const db = {};
+
+    await runExportQuestionFeedback(
+      ['--format', 'json', '--include-comments'],
+      output,
+      errorOutput,
+      {
+        createSql: (databaseUrl) => {
+          expect(databaseUrl).toBe(process.env.DATABASE_URL);
+          return sql;
+        },
+        createDb: (receivedSql) => {
+          expect(receivedSql).toBe(sql);
+          return db;
+        },
+        readRows: (receivedDb) => {
+          expect(receivedDb).toBe(db);
+          return Promise.resolve([BASE_ROW]);
+        },
+      },
+    );
+
+    expect(JSON.parse(output.text())).toEqual([
+      {
+        feedbackId: 'feedback-1',
+        questionId: 'question-1',
+        questionSlug: 'question-slug-1',
+        attemptId: 'attempt-1',
+        practiceSessionId: null,
+        kind: 'report',
+        rating: null,
+        category: 'ambiguous_wording',
+        createdAt: '2026-06-03T12:00:00.000Z',
+        userId: '[redacted]',
+        hasComment: true,
+        comment: 'Contains comma, newline\nand private details',
+      },
+    ]);
+    expect(errorOutput.text()).toContain(
+      'WARNING: --include-comments exports free-text comments',
+    );
+    expect(sql.end).toHaveBeenCalledWith({ timeout: 5 });
+  });
 });
+
+describe('readQuestionFeedbackRows', () => {
+  it('selects feedback rows joined to question slugs in newest-first order', async () => {
+    const calls: string[] = [];
+    const selectedRows = [BASE_ROW];
+    const fakeDb = {
+      select(selection: Record<string, unknown>) {
+        calls.push(`select:${Object.keys(selection).join(',')}`);
+        return {
+          from(table: unknown) {
+            expect(table).toBe(schema.questionFeedback);
+            calls.push('from:questionFeedback');
+            return {
+              innerJoin(tableToJoin: unknown, condition: unknown) {
+                expect(tableToJoin).toBe(schema.questions);
+                expect(condition).toBeDefined();
+                calls.push('innerJoin:questions');
+                return {
+                  orderBy(...orderings: unknown[]) {
+                    expect(orderings).toHaveLength(2);
+                    calls.push('orderBy:createdAt,id');
+                    return Promise.resolve(selectedRows);
+                  },
+                };
+              },
+            };
+          },
+        };
+      },
+    };
+
+    const rows = await readQuestionFeedbackRows(
+      fakeDb as unknown as Parameters<typeof readQuestionFeedbackRows>[0],
+    );
+
+    expect(rows).toEqual(selectedRows);
+    expect(calls).toEqual([
+      'select:id,userId,questionId,questionSlug,attemptId,practiceSessionId,kind,rating,category,comment,createdAt',
+      'from:questionFeedback',
+      'innerJoin:questions',
+      'orderBy:createdAt,id',
+    ]);
+  });
+});
+
+function createWritableSink(): NodeJS.WritableStream & { text(): string } {
+  let value = '';
+
+  return {
+    write(chunk: string | Uint8Array) {
+      value += String(chunk);
+      return true;
+    },
+    text() {
+      return value;
+    },
+  } as NodeJS.WritableStream & { text(): string };
+}

--- a/scripts/export-question-feedback.ts
+++ b/scripts/export-question-feedback.ts
@@ -48,11 +48,30 @@ type QuestionFeedbackExportRecord = {
 };
 
 type QuestionFeedbackExportDb = PostgresJsDatabase<typeof schema>;
+type QuestionFeedbackExportSql = Pick<ReturnType<typeof postgres>, 'end'>;
+
+export type QuestionFeedbackExportDeps<
+  TSql extends QuestionFeedbackExportSql,
+  TDb,
+> = {
+  createSql(databaseUrl: string): TSql;
+  createDb(sql: TSql): TDb;
+  readRows(db: TDb): Promise<QuestionFeedbackExportRow[]>;
+};
 
 const DEFAULT_OPTIONS: QuestionFeedbackExportOptions = {
   format: 'csv',
   includeUserId: false,
   includeComments: false,
+};
+
+const DEFAULT_DEPS: QuestionFeedbackExportDeps<
+  ReturnType<typeof postgres>,
+  QuestionFeedbackExportDb
+> = {
+  createSql: (databaseUrl) => postgres(databaseUrl, { max: 1 }),
+  createDb: (sql) => drizzle(sql, { schema }),
+  readRows: (db) => readQuestionFeedbackRows(db),
 };
 
 export function parseQuestionFeedbackExportArgs(
@@ -132,7 +151,7 @@ export function formatQuestionFeedbackExport(
   return formatCsv(records, options);
 }
 
-async function readQuestionFeedbackRows(
+export async function readQuestionFeedbackRows(
   db: QuestionFeedbackExportDb,
 ): Promise<QuestionFeedbackExportRow[]> {
   return db
@@ -164,6 +183,10 @@ export async function runExportQuestionFeedback(
   argv = process.argv.slice(2),
   output: NodeJS.WritableStream = process.stdout,
   errorOutput: NodeJS.WritableStream = process.stderr,
+  deps: QuestionFeedbackExportDeps<
+    QuestionFeedbackExportSql,
+    unknown
+  > = DEFAULT_DEPS,
 ): Promise<void> {
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
@@ -177,11 +200,11 @@ export async function runExportQuestionFeedback(
     errorOutput.write(`${warning}\n`);
   }
 
-  const sql = postgres(databaseUrl, { max: 1 });
-  const db = drizzle(sql, { schema });
+  const sql = deps.createSql(databaseUrl);
+  const db = deps.createDb(sql);
 
   try {
-    const rows = await readQuestionFeedbackRows(db);
+    const rows = await deps.readRows(db);
     output.write(formatQuestionFeedbackExport(rows, options));
   } finally {
     await sql.end({ timeout: 5 });

--- a/scripts/export-question-feedback.ts
+++ b/scripts/export-question-feedback.ts
@@ -1,0 +1,295 @@
+import { pathToFileURL } from 'node:url';
+import dotenv from 'dotenv';
+import { desc, eq } from 'drizzle-orm';
+import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import * as schema from '../db/schema';
+
+dotenv.config({ path: '.env.local', quiet: true });
+dotenv.config({ path: '.env', quiet: true });
+
+const REDACTED_USER_ID = '[redacted]';
+
+export type QuestionFeedbackExportFormat = 'csv' | 'json';
+
+export type QuestionFeedbackExportOptions = {
+  format: QuestionFeedbackExportFormat;
+  includeUserId: boolean;
+  includeComments: boolean;
+};
+
+export type QuestionFeedbackExportRow = {
+  id: string;
+  userId: string;
+  questionId: string;
+  questionSlug: string;
+  attemptId: string | null;
+  practiceSessionId: string | null;
+  kind: schema.QuestionFeedbackKind;
+  rating: schema.QuestionFeedbackRating | null;
+  category: schema.QuestionFeedbackCategory | null;
+  comment: string | null;
+  createdAt: Date | string;
+};
+
+type QuestionFeedbackExportRecord = {
+  feedbackId: string;
+  questionId: string;
+  questionSlug: string;
+  attemptId: string | null;
+  practiceSessionId: string | null;
+  kind: schema.QuestionFeedbackKind;
+  rating: schema.QuestionFeedbackRating | null;
+  category: schema.QuestionFeedbackCategory | null;
+  createdAt: string;
+  userId: string;
+  hasComment: boolean;
+  comment?: string | null;
+};
+
+type QuestionFeedbackExportDb = PostgresJsDatabase<typeof schema>;
+
+const DEFAULT_OPTIONS: QuestionFeedbackExportOptions = {
+  format: 'csv',
+  includeUserId: false,
+  includeComments: false,
+};
+
+export function parseQuestionFeedbackExportArgs(
+  argv: string[],
+): QuestionFeedbackExportOptions {
+  const options = { ...DEFAULT_OPTIONS };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--include-user-id') {
+      options.includeUserId = true;
+      continue;
+    }
+
+    if (arg === '--include-comments') {
+      options.includeComments = true;
+      continue;
+    }
+
+    if (arg === '--json') {
+      options.format = 'json';
+      continue;
+    }
+
+    if (arg === '--csv') {
+      options.format = 'csv';
+      continue;
+    }
+
+    if (arg === '--format') {
+      const value = argv[index + 1];
+      if (value !== 'csv' && value !== 'json') {
+        throw new Error('Invalid --format: expected "csv" or "json"');
+      }
+      options.format = value;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown export flag: ${arg}`);
+  }
+
+  return options;
+}
+
+export function getQuestionFeedbackExportPrivacyWarnings(
+  options: QuestionFeedbackExportOptions,
+): string[] {
+  const warnings: string[] = [];
+
+  if (options.includeUserId) {
+    warnings.push(
+      'WARNING: --include-user-id exports raw user identifiers and may contain PII.',
+    );
+  }
+
+  if (options.includeComments) {
+    warnings.push(
+      'WARNING: --include-comments exports free-text comments that may contain PII/PHI.',
+    );
+  }
+
+  return warnings;
+}
+
+export function formatQuestionFeedbackExport(
+  rows: QuestionFeedbackExportRow[],
+  options: QuestionFeedbackExportOptions,
+): string {
+  const records = rows.map((row) => toExportRecord(row, options));
+
+  if (options.format === 'json') {
+    return `${JSON.stringify(records, null, 2)}\n`;
+  }
+
+  return formatCsv(records, options);
+}
+
+async function readQuestionFeedbackRows(
+  db: QuestionFeedbackExportDb,
+): Promise<QuestionFeedbackExportRow[]> {
+  return db
+    .select({
+      id: schema.questionFeedback.id,
+      userId: schema.questionFeedback.userId,
+      questionId: schema.questionFeedback.questionId,
+      questionSlug: schema.questions.slug,
+      attemptId: schema.questionFeedback.attemptId,
+      practiceSessionId: schema.questionFeedback.practiceSessionId,
+      kind: schema.questionFeedback.kind,
+      rating: schema.questionFeedback.rating,
+      category: schema.questionFeedback.category,
+      comment: schema.questionFeedback.comment,
+      createdAt: schema.questionFeedback.createdAt,
+    })
+    .from(schema.questionFeedback)
+    .innerJoin(
+      schema.questions,
+      eq(schema.questionFeedback.questionId, schema.questions.id),
+    )
+    .orderBy(
+      desc(schema.questionFeedback.createdAt),
+      desc(schema.questionFeedback.id),
+    );
+}
+
+export async function runExportQuestionFeedback(
+  argv = process.argv.slice(2),
+  output: NodeJS.WritableStream = process.stdout,
+  errorOutput: NodeJS.WritableStream = process.stderr,
+): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error(
+      'DATABASE_URL environment variable is required for export:feedback',
+    );
+  }
+
+  const options = parseQuestionFeedbackExportArgs(argv);
+  for (const warning of getQuestionFeedbackExportPrivacyWarnings(options)) {
+    errorOutput.write(`${warning}\n`);
+  }
+
+  const sql = postgres(databaseUrl, { max: 1 });
+  const db = drizzle(sql, { schema });
+
+  try {
+    const rows = await readQuestionFeedbackRows(db);
+    output.write(formatQuestionFeedbackExport(rows, options));
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+function toExportRecord(
+  row: QuestionFeedbackExportRow,
+  options: QuestionFeedbackExportOptions,
+): QuestionFeedbackExportRecord {
+  const record: QuestionFeedbackExportRecord = {
+    feedbackId: row.id,
+    questionId: row.questionId,
+    questionSlug: row.questionSlug,
+    attemptId: row.attemptId,
+    practiceSessionId: row.practiceSessionId,
+    kind: row.kind,
+    rating: row.rating,
+    category: row.category,
+    createdAt: toIsoString(row.createdAt),
+    userId: options.includeUserId ? row.userId : REDACTED_USER_ID,
+    hasComment: row.comment !== null && row.comment.length > 0,
+  };
+
+  if (options.includeComments) {
+    record.comment = row.comment;
+  }
+
+  return record;
+}
+
+function formatCsv(
+  records: QuestionFeedbackExportRecord[],
+  options: QuestionFeedbackExportOptions,
+): string {
+  const headers = [
+    'feedback_id',
+    'question_id',
+    'question_slug',
+    'attempt_id',
+    'practice_session_id',
+    'kind',
+    'rating',
+    'category',
+    'created_at',
+    'user_id',
+    'has_comment',
+  ];
+
+  if (options.includeComments) {
+    headers.push('comment');
+  }
+
+  const lines = [
+    headers.join(','),
+    ...records.map((record) => csvRecordLine(record, options)),
+  ];
+
+  return `${lines.join('\n')}\n`;
+}
+
+function csvRecordLine(
+  record: QuestionFeedbackExportRecord,
+  options: QuestionFeedbackExportOptions,
+): string {
+  const values = [
+    record.feedbackId,
+    record.questionId,
+    record.questionSlug,
+    record.attemptId,
+    record.practiceSessionId,
+    record.kind,
+    record.rating,
+    record.category,
+    record.createdAt,
+    record.userId,
+    String(record.hasComment),
+  ];
+
+  if (options.includeComments) {
+    values.push(record.comment ?? null);
+  }
+
+  return values.map(csvCell).join(',');
+}
+
+function csvCell(value: string | null): string {
+  if (value === null) return '';
+  if (!/[",\n\r]/.test(value)) return value;
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function toIsoString(value: Date | string): string {
+  return value instanceof Date
+    ? value.toISOString()
+    : new Date(value).toISOString();
+}
+
+async function main(): Promise<void> {
+  await runExportQuestionFeedback();
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add the local-only question feedback export script with privacy-preserving CSV/JSON output
- add unit coverage for redaction defaults, raw-data opt-in flags, JSON/CSV formatting, and missing DATABASE_URL
- document the verified SQL analytics appendix and package script

## Verification
- pnpm typecheck
- pnpm lint (19 pre-existing nursery file-size warnings)
- pnpm test --run (2,630 tests)
- pnpm test:browser (295 tests)
- DATABASE_URL=local test DB pnpm test:integration (108 tests)
- pnpm build
- documented SQL queries verified against local naltrexone-test-db


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to export question feedback to CSV or JSON with opt-in flags for including user IDs and comment text; emits privacy warnings.

* **Documentation**
  * Added an analytics guide with query examples and privacy guidance for analyzing question feedback.
  * Updated the spec to reference the new analytics guide.

* **Tests**
  * Added end-to-end tests covering export formats, privacy controls, CLI parsing, warnings, and DB interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->