### PR TITLE
Add DEBT-405 (question rating control placement) debt doc

### DIFF
--- a/docs/debt/debt-405-question-rating-control-placement.md
+++ b/docs/debt/debt-405-question-rating-control-placement.md
@@ -1,0 +1,89 @@
+# DEBT-404: Question Rating Control Placement — Move to a Post-Action Footer
+
+**Priority:** P3
+**Created:** 2026-06-04
+**Source:** SPEC-041 question-feedback rating (shipped). Placement flagged in use; iterated twice via Claude in Design (round 1: inset box vs fold-in; round 2: fold-in vs post-action footer).
+**Related:** [DEBT-337](./debt-337-future-feedback-enhancements.md) (sibling feedback/practice polish), [DEBT-381](./debt-381-question-content-typography-audit-and-preference-path.md), [SPEC-041](../_archive/specs/spec-041-question-feedback.md), design docs `docs/frontend/standards.md` / `docs/frontend/pattern-registry.md` / `docs/frontend/design-principles.md`.
+
+**Status:** Active
+
+---
+
+## Problem
+
+The per-question rating control ("Was this a good question?" 👍/👎) ships in the wrong place. It is rendered as a **bare sibling** of the explanation card, sitting in the column **between the explanation and the primary `Next` button**:
+
+- `components/question/question-surface-body.tsx:54-61` — inside `feedbackCard`, `<QuestionFeedbackRating />` is rendered immediately after `<Feedback />` with **no separating spacing**. The `space-y-6` that paces the rest of the surface lives on the parent `<section>` (`app/(app)/app/practice/components/practice-view.tsx:444-451`) and never reaches inside that wrapper, so the rating butts against the bottom of the explanation card.
+- Because the thumbs are circular `size="icon"` Buttons (taller than the label text), their **tops** collide with the card while the shorter label keeps its line-height buffer — the asymmetric "buttons touching the card, label floating" look.
+- More fundamentally: the rating is an **optional, low-stakes** control, but its position puts it **in the path of the primary CTA**. The reading flow becomes explanation → rating prompt → `Next`, which gives an optional widget false prominence and makes it read like a gate before progressing.
+
+This is live on a shipped feature; the control works, but the placement does not.
+
+## Decision
+
+**Move the rating out of the content column and render it as a quiet, full-width footer *below* the action bar.**
+
+On the active practice answer-review surface, the action bar (`Next` / `Bookmark` / `Give feedback`) is rendered **after** the `<section>` (`practice-view.tsx:537`). The rating moves to render **after** `{actionBar}`, as a post-action footer:
+
+- **Boxless (variant B1):** separated from the action bar by a full-width `border-t` hairline (documented border token), content centered and de-emphasized (muted). **No fill, no surrounding box, no padding container.** This is the chosen treatment.
+- Keep a **minimal muted label** in this position. Unlike the inline placement, the footer sits *after* the action bar and is visually decontextualized from the question, so a short label ("Was this question helpful?", which maps cleanly to the `helpful` / `not_helpful` value object) aids clarity. The label copy is a low-cost, easily-reversible knob — drop it later if real usage shows the thumbs are self-evident here. The `<legend class="sr-only">` stays regardless.
+
+This settles the original complaint outright: the rating **physically follows `Next`, so it cannot gate or compete with the primary CTA**, and it stops floating because a full-width hairline + centered muted content reads unmistakably as a post-action footer rather than a dropped control.
+
+This is the **minimal, lower-risk** step. It is explicitly an interim placement chosen to fix the current broken state and learn from real usage — not a claim that it is the permanent final form. Fold-in (below) remains a live future option.
+
+## Rejected / deferred alternatives
+
+| Option | Verdict | Why |
+|--------|---------|-----|
+| **Bordered inset box** at end of the explanation (`bg-muted/20` + border + padding) | **Rejected** | Adds a *third* boxed surface to the column; the border/fill reads as a visual "stop sign" right before `Next`. Heavy for a two-button control. |
+| **In-place above `Next`** (current placement, even with spacing/divider fixes) | **Rejected** | Spacing fixes the collision but not the root issue — it still sits between the content and the primary CTA. This is the complaint. |
+| **Fold into the action bar** (👍/👎 join the right secondary cluster beside `Give feedback`) | **Deferred, not rejected** | Cleanest grouping of meta-actions, and intuitively attractive — but it overloads a bar that **already wraps on mobile** (nav + save + rate + report), pairs a one-tap signal with the heavier `Give feedback` *dialog* (conflating two intents), and makes the filled button color the **sole** confirmation. Revisit after living with the footer. |
+| **Light-container footer (variant B2)** — same footer position, `bg-muted/20` band | **Not chosen** | Re-introduces a boxed surface close in spirit to the rejected inset, for no added clarity over B1's hairline. Hold in reserve only if the footer ever needs to anchor more than the rating. |
+
+## Scope — surfaces affected
+
+The rating control is **centralized**, so relocating it touches every consumer. Keep them visually consistent:
+
+1. **`app/(app)/app/practice/components/practice-view.tsx`** — active practice / tutor answer-review (the flagged surface, has the bottom action bar). **Primary target** of this decision.
+2. **`app/(app)/app/questions/[slug]/question-page-client.tsx:369`** — standalone question-review page; also renders the rating via `QuestionSurfaceBody`'s `questionFeedbackRating` prop. Must receive the same treatment; confirm its bottom layout supports a post-action footer.
+3. **`app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx:157`** — post-exam review renders `<QuestionFeedbackRating>` **directly**, per question, in a **stacked list** of answered questions. A single page-bottom footer does **not** map here; this surface keeps the rating attached per-question but **must still inherit the spacing/boxless fix** (no collision, no inset box) so the control looks the same everywhere.
+
+Because two surfaces render the control through `QuestionSurfaceBody` and one renders it directly, decide during implementation between:
+- (a) giving `QuestionSurfaceBody` an explicit, optional **footer slot** the consumer positions, vs
+- (b) lifting the rating out of `QuestionSurfaceBody` entirely and letting each surface place it.
+
+Prefer the approach that keeps a single source of truth for the control's markup and avoids duplicating the footer chrome across surfaces.
+
+## Implementation plan (TDD)
+
+1. **Stop rendering the rating inside the content body.** In `components/question/question-surface-body.tsx:54-61`, remove `<QuestionFeedbackRating />` from `feedbackCard`. Keep `<Feedback />` and the `feedbackRef` wrapper intact — `feedbackRef` exists to `scrollIntoView` the explanation when an answer is submitted (`practice-view.tsx:335-338`) and must continue to target the explanation, not the rating.
+2. **Render the footer after the action bar.** In `practice-view.tsx`, render the rating in a footer **after** `{actionBar}` (currently at `:537`), gated on the same condition that produces feedback today (non-exam, answered — `feedbackResult` / `hasBooleanCorrectness`). Wrap it: full-width, `border-t` hairline (documented border token from `pattern-registry.md`), centered, muted.
+3. **Apply the same relocation to `question-page-client.tsx`** and ensure **`post-exam-review-view.tsx`** inherits the boxless/spacing fix (no inset, no collision) even though it stays per-question.
+4. **Label copy:** update the visible label to "Was this question helpful?" (maps to `helpful`/`not_helpful`); keep it muted. `legend` stays `sr-only` as "Rate this question".
+5. **Tests first / updated:**
+   - `components/question/question-surface-body.test.tsx` — assert the rating is **no longer** rendered inside the surface body.
+   - `app/(app)/app/practice/components/practice-view-answer-feedback.test.tsx` (and `practice-view-layout.test.tsx`) — assert the rating renders **after** the `data-testid="bottom-action-bar"` element, in the footer region.
+   - `components/question/question-feedback-rating.test.tsx` — updated label copy; control semantics unchanged.
+   - `app/(app)/app/questions/[slug]/question-page-client.test.tsx` and `app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx` — update any assertions that depend on the rating's old position.
+
+## Accessibility — preserve in all variants
+
+- `<fieldset>` + `<legend className="sr-only">Rate this question</legend>`.
+- `aria-pressed` on each toggle Button.
+- The canonical focus ring (inherited from `<Button>`) — never hand-rolled.
+- `<Button>` for every interactive target (no raw `<button>`).
+- An `aria-live="polite"` status region so `saving` / `saved` / `error` are still announced (the existing `<output>`). Visible status text in the footer is acceptable; at minimum keep it `sr-only`.
+
+## Acceptance criteria
+
+- On the active practice answer-review surface, the rating no longer appears between the explanation card and `Next`; it renders **after** the action bar as a hairline-separated, centered, muted footer (boxless — no inset box, no fill).
+- No bordered inset box and no above-`Next` placement remain.
+- The rating looks consistent across all three surfaces (practice view, question page, post-exam review); the post-exam list keeps per-question placement but with the same boxless/spacing treatment.
+- `fieldset`/`legend`, `aria-pressed`, focus ring, `<Button>`, and the `aria-live` status are all preserved.
+- `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm build` green; design-token regression scan passes (semantic tokens + documented opacity scale only).
+
+## Notes / future
+
+- Fold-in remains the most likely "v2" if usage shows the footer is under-discovered; this doc records *why* it was deferred (action-bar overload on mobile, intent conflation with the `Give feedback` dialog, color-only confirmation) so it is not re-litigated from scratch.
+- This is interim by design. Re-evaluate placement and the label after the control has been used in practice.

--- a/docs/debt/debt-405-question-rating-control-placement.md
+++ b/docs/debt/debt-405-question-rating-control-placement.md
@@ -56,11 +56,10 @@ The rating control is **centralized**, so relocating it touches every consumer. 
 2. **`app/(app)/app/questions/[slug]/question-page-client.tsx:369`** — standalone question-review page; also renders the rating via `QuestionSurfaceBody`'s `questionFeedbackRating` prop. Must receive the same treatment; confirm its bottom layout supports a post-action footer.
 3. **`app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx:157`** — post-exam review currently renders `<QuestionFeedbackRating>` **directly** after `<Feedback />`, but the live surface shows one focused `currentRow` at a time with a `data-testid="bottom-action-bar"` after the review section (`post-exam-review-view.tsx:176-228`). It is not a stacked list in the current code. Apply the same post-action footer treatment here as well: render the rating after that action bar when the current row is available and `questionFeedback` exists.
 
-Because two surfaces render the control through `QuestionSurfaceBody` and one renders it directly, decide during implementation between:
-- (a) giving `QuestionSurfaceBody` an explicit, optional **footer slot** the consumer positions, vs
-- (b) lifting the rating out of `QuestionSurfaceBody` entirely and letting each surface place it.
+The footer renders **after each surface's action bar**, and that action bar lives in the parent component (`practice-view.tsx`, `question-page-client.tsx`, `post-exam-review-view.tsx`), **not inside `QuestionSurfaceBody`**. A "footer slot inside `QuestionSurfaceBody`" therefore cannot express this placement. The implementation is:
 
-Prefer the approach that keeps a single source of truth for the control's markup and avoids duplicating the footer chrome across surfaces.
+- **Lift the rating out of `QuestionSurfaceBody`** — remove the `questionFeedbackRating` prop + render at `question-surface-body.tsx:54-61` and its two call sites (`practice-view.tsx:523`, `question-page-client.tsx:369`); `post-exam-review-view.tsx` already renders the control directly, so just relocate it there.
+- **Extract one shared footer component** (e.g. `components/question/question-rating-footer.tsx`) that wraps `QuestionFeedbackRating` in the registry-approved post-action footer chrome, and render it after the `data-testid="bottom-action-bar"` in all three parents. Single source of truth for both the control and the footer chrome — no duplicated chrome.
 
 ## Implementation plan (TDD)
 

--- a/docs/debt/debt-405-question-rating-control-placement.md
+++ b/docs/debt/debt-405-question-rating-control-placement.md
@@ -1,4 +1,4 @@
-# DEBT-404: Question Rating Control Placement — Move to a Post-Action Footer
+# DEBT-405: Question Rating Control Placement — Move to a Post-Action Footer
 
 **Priority:** P3
 **Created:** 2026-06-04
@@ -25,10 +25,17 @@ This is live on a shipped feature; the control works, but the placement does not
 
 On the active practice answer-review surface, the action bar (`Next` / `Bookmark` / `Give feedback`) is rendered **after** the `<section>` (`practice-view.tsx:537`). The rating moves to render **after** `{actionBar}`, as a post-action footer:
 
-- **Boxless (variant B1):** separated from the action bar by a full-width `border-t` hairline (documented border token), content centered and de-emphasized (muted). **No fill, no surrounding box, no padding container.** This is the chosen treatment.
+- **Boxless (variant B1):** separated from the action bar by a full-width `border-t border-border` hairline (Pattern Registry M-2 `Standard` content separator), content centered and de-emphasized (`text-sm text-muted-foreground`). **No fill, no surrounding box, no card-like padding container.** This is the chosen treatment.
 - Keep a **minimal muted label** in this position. Unlike the inline placement, the footer sits *after* the action bar and is visually decontextualized from the question, so a short label ("Was this question helpful?", which maps cleanly to the `helpful` / `not_helpful` value object) aids clarity. The label copy is a low-cost, easily-reversible knob — drop it later if real usage shows the thumbs are self-evident here. The `<legend class="sr-only">` stays regardless.
 
 This settles the original complaint outright: the rating **physically follows `Next`, so it cannot gate or compete with the primary CTA**, and it stops floating because a full-width hairline + centered muted content reads unmistakably as a post-action footer rather than a dropped control.
+
+**Design-system prerequisite:** a full-width, post-action rating footer is a **new composition pattern**, not an existing named Pattern Registry entry. Before changing `app/**` or `components/**`, add a registry entry for this pattern (for example, a question-flow footer/chrome entry) that canonically defines:
+
+- wrapper: `border-t border-border` (M-2 `Standard` separator) plus only spacing needed to separate the footer from the action bar;
+- content row: centered, wrapping, `gap-3`, `text-sm text-muted-foreground`;
+- no `bg-*` fill, no `Card`, no bordered inset container, and no undocumented opacity values;
+- interactive targets remain `<Button>` instances, so focus rings stay inherited from the Button primitive.
 
 This is the **minimal, lower-risk** step. It is explicitly an interim placement chosen to fix the current broken state and learn from real usage — not a claim that it is the permanent final form. Fold-in (below) remains a live future option.
 
@@ -47,7 +54,7 @@ The rating control is **centralized**, so relocating it touches every consumer. 
 
 1. **`app/(app)/app/practice/components/practice-view.tsx`** — active practice / tutor answer-review (the flagged surface, has the bottom action bar). **Primary target** of this decision.
 2. **`app/(app)/app/questions/[slug]/question-page-client.tsx:369`** — standalone question-review page; also renders the rating via `QuestionSurfaceBody`'s `questionFeedbackRating` prop. Must receive the same treatment; confirm its bottom layout supports a post-action footer.
-3. **`app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx:157`** — post-exam review renders `<QuestionFeedbackRating>` **directly**, per question, in a **stacked list** of answered questions. A single page-bottom footer does **not** map here; this surface keeps the rating attached per-question but **must still inherit the spacing/boxless fix** (no collision, no inset box) so the control looks the same everywhere.
+3. **`app/(app)/app/practice/[sessionId]/components/post-exam-review-view.tsx:157`** — post-exam review currently renders `<QuestionFeedbackRating>` **directly** after `<Feedback />`, but the live surface shows one focused `currentRow` at a time with a `data-testid="bottom-action-bar"` after the review section (`post-exam-review-view.tsx:176-228`). It is not a stacked list in the current code. Apply the same post-action footer treatment here as well: render the rating after that action bar when the current row is available and `questionFeedback` exists.
 
 Because two surfaces render the control through `QuestionSurfaceBody` and one renders it directly, decide during implementation between:
 - (a) giving `QuestionSurfaceBody` an explicit, optional **footer slot** the consumer positions, vs
@@ -57,15 +64,17 @@ Prefer the approach that keeps a single source of truth for the control's markup
 
 ## Implementation plan (TDD)
 
-1. **Stop rendering the rating inside the content body.** In `components/question/question-surface-body.tsx:54-61`, remove `<QuestionFeedbackRating />` from `feedbackCard`. Keep `<Feedback />` and the `feedbackRef` wrapper intact — `feedbackRef` exists to `scrollIntoView` the explanation when an answer is submitted (`practice-view.tsx:335-338`) and must continue to target the explanation, not the rating.
-2. **Render the footer after the action bar.** In `practice-view.tsx`, render the rating in a footer **after** `{actionBar}` (currently at `:537`), gated on the same condition that produces feedback today (non-exam, answered — `feedbackResult` / `hasBooleanCorrectness`). Wrap it: full-width, `border-t` hairline (documented border token from `pattern-registry.md`), centered, muted.
-3. **Apply the same relocation to `question-page-client.tsx`** and ensure **`post-exam-review-view.tsx`** inherits the boxless/spacing fix (no inset, no collision) even though it stays per-question.
-4. **Label copy:** update the visible label to "Was this question helpful?" (maps to `helpful`/`not_helpful`); keep it muted. `legend` stays `sr-only` as "Rate this question".
-5. **Tests first / updated:**
+1. **Pattern Registry first.** Add the post-action rating footer pattern to `docs/frontend/pattern-registry.md` before changing source. The governing docs require this for novel UI patterns (`standards.md:29-31`, `.claude/rules/frontend.md:96-108`); today the registry documents the usable tokens (`M-2`, Button conventions), but not this composition.
+2. **Stop rendering the rating inside the content body.** In `components/question/question-surface-body.tsx:54-61`, remove `<QuestionFeedbackRating />` from `feedbackCard`. Keep `<Feedback />` and the `feedbackRef` wrapper intact — `feedbackRef` exists to `scrollIntoView` the explanation when an answer is submitted (`practice-view.tsx:335-338`) and must continue to target the explanation, not the rating.
+3. **Render the footer after the action bar.** In `practice-view.tsx`, render the rating in a footer **after** `{actionBar}` (currently at `:537`), gated on the same condition that produces feedback today (non-exam, answered — `feedbackResult` / `hasBooleanCorrectness`). Wrap it with the registry-approved post-action footer classes: full-width `border-t border-border`, centered, wrapping `gap-3`, muted label/status, no fill.
+4. **Apply the same relocation to `question-page-client.tsx` and `post-exam-review-view.tsx`.** The standalone review page has its action bar at `question-page-client.tsx:391-499`; post-exam review has its action bar at `post-exam-review-view.tsx:176-228`. Both should render the rating footer after those action bars using their existing rating gates (`isReviewMode && questionFeedback` for standalone review; `currentRow?.isAvailable && questionFeedback` for post-exam review).
+5. **Label copy:** update the visible label to "Was this question helpful?" (maps to `helpful`/`not_helpful`); keep it muted. `legend` stays `sr-only` as "Rate this question".
+6. **Tests first / updated:**
    - `components/question/question-surface-body.test.tsx` — assert the rating is **no longer** rendered inside the surface body.
-   - `app/(app)/app/practice/components/practice-view-answer-feedback.test.tsx` (and `practice-view-layout.test.tsx`) — assert the rating renders **after** the `data-testid="bottom-action-bar"` element, in the footer region.
+   - `app/(app)/app/practice/components/practice-view-answer-feedback.test.tsx` (and `practice-view-layout.test.tsx` if the footer wrapper needs a layout-level assertion) — assert the rating renders **after** the `data-testid="bottom-action-bar"` element, in the footer region.
    - `components/question/question-feedback-rating.test.tsx` — updated label copy; control semantics unchanged.
-   - `app/(app)/app/questions/[slug]/question-page-client.test.tsx` and `app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx` — update any assertions that depend on the rating's old position.
+   - `app/(app)/app/questions/[slug]/question-page-client.test.tsx` and `app/(app)/app/practice/[sessionId]/components/post-exam-review-view.test.tsx` — assert the rating footer follows each surface's `data-testid="bottom-action-bar"`, not merely that it appears after the explanation.
+   - Grep cleanup: the current position-sensitive assertions are in `question-surface-body.test.tsx`, `practice-view-answer-feedback.test.tsx`, `question-page-client.test.tsx`, and `post-exam-review-view.test.tsx`; update all of them so no old "after explanation" contract remains.
 
 ## Accessibility — preserve in all variants
 
@@ -74,12 +83,13 @@ Prefer the approach that keeps a single source of truth for the control's markup
 - The canonical focus ring (inherited from `<Button>`) — never hand-rolled.
 - `<Button>` for every interactive target (no raw `<button>`).
 - An `aria-live="polite"` status region so `saving` / `saved` / `error` are still announced (the existing `<output>`). Visible status text in the footer is acceptable; at minimum keep it `sr-only`.
+- Mobile behavior: the footer row must wrap without overlapping the action bar, and its tab/reading order must follow the action bar. Do not convert the action bar or rating footer into a sticky shell; current review action bars are document-flow siblings.
 
 ## Acceptance criteria
 
 - On the active practice answer-review surface, the rating no longer appears between the explanation card and `Next`; it renders **after** the action bar as a hairline-separated, centered, muted footer (boxless — no inset box, no fill).
 - No bordered inset box and no above-`Next` placement remain.
-- The rating looks consistent across all three surfaces (practice view, question page, post-exam review); the post-exam list keeps per-question placement but with the same boxless/spacing treatment.
+- The rating looks consistent across all three surfaces (practice view, question page, post-exam review); all three render the rating after their respective action bars as the same boxless post-action footer.
 - `fieldset`/`legend`, `aria-pressed`, focus ring, `<Button>`, and the `aria-live` status are all preserved.
 - `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm build` green; design-token regression scan passes (semantic tokens + documented opacity scale only).
 

--- a/docs/debt/index.md
+++ b/docs/debt/index.md
@@ -22,8 +22,9 @@ Technical debt documents known shortcuts, deferred work, and architectural compr
 | [DEBT-349](./debt-349-cross-request-published-content-caching.md) | Optional Tier 2 cross-request caching for immutable published questions and tag lists after DEBT-344 shipped request-scoped dedup | P3 | — |
 | [DEBT-381](./debt-381-question-content-typography-audit-and-preference-path.md) | Question content typography audit — Quick Practice, Tutor, and Exam are already unified at the Typography Policy Medium content tier. Do not globally shrink question text; if needed later, add a user-selectable Markdown/content-size preference while leaving UI chrome unchanged. | P3 | — |
 | [DEBT-391](./debt-391-local-e2e-schema-drift-preflight.md) | Local authenticated E2E can run against a stale `.env.local` Neon branch because the current preflight checks only database connectivity and one historical idempotency schema contract, not the full Drizzle migration journal. Add a full migration-journal/schema-drift preflight so local E2E fails fast with a targeted migration instruction instead of surfacing generic write-path errors mid-suite. | P2 | — |
+| [DEBT-405](./debt-405-question-rating-control-placement.md) | SPEC-041 question rating (👍/👎) ships in the wrong place — rendered as a bare sibling of the explanation card, it collides with the card and sits in the path of the primary `Next` CTA. Decision: move it to a boxless, hairline-separated post-action footer rendered after the action bar so it can't gate or float before `Next`. Fold-into-the-action-bar deferred (mobile bar overload, intent conflation with `Give feedback`, color-only confirmation). Centralized control → applies across practice view, question page, and post-exam review. | P3 | — |
 
-**Next Debt ID:** DEBT-404
+**Next Debt ID:** DEBT-406
 
 ---
 


### PR DESCRIPTION
## DEBT-405 — Question rating control placement (decision + implementation)

Moves the SPEC-041 question rating (👍/👎) out of the content column — where it collided with the explanation card and sat in the path of the primary **Next** CTA — into a **boxless, hairline-separated footer rendered *after* the action bar**, uniformly across all three surfaces that render it.

### What's in this PR
- **Decision record:** `docs/debt/debt-405-question-rating-control-placement.md` (survived two independent adversarial audit passes).
- **Design-system first:** Pattern Registry **F-9: Post-Action Rating Footer** added to `docs/frontend/pattern-registry.md` *before* any component change (per the "never invent a pattern" rule), reusing **M-2 `Standard`** (`border-t border-border`).
- **Single source of truth:** new `components/question/question-rating-footer.tsx` (boxless chrome wrapping the existing rating control).
- **Lifted out** of `QuestionSurfaceBody` (prop + render + import removed; `feedbackRef` still targets the explanation for the submit-scroll).
- **Rendered after `data-testid="bottom-action-bar"`** on all three surfaces — practice view, standalone question review, post-exam review — each behind its existing rating gate.
- **Copy:** "Was this a good question?" → **"Was this question helpful?"** (maps to the `helpful`/`not_helpful` value object), de-emphasized to muted.
- **Token-regression coverage** added for the new footer.

### TDD + verification
- Red → green order preserved; position tests assert the rating renders **after** the action bar (not just present), and the surface-body test now asserts **absence**.
- a11y preserved end-to-end: `<fieldset>` + `sr-only` legend, `aria-pressed`, `aria-live` status, `<Button>` everywhere, canonical focus ring.
- **Full gate green under Node 24:** `typecheck` ✅ · `lint` ✅ (19 known warnings) · `test --run` ✅ 2637 · `test:browser` ✅ 295 · `build` ✅.

### Rebase note
Rebased onto current `dev` after the Stripe DEBT-404/406 merges. Only `docs/debt/index.md` conflicted — resolved to keep the **DEBT-405** active row and dev's **`Next Debt ID: DEBT-407`** (404 + 406 now taken). No code conflicts (dev's changes were Stripe-only).

### Not run (and why)
Integration/E2E not run: no DB/schema/migration change and no billing-flow change in this PR; dev's Stripe work was gated separately in #400/#401.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented specification for repositioning the question rating control to a footer appearing below the action bar. Updates include refined label copy ("Was this question helpful?"), minimal visual styling with hairline separation, and full coverage across practice answer review, standalone question review, and post-exam review surfaces, all while preserving accessibility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->