### PR TITLE
DEBT-415: Align E2E suite with flag-on trial flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,8 @@ jobs:
         # lives in this repository. Keep E2E on for pushes and human same-repo PRs.
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
         run: pnpm test:e2e
+        env:
+          FREE_TRIAL_ENABLED: 'true'
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}

--- a/scripts/e2e-local-orchestrator.test.ts
+++ b/scripts/e2e-local-orchestrator.test.ts
@@ -84,7 +84,10 @@ describe('createE2ECommandPlan', () => {
         'tests/e2e/smoke.spec.ts',
         '--project=chromium',
       ],
-      env: { DATABASE_URL: dockerUrl },
+      env: {
+        DATABASE_URL: dockerUrl,
+        FREE_TRIAL_ENABLED: 'true',
+      },
     });
   });
 
@@ -103,6 +106,7 @@ describe('createE2ECommandPlan', () => {
         label: 'Run Playwright E2E',
         command: 'pnpm',
         args: ['exec', 'playwright', 'test', 'tests/e2e/practice.spec.ts'],
+        env: { FREE_TRIAL_ENABLED: 'true' },
       },
     ]);
   });
@@ -121,6 +125,7 @@ describe('createE2ECommandPlan', () => {
         label: 'Run Playwright E2E',
         command: 'pnpm',
         args: ['exec', 'playwright', 'test'],
+        env: { FREE_TRIAL_ENABLED: 'true' },
       },
     ]);
   });

--- a/scripts/e2e-local-orchestrator.ts
+++ b/scripts/e2e-local-orchestrator.ts
@@ -32,6 +32,9 @@ const LOCAL_E2E_DB_USER = 'postgres';
 const LOCAL_E2E_DB_PASSWORD = 'postgres';
 const LOCAL_E2E_DB_NAME = 'addiction_boards_test';
 const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes']);
+const FLAG_ON_E2E_ENV = {
+  FREE_TRIAL_ENABLED: 'true',
+} as const;
 
 function isTruthyEnvFlag(value: string | undefined): boolean {
   if (!value) return false;
@@ -63,6 +66,7 @@ export function createE2ECommandPlan({
         label: 'Run Playwright E2E',
         command: 'pnpm',
         args: ['exec', 'playwright', 'test', ...playwrightArgs],
+        env: { ...FLAG_ON_E2E_ENV },
       },
     ];
   }
@@ -102,6 +106,7 @@ export function createE2ECommandPlan({
       args: ['exec', 'playwright', 'test', ...playwrightArgs],
       env: {
         DATABASE_URL: databaseUrl,
+        ...FLAG_ON_E2E_ENV,
       },
     },
   ];

--- a/tests/e2e/helpers/subscription.ts
+++ b/tests/e2e/helpers/subscription.ts
@@ -1,4 +1,23 @@
 import { expect, type Page } from '@playwright/test';
+import postgres from 'postgres';
+import Stripe from 'stripe';
+import { seedTestSubscription } from './seed-test-user';
+
+type E2EBillingState = {
+  userId: string;
+  stripeCustomerId: string;
+};
+
+type E2EStripeSubscriptionRow = {
+  stripeSubscriptionId: string;
+  status: string;
+  currentPeriodEnd: Date;
+};
+
+const TERMINAL_STRIPE_SUBSCRIPTION_STATUSES = new Set([
+  'canceled',
+  'incomplete_expired',
+]);
 
 export async function ensureSubscribed(page: Page): Promise<void> {
   await page.goto('/pricing');
@@ -6,4 +25,155 @@ export async function ensureSubscribed(page: Page): Promise<void> {
   await expect(page.getByText("You're already subscribed")).toBeVisible({
     timeout: 15_000,
   });
+}
+
+function requireE2EEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required for E2E trial subscription helpers.`);
+  }
+  return value;
+}
+
+async function resolveE2EBillingState(
+  sql: ReturnType<typeof postgres>,
+): Promise<E2EBillingState> {
+  const email = requireE2EEnv('E2E_CLERK_USER_USERNAME');
+  const rows = await sql<E2EBillingState[]>`
+    SELECT
+      u.id AS "userId",
+      sc.stripe_customer_id AS "stripeCustomerId"
+    FROM users u
+    INNER JOIN stripe_customers sc ON sc.user_id = u.id
+    WHERE u.email = ${email}
+    LIMIT 1
+  `;
+  const state = rows[0];
+  if (!state) {
+    throw new Error(
+      'E2E Stripe customer mapping is missing; global setup must seed the E2E user before trial-start tests.',
+    );
+  }
+  return state;
+}
+
+function createStripeClient(): Stripe {
+  return new Stripe(requireE2EEnv('STRIPE_SECRET_KEY'));
+}
+
+async function cancelCustomerSubscriptions(
+  stripe: Stripe,
+  stripeCustomerId: string,
+): Promise<void> {
+  for await (const subscription of stripe.subscriptions.list({
+    customer: stripeCustomerId,
+    limit: 100,
+  })) {
+    if (TERMINAL_STRIPE_SUBSCRIPTION_STATUSES.has(subscription.status)) {
+      continue;
+    }
+    await stripe.subscriptions.cancel(subscription.id);
+  }
+}
+
+async function clearCustomerPaymentMethods(
+  stripe: Stripe,
+  stripeCustomerId: string,
+): Promise<void> {
+  const customer = await stripe.customers.retrieve(stripeCustomerId);
+  if ('deleted' in customer && customer.deleted) {
+    throw new Error('E2E Stripe customer was unexpectedly deleted.');
+  }
+
+  if (customer.invoice_settings.default_payment_method) {
+    await stripe.customers.update(stripeCustomerId, {
+      invoice_settings: { default_payment_method: '' },
+    });
+  }
+
+  for await (const paymentMethod of stripe.paymentMethods.list({
+    customer: stripeCustomerId,
+    type: 'card',
+    limit: 100,
+  })) {
+    await stripe.paymentMethods.detach(paymentMethod.id);
+  }
+}
+
+export async function resetE2EUserToFirstTimer(): Promise<void> {
+  const sql = postgres(requireE2EEnv('DATABASE_URL'), { max: 1 });
+  const stripe = createStripeClient();
+
+  try {
+    const { userId, stripeCustomerId } = await resolveE2EBillingState(sql);
+    await cancelCustomerSubscriptions(stripe, stripeCustomerId);
+    await clearCustomerPaymentMethods(stripe, stripeCustomerId);
+    await sql`
+      DELETE FROM stripe_subscriptions
+      WHERE user_id = ${userId}
+    `;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+export async function restoreE2EUserPaidSubscription(): Promise<void> {
+  await seedTestSubscription();
+}
+
+export async function completeNoCardTrialCheckout(page: Page): Promise<void> {
+  await expect(page).toHaveURL(/checkout\.stripe\.com/, { timeout: 30_000 });
+  const startTrialButton = page
+    .getByRole('button', {
+      name: /start (free )?trial|subscribe|continue/i,
+    })
+    .first();
+  await expect(startTrialButton).toBeVisible({ timeout: 30_000 });
+  await startTrialButton.click();
+}
+
+export async function expectE2EUserHasTrialWithoutPaymentMethod(): Promise<void> {
+  const sql = postgres(requireE2EEnv('DATABASE_URL'), { max: 1 });
+  const stripe = createStripeClient();
+
+  try {
+    const { userId, stripeCustomerId } = await resolveE2EBillingState(sql);
+    const rows = await sql<E2EStripeSubscriptionRow[]>`
+      SELECT
+        stripe_subscription_id AS "stripeSubscriptionId",
+        status,
+        current_period_end AS "currentPeriodEnd"
+      FROM stripe_subscriptions
+      WHERE user_id = ${userId}
+      LIMIT 1
+    `;
+    const subscriptionRow = rows[0];
+
+    expect(subscriptionRow).toBeDefined();
+    expect(subscriptionRow?.status).toBe('trialing');
+    expect(subscriptionRow?.currentPeriodEnd.getTime()).toBeGreaterThan(
+      Date.now(),
+    );
+
+    const subscription = await stripe.subscriptions.retrieve(
+      subscriptionRow?.stripeSubscriptionId ?? '',
+    );
+    expect(subscription.status).toBe('trialing');
+    expect(subscription.default_payment_method).toBeNull();
+
+    const customer = await stripe.customers.retrieve(stripeCustomerId);
+    if ('deleted' in customer && customer.deleted) {
+      throw new Error('E2E Stripe customer was unexpectedly deleted.');
+    }
+    expect(customer.invoice_settings.default_payment_method).toBeNull();
+
+    const cardPaymentMethods = await stripe.paymentMethods.list({
+      customer: stripeCustomerId,
+      type: 'card',
+      limit: 1,
+    });
+    expect(cardPaymentMethods.data).toHaveLength(0);
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
 }

--- a/tests/e2e/pricing-unauthenticated.spec.ts
+++ b/tests/e2e/pricing-unauthenticated.spec.ts
@@ -6,12 +6,12 @@ test('unauthenticated user is redirected to sign-up when starting checkout', asy
   await page.goto('/pricing');
   await expect(page.getByRole('heading', { name: 'Pricing' })).toBeVisible();
 
-  const subscribeMonthly = page.getByRole('button', {
-    name: 'Subscribe Monthly',
+  const startTrial = page.getByRole('button', {
+    name: 'Start 7-day free trial',
   });
-  await expect(subscribeMonthly).toBeVisible();
+  await expect(startTrial.first()).toBeVisible();
 
-  await subscribeMonthly.click();
+  await startTrial.first().click();
 
   await expect(page).toHaveURL(/\/sign-up/, { timeout: 15_000 });
 });

--- a/tests/e2e/trial-start.spec.ts
+++ b/tests/e2e/trial-start.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+import {
+  hasClerkCredentials,
+  signInWithClerkPassword,
+} from './helpers/clerk-auth';
+import { runE2EUserStateReset } from './helpers/reset-e2e-user-state';
+import {
+  completeNoCardTrialCheckout,
+  expectE2EUserHasTrialWithoutPaymentMethod,
+  resetE2EUserToFirstTimer,
+  restoreE2EUserPaidSubscription,
+} from './helpers/subscription';
+
+test.describe('trial start', () => {
+  // Hosted Stripe Checkout plus Clerk sign-in can take longer than app-only flows.
+  test.setTimeout(120_000);
+  test.skip(!hasClerkCredentials, 'Missing Clerk E2E credentials');
+
+  test.beforeEach(async () => {
+    await runE2EUserStateReset();
+    await resetE2EUserToFirstTimer();
+  });
+
+  test.afterEach(async () => {
+    await restoreE2EUserPaidSubscription();
+  });
+
+  test('first-time user starts a no-card trial and reaches the app with trial access', async ({
+    page,
+  }) => {
+    await signInWithClerkPassword(page);
+
+    await page.goto('/pricing');
+    await expect(page.getByRole('heading', { name: 'Pricing' })).toBeVisible();
+
+    await page
+      .getByRole('button', { name: 'Start 7-day free trial' })
+      .first()
+      .click();
+
+    await completeNoCardTrialCheckout(page);
+
+    await expect(
+      page.getByRole('heading', {
+        name: 'Your 7-day free trial has started — no charge today',
+      }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await expect(page).toHaveURL(/\/app\//, { timeout: 15_000 });
+    await expect(page.getByText(/\d+ days? left in trial/)).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Add a card to keep access' }),
+    ).toBeVisible();
+
+    await expectE2EUserHasTrialWithoutPaymentMethod();
+  });
+});


### PR DESCRIPTION
## Summary

Implements DEBT-415's decided E2E tail now that the free trial is live:

- runs CI and local E2E with FREE_TRIAL_ENABLED=true
- updates the anonymous pricing E2E to assert the trial-forward CTA
- adds tests/e2e/trial-start.spec.ts for the no-card hosted Checkout trial flow
- adds E2E helper cleanup to reset the shared test user to first-timer billing state for the trial spec and restore the paid seed afterward

## TDD / Red-Green Evidence

- Red: scripts/e2e-local-orchestrator.test.ts failed because the Playwright child env did not include FREE_TRIAL_ENABLED=true.
- Green: local runner now injects the flag; focused orchestrator test passes.
- Focused E2E: pricing-unauthenticated + trial-start passed, including hosted Stripe Checkout, checkout-success interstitial, dashboard countdown, Add a card affordance, and Stripe/customer assertions for no payment method.

## Validation

- pnpm typecheck
- pnpm lint (exit 0; existing 19 noExcessiveLinesPerFile nursery warnings)
- pnpm test --run (334 files / 2735 tests)
- pnpm test:browser (57 files / 297 tests)
- pnpm test:integration (19 passed / 1 skipped; 108 passed / 2 skipped)
- pnpm build
- pnpm test:e2e --reporter=line (36/36 passed, flag-on)

## Scope Guard

No product runtime code changed. This PR is E2E config, E2E assertions, and E2E helper coverage only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can start a 7-day free trial from the pricing page without entering card details; CTA updated to "Start 7-day free trial".

* **Tests**
  * Added end-to-end coverage verifying no-card trial signup, activation, trial-state UI, and post-signup app access.

* **Chores**
  * E2E and CI runs now consistently enable free-trial scenarios to improve test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->