### PR TITLE
DEBT-391 — Local E2E migration-ledger schema-drift preflight

### DIFF
--- a/docs/debt/debt-391-local-e2e-schema-drift-preflight.md
+++ b/docs/debt/debt-391-local-e2e-schema-drift-preflight.md
@@ -13,19 +13,19 @@
 
 Local authenticated E2E can run against a database that is behind the checked-out migration journal.
 
-The current local E2E path loads `.env.local`: `playwright.config.ts:4-7` says it prefers `.env.local` and then `.env`. The global setup always runs before the Chromium project: `tests/e2e/global.setup.ts:7-11` calls `runE2ECredentialHealthCheck()`, `seedTestSubscription()`, `runE2EUserStateReset()`, and `clerkSetup()`.
+The current local E2E path loads `.env.local`: `playwright.config.ts:4-7` says it prefers `.env.local` and then `.env`. The setup project runs before the Chromium project because `playwright.config.ts:24-34` declares the `setup` project and makes Chromium depend on it. The setup body is still the pre-mutation choke point: `tests/e2e/global.setup.ts:7-11` calls `runE2ECredentialHealthCheck()`, `seedTestSubscription()`, `runE2EUserStateReset()`, and `clerkSetup()`.
 
-That preflight catches connectivity and one historical schema contract, but not full migration drift. `tests/e2e/helpers/credential-health-check.ts:141-149` verifies `SELECT 1`, and `credential-health-check.ts:152-181` checks only whether `idempotency_keys.completed_at` exists. There is no comparison between `db/migrations/meta/_journal.json` and Drizzle's migration ledger table (`drizzle.__drizzle_migrations` by default for Postgres), and no contract check for the current write-path tables.
+That preflight catches connectivity and one historical schema contract, but not full migration drift. `tests/e2e/helpers/credential-health-check.ts:141-149` verifies `SELECT 1`, `credential-health-check.ts:152-181` checks only whether `idempotency_keys.completed_at` exists, and `credential-health-check.ts:371-386` wires only those two database checks into the `database` validator. There is no comparison between `db/migrations/meta/_journal.json` and Drizzle's migration ledger table (`drizzle.__drizzle_migrations` for this repo's Postgres migrator), and no contract check for the current write-path tables.
 
-SPEC-040 made this visible. Migration `db/migrations/0017_flaky_ser_duncan.sql:1-4` makes `attempts.selected_choice_id` nullable, adds `attempts.is_omitted`, and adds the two CHECK constraints. Migration `db/migrations/0018_backfill-omitted-exam-attempts.sql:2-42` backfills omitted-incorrect attempts where no session/question attempt exists. When local `.env.local` targeted the Neon `dev` branch before those migrations had been applied, pages and auth still loaded, but answer-submission E2E paths failed with a generic "Failed to insert attempt" instead of a targeted "this database is behind migrations" error.
+SPEC-040 made this visible. Migration `db/migrations/0017_flaky_ser_duncan.sql:1-4` makes `attempts.selected_choice_id` nullable, adds `attempts.is_omitted`, and adds the two CHECK constraints. Migration `db/migrations/0018_backfill-omitted-exam-attempts.sql:2-42` backfills omitted-incorrect attempts where no session/question attempt exists. When local `.env.local` targeted the Neon `dev` branch before those migrations had been applied, pages and auth still loaded, but answer-submission E2E paths failed with a generic "Failed to insert attempt" instead of a targeted "this database is behind migrations" error. The live journal has since advanced through SPEC-041 (`db/migrations/meta/_journal.json:138-150` adds `0019_illegal_warbound` and `0020_fat_ironclad`), so the fix must compute missing migrations from the journal dynamically rather than hard-coding the SPEC-040 names.
 
-CI did not catch this local drift because CI uses its own fresh Postgres service. `.github/workflows/ci.yml:35-38` sets a CI-local `DATABASE_URL`, `.github/workflows/ci.yml:105-109` runs `pnpm db:migrate` and `pnpm db:seed`, and `.github/workflows/ci.yml:187-189` runs `pnpm test:e2e` only after that setup.
+CI did not catch this local drift because CI uses its own fresh Postgres service. `.github/workflows/ci.yml:35-38` sets a CI-local `DATABASE_URL`, `.github/workflows/ci.yml:105-109` runs `pnpm db:migrate` and `pnpm db:seed`, and `.github/workflows/ci.yml:189-193` runs `pnpm test:e2e` only after that setup.
 
 ---
 
 ## Why Existing Docs Were Not Enough
 
-The source-of-truth docs already say the right operational rule. `docs/dev/deployment-environments.md:101-141` documents that missing migrations cause write failures and that the fix is running `pnpm db:migrate` against the exact target database. `docs/dev/deployment-procedure.md:8-16` states that Vercel deploys code only and does not run migrations or seeds. `docs/dev/deployment-procedure.md:40-45` makes target-environment migration a manual operator step, separate from CI.
+The source-of-truth docs already say the right operational rule. `docs/dev/deployment-environments.md:101-140` documents that missing migrations cause write failures and that the fix is running `pnpm db:migrate` against the exact target database. `docs/dev/deployment-procedure.md:8-16` states that Vercel deploys code only and does not run migrations or seeds. `docs/dev/deployment-procedure.md:40-45` makes target-environment migration a manual operator step, separate from CI.
 
 The gap is automation and placement:
 
@@ -41,20 +41,21 @@ Implement a local E2E schema-drift preflight before any mutating E2E setup runs.
 
 The preflight should:
 
-1. Read the expected migration list from `db/migrations/meta/_journal.json`.
-2. Query `drizzle.__drizzle_migrations` on the active `DATABASE_URL`.
-3. Compare repo journal entries to ledger rows by `entries[].when` (`db/migrations/meta/_journal.json`) and `created_at` (`drizzle.__drizzle_migrations`). Drizzle's table stores `hash` and `created_at`, not the human-readable `tag`, so map any missing `when` values back to journal `tag` values for the error message.
-4. Fail fast when the target database is missing migrations present in the repo.
-5. Print a clear, non-secret remediation message, such as:
+1. Read the expected migration list from `db/migrations/meta/_journal.json`, using `entries[].idx`, `entries[].tag`, and `entries[].when` as the source of truth.
+2. Query `drizzle.__drizzle_migrations` on the active `DATABASE_URL`. This repo's `drizzle.config.ts:14-21` sets `schema`, `out`, `dialect`, and `dbCredentials` only, with no custom `migrationsSchema` or `migrationsTable`; `package.json:25` runs `db:migrate` as `drizzle-kit migrate`, so the Postgres ledger remains the Drizzle default `drizzle.__drizzle_migrations`.
+3. Compare repo journal entries to ledger rows by numeric `entries[].when` (`db/migrations/meta/_journal.json`) and `created_at` (`drizzle.__drizzle_migrations`). The applied ledger table stores `id`, `hash`, and `created_at` (`bigint`), not the human-readable `tag`, so map any missing `when` values back to journal `tag` values for the error message.
+4. Treat a missing `drizzle` schema or missing `drizzle.__drizzle_migrations` table as schema drift, not as an unexpected setup crash.
+5. Fail fast when the target database is missing migrations present in the repo.
+6. Print a clear, non-secret remediation message, such as:
 
 ```text
 E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS
-The database used by .env.local is behind the repo migration journal.
-Missing migrations: 0017_flaky_ser_duncan, 0018_backfill-omitted-exam-attempts.
-Confirm this is the intended non-production database, then run: DATABASE_URL="<verified target>" pnpm db:migrate
+The database used by E2E is behind the repo migration journal.
+Missing migrations: 0019_illegal_warbound, 0020_fat_ironclad.
+For local runs, confirm .env.local points at the intended non-production database, then run: DATABASE_URL="<verified target>" pnpm db:migrate
 ```
 
-This belongs in the E2E preflight path before `seedTestSubscription()` because `tests/e2e/global.setup.ts:7-11` currently calls the credential health check before seeding and user-state reset. The check should be independently unit-tested alongside `tests/e2e/helpers/credential-health-check.test.ts`.
+This belongs in the E2E preflight path before `seedTestSubscription()` because `tests/e2e/global.setup.ts:7-11` currently calls the credential health check before seeding and user-state reset. Add the check to the database validator in `tests/e2e/helpers/credential-health-check.ts:371-386`, after `checkDatabaseConnectivity(sql)` and before `verifyIdempotencySchema(sql)`, so one Postgres connection covers connectivity, full ledger drift, and the historical idempotency-column contract. The check should be independently unit-tested alongside `tests/e2e/helpers/credential-health-check.test.ts`.
 
 ---
 
@@ -79,6 +80,8 @@ The existing environment docs intentionally follow this rule: `docs/dev/deployme
 
 - `pnpm test:e2e` fails before the Playwright browser project when `.env.local` points at a database missing repo migrations.
 - The failure message names the missing migration tags without printing credentials.
+- A missing `drizzle` schema or missing `drizzle.__drizzle_migrations` table produces the same schema-drift error path, with migration tags derived from the repo journal.
 - A fully migrated local E2E database continues through the existing credential, Stripe, Clerk, and reset checks.
 - The check works for CI's fresh Postgres path as well as `.env.local`.
 - The implementation preserves the rule that CI validates migrations on CI Postgres but does not migrate Vercel/Neon Preview or Production databases.
+- Unit coverage proves at least these cases: no missing migrations, one or more missing `created_at` values, absent ledger table/schema, and error formatting that omits `DATABASE_URL`, hostnames, passwords, and Drizzle `hash` values.

--- a/tests/e2e/helpers/credential-health-check.test.ts
+++ b/tests/e2e/helpers/credential-health-check.test.ts
@@ -1,10 +1,14 @@
+import type postgres from 'postgres';
 import Stripe from 'stripe';
 import { describe, expect, it, vi } from 'vitest';
 import {
   type CredentialHealthCheckServices,
   CredentialValidationError,
+  computeMissingMigrations,
   fetchWithTimeout,
+  formatSchemaDriftMessage,
   runE2ECredentialHealthCheck,
+  verifyMigrationLedger,
 } from './credential-health-check';
 
 type RequiredEnvKey =
@@ -36,6 +40,7 @@ function createServices(
 ): CredentialHealthCheckServices {
   return {
     checkDatabaseConnectivity: vi.fn(async (_sql) => {}),
+    verifyMigrationLedger: vi.fn(async (_sql) => {}),
     verifyIdempotencySchema: vi.fn(async (_sql) => {}),
     resolveClerkUserId: vi.fn(async () => 'user_123'),
     verifyClerkPassword: vi.fn(async () => true),
@@ -194,9 +199,25 @@ describe('runE2ECredentialHealthCheck', () => {
       .calls[0]?.[0];
     const schemaCallArg = vi.mocked(services.verifyIdempotencySchema).mock
       .calls[0]?.[0];
+    const migrationCallArg = vi.mocked(services.verifyMigrationLedger).mock
+      .calls[0]?.[0];
     expect(databaseCallArg).toBeDefined();
+    expect(migrationCallArg).toBeDefined();
     expect(schemaCallArg).toBeDefined();
+    expect(migrationCallArg).toBe(databaseCallArg);
     expect(schemaCallArg).toBe(databaseCallArg);
+    expect(
+      vi.mocked(services.checkDatabaseConnectivity).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(services.verifyMigrationLedger).mock.invocationCallOrder[0] ??
+        0,
+    );
+    expect(
+      vi.mocked(services.verifyMigrationLedger).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(services.verifyIdempotencySchema).mock.invocationCallOrder[0] ??
+        0,
+    );
     expect(services.resolveClerkUserId).toHaveBeenCalledWith({
       email: env.E2E_CLERK_USER_USERNAME,
       clerkSecretKey: env.CLERK_SECRET_KEY,
@@ -258,6 +279,7 @@ describe('runE2ECredentialHealthCheck', () => {
     );
 
     expect(services.checkDatabaseConnectivity).not.toHaveBeenCalled();
+    expect(services.verifyMigrationLedger).not.toHaveBeenCalled();
     expect(services.verifyIdempotencySchema).not.toHaveBeenCalled();
     expect(services.resolveClerkUserId).not.toHaveBeenCalled();
     expect(services.verifyClerkPassword).not.toHaveBeenCalled();
@@ -341,6 +363,7 @@ describe('runE2ECredentialHealthCheck', () => {
     const verifyClerkPassword = vi.fn(async () => true);
     const services: Partial<CredentialHealthCheckServices> = {
       checkDatabaseConnectivity: vi.fn(async (_sql) => {}),
+      verifyMigrationLedger: vi.fn(async (_sql) => {}),
       verifyIdempotencySchema: vi.fn(async (_sql) => {}),
       verifyClerkPassword,
       verifyStripeSecretKey: vi.fn(async (_stripe) => {}),
@@ -373,6 +396,7 @@ describe('runE2ECredentialHealthCheck', () => {
     const env = createEnv();
     const services: Partial<CredentialHealthCheckServices> = {
       checkDatabaseConnectivity: vi.fn(async (_sql) => {}),
+      verifyMigrationLedger: vi.fn(async (_sql) => {}),
       verifyIdempotencySchema: vi.fn(async (_sql) => {}),
       verifyStripeSecretKey: vi.fn(async (_stripe) => {}),
       verifyStripePriceId: vi.fn(async (_input) => {}),
@@ -480,6 +504,7 @@ describe('runE2ECredentialHealthCheck', () => {
     const env = createEnv();
     const services: Partial<CredentialHealthCheckServices> = {
       checkDatabaseConnectivity: vi.fn(async (_sql) => {}),
+      verifyMigrationLedger: vi.fn(async (_sql) => {}),
       verifyIdempotencySchema: vi.fn(async (_sql) => {}),
       resolveClerkUserId: vi.fn(async () => 'user_123'),
       verifyClerkPassword: vi.fn(async () => true),
@@ -513,6 +538,7 @@ describe('runE2ECredentialHealthCheck', () => {
     const env = createEnv();
     const services: Partial<CredentialHealthCheckServices> = {
       checkDatabaseConnectivity: vi.fn(async (_sql) => {}),
+      verifyMigrationLedger: vi.fn(async (_sql) => {}),
       verifyIdempotencySchema: vi.fn(async (_sql) => {}),
       resolveClerkUserId: vi.fn(async () => 'user_123'),
       verifyClerkPassword: vi.fn(async () => true),
@@ -545,5 +571,112 @@ describe('runE2ECredentialHealthCheck', () => {
       priceRetrieveSpy.mockRestore();
       accountRetrieveSpy.mockRestore();
     }
+  });
+});
+
+describe('migration ledger schema-drift preflight', () => {
+  const journalEntries = [
+    { idx: 0, tag: '0000_jazzy_vermin', when: 1769893923091 },
+    {
+      idx: 1,
+      tag: '0001_attempts_selected_choice_not_null',
+      when: 1769942859252,
+    },
+    { idx: 2, tag: '0002_curious_firelord', when: 1770067162278 },
+  ] as const;
+
+  it('passes through silently when every journal migration exists in the ledger', async () => {
+    expect(
+      computeMissingMigrations(journalEntries, [
+        1769893923091,
+        '1769942859252',
+        1770067162278n,
+      ]),
+    ).toEqual([]);
+
+    const sql = vi.fn(async () => [
+      { createdAt: 1769893923091 },
+      { createdAt: '1769942859252' },
+      { createdAt: 1770067162278n },
+    ]);
+
+    await expect(
+      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws the schema-drift code when one or more journal migrations are absent from the ledger', async () => {
+    expect(computeMissingMigrations(journalEntries, [1769893923091])).toEqual([
+      '0001_attempts_selected_choice_not_null',
+      '0002_curious_firelord',
+    ]);
+
+    const sql = vi.fn(async () => [{ createdAt: 1769893923091 }]);
+
+    await expect(
+      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
+    ).rejects.toMatchObject({
+      code: 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS',
+      message:
+        'The database used by E2E is behind the repo migration journal. Missing migrations: 0001_attempts_selected_choice_not_null, 0002_curious_firelord.',
+      fix: expect.stringContaining(
+        'DATABASE_URL="<verified target>" pnpm db:migrate',
+      ),
+    });
+  });
+
+  it('treats an absent drizzle schema as schema drift with all journal migrations missing', async () => {
+    const missingSchemaError = Object.assign(
+      new Error('schema "drizzle" does not exist'),
+      { code: '3F000' },
+    );
+    const sql = vi.fn(async () => {
+      throw missingSchemaError;
+    });
+
+    await expect(
+      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
+    ).rejects.toMatchObject({
+      code: 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS',
+      message:
+        'The database used by E2E is behind the repo migration journal. Missing migrations: 0000_jazzy_vermin, 0001_attempts_selected_choice_not_null, 0002_curious_firelord.',
+    });
+  });
+
+  it('treats an absent drizzle migration table as schema drift with all journal migrations missing', async () => {
+    const missingTableError = Object.assign(
+      new Error('relation "drizzle.__drizzle_migrations" does not exist'),
+      { code: '42P01' },
+    );
+    const sql = vi.fn(async () => {
+      throw missingTableError;
+    });
+
+    await expect(
+      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
+    ).rejects.toMatchObject({
+      code: 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS',
+      message:
+        'The database used by E2E is behind the repo migration journal. Missing migrations: 0000_jazzy_vermin, 0001_attempts_selected_choice_not_null, 0002_curious_firelord.',
+    });
+  });
+
+  it('formats missing migration messages without leaking secrets, hostnames, passwords, or Drizzle hashes', () => {
+    const databaseUrl =
+      'postgresql://e2e_owner:super-secret-password@ep-private-host.neon.tech/addiction_boards';
+    const drizzleHash =
+      'bd3f2c7ad0212ddc9fbb7c2c07bdc4c7b4f9cce34638f93af18c0218cdd7e4e5';
+    const message = formatSchemaDriftMessage([
+      '0019_illegal_warbound',
+      '0020_fat_ironclad',
+    ]);
+
+    expect(message).toContain(
+      'Missing migrations: 0019_illegal_warbound, 0020_fat_ironclad.',
+    );
+    expect(message).not.toContain(databaseUrl);
+    expect(message).not.toContain('ep-private-host.neon.tech');
+    expect(message).not.toContain('super-secret-password');
+    expect(message).not.toContain(drizzleHash);
   });
 });

--- a/tests/e2e/helpers/credential-health-check.ts
+++ b/tests/e2e/helpers/credential-health-check.ts
@@ -1,5 +1,6 @@
 import postgres from 'postgres';
 import Stripe from 'stripe';
+import migrationJournal from '../../../db/migrations/meta/_journal.json';
 
 export const CLERK_API_BASE = 'https://api.clerk.com/v1';
 export const CLERK_API_TIMEOUT_MS = 15_000;
@@ -36,6 +37,7 @@ export class CredentialValidationError extends Error {
 
 export type CredentialHealthCheckServices = {
   checkDatabaseConnectivity: (sql: postgres.Sql) => Promise<void>;
+  verifyMigrationLedger: (sql: postgres.Sql) => Promise<void>;
   verifyIdempotencySchema: (sql: postgres.Sql) => Promise<void>;
   resolveClerkUserId: (input: {
     clerkSecretKey: string;
@@ -66,6 +68,25 @@ type ResolvedEnv = {
   stripeSecretKey?: string;
   stripeMonthlyPriceId?: string;
 };
+
+export type MigrationJournalEntry = {
+  idx: number;
+  tag: string;
+  when: number;
+};
+
+type MigrationLedgerCreatedAt = number | string | bigint | null | undefined;
+
+const SCHEMA_DRIFT_MIGRATIONS_CODE = 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS';
+const SCHEMA_DRIFT_MIGRATIONS_FIX =
+  'For local runs, confirm .env.local points at the intended non-production database, then run: DATABASE_URL="<verified target>" pnpm db:migrate';
+
+const MIGRATION_JOURNAL_ENTRIES: readonly MigrationJournalEntry[] =
+  migrationJournal.entries.map(({ idx, tag, when }) => ({
+    idx,
+    tag,
+    when,
+  }));
 
 const REQUIRED_ENV_VARS: readonly RequiredEnvVar[] = [
   {
@@ -137,6 +158,85 @@ export async function fetchWithTimeout(
   }
 }
 
+export function computeMissingMigrations(
+  journalEntries: readonly MigrationJournalEntry[],
+  appliedCreatedAt: readonly MigrationLedgerCreatedAt[],
+): string[] {
+  const appliedMigrationTimes = new Set(
+    appliedCreatedAt
+      .map((createdAt) => Number(createdAt))
+      .filter((createdAt) => Number.isFinite(createdAt)),
+  );
+
+  return journalEntries
+    .filter((entry) => !appliedMigrationTimes.has(entry.when))
+    .map((entry) => entry.tag);
+}
+
+export function formatSchemaDriftMessage(
+  missingMigrationTags: readonly string[],
+): string {
+  return `The database used by E2E is behind the repo migration journal. Missing migrations: ${missingMigrationTags.join(', ')}.`;
+}
+
+function createSchemaDriftMigrationsError(
+  missingMigrationTags: readonly string[],
+  options?: ErrorOptions,
+): CredentialValidationError {
+  return new CredentialValidationError(
+    SCHEMA_DRIFT_MIGRATIONS_CODE,
+    formatSchemaDriftMessage(missingMigrationTags),
+    SCHEMA_DRIFT_MIGRATIONS_FIX,
+    options,
+  );
+}
+
+function isMissingMigrationLedgerError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const code = (error as { code?: unknown }).code;
+  return code === '3F000' || code === '42P01';
+}
+
+export async function verifyMigrationLedger(
+  sql: postgres.Sql,
+  journalEntries: readonly MigrationJournalEntry[] = MIGRATION_JOURNAL_ENTRIES,
+): Promise<void> {
+  try {
+    const appliedMigrations = await sql<
+      { createdAt: number | string | bigint }[]
+    >`
+      SELECT created_at AS "createdAt"
+      FROM drizzle.__drizzle_migrations
+    `;
+    const missingMigrationTags = computeMissingMigrations(
+      journalEntries,
+      appliedMigrations.map((migration) => migration.createdAt),
+    );
+
+    if (missingMigrationTags.length > 0) {
+      throw createSchemaDriftMigrationsError(missingMigrationTags);
+    }
+  } catch (error) {
+    if (error instanceof CredentialValidationError) {
+      throw error;
+    }
+
+    if (isMissingMigrationLedgerError(error)) {
+      throw createSchemaDriftMigrationsError(
+        journalEntries.map((entry) => entry.tag),
+        { cause: error instanceof Error ? error : undefined },
+      );
+    }
+
+    throw new CredentialValidationError(
+      SCHEMA_DRIFT_MIGRATIONS_CODE,
+      'Unable to verify the Drizzle migration ledger.',
+      SCHEMA_DRIFT_MIGRATIONS_FIX,
+      { cause: error instanceof Error ? error : undefined },
+    );
+  }
+}
+
 const defaultServices: CredentialHealthCheckServices = {
   checkDatabaseConnectivity: async (sql) => {
     try {
@@ -149,6 +249,7 @@ const defaultServices: CredentialHealthCheckServices = {
       );
     }
   },
+  verifyMigrationLedger,
   verifyIdempotencySchema: async (sql) => {
     try {
       const rows = await sql<{ hasCompletedAt: boolean }[]>`
@@ -382,6 +483,7 @@ function buildValidators(
         const sql = postgres(databaseUrl, { max: 1 });
         try {
           await services.checkDatabaseConnectivity(sql);
+          await services.verifyMigrationLedger(sql);
           await services.verifyIdempotencySchema(sql);
         } finally {
           try {


### PR DESCRIPTION
## Problem

Local authenticated E2E could run against a database **behind the checked-out migration journal**. The existing preflight (`tests/e2e/helpers/credential-health-check.ts`) verified only `SELECT 1` connectivity and the single historical `idempotency_keys.completed_at` column — it never compared the repo's migration journal against the database's applied-migration ledger. Result: pages and auth loaded, but answer-submission paths failed later with a generic `Failed to insert attempt` instead of a clear "this database is behind migrations" error. CI never caught it because CI uses a fresh, freshly-migrated Postgres each run.

Resolves **DEBT-391** (`docs/debt/debt-391-local-e2e-schema-drift-preflight.md`).

## Solution

Add a migration-ledger drift check to the E2E preflight, wired into the existing `database` validator **between** connectivity and the idempotency-schema contract, so one Postgres connection covers all three.

- New `verifyMigrationLedger(sql)` service on `CredentialHealthCheckServices` (+ `defaultServices`).
- Reads the repo journal (`db/migrations/meta/_journal.json`) as the source of truth.
- Queries `drizzle.__drizzle_migrations.created_at` and compares to journal `entries[].when` — exactly how Drizzle's own migrator records applied migrations.
- Pure, separately-tested helpers: `computeMissingMigrations(...)` and `formatSchemaDriftMessage(...)`.
- A missing `drizzle` schema (`3F000`) or missing `__drizzle_migrations` table (`42P01`) is treated as drift (all journal migrations missing), not an unhandled crash.
- Fails fast with `E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS`, naming the missing migration **tags** and leaking no secrets (no `DATABASE_URL`, hostnames, passwords, or Drizzle `hash`).

## Acceptance criteria → tests

All in `tests/e2e/helpers/credential-health-check.test.ts`:

- No missing migrations → passes silently
- One or more journal migrations absent from ledger → throws `SCHEMA_DRIFT_MIGRATIONS`
- Absent `drizzle` schema → same drift path, all tags missing
- Absent `__drizzle_migrations` table → same drift path, all tags missing
- Message omits secrets/hostnames/passwords/hash
- Validator order: connectivity → migration ledger → idempotency, on one shared `sql` connection

## Gate

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (only the pre-existing 19 nursery file-size warnings)
- `pnpm test --run` ✅ — 331 files / 2643 tests (+5 new)
- `pnpm build` ✅ (diff is `tests/e2e/helpers/` only — never in the Next build graph)

## Scope

Two files: the E2E helper + its unit tests. No production app code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database schema drift detection to preflight checks, catching missing migrations before E2E tests run and providing clear remediation guidance.

* **Tests**
  * Expanded test coverage for migration ledger validation and schema drift error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->