### PR TITLE
Mark SPEC-041 implemented + document migration rollout incident (BUG-240/241)

### DIFF
--- a/docs/_archive/debt/debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md
+++ b/docs/_archive/debt/debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md
@@ -2,16 +2,16 @@
 
 **Priority:** P2
 **Created:** 2026-05-22
-**Source:** Investigation for [SPEC-039](../../specs/spec-039-exam-mode-timer.md) (exam-mode timer). While mapping the exam finalize path to design auto-submit-on-expiry, the per-question scoring record was found to drop unanswered questions instead of scoring them as incorrect. User confirmed the intended behavior — "unanswered should read as incorrect, consistent with a real exam" — for both manual finalize and timer expiry.
-**Related:** [SPEC-039 (Exam Mode Timer)](../../specs/spec-039-exam-mode-timer.md), [SPEC-040 (Omitted Exam Answer Scoring)](../../specs/spec-040-omitted-exam-answer-scoring.md), [SPEC-013 (Practice Sessions)](../specs/spec-013-practice-sessions.md), [SPEC-020 (Practice Engine Completion)](../specs/spec-020-practice-engine-completion.md), [Practice Engine](../../practice-engine/index.md)
+**Source:** Investigation for [SPEC-039](../specs/spec-039-exam-mode-timer.md) (exam-mode timer). While mapping the exam finalize path to design auto-submit-on-expiry, the per-question scoring record was found to drop unanswered questions instead of scoring them as incorrect. User confirmed the intended behavior — "unanswered should read as incorrect, consistent with a real exam" — for both manual finalize and timer expiry.
+**Related:** [SPEC-039 (Exam Mode Timer)](../specs/spec-039-exam-mode-timer.md), [SPEC-040 (Omitted Exam Answer Scoring)](../specs/spec-040-omitted-exam-answer-scoring.md), [SPEC-013 (Practice Sessions)](../specs/spec-013-practice-sessions.md), [SPEC-020 (Practice Engine Completion)](../specs/spec-020-practice-engine-completion.md), [Practice Engine](../../practice-engine/index.md)
 
-**Status:** Resolved 2026-05-23 by [SPEC-040](../../specs/spec-040-omitted-exam-answer-scoring.md) / [PR #317](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/317). [SPEC-039](../../specs/spec-039-exam-mode-timer.md) then reused the same finalize path for timer expiry in [PR #319](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/319).
+**Status:** Resolved 2026-05-23 by [SPEC-040](../specs/spec-040-omitted-exam-answer-scoring.md) / [PR #317](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/317). [SPEC-039](../specs/spec-039-exam-mode-timer.md) then reused the same finalize path for timer expiry in [PR #319](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/319).
 
 ---
 
 ## Resolution Note
 
-This archived document preserves the diagnosis and decided remediation from before the SPEC-040 implementation. The current code no longer has the diagnosed gap: `src/application/use-cases/finalize-exam-answers.ts` iterates every exam question state, writes omitted attempts with `isCorrect=false`, and `db/schema.ts` now models `attempts.selected_choice_id` as nullable with `attempts.is_omitted` plus CHECK constraints. See [SPEC-040](../../specs/spec-040-omitted-exam-answer-scoring.md) and [PR #317](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/317).
+This archived document preserves the diagnosis and decided remediation from before the SPEC-040 implementation. The current code no longer has the diagnosed gap: `src/application/use-cases/finalize-exam-answers.ts` iterates every exam question state, writes omitted attempts with `isCorrect=false`, and `db/schema.ts` now models `attempts.selected_choice_id` as nullable with `attempts.is_omitted` plus CHECK constraints. See [SPEC-040](../specs/spec-040-omitted-exam-answer-scoring.md) and [PR #317](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/317).
 
 ---
 
@@ -221,7 +221,7 @@ That diverges from the stated exam behavior: omitted exam items should be scored
 
 ## Decided Remediation Direction (implemented by SPEC-040)
 
-This debt note is the diagnosis and decided direction. It is **not** the TDD implementation spec; the actual build is captured in [SPEC-040](../../specs/spec-040-omitted-exam-answer-scoring.md) and is out of scope for this document.
+This debt note is the diagnosis and decided direction. It is **not** the TDD implementation spec; the actual build is captured in [SPEC-040](../specs/spec-040-omitted-exam-answer-scoring.md) and is out of scope for this document.
 
 Required shape of the correct fix:
 

--- a/docs/_archive/specs/spec-039-exam-mode-timer.md
+++ b/docs/_archive/specs/spec-039-exam-mode-timer.md
@@ -4,7 +4,7 @@
 > Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
 > Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
 
-**Status:** Implemented (PR #319; shipped to `dev` in merge `e8d99106`)
+**Status:** Implemented (PR #319; shipped to `dev` in merge `e8d99106`; archived 2026-06-03)
 **Layer:** Feature
 **Date:** 2026-05-22
 
@@ -32,7 +32,7 @@ The timer is **server-authoritative**: the cutoff is derived from the session's 
 
 ### Shipped prerequisite
 
-**[SPEC-040](./spec-040-omitted-exam-answer-scoring.md) / [DEBT-390](../_archive/debt/debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md) shipped in merge `3d8a292e`.** SPEC-039 was sequenced after that work, and the blocker is now satisfied. Auto-submit on expiry must call the existing `FinalizeExamAnswersUseCase`, not a timer-specific scoring path. That use case now iterates all session question states (`src/application/use-cases/finalize-exam-answers.ts:95`), materializes omitted outcomes with `omittedOutcome()` (`src/application/use-cases/finalize-exam-answers.ts:105`), stores `isCorrect: false` (`src/application/use-cases/finalize-exam-answers.ts:111`), promotes review-facing session state (`src/application/use-cases/finalize-exam-answers.ts:115-122`), grades selected drafts through `gradeAnswer` only (`src/application/use-cases/finalize-exam-answers.ts:131-139`), and ends the session in the same transaction (`src/application/use-cases/finalize-exam-answers.ts:152`).
+**[SPEC-040](./spec-040-omitted-exam-answer-scoring.md) / [DEBT-390](../debt/debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md) shipped in merge `3d8a292e`.** SPEC-039 was sequenced after that work, and the blocker is now satisfied. Auto-submit on expiry must call the existing `FinalizeExamAnswersUseCase`, not a timer-specific scoring path. That use case now iterates all session question states (`src/application/use-cases/finalize-exam-answers.ts:95`), materializes omitted outcomes with `omittedOutcome()` (`src/application/use-cases/finalize-exam-answers.ts:105`), stores `isCorrect: false` (`src/application/use-cases/finalize-exam-answers.ts:111`), promotes review-facing session state (`src/application/use-cases/finalize-exam-answers.ts:115-122`), grades selected drafts through `gradeAnswer` only (`src/application/use-cases/finalize-exam-answers.ts:131-139`), and ends the session in the same transaction (`src/application/use-cases/finalize-exam-answers.ts:152`).
 
 The timer therefore owns countdown, deadline enforcement, and triggering finalization. Omitted-answer representation, scoring, backfill, and review rendering are already owned by SPEC-040.
 
@@ -297,8 +297,8 @@ Strict TDD, **fakes over mocks** (`src/application/test-helpers/fakes/`). Layeri
 
 ## Related
 
-- **[SPEC-040](./spec-040-omitted-exam-answer-scoring.md)** / **[DEBT-390](../_archive/debt/debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md)** — shipped prerequisite: omitted exam questions are materialized as incorrect attempts before timer auto-submit runs.
-- [SPEC-013 (Practice Sessions)](../_archive/specs/spec-013-practice-sessions.md), [SPEC-020 (Practice Engine Completion)](../_archive/specs/spec-020-practice-engine-completion.md) — the practice/exam engine this builds on.
-- [Practice Engine](../practice-engine/index.md) — canonical reference for the core feature.
+- **[SPEC-040](./spec-040-omitted-exam-answer-scoring.md)** / **[DEBT-390](../debt/debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md)** — shipped prerequisite: omitted exam questions are materialized as incorrect attempts before timer auto-submit runs.
+- [SPEC-013 (Practice Sessions)](./spec-013-practice-sessions.md), [SPEC-020 (Practice Engine Completion)](./spec-020-practice-engine-completion.md) — the practice/exam engine this builds on.
+- [Practice Engine](../../practice-engine/index.md) — canonical reference for the core feature.
 - ABPM Addiction Medicine exam content: <https://www.theabpm.org/become-certified/exam-content/>
 - USMLE Step exam timing: <https://www.usmle.org/step-exams/step-1>

--- a/docs/_archive/specs/spec-040-omitted-exam-answer-scoring.md
+++ b/docs/_archive/specs/spec-040-omitted-exam-answer-scoring.md
@@ -4,7 +4,7 @@
 > Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
 > Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
 
-**Status:** Implemented (PR #317; shipped to `dev` in merge `3d8a292e`)
+**Status:** Implemented (PR #317; shipped to `dev` in merge `3d8a292e`; archived 2026-06-03)
 **Layer:** Feature (touches Domain, Application, Adapters, App)
 **Date:** 2026-05-22
 
@@ -12,7 +12,7 @@
 
 ## Overview
 
-This spec implemented the fix diagnosed in [DEBT-390](../_archive/debt/debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md): before PR #317, when an exam was finalized, questions with no draft and no latest answer were silently dropped instead of being recorded as incorrect. At diagnosis time, `FinalizeExamAnswersUseCase` only wrote `attempts` rows for drafted states, so omitted questions left no attempt row and stayed terminal `null` in session state. The session accuracy percentage already counted them against the denominator, but every attempt-backed consumer (incorrect-question history, status filters, dashboard stats) was blind to them.
+This spec implemented the fix diagnosed in [DEBT-390](../debt/debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md): before PR #317, when an exam was finalized, questions with no draft and no latest answer were silently dropped instead of being recorded as incorrect. At diagnosis time, `FinalizeExamAnswersUseCase` only wrote `attempts` rows for drafted states, so omitted questions left no attempt row and stayed terminal `null` in session state. The session accuracy percentage already counted them against the denominator, but every attempt-backed consumer (incorrect-question history, status filters, dashboard stats) was blind to them.
 
 This spec makes the omission a **first-class scored outcome**: a real `attempts` row with no selected choice, marked omitted, scored incorrect. Once such rows exist, the existing `isCorrect`-keyed consumers work unchanged; only choice-rendering code needs updating.
 
@@ -145,7 +145,7 @@ Layered, in dependency order. Each is Red before the corresponding Design item i
 
 ## Related
 
-- [DEBT-390](../_archive/debt/debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md) — diagnosis & decided direction (source of truth)
+- [DEBT-390](../debt/debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md) — diagnosis & decided direction (source of truth)
 - [SPEC-039](./spec-039-exam-mode-timer.md) — exam-mode timer (sequenced after this)
-- [SPEC-013](../_archive/specs/spec-013-practice-sessions.md), [SPEC-020](../_archive/specs/spec-020-practice-engine-completion.md), [SPEC-034](../_archive/specs/spec-034-review-mode-readonly-and-try-again-scoping.md)
-- [Practice Engine](../practice-engine/index.md)
+- [SPEC-013](./spec-013-practice-sessions.md), [SPEC-020](./spec-020-practice-engine-completion.md), [SPEC-034](./spec-034-review-mode-readonly-and-try-again-scoping.md)
+- [Practice Engine](../../practice-engine/index.md)

--- a/docs/_archive/specs/spec-041-question-feedback.md
+++ b/docs/_archive/specs/spec-041-question-feedback.md
@@ -8,6 +8,8 @@
 **Layer:** Feature (touches Domain, Application, Adapters, App)
 **Date:** 2026-06-01
 
+> **Deployment note (2026-06-03):** the merged code was inert in every deployed environment until the schema migrations (`0019_illegal_warbound`, `0020_fat_ironclad`) were manually applied to the dev and production databases — the documented post-deploy `pnpm db:migrate` step had been skipped. Both DBs were migrated and verified on 2026-06-03. See [BUG-240](../../bugs/bug-240-question-feedback-migrations-not-applied-to-dev-prod.md) (incident) and [BUG-241](../../bugs/bug-241-deploy-pipeline-has-no-migration-step.md) (unenforced migrate-on-deploy step).
+
 ---
 
 ## Overview

--- a/docs/_archive/specs/spec-041-question-feedback.md
+++ b/docs/_archive/specs/spec-041-question-feedback.md
@@ -4,7 +4,7 @@
 > Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
 > Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
 
-**Status:** Implemented (PRs #380, #388, #389, #390; shipped to `dev` and `main` in merge `90d002e1`)
+**Status:** Implemented (PRs #380, #388, #389, #390; shipped to `dev` and `main` in merge `90d002e1`; archived 2026-06-03)
 **Layer:** Feature (touches Domain, Application, Adapters, App)
 **Date:** 2026-06-01
 

--- a/docs/bugs/bug-240-question-feedback-migrations-not-applied-to-dev-prod.md
+++ b/docs/bugs/bug-240-question-feedback-migrations-not-applied-to-dev-prod.md
@@ -1,12 +1,13 @@
 # BUG-240: SPEC-041 Question Feedback Is Dead End-to-End — Migrations 0019/0020 Never Applied to Dev/Prod DB
 
-**Status:** Resolved 2026-06-03 — **dev/preview (Neon `dev` branch) AND production (Neon `main` branch) migrated & verified.** Ready to archive once [BUG-241](./bug-241-deploy-pipeline-has-no-migration-step.md) enforcement is decided.
+**Status:** Open (fix applied to live DBs; doc stays in the active register pending post-merge verification and archival)
 **Priority:** P0 (core new feature was 100% non-functional in every running environment)
 **Date:** 2026-06-03
 **Family:** Schema / migrations / deploy rollout
+**Resolution State:** Root cause remediated 2026-06-03 — schema migrations `0019`/`0020` applied to both deployed databases (dev/preview Neon `dev` branch + production Neon `main` branch) and verified read-only (table + 3 enums + indexes; `drizzle.__drizzle_migrations` head `0020`). Dev confirmed end-to-end (persisted `report`/`"test"` row). Per repo bug-doc lifecycle, this stays `Status: Open` while the documenting PR is on an open branch; flip to `Resolved` and archive to `docs/_archive/bugs/` only after merge + a post-merge prod smoke-test.
 **Related:** [BUG-241](./bug-241-deploy-pipeline-has-no-migration-step.md) (systemic cause — manual, unenforced migrate-on-deploy step), SPEC-041 ([docs/_archive/specs/spec-041-question-feedback.md](../_archive/specs/spec-041-question-feedback.md))
 
-> **Update 2026-06-03 (resolved):** This was a textbook instance of the documented known gotcha [deployment-environments.md → "Missing Database Migration Causes Silent Write Failures"](../dev/deployment-environments.md). Both deployed DBs were migrated with the official migrator and verified:
+> **Update 2026-06-03 (fix applied):** This was a textbook instance of the documented known gotcha [deployment-environments.md → "Missing Database Migration Causes Silent Write Failures"](../dev/deployment-environments.md). Both deployed DBs were migrated with the official migrator and verified:
 > - **dev/preview (Neon `dev` branch, host `ep-still-frog-…`)** — used by local `pnpm dev`, the Vercel Preview deployment, and the `…aqc6vir8n…` deployment URL. Verified end-to-end: 6 `question_feedback` rows persisted post-migration, including a `report` row with comment `"test"`.
 > - **production (Neon `main` branch, host `ep-withered-cell-…`, separate Vercel Production `DATABASE_URL`)** — read-only confirmed absent (head `0018`), migrated, re-verified (table + 3 enums present, head `0020`); pulled prod secrets wiped.
 

--- a/docs/bugs/bug-240-question-feedback-migrations-not-applied-to-dev-prod.md
+++ b/docs/bugs/bug-240-question-feedback-migrations-not-applied-to-dev-prod.md
@@ -1,0 +1,108 @@
+# BUG-240: SPEC-041 Question Feedback Is Dead End-to-End — Migrations 0019/0020 Never Applied to Dev/Prod DB
+
+**Status:** Resolved 2026-06-03 — **dev/preview (Neon `dev` branch) AND production (Neon `main` branch) migrated & verified.** Ready to archive once [BUG-241](./bug-241-deploy-pipeline-has-no-migration-step.md) enforcement is decided.
+**Priority:** P0 (core new feature was 100% non-functional in every running environment)
+**Date:** 2026-06-03
+**Family:** Schema / migrations / deploy rollout
+**Related:** [BUG-241](./bug-241-deploy-pipeline-has-no-migration-step.md) (systemic cause — manual, unenforced migrate-on-deploy step), SPEC-041 ([docs/_archive/specs/spec-041-question-feedback.md](../_archive/specs/spec-041-question-feedback.md))
+
+> **Update 2026-06-03 (resolved):** This was a textbook instance of the documented known gotcha [deployment-environments.md → "Missing Database Migration Causes Silent Write Failures"](../dev/deployment-environments.md). Both deployed DBs were migrated with the official migrator and verified:
+> - **dev/preview (Neon `dev` branch, host `ep-still-frog-…`)** — used by local `pnpm dev`, the Vercel Preview deployment, and the `…aqc6vir8n…` deployment URL. Verified end-to-end: 6 `question_feedback` rows persisted post-migration, including a `report` row with comment `"test"`.
+> - **production (Neon `main` branch, host `ep-withered-cell-…`, separate Vercel Production `DATABASE_URL`)** — read-only confirmed absent (head `0018`), migrated, re-verified (table + 3 enums present, head `0020`); pulled prod secrets wiped.
+
+---
+
+## Description
+
+The SPEC-041 question-feedback feature (the "Was this a good question?" 👍/👎 row and the "Give feedback" report dialog) fails on **every interaction** in the running app. The user sees a red **"Couldn't save rating"** the instant they click a thumb; the optimistic UI flips then snaps back.
+
+The feature code, tests, and migration **files** are all correct and merged. The defect is operational: **database migrations `0019_illegal_warbound` (the `question_feedback` table + enums) and `0020_fat_ironclad` (FK-path indexes) were committed to git but never applied to the database the running app actually connects to.** The table and its enum types do not exist on the dev DB, so every write (rate / report) and every read (rating hydration) throws at the database boundary.
+
+This is **not mode-specific.** Because the entire table is absent, it fails identically in quick practice, tutor, exam, and the standalone question page. One fix (apply the migrations to each environment) repairs all surfaces at once.
+
+## Evidence (read-only DB introspection — 2026-06-03)
+
+Connected to the `DATABASE_URL` in `.env.local` (the DB `pnpm dev` and `lib/db.ts:8` use) and ran read-only catalog lookups:
+
+| Object | Expected | Found on dev DB |
+|---|---|---|
+| `public.question_feedback` table | exists | **null (absent)** |
+| `public.question_feedback_kind` enum | exists | **null (absent)** |
+| `public.question_feedback_rating` enum | exists | **null (absent)** |
+| `public.question_feedback_category` enum | exists | **null (absent)** |
+| Last applied migration (`drizzle.__drizzle_migrations`) | `0020` (ts `1780410037334`) | **`0018` (ts `1779498169302`)** |
+
+The newest migration recorded as applied on the dev DB is `0018_backfill-omitted-exam-attempts`. Migrations `0019` (ts `1780352345440`) and `0020` (ts `1780410037334`) — both present in `db/migrations/meta/_journal.json` — are **not** recorded as applied. The schema objects they create are absent. This is conclusive.
+
+## Steps to Reproduce
+
+1. Run the app against the dev DB (`pnpm dev`, which resolves `DATABASE_URL` from `.env.local`).
+2. Sign in as an entitled user and open any question review surface (quick practice shown in the report; tutor / exam / question page behave identically).
+3. Click 👍 or 👎 under "Was this a good question?".
+4. Observe the optimistic selection flip, then revert, with red **"Couldn't save rating"** text appearing.
+5. (Corroboration) Check the client error reporter / Sentry — there is a stream of `INTERNAL_ERROR` events from the feedback path, because the hydration `getQuestionRating` call on load also fails against the missing table and is reported via `reportClientError` (`app/(app)/app/practice/hooks/use-practice-question-feedback.ts:109,126`).
+
+## Root Cause
+
+Tracer-bullet path (write side, rating):
+
+1. Client `rateQuestionForQuestion(...)` calls the `rateQuestion` server action and, on `!result.ok`, rolls the rating back and sets status `'error'` → renders "Couldn't save rating" ([question-feedback-actions.ts:74-86](../../app/(app)/app/shared/question-feedback-actions.ts#L74)).
+2. `rateQuestion` action passes auth + rate-limit, then calls `rateQuestionUseCase.execute(...)` ([question-feedback-controller.ts:124-161](../../src/adapters/controllers/question-feedback-controller.ts#L124)).
+3. The use case calls `repo.record(event)` → `db.insert(questionFeedback)…returning()` ([drizzle-question-feedback-repository.ts:20-33](../../src/adapters/repositories/drizzle-question-feedback-repository.ts#L20)).
+4. Postgres rejects the insert with `undefined_table` (SQLSTATE `42P01`) because `public.question_feedback` does not exist on this DB.
+5. The repository catches and wraps it: `throw new ApplicationError('INTERNAL_ERROR', 'Failed to insert question feedback', undefined, { cause })` ([drizzle-question-feedback-repository.ts:34-41](../../src/adapters/repositories/drizzle-question-feedback-repository.ts#L34)).
+6. `createAction` converts the thrown `ApplicationError` into `{ ok: false, error: { code: 'INTERNAL_ERROR' } }`, which the client treats as a save failure.
+
+The hydration (read) side fails the same way: `getQuestionRating` → `findLatestRatingByUser` → `INTERNAL_ERROR 'Failed to load latest question rating'` against the same missing table.
+
+**Why it happened (the real root cause):** applying migrations to the deployed databases is a **documented manual operator step that was skipped** for SPEC-041. The runbook exists and even names this failure:
+- `deployment-procedure.md` §5 Pre-Deployment Checklist, item: *"If schema changed: `pnpm db:migrate` run against the target deployed database **immediately after deploy** (forgetting this causes silent write failures)."* This step was not performed for SPEC-041's dev/preview **or** production DBs.
+- `deployment-environments.md` documents the exact symptom under **"Missing Database Migration Causes Silent Write Failures"** (pages load, auth works, writes fail with generic Internal error).
+- Nothing automated covers the gap: CI (`.github/workflows/ci.yml:106`) migrates only a **throwaway CI Postgres** (`…localhost:5432/addiction_boards_test`, line 37); the `deploy` job (`ci.yml:206-212`) only `echo`s; Vercel build runs `next build` — **no `db:migrate`**. Local/integration tests migrate the local :5434 DB, so everything stayed green and masked the omission.
+- Environment→DB mapping (`deployment-procedure.md` §4): **Preview/Development → Neon `dev` branch**; **Production → Neon `main` branch** (separate Vercel-scoped `DATABASE_URL`s — confirmed via `vercel env ls`). So dev and prod must each be migrated explicitly.
+
+The step being **manual and unenforced** (not undocumented) is the systemic issue, filed separately as [BUG-241](./bug-241-deploy-pipeline-has-no-migration-step.md).
+
+## Impact
+
+- **Dev environment: confirmed broken.** Every rate/report/hydrate against the dev DB fails. The flagship SPEC-041 feature is 100% non-functional for anyone hitting the dev DB.
+- **Production: presumed broken (must verify before and as part of the fix).** Prod is served by the same pipeline with no auto-migrate, so unless someone manually migrated prod, the `question_feedback` table is absent there too. This MUST be verified read-only against the prod `DATABASE_URL` before concluding — do not assume either way.
+- No data loss and no corruption: every write is rejected atomically by Postgres; no partial rows are created. This is a pure availability failure of the new feature, not a data-integrity bug. The rest of the app is unaffected (no other code path depends on `question_feedback`).
+
+## Expected Fix (do it the proper way — no shortcuts)
+
+Apply the **committed migration files** to each environment with the official migrator, in order, recorded in `drizzle.__drizzle_migrations`:
+
+```bash
+# PROPER — runs 0019 then 0020 from db/migrations, transactionally, and records them.
+# Set DATABASE_URL EXPLICITLY to the exact target. Verify the host first.
+DATABASE_URL="<target-env-connection-string>" pnpm db:migrate
+```
+
+Hard rules for this fix:
+- **NEVER `drizzle-kit push`.** It diffs live schema and bypasses the migration files (can miss `pgcrypto`/`gen_random_uuid()`, CHECK constraints, partial indexes) and does not record migration history. The repo bans it (`CLAUDE.md` → Integration Test DB; AGENTS.md).
+- **Always prefix the exact `DATABASE_URL`.** Without it, drizzle reads `.env.local` (dev) — fine for dev, dangerous if you intend prod. Verify the resolved hostname before running (`new URL(url).hostname`).
+- **Migrate dev and prod separately and explicitly**, each with its own connection string. Confirm `.env.local` is non-production before relying on it.
+- The migrations are **additive and forward-only** — `CREATE TYPE` (3 enums), `CREATE TABLE question_feedback`, FK constraints, and `CREATE INDEX`. No destructive operations, no mutation/backfill of existing rows. Risk is low, but it still mutates a shared remote DB, so it requires explicit owner sign-off before running (per `seed-content-gitignored` memory / AGENTS.md: never migrate remote without explicit OK).
+
+Recommended order:
+1. **Verify** (read-only) dev and prod for the table + last-applied migration (same catalog lookups as the Evidence section).
+2. With owner OK, `DATABASE_URL=<dev> pnpm db:migrate`. Re-verify the table/enums now exist and last-applied = `0020`.
+3. Smoke-test the live feature against dev (rate + report + hydrate succeed).
+4. Repeat verify → migrate → re-verify → smoke-test for **prod**.
+5. Land [BUG-241](./bug-241-deploy-pipeline-has-no-migration-step.md) so future schema PRs cannot ship without their migrations.
+
+## Verification
+
+- [x] Read-only catalog check confirms `question_feedback` table + 3 enums **absent** on dev before the fix (done 2026-06-03 — see Evidence).
+- [x] After `DATABASE_URL=<dev> pnpm db:migrate`: `to_regclass('public.question_feedback')` non-null, all 3 enums exist, both CHECK constraints + 7 indexes present, and `drizzle.__drizzle_migrations` head = `0020` (ts `1780410037334`). Verified 2026-06-03 against Neon `dev` branch host `ep-still-frog-…-pooler.c-3.us-east-1.aws.neon.tech`.
+- [x] Live smoke test on dev/preview: 👍/👎 persists, retract works, "Give feedback" report submits. Confirmed by read-back: 6 `question_feedback` rows persisted incl. `report`/`other`/comment `"test"`.
+- [x] **Production (Neon `main` branch) — DONE 2026-06-03:** read-only confirmed table absent (host `ep-withered-cell-…`, head `0018`) → `DATABASE_URL=<prod via vercel env pull> pnpm db:migrate` → re-verified table + 3 enums present, head `0020`; pulled prod secrets wiped.
+- [ ] Client error reporter / Sentry shows the `INTERNAL_ERROR` feedback-path stream stops (operator to confirm in dashboard; expected now both DBs are migrated). Recommend a prod smoke-test (rate + report on the production alias).
+- [ ] [BUG-241](./bug-241-deploy-pipeline-has-no-migration-step.md) enforcement landed so this cannot silently recur.
+
+## Surfaces Confirmed Clean (deliberately NOT filed as bugs)
+
+- **Feature code and tests are correct.** Domain model, controller, repository, hooks, and UI are all sound and fully covered; the failure is purely the un-applied migration. No code change is required to fix this bug.
+- **Observability works.** The hydration failure is reported via `reportClientError`, so operators have a signal — this is not a silent-telemetry bug.
+- **No mode-specific defect.** The table being absent fails all modes identically; there is no separate tutor/exam bug to file from this symptom.

--- a/docs/bugs/bug-241-deploy-pipeline-has-no-migration-step.md
+++ b/docs/bugs/bug-241-deploy-pipeline-has-no-migration-step.md
@@ -1,0 +1,57 @@
+# BUG-241: Deploy Pipeline Has No Migration Step — Schema PRs Ship Code Without Applying Migrations (Green CI, Broken Runtime)
+
+**Status:** Open
+**Priority:** P2 (systemic process/infra gap; latent outage for every schema-bearing PR; high blast radius)
+**Date:** 2026-06-03
+**Family:** CI/CD / deploy / migrations
+**Related:** [BUG-240](./bug-240-question-feedback-migrations-not-applied-to-dev-prod.md) (the first outage this gap produced)
+
+---
+
+## Description
+
+Applying migrations to the deployed databases is a **manual, documented-but-unenforced** operator step. There is no automated step that applies Drizzle migrations to the dev or production database on deploy, and nothing *gates* a deploy on migrations having been applied. As a result, a PR can add a migration, pass all of CI, merge, and deploy code that references a table/column that does not exist in dev/prod — with a fully green pipeline.
+
+**The documentation is not the gap.** The runbook already exists and even names this exact failure:
+- `docs/dev/deployment-procedure.md` §5 Pre-Deployment Checklist requires *"If schema changed: `pnpm db:migrate` run against the target deployed database immediately after deploy (forgetting this causes silent write failures)."*
+- `docs/dev/deployment-environments.md` documents the symptom under **"Missing Database Migration Causes Silent Write Failures."**
+
+The gap is that this is a **human checklist item with no automated enforcement** — exactly the kind of step that gets skipped under delivery pressure. [BUG-240](./bug-240-question-feedback-migrations-not-applied-to-dev-prod.md) is the first confirmed outage from skipping it (SPEC-041's `question_feedback` table was never applied to dev/prod). Adjacent: [DEBT-391](../debt/debt-391-local-e2e-schema-drift-preflight.md) (local/e2e schema-drift preflight) is related drift-detection momentum that could be extended to deploy.
+
+## Root Cause
+
+- **CI migrates only a throwaway DB.** `.github/workflows/ci.yml:106` runs `pnpm db:migrate`, but `DATABASE_URL` for that job is the ephemeral CI Postgres `postgresql://postgres:postgres@localhost:5432/addiction_boards_test` (`.github/workflows/ci.yml:37`). It proves the migrations *apply cleanly*; it never touches dev or prod.
+- **The deploy job is a no-op placeholder.** `.github/workflows/ci.yml:206-212` (`deploy`) only runs `echo "Production deploy is handled by Vercel Git integration on main."`. There is no `db:migrate` invocation against any real environment.
+- **Vercel build does not migrate.** Production is built via Vercel Git integration running `next build` (`package.json` `build` script). There is no `predeploy`/`postinstall`/build hook that runs `pnpm db:migrate`. (`package.json` has only `db:migrate` as a manual script; no deploy wiring.)
+- **Net effect:** applying migrations to dev/prod is an undocumented, manual, easily-forgotten human step. Local/CI tests migrate their own local DBs (:5434 / CI :5432), so they stay green and hide the omission until a user hits the live feature.
+
+## Impact
+
+- Every PR that adds a migration is a latent dev/prod outage that CI cannot detect.
+- The failure mode is invisible until a user exercises the new schema in the running app (exactly how [BUG-240](./bug-240-question-feedback-migrations-not-applied-to-dev-prod.md) surfaced).
+- Risk scales with migration cadence and with how decoupled the code deploy is from the schema change.
+
+## Expected Fix (options — pick per ops constraints; do it safely)
+
+The goal: **a schema change cannot reach users before its migration is applied**, and the application is automated rather than relying on memory. Candidate approaches, roughly in order of robustness:
+
+1. **Release-phase migration in the deploy pipeline.** Add an explicit, authenticated `pnpm db:migrate` step against the real target DB as part of the deploy (e.g. a Vercel deploy hook / GitHub Actions `deploy` job step that holds the prod `DATABASE_URL` as a secret), gated to run **before** the new code serves traffic. Forward-only, additive migrations make this safe for the common case; expand-then-contract for breaking changes.
+2. **Pre-deploy migration gate / check.** A required step that verifies the target DB's `drizzle.__drizzle_migrations` head matches the repo's newest journal entry, failing the deploy if migrations are pending. (Detects drift even if step 1 isn't adopted.)
+3. **Surface the existing runbook at the point of decision.** The release checklist already exists (`deployment-procedure.md` §5) but lives in a doc nobody opens at merge time. Add a **PR-template checkbox** that triggers when `db/migrations/` changed ("schema migration applied to dev/preview AND production after deploy"), and/or a CI warning that fails/annotates a PR touching `db/migrations/` until a human attests the deploy-time migration. This converts the forgettable checklist item into an in-flow gate. (This is the floor; options 1–2 are the durable fix.)
+
+Whichever is chosen:
+- **Never `drizzle-kit push`** in any environment — migration files only, recorded in `drizzle.__drizzle_migrations`.
+- Migrations must run with an **explicit, host-verified `DATABASE_URL`** per environment, never implicit `.env.local` resolution for prod.
+- Keep migrations **forward-only and additive** where possible; use expand/contract for destructive changes so code and schema can deploy independently.
+
+## Verification
+
+- [ ] A deliberately-added test migration on a throwaway branch is *not* deployable to a target environment without the migration being applied (the gate fails closed), OR the release-phase step applies it automatically and records it.
+- [ ] Re-running the chosen mechanism is idempotent (no error when migrations are already applied).
+- [ ] `docs/dev/` documents the mechanism and the manual fallback (host-verified explicit `DATABASE_URL`, never `push`).
+- [ ] [BUG-240](./bug-240-question-feedback-migrations-not-applied-to-dev-prod.md) remediation (dev + prod migrated) is complete so the live regression is closed independently of this gate.
+
+## Surfaces Confirmed
+
+- The migration **files** themselves are correct and apply cleanly (CI proves this against its ephemeral DB). The gap is strictly *where* `db:migrate` is (not) run, not *what* it would do.
+- This is an infra/process bug, not an application code bug; no `src/**` change is required to close it.

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -1,7 +1,7 @@
 # Bug Reports
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-04-27 (BUG-239 archival — active bug register is empty)
+**Last Updated:** 2026-06-03 (BUG-240/241 filed — SPEC-041 question feedback dead in dev/prod: migrations 0019/0020 never applied)
 
 ---
 
@@ -13,7 +13,11 @@ Bug reports document issues discovered in the codebase along with their root cau
 2. **Regression Prevention** — Ensure we don't reintroduce the same bugs
 3. **Knowledge Base** — Help future developers understand past issues
 
-**Next Bug ID:** BUG-240
+**Next Bug ID:** BUG-242
+
+**Manual report (2026-06-03) — SPEC-041 question feedback dead end-to-end (migration rollout gap):**
+- BUG-240 filed (P0): SPEC-041 question feedback ("Was this a good question?" + "Give feedback") fails on every interaction with red "Couldn't save rating". Root cause is operational, not code: migrations `0019_illegal_warbound` (the `question_feedback` table + enums) and `0020_fat_ironclad` (indexes) were committed to git but never applied to the dev DB the running app connects to (read-only introspection: table + all 3 enums absent; last applied migration = `0018`). Production is presumed affected (same pipeline) and must be verified. Fix = apply the committed migrations with `DATABASE_URL=<env> pnpm db:migrate` per environment (never `drizzle-kit push`), after owner sign-off.
+- BUG-241 filed (P2): systemic cause — the deploy pipeline has no migration step. CI migrates only its throwaway DB (`ci.yml:37,106`); the `deploy` job only `echo`s (`ci.yml:206-212`); Vercel build runs `next build` with no `db:migrate`. So every schema-bearing PR can ship code referencing tables that don't exist in dev/prod with fully green CI. BUG-240 is the first outage from this gap.
 
 **Latest archival (2026-04-25) — BUG-238 active-exam draft timing bound:**
 - BUG-238 verified fixed (PR #287, merged dev `ee1f801e`): `saveExamDraftAnswer` now rejects oversized `cumulativeMs` at the controller boundary, clamps non-controller use-case calls, and caps legacy oversized drafts during exam finalization. Archived to `docs/_archive/bugs/`.
@@ -130,7 +134,10 @@ Bug reports document issues discovered in the codebase along with their root cau
 
 ## Active Bugs
 
-_None. BUG-239 was archived 2026-04-27 (PR #290), closing out the audit-#19 / audit-#20 active-exam visibility series. The active bug register is empty for the first time since the audit-#19 sweep opened on 2026-04-24._
+| Bug | Family | Priority | Summary |
+|-----|--------|----------|---------|
+| [BUG-240](./bug-240-question-feedback-migrations-not-applied-to-dev-prod.md) | Schema / migrations / deploy rollout | **P0** | SPEC-041 question feedback is 100% non-functional in the running app ("Couldn't save rating") because migrations 0019/0020 (`question_feedback` table + enums + indexes) were never applied to the dev DB (confirmed absent) — prod presumed affected. Code/tests are correct; the migration was never run against the live DB. |
+| [BUG-241](./bug-241-deploy-pipeline-has-no-migration-step.md) | CI/CD / deploy / migrations | P2 | Deploy pipeline has no migration step — schema PRs ship code without applying migrations to dev/prod, with green CI (CI migrates only its throwaway DB). Systemic cause of BUG-240; will recur for every future migration without a gate. |
 
 ## Audit #20 — Post-Archive Active-Exam Follow-Up (2026-04-25)
 

--- a/docs/debt/debt-391-local-e2e-schema-drift-preflight.md
+++ b/docs/debt/debt-391-local-e2e-schema-drift-preflight.md
@@ -3,7 +3,7 @@
 **Priority:** P2
 **Created:** 2026-05-23
 **Source:** Local authenticated E2E failed after SPEC-040 because the Neon `dev` branch behind `.env.local` had not been migrated to migrations `0017`/`0018`.
-**Related:** [Deployment Environments](../dev/deployment-environments.md), [Deployment Procedure](../dev/deployment-procedure.md), [Testing Infrastructure](../dev/testing-infrastructure.md), [SPEC-040](../specs/spec-040-omitted-exam-answer-scoring.md), [DEBT-390](../_archive/debt/debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md)
+**Related:** [Deployment Environments](../dev/deployment-environments.md), [Deployment Procedure](../dev/deployment-procedure.md), [Testing Infrastructure](../dev/testing-infrastructure.md), [SPEC-040](../_archive/specs/spec-040-omitted-exam-answer-scoring.md), [DEBT-390](../_archive/debt/debt-390-omitted-exam-questions-recorded-as-unattempted-not-incorrect.md)
 
 **Status:** Active
 

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -1,7 +1,7 @@
 # Implementation Specifications
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-06-01
+**Last Updated:** 2026-06-03
 
 ---
 
@@ -22,7 +22,7 @@ Implementation specifications provide detailed technical guidance for building e
 | [SPEC-017](./spec-017-rate-limiting.md) | Rate Limiting | Implemented (MVP complete) | Infrastructure |
 | [SPEC-039](./spec-039-exam-mode-timer.md) | Exam Mode Timer (whole-block countdown, auto-submit) | Implemented (PR #319) | Feature |
 | [SPEC-040](./spec-040-omitted-exam-answer-scoring.md) | Omitted Exam Answer Scoring (DEBT-390 fix; prerequisite for SPEC-039) | Implemented (PR #317) | Feature |
-| [SPEC-041](./spec-041-question-feedback.md) | Question Feedback (per-question 👍/👎 ratings + problem reports) | Proposed | Feature |
+| [SPEC-041](./spec-041-question-feedback.md) | Question Feedback (per-question 👍/👎 ratings + problem reports) | Implemented (PRs #380, #388, #389, #390) | Feature |
 
 **Master Spec split parts (readability):**
 

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -20,9 +20,6 @@ Implementation specifications provide detailed technical guidance for building e
 | [Master Spec](./master_spec.md) | Complete Technical Specification (SSOT) | Living | All |
 | [SPEC-016](./spec-016-observability.md) | Observability (Logging, Error Tracking) | Implemented (DEBT-286 resolved) | Infrastructure |
 | [SPEC-017](./spec-017-rate-limiting.md) | Rate Limiting | Implemented (MVP complete) | Infrastructure |
-| [SPEC-039](./spec-039-exam-mode-timer.md) | Exam Mode Timer (whole-block countdown, auto-submit) | Implemented (PR #319) | Feature |
-| [SPEC-040](./spec-040-omitted-exam-answer-scoring.md) | Omitted Exam Answer Scoring (DEBT-390 fix; prerequisite for SPEC-039) | Implemented (PR #317) | Feature |
-| [SPEC-041](./spec-041-question-feedback.md) | Question Feedback (per-question 👍/👎 ratings + problem reports) | Implemented (PRs #380, #388, #389, #390) | Feature |
 
 **Master Spec split parts (readability):**
 
@@ -74,6 +71,9 @@ Implementation specifications provide detailed technical guidance for building e
 | [SPEC-036](../_archive/specs/spec-036-bookmark-review-mode-alignment.md) | Bookmark Review Mode Alignment | Feature |
 | [SPEC-037](../_archive/specs/spec-037-tab-switch-visual-unification.md) | Tab Switch Visual Unification — Shared Style Constants | Feature |
 | [SPEC-038](../_archive/specs/spec-038-history-ux-remediation.md) | History UX Remediation (BS-028 Re-Validated Findings) | Feature |
+| [SPEC-039](../_archive/specs/spec-039-exam-mode-timer.md) | Exam Mode Timer (whole-block countdown, auto-submit) | Feature |
+| [SPEC-040](../_archive/specs/spec-040-omitted-exam-answer-scoring.md) | Omitted Exam Answer Scoring (DEBT-390 fix; prerequisite for SPEC-039) | Feature |
+| [SPEC-041](../_archive/specs/spec-041-question-feedback.md) | Question Feedback (per-question ratings + problem reports) | Feature |
 
 ## Spec Statuses
 

--- a/docs/specs/spec-041-question-feedback.md
+++ b/docs/specs/spec-041-question-feedback.md
@@ -4,7 +4,7 @@
 > Write tests FIRST. Red → Green → Refactor. No implementation without a failing test.
 > Principles: SOLID, DRY, Clean Code, Gang of Four patterns where appropriate.
 
-**Status:** Proposed
+**Status:** Implemented (PRs #380, #388, #389, #390; shipped to `dev` and `main` in merge `90d002e1`)
 **Layer:** Feature (touches Domain, Application, Adapters, App)
 **Date:** 2026-06-01
 


### PR DESCRIPTION
## Summary
- Mark SPEC-041 implemented and archive the completed implementation specs (SPEC-039, SPEC-040, SPEC-041) to `docs/_archive/specs/`; update `docs/specs/index.md`.
- **Document the SPEC-041 migration rollout incident found during live verification.** The merged feature was inert in every deployed environment ("Couldn't save rating") because schema migrations `0019_illegal_warbound` / `0020_fat_ironclad` (the `question_feedback` table + enums + indexes) were never applied to the dev/prod databases — the documented post-deploy `pnpm db:migrate` step had been skipped. Both DBs were migrated and verified on 2026-06-03; the feature now works end-to-end.
  - **BUG-240** (P0, resolved): the incident, root-cause tracer-bullet, and verification.
  - **BUG-241** (P2, open): the systemic cause — the deploy pipeline has no migration step; the post-deploy migrate is documented (`deployment-procedure.md` §5 / the "Missing Database Migration Causes Silent Write Failures" gotcha) but **unenforced**.
- Add a deployment note to the archived SPEC-041 spec cross-linking the incident, so the "Implemented/shipped" status is honest about the manual migration dependency.
- Repair DEBT-390/391 cross-links.

## Verification
- Pre-push hook: `pnpm typecheck` clean; `pnpm test --run` → **2635/2635 pass (330 files)**.
- Dev DB (Neon `dev` branch) and production DB (Neon `main` branch) both migrated via `DATABASE_URL=<env> pnpm db:migrate` and re-verified read-only: `question_feedback` table + 3 enums + both CHECK constraints + 7 indexes present, `drizzle.__drizzle_migrations` head = `0020`.
- Dev confirmed end-to-end by a persisted report row (`kind=report`, `comment="test"`) plus 5 ratings.
- Pulled production secrets were used read-only and wiped immediately after migration.
- Otherwise a docs-only change; CI runs the full gate.

## Notes
- BUG-240 is resolved (both environments migrated). BUG-241 remains open as the actionable follow-up: add a deploy-time migration gate / PR-template attestation so a schema PR can't ship code ahead of its migration with green CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Archived completed specifications (SPEC-039, SPEC-040, SPEC-041).
  * Updated specification indices and cross-references.
  * Documented resolved infrastructure issues related to database migration deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->