### PR TITLE
Split stripe out of npm-minor-and-patch Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,7 @@ updates:
           - '*'
         exclude-patterns:
           - '@biomejs/biome'
+          - 'stripe'
         update-types:
           - minor
           - patch
@@ -33,6 +34,18 @@ updates:
         applies-to: version-updates
         patterns:
           - '@biomejs/biome'
+        update-types:
+          - minor
+          - patch
+          - major
+      stripe:
+        # Split out per DEBT-393 precedent: a stripe SDK bump couples to a
+        # billing-sensitive STRIPE_API_VERSION (lib/stripe.ts) upgrade that
+        # needs changelog review + webhook/checkout verification, so it must
+        # not block the routine minor/patch group.
+        applies-to: version-updates
+        patterns:
+          - 'stripe'
         update-types:
           - minor
           - patch


### PR DESCRIPTION
## Problem

The npm-minor-and-patch group PR (#395) red-failed because it bundled `stripe` 22.1.1→22.2.0, whose new SDK types require apiVersion `2026-05-27.dahlia` while `lib/stripe.ts` pins `2026-04-22.dahlia` (TS2322). A stripe bump is **billing-sensitive** — `lib/stripe.ts` mandates changelog review + webhook/checkout verification — so it shouldn't gate 7 routine updates.

## Solution

Mirror the **DEBT-393 biome split**: exclude `stripe` from `npm-minor-and-patch` and give it its own `stripe` group. The routine group can then land green; stripe gets its own careful, billing-reviewed PR.

## Follow-ups (after merge)
- `@dependabot recreate` #395 → regenerates the group without stripe → 7 safe updates → merge.
- Handle the stripe 22.2.0 + `STRIPE_API_VERSION` upgrade as its own PR (plan + webhook/checkout verification).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to better manage package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->