### PR TITLE
Fix BUG-244/246 billing maintenance cron and deletion drain

### DIFF
--- a/app/api/cron/reconcile-stripe-subscriptions/route.test.ts
+++ b/app/api/cron/reconcile-stripe-subscriptions/route.test.ts
@@ -2,8 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RateLimiter } from '@/src/application/ports/gateways';
 import { FakeRateLimiter } from '@/src/application/test-helpers/fakes';
 
-const { reconcileStripeSubscriptions, createContainer } = vi.hoisted(() => ({
+const {
+  reconcileStripeSubscriptions,
+  drainPendingStripeCancellations,
+  createContainer,
+} = vi.hoisted(() => ({
   reconcileStripeSubscriptions: vi.fn(),
+  drainPendingStripeCancellations: vi.fn(),
   createContainer: vi.fn(),
 }));
 
@@ -26,11 +31,16 @@ vi.mock('@/lib/container', () => ({
   createContainer,
 }));
 
+vi.mock('@/src/adapters/jobs/drain-pending-stripe-cancellations', () => ({
+  drainPendingStripeCancellations,
+  PENDING_STRIPE_CANCELLATION_STALE_AFTER_MINUTES: 15,
+}));
+
 import {
   RECONCILE_STRIPE_SUBSCRIPTIONS_DEFAULT_CONCURRENCY,
   RECONCILE_STRIPE_SUBSCRIPTIONS_MAX_LIMIT,
 } from '@/src/adapters/jobs/reconcile-stripe-subscriptions';
-import { POST } from './route';
+import { GET, POST } from './route';
 
 type CronContainer = {
   env: {
@@ -54,10 +64,12 @@ type CronContainer = {
   };
   createStripeCustomerRepository: ReturnType<typeof vi.fn>;
   createSubscriptionRepository: ReturnType<typeof vi.fn>;
+  createPendingStripeCancellationRepository: ReturnType<typeof vi.fn>;
 };
 
 function createMockContainer(): CronContainer {
   const rateLimiter = new FakeRateLimiter();
+  const pendingStripeCancellationRepository = {};
 
   return {
     env: {
@@ -83,6 +95,9 @@ function createMockContainer(): CronContainer {
     },
     createStripeCustomerRepository: vi.fn(),
     createSubscriptionRepository: vi.fn(),
+    createPendingStripeCancellationRepository: vi.fn(
+      () => pendingStripeCancellationRepository,
+    ),
   };
 }
 
@@ -97,6 +112,13 @@ describe('POST /api/cron/reconcile-stripe-subscriptions', () => {
       updated: 0,
       failed: 0,
       failures: [],
+    });
+    drainPendingStripeCancellations.mockResolvedValue({
+      scanned: 0,
+      drained: 0,
+      failed: 0,
+      failures: [],
+      dryRun: true,
     });
 
     container = createMockContainer();
@@ -436,5 +458,111 @@ describe('POST /api/cron/reconcile-stripe-subscriptions', () => {
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({ error: 'Internal error' });
     expect(container.logger.error).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GET /api/cron/reconcile-stripe-subscriptions', () => {
+  let container: CronContainer;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    reconcileStripeSubscriptions.mockResolvedValue({
+      scanned: 0,
+      updated: 0,
+      failed: 0,
+      failures: [],
+    });
+    drainPendingStripeCancellations.mockResolvedValue({
+      scanned: 0,
+      drained: 0,
+      failed: 0,
+      failures: [],
+      dryRun: true,
+    });
+
+    container = createMockContainer();
+    createContainer.mockReturnValue(container);
+  });
+
+  it('returns 401 before container work when authorization header is missing', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/cron/reconcile-stripe-subscriptions', {
+        method: 'GET',
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(container.createRateLimiter).toBeDefined();
+    expect(reconcileStripeSubscriptions).not.toHaveBeenCalled();
+    expect(
+      container.db.query.stripeSubscriptions.findMany,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 before reconciliation when bearer token is invalid', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/cron/reconcile-stripe-subscriptions', {
+        method: 'GET',
+        headers: {
+          authorization: 'Bearer wrong-secret',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(reconcileStripeSubscriptions).not.toHaveBeenCalled();
+    expect(
+      container.db.query.stripeSubscriptions.findMany,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('runs the same reconciliation path as POST when the bearer token is valid', async () => {
+    const response = await GET(
+      new Request(
+        'http://localhost/api/cron/reconcile-stripe-subscriptions?limit=12&offset=7&dryRun=true',
+        {
+          method: 'GET',
+          headers: {
+            authorization: 'Bearer test-secret',
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(reconcileStripeSubscriptions).toHaveBeenCalledWith(
+      {
+        limit: 12,
+        offset: 7,
+        dryRun: true,
+      },
+      expect.any(Object),
+    );
+  });
+
+  it('drains pending Stripe cancellations through the same authenticated GET run', async () => {
+    const response = await GET(
+      new Request(
+        'http://localhost/api/cron/reconcile-stripe-subscriptions?dryRun=false',
+        {
+          method: 'GET',
+          headers: {
+            authorization: 'Bearer test-secret',
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(drainPendingStripeCancellations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dryRun: false,
+      }),
+      expect.objectContaining({
+        pendingStripeCancellations: expect.any(Object),
+        logger: container.logger,
+      }),
+    );
   });
 });

--- a/app/api/cron/reconcile-stripe-subscriptions/route.ts
+++ b/app/api/cron/reconcile-stripe-subscriptions/route.ts
@@ -1,6 +1,11 @@
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { createContainer } from '@/lib/container';
+import { cancelStripeCustomerSubscriptions } from '@/src/adapters/gateways/stripe-subscription-canceler';
+import {
+  drainPendingStripeCancellations,
+  PENDING_STRIPE_CANCELLATION_STALE_AFTER_MINUTES,
+} from '@/src/adapters/jobs/drain-pending-stripe-cancellations';
 import {
   RECONCILE_STRIPE_SUBSCRIPTIONS_DEFAULT_CONCURRENCY,
   RECONCILE_STRIPE_SUBSCRIPTIONS_DEFAULT_LIMIT,
@@ -62,7 +67,7 @@ function parseBoolean(value: string | null, fallback: boolean): boolean {
   return fallback;
 }
 
-export async function POST(req: Request) {
+async function handleCronRequest(req: Request): Promise<NextResponse> {
   const container = createContainer();
 
   const tokenResult = getAuthorizationToken(req);
@@ -146,6 +151,13 @@ export async function POST(req: Request) {
   );
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 0);
   const dryRun = parseBoolean(url.searchParams.get('dryRun'), true);
+  const pendingCancellationStaleMinutes = parseNonNegativeInt(
+    url.searchParams.get('pendingCancellationStaleMinutes'),
+    PENDING_STRIPE_CANCELLATION_STALE_AFTER_MINUTES,
+  );
+  const pendingCancellationOlderThan = new Date(
+    Date.now() - pendingCancellationStaleMinutes * 60 * 1000,
+  );
   const concurrencyParam = url.searchParams.get('concurrency');
   const concurrency =
     concurrencyParam !== null
@@ -158,7 +170,10 @@ export async function POST(req: Request) {
         )
       : null;
 
-  let result: unknown;
+  let result: Awaited<ReturnType<typeof reconcileStripeSubscriptions>>;
+  let pendingStripeCancellations: Awaited<
+    ReturnType<typeof drainPendingStripeCancellations>
+  >;
   try {
     result = await reconcileStripeSubscriptions(
       concurrency === null
@@ -197,13 +212,30 @@ export async function POST(req: Request) {
           ),
       },
     );
+    pendingStripeCancellations = await drainPendingStripeCancellations(
+      {
+        olderThan: pendingCancellationOlderThan,
+        dryRun,
+      },
+      {
+        pendingStripeCancellations:
+          container.createPendingStripeCancellationRepository(),
+        cancelStripeCustomerSubscriptions: (stripeCustomerId) =>
+          cancelStripeCustomerSubscriptions(
+            container.stripe,
+            container.logger,
+            stripeCustomerId,
+          ),
+        logger: container.logger,
+      },
+    );
   } catch (error) {
     container.logger.error(
       {
         route: ROUTE,
         error: error instanceof Error ? error.message : String(error),
       },
-      'Failed to reconcile Stripe subscriptions',
+      'Failed to run Stripe billing maintenance',
     );
     return NextResponse.json(
       { error: 'Internal error' },
@@ -211,5 +243,16 @@ export async function POST(req: Request) {
     );
   }
 
-  return NextResponse.json(result, { status: HTTP_OK });
+  return NextResponse.json(
+    { ...result, pendingStripeCancellations },
+    { status: HTTP_OK },
+  );
+}
+
+export async function GET(req: Request) {
+  return handleCronRequest(req);
+}
+
+export async function POST(req: Request) {
+  return handleCronRequest(req);
 }

--- a/docs/bugs/bug-244-reconciliation-cron-never-scheduled.md
+++ b/docs/bugs/bug-244-reconciliation-cron-never-scheduled.md
@@ -1,6 +1,6 @@
 # BUG-244: The Stripe Reconciliation Safety Net Never Runs — No Scheduler Invokes the Cron Route
 
-**Status:** Open
+**Status:** In Progress (implemented on `fix/bug-244-246-reconciliation-cron-and-deletion-drain`; pending PR review/merge)
 **Priority:** P2 (the designed self-heal for duplicate subscriptions and drifted rows is dead; duplicates keep billing until noticed by hand)
 **Date:** 2026-06-11
 **Family:** Billing / reconciliation / deploy-infra
@@ -10,25 +10,25 @@
 
 ## Description
 
-`reconcileStripeSubscriptions` exists to be the billing safety net: detect a user with multiple blocking Stripe subscriptions, pick the canonical winner, persist it, and cancel the duplicates; and heal local rows that drifted from Stripe. It has been hardened repeatedly (BUG-120 authoritative conflict strategy, BUG-205 canonical-winner selection, DEBT-155 legacy-duplicate cleanup). But **nothing in the repository ever invokes it.** There is no Vercel cron configuration and no scheduled GitHub Action, so the route is never called in any environment except its own tests.
+`reconcileStripeSubscriptions` exists to be the billing safety net: detect a user with multiple blocking Stripe subscriptions, pick the canonical winner, persist it, and cancel the duplicates; and heal local rows that drifted from Stripe. It has been hardened repeatedly (BUG-120 authoritative conflict strategy, BUG-205 canonical-winner selection, DEBT-155 legacy-duplicate cleanup). Before this fix, **nothing in the repository ever invoked it**: there was no Vercel cron configuration and no scheduled GitHub Action, so the route was never called in any environment except its own tests.
 
-Two independent facts make it dead in production:
+Two independent pre-fix facts made it dead in production:
 
-1. **No scheduler exists.** There is no `vercel.json`/`vercel.ts` in the repo (so no `crons` block), and no workflow under `.github/workflows/` has a `schedule:` trigger that calls the route. The spec documents the route and its rate limit (`docs/specs/spec-017-rate-limiting.md:33`) and lists `CRON_SECRET` as a production env var (`docs/specs/master_spec_part4.md:309`), but no doc wires an actual cadence.
-2. **Even a manual call defaults to a non-destructive dry run for duplicate cancellation.** The route's `dryRun` defaults to `true` (`app/api/cron/reconcile-stripe-subscriptions/route.ts:148`), and duplicate cancellation (phase 5) only runs when `dryRun === false` (`src/adapters/jobs/reconcile-stripe-subscriptions.ts:239-262`). The canonical-winner **upsert (phase 4) runs regardless of `dryRun`** (`:221-235`), so a one-off `POST … ?dryRun=false` would both heal rows and cancel duplicates — but absent a scheduler this never happens automatically.
+1. **No scheduler existed.** There was no `vercel.json`/`vercel.ts` in the repo (so no `crons` block), and no workflow under `.github/workflows/` had a `schedule:` trigger that called the route. The spec documents the route and its rate limit (`docs/specs/spec-017-rate-limiting.md:33`) and lists `CRON_SECRET` as a production env var (`docs/specs/master_spec_part4.md:309`), but no doc wired an actual cadence.
+2. **Even a manual call defaulted to a non-destructive dry run for duplicate cancellation.** The route's `dryRun` still intentionally defaults to `true` for rollout (`app/api/cron/reconcile-stripe-subscriptions/route.ts:153`), and duplicate cancellation (phase 5) only runs when `dryRun === false` (`src/adapters/jobs/reconcile-stripe-subscriptions.ts:239-262`). The canonical-winner **upsert (phase 4) runs regardless of `dryRun`** (`:221-235`), so a one-off `POST … ?dryRun=false` would both heal rows and cancel duplicates — but absent a scheduler this never happened automatically.
 
-Additionally, Vercel native cron jobs issue **GET** requests, while the route exports **POST only** (`route.ts:65`), so even adding a bare `vercel.json` cron entry would not drive it without a method change — worth noting so the fix is not mis-scoped.
+Additionally, Vercel native cron jobs issue **GET** requests, while the route exported **POST only** pre-fix, so even adding a bare `vercel.json` cron entry would not have driven it without a method change. The implementation adds a thin `GET` handler that reuses the same auth/rate-limit/work path as `POST` (`app/api/cron/reconcile-stripe-subscriptions/route.ts:252-257`).
 
-## Steps to Reproduce
+## Original Steps to Reproduce (pre-fix; no longer true on this branch)
 
-1. `rg -n "schedule:" .github/workflows/` → no match invoking the reconcile route.
-2. `ls vercel.json vercel.ts` → neither exists (no `crons`).
-3. `rg "export (async )?function (GET|POST)" app/api/cron/reconcile-stripe-subscriptions/route.ts` → only `POST`.
-4. Conclude: in production the job is unreachable by any automated caller; the only invocations are unit tests (`route.test.ts`, `reconcile-stripe-subscriptions.test.ts`).
+1. On the base commit before this fix, `rg -n "schedule:" .github/workflows/` had no match invoking the reconcile route.
+2. On the base commit before this fix, `ls vercel.json vercel.ts` found neither file.
+3. On the base commit before this fix, `rg "export (async )?function (GET|POST)" app/api/cron/reconcile-stripe-subscriptions/route.ts` found only `POST`.
+4. On this branch, the expected state is inverted: `vercel.json:3-8` registers a cron, and `route.ts:252-257` exports both `GET` and `POST`.
 
-## Root Cause
+## Root Cause (pre-fix)
 
-- `app/api/cron/reconcile-stripe-subscriptions/route.ts:65` exports `POST` only; `:148` defaults `dryRun` to `true`.
+- The route exported `POST` only; current code fixes this with shared `GET`/`POST` exports (`app/api/cron/reconcile-stripe-subscriptions/route.ts:252-257`) while preserving the intentional `dryRun=true` default (`:153`).
 - `src/adapters/jobs/reconcile-stripe-subscriptions.ts:221-235` (phase 4 upsert, always) vs `:237-262` (phase 5 cancel, `dryRun`-gated).
 - No `vercel.json`/`vercel.ts` `crons` and no `.github/workflows/*.yml` `schedule:` step references the route — the wiring that would call it was never added.
 
@@ -40,7 +40,18 @@ This is the BUG-241 pattern applied to billing reconciliation: a correct, tested
 - Drifted local rows that the job would heal (including the BUG-242 / BUG-243 corrupted-row lockouts) never get the periodic correction the architecture assumes — those users stay locked out until an unrelated webhook happens to rewrite the row.
 - Several prior fixes (BUG-120, BUG-205, DEBT-155) are effectively inert in production because their only runtime path is this unscheduled job.
 
-## Expected Fix (options — pick per ops constraints)
+## Implemented Resolution
+
+The chosen path is Vercel cron plus a thin `GET` handler, with `POST` preserved for manual/operator runs:
+
+1. `vercel.json:3-8` registers a daily UTC cron at `/api/cron/reconcile-stripe-subscriptions?dryRun=true`, intentionally starting in dry-run for owner observation.
+2. `app/api/cron/reconcile-stripe-subscriptions/route.ts:252-257` now exports `GET` and `POST`, both delegating to the same handler. The handler keeps the bearer-token check (`:73-109`) and rate limit (`:111-128`) before any reconciliation or drain work.
+3. The handler still defaults `dryRun=true`; duplicate cancellation remains `dryRun=false`-gated in phase 5. The owner flips the cron path to `dryRun=false` only after reviewing one scheduled dry-run report in production logs.
+4. The same scheduled run also drains stale `pending_stripe_cancellations` rows (BUG-246) so there is one billing-maintenance scheduler instead of parallel cron mechanisms.
+
+Rejected alternative: a scheduled GitHub Action was rejected because Vercel is the deploy target and Vercel cron already supplies authenticated GET invocations via `CRON_SECRET`.
+
+## Original Fix Options (superseded)
 
 1. **Vercel cron (preferred if deploying on Vercel).** Add a `crons` entry (in `vercel.json` or `vercel.ts`) on a sensible cadence (e.g. hourly/daily), and adapt the route to accept Vercel's authenticated **GET** (Vercel sends `Authorization: Bearer $CRON_SECRET`) — or add a thin `GET` handler that calls the same logic. Invoke with an explicit, bounded `dryRun=false` once observed safe in dry-run.
 2. **Scheduled GitHub Action.** A `schedule:`-triggered workflow that `POST`s the route with the `CRON_SECRET` bearer token and `?dryRun=false&limit=…`, paginating `offset`. Keeps the route POST-only.
@@ -48,13 +59,15 @@ This is the BUG-241 pattern applied to billing reconciliation: a correct, tested
 
 ## Verification
 
-- [ ] After wiring: a scheduled invocation appears in deploy/runtime logs on cadence with a 200 and a non-error `{ scanned, updated, failed }` report.
-- [ ] Re-running is idempotent (canonical upsert is a no-op when already converged; duplicate cancel is `idempotencyKey`-guarded at `reconcile-stripe-subscriptions.ts:245-247`).
-- [ ] A seeded duplicate-subscription fixture is reduced to one blocking subscription after a `dryRun=false` run.
+- [x] Code-level wiring: `GET` and `POST` both call the same authenticated reconciliation path; invalid/missing bearer tokens do not run reconciliation.
+- [x] Re-running remains idempotent (canonical upsert is a no-op when already converged; duplicate cancel is `idempotencyKey`-guarded at `reconcile-stripe-subscriptions.ts:245-247`).
+- [x] Existing reconcile regression coverage still proves a seeded duplicate-subscription fixture is reduced to one blocking subscription after a `dryRun=false` run.
+- [ ] Post-deploy: a scheduled invocation appears in Vercel runtime logs on cadence with a 200 and a non-error `{ scanned, updated, failed, pendingStripeCancellations }` report. This cannot be proven in CI.
+- [ ] Post-deploy: owner reviews one `dryRun=true` scheduled report, then flips the cron path to `dryRun=false` and redeploys.
 - [ ] `CRON_SECRET` is present in the target environment (already required by `master_spec_part4.md:309`).
 
 ## Surfaces Confirmed
 
-- The job logic itself is correct and tested; the gap is strictly the absence of any scheduled caller (and the GET/POST method mismatch a Vercel cron would hit).
+- The job logic itself is correct and tested; the fixed gap was strictly the absence of any scheduled caller (and the GET/POST method mismatch a Vercel cron would hit).
 - Phase 5 cancels duplicate subscriptions immediately with no proration/refund handling (`reconcile-stripe-subscriptions.ts:242-249`); when this job is finally wired up, a double-charged user keeps both charges unless refunds are handled operationally — call this out in the runbook for the fix.
 - Cron auth ordering (secret check before any work, timing-safe compare) is correct and not a regression of BUG-207.

--- a/docs/bugs/bug-246-deleted-account-stripe-cancellation-no-drain.md
+++ b/docs/bugs/bug-246-deleted-account-stripe-cancellation-no-drain.md
@@ -1,40 +1,52 @@
 # BUG-246: Deleted-Account Stripe Cancellation Has No Drain Beyond Svix Retries — Cascade-Deleted Local Rows Make the Leak Invisible
 
-**Status:** Open
+**Status:** In Progress (implemented on `fix/bug-244-246-reconciliation-cron-and-deletion-drain`; pending PR review/merge)
 **Priority:** P2 (tail-risk: Stripe keeps charging a customer whose account no longer exists; rare trigger, but no monitoring and no recovery path)
 **Date:** 2026-06-11
 **Family:** Billing / Clerk account deletion / money-moves-wrong tail risk
-**Related:** [BUG-244](./bug-244-reconciliation-cron-never-scheduled.md) (no scheduled job exists to drain the queue), [DEBT-304](../_archive/debt/debt-304-clerk-user-deleted-cancel-idempotency.md) (made the cancel idempotent — did not add a drain), [BUG-023](../_archive/bugs/bug-023-missing-clerk-user-deletion-webhook.md) (original deletion-webhook gap), [BUG-208](../_archive/bugs/bug-208-clerk-webhook-deletion-not-transactional.md) / [BUG-209](../_archive/bugs/bug-209-clerk-webhook-lacks-idempotency.md) (deletion races / replay)
+**Related:** [BUG-244](./bug-244-reconciliation-cron-never-scheduled.md) (same scheduled billing-maintenance run now drives the queue drain), [DEBT-304](../_archive/debt/debt-304-clerk-user-deleted-cancel-idempotency.md) (made the cancel idempotent — did not add a drain), [BUG-023](../_archive/bugs/bug-023-missing-clerk-user-deletion-webhook.md) (original deletion-webhook gap), [BUG-208](../_archive/bugs/bug-208-clerk-webhook-deletion-not-transactional.md) / [BUG-209](../_archive/bugs/bug-209-clerk-webhook-lacks-idempotency.md) (deletion races / replay)
 
 ---
 
 ## Description
 
-When a Clerk `user.deleted` webhook fires, the controller deletes the local user, schedules a Stripe cancellation in `pending_stripe_cancellations`, and then — **post-commit, in the same request** — cancels all of the customer's Stripe subscriptions. If that post-commit cancellation fails (Stripe outage, 5xx streak), the only retry mechanism is Svix re-delivering that one `user.deleted` event, which is bounded by the provider retry horizon. **No cron or scheduled job ever drains `pending_stripe_cancellations` afterward** (the table is read/written only by this one controller), and the would-be safety net — the reconciliation job — is itself never scheduled (BUG-244).
+When a Clerk `user.deleted` webhook fires, the controller deletes the local user, schedules a Stripe cancellation in `pending_stripe_cancellations`, and then — **post-commit, in the same request** — cancels all of the customer's Stripe subscriptions. If that post-commit cancellation fails (Stripe outage, 5xx streak), the only retry mechanism was Svix re-delivering that one `user.deleted` event, which is bounded by the provider retry horizon. Before this fix, **no cron or scheduled job ever drained `pending_stripe_cancellations` afterward** (the table was read/written only by this one controller), and the would-be safety net — the reconciliation job — was itself never scheduled (BUG-244).
 
-Worse, the local user row (and its cascade-linked `stripe_subscriptions` row) is already deleted by the time the cancellation is attempted, so even a *scheduled* reconciliation job would not see the orphaned live Stripe subscription — it iterates local `stripe_subscriptions` rows, and there is none. The leak is therefore both un-retried past the Svix window and invisible to every existing reconciliation surface.
+Worse, the local user row (and its cascade-linked `stripe_subscriptions` row) is already deleted by the time the cancellation is attempted, so even a *scheduled* reconciliation job would not see the orphaned live Stripe subscription — it iterates local `stripe_subscriptions` rows, and there is none. The implementation fixes this by folding a pending-cancellation drain into the scheduled billing-maintenance run; the drain works directly from the pending row's `stripeCustomerId`, not from deleted local subscription state.
 
-## Steps to Reproduce
+## Original Steps to Reproduce (pre-fix)
 
 1. A user with an active subscription deletes their Clerk account.
 2. Stripe (or the network) is unavailable for longer than the Svix retry horizon at the moment the post-commit cancel runs.
-3. After Svix exhausts retries, observe: the `pending_stripe_cancellations` row remains; the Stripe subscription is still active and still billing; the local user + subscription rows are gone; nothing will ever retry the cancel.
+3. After Svix exhausts retries on the base commit before this fix, observe: the `pending_stripe_cancellations` row remains; the Stripe subscription is still active and still billing; the local user + subscription rows are gone; nothing will ever retry the cancel.
 
-## Root Cause
+## Root Cause (pre-fix)
 
 1. `src/adapters/controllers/clerk-webhook-controller.ts:344-348` — inside the transaction, the cancellation is scheduled in `pending_stripe_cancellations` (keyed by `eventId`).
 2. `clerk-webhook-controller.ts:360-376` — **post-commit**, `cancelStripeCustomerSubscriptions(stripeCustomerId)` runs; on success it deletes the pending row and marks the event processed. On failure it calls `persistFailure` and rethrows → route returns 500 → Svix retries (bounded).
-3. The pending row is the **only** durable record of the obligation, and `rg` confirms `findByEventId` / `schedule` / `deleteByEventId` are referenced **only** in this controller (`src/adapters/repositories/drizzle-pending-stripe-cancellation-repository.ts`) — no cron, job, or startup task drains it.
-4. `db/schema.ts:181-183` — `stripe_subscriptions.userId` is `onDelete: 'cascade'` from `users.id` (as is `stripe_customers.userId`, `:160-162`); deleting the user in step 2 (`clerk-webhook-controller.ts:334`) removes the local subscription row, so `reconcileStripeSubscriptions` (which iterates `stripe_subscriptions`, `route.ts:175-190`) can never re-discover the orphaned Stripe subscription — and per BUG-244 it never runs anyway.
+3. The pending row was the **only** durable record of the obligation, and pre-fix `rg` confirmed `findByEventId` / `schedule` / `deleteByEventId` were referenced **only** in this controller (`src/adapters/repositories/drizzle-pending-stripe-cancellation-repository.ts`) — no cron, job, or startup task drained it.
+4. `db/schema.ts:181-183` — `stripe_subscriptions.userId` is `onDelete: 'cascade'` from `users.id` (as is `stripe_customers.userId`, `:160-162`); deleting the user in step 2 (`clerk-webhook-controller.ts:334`) removes the local subscription row, so `reconcileStripeSubscriptions` (which iterates `stripe_subscriptions`, `app/api/cron/reconcile-stripe-subscriptions/route.ts:190-205`) can never re-discover the orphaned Stripe subscription. BUG-244 now schedules reconciliation, but this BUG-246 drain still must work from `pending_stripe_cancellations.stripeCustomerId`.
 5. `pending_stripe_cancellations.eventId` is itself `onDelete: 'cascade'` from `clerk_events` (`db/schema.ts:266-268`); if the clerk event is ever pruned the pending row vanishes with it, erasing the last trace of the obligation.
 
 ## Impact
 
 - Stripe continues charging a customer whose account no longer exists — a payment with no corresponding user and no in-product way to stop it (the account is gone, so the user cannot self-serve cancel).
-- The unprocessed `pending_stripe_cancellations` row has **no alerting**, so the leak is silent until a chargeback/complaint.
+- Pre-fix, the unprocessed `pending_stripe_cancellations` row had **no alerting**, so the leak was silent until a chargeback/complaint. The implemented drain now logs stale-row counts before retrying.
 - Probability is low (requires account deletion to coincide with a Stripe outage past the Svix window), hence P2 not P0 — but the consequence is real money moving wrong indefinitely with no recovery path.
 
-## Expected Fix (options)
+## Implemented Resolution
+
+The chosen path folds the queue drain into the same scheduled billing-maintenance run as BUG-244:
+
+1. `src/application/ports/pending-stripe-cancellation-repository.ts`, `src/adapters/repositories/drizzle-pending-stripe-cancellation-repository.ts`, and `src/application/test-helpers/fakes/fake-pending-stripe-cancellation-repository.ts` add a shared `listStale(olderThan)` contract. No schema migration is needed; `pending_stripe_cancellations` already has `eventId`, `stripeCustomerId`, and indexed `createdAt`.
+2. `src/adapters/jobs/drain-pending-stripe-cancellations.ts` lists stale rows older than 15 minutes, logs a warning with count/age, and in `dryRun=false` calls the existing `cancelStripeCustomerSubscriptions` path using the row's `stripeCustomerId`.
+3. The drain deletes the pending row on success, treats `isAlreadyCanceledError` as success, and keeps the row with an error log on real cancellation failure.
+4. The cron route calls the drain after reconciliation in the same authenticated `GET`/`POST` run. `dryRun=true` reports stale rows without canceling or deleting; `dryRun=false` performs the cancellation and deletion.
+5. The `clerk_events -> pending_stripe_cancellations` cascade remains unchanged in this PR. The mitigation is operational: the scheduled drain cadence must remain shorter than any future `clerk_events` prune horizon. A schema change is rejected as out of scope for this BUG-244/246 fix.
+
+Rejected alternative: a separate drain cron was rejected because it would create a second scheduler to observe, secure, and operate; folding the drain into reconciliation gives one billing-maintenance invocation and reuses the existing cron auth path.
+
+## Original Fix Options (superseded)
 
 1. **Drain the queue on a schedule (preferred).** Add a scheduled job (or fold into the reconciliation cron once BUG-244 wires one) that reads `pending_stripe_cancellations` older than N minutes, calls `cancelStripeCustomerSubscriptions` for each, and deletes the row on success. This closes both the past-Svix-window gap and the invisibility (the pending row carries the `stripeCustomerId` directly, so it does not depend on the deleted local subscription row).
 2. **Alert on stale rows.** Emit a metric/log when any `pending_stripe_cancellations` row exceeds an age threshold, so an outage-window leak is caught operationally even before the drain runs.
@@ -42,13 +54,15 @@ Worse, the local user row (and its cascade-linked `stripe_subscriptions` row) is
 
 ## Verification
 
-- [ ] Test: a `user.deleted` whose post-commit cancel throws leaves a `pending_stripe_cancellations` row; a subsequent drain-job run cancels the Stripe subscription and deletes the row.
-- [ ] Test: the drain is idempotent against an already-canceled subscription (reuses `isAlreadyCanceledError`, as the inline path already does).
+- [x] Test: a `user.deleted` whose post-commit cancel throws leaves a `pending_stripe_cancellations` row; a subsequent drain-job run cancels the Stripe customer subscriptions and deletes the row.
+- [x] Test: the drain is idempotent against an already-canceled subscription (reuses `isAlreadyCanceledError`, as the inline path already does).
+- [x] Test: fresh rows newer than the stale threshold are not drained.
+- [x] Test: real Drizzle `listStale(olderThan)` returns only stale pending rows, and the drain removes stale rows while leaving fresh rows.
 - [ ] Manual: simulate Stripe 5xx during deletion, confirm the row persists and is later drained.
-- [ ] Alerting fires for a row older than the threshold.
+- [x] Alerting/logging fires for rows older than the threshold.
 
 ## Surfaces Confirmed
 
 - The **happy path and same-request retry** are correct: idempotent cancel (DEBT-304), tombstone + advisory-lock deletion races (BUG-208/209), pending row written transactionally before the post-commit attempt.
-- The gap is strictly the absence of any drain **after** Svix retries are exhausted, compounded by the cascade-deleted local row hiding the orphan from reconciliation.
-- `cancelStripeCustomerSubscriptions` itself (list `status:'all'`, skip already-canceled, idempotency-keyed cancel) is correct and reusable as-is by the proposed drain job.
+- The fixed gap was strictly the absence of any drain **after** Svix retries are exhausted, compounded by the cascade-deleted local row hiding the orphan from reconciliation.
+- `cancelStripeCustomerSubscriptions` itself (list `status:'all'`, skip already-canceled, idempotency-keyed cancel) is correct and reused as-is by the implemented drain job.

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -1,7 +1,7 @@
 # Bug Reports
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-06-12 (BUG-242/243 resolved + archived via PR #419 — shared subscription write-guard; BUG-244–247 remain open from the Audit #21 Stripe sweep; BUG-241 remains open for deploy migration enforcement)
+**Last Updated:** 2026-06-12 (BUG-242/243 resolved + archived via PR #419 — shared subscription write-guard; BUG-244/246 implemented on fix branch pending owner grade; BUG-245/247 remain open from the Audit #21 Stripe sweep; BUG-241 remains open for deploy migration enforcement)
 
 ---
 
@@ -143,9 +143,9 @@ Bug reports document issues discovered in the codebase along with their root cau
 
 | Bug | Family | Priority | Summary |
 |-----|--------|----------|---------|
-| [BUG-244](./bug-244-reconciliation-cron-never-scheduled.md) | Billing / reconciliation / deploy-infra | P2 | The Stripe reconciliation safety net never runs — no Vercel cron / scheduled Action invokes the POST-only route, and it defaults to `dryRun=true`. Duplicate subscriptions and drifted rows are never auto-healed; BUG-120/205/DEBT-155 fixes are inert in production. |
+| [BUG-244](./bug-244-reconciliation-cron-never-scheduled.md) | Billing / reconciliation / deploy-infra | P2 | Implemented on fix branch: a Vercel cron invokes the reconciliation route via authenticated `GET`, starts in `dryRun=true`, preserves `POST`, and leaves scheduled firing + dryRun=false flip as the owner post-deploy observation step. |
 | [BUG-245](./bug-245-concurrent-two-tab-checkout-creates-duplicate-subscriptions.md) | Billing / checkout race / idempotency | P2 | Concurrent two-tab subscribe defeats every duplicate guard (all key on a not-yet-existing subscription) and per-tab random UUIDs bypass the BUG-148 deterministic-key collapse → two live subscriptions on one customer; masked in-app by the single local row. |
-| [BUG-246](./bug-246-deleted-account-stripe-cancellation-no-drain.md) | Billing / Clerk deletion / money tail-risk | P2 | Deleted-account Stripe cancellation has no drain beyond Svix retries; cascade-deleted local rows hide the orphan from reconciliation → Stripe keeps billing a deleted account with no monitoring or recovery path. |
+| [BUG-246](./bug-246-deleted-account-stripe-cancellation-no-drain.md) | Billing / Clerk deletion / money tail-risk | P2 | Implemented on fix branch: the billing-maintenance cron drains stale `pending_stripe_cancellations` from their stored `stripeCustomerId`, logs stale rows, deletes on success/already-canceled, and preserves failed rows for retry. |
 | [BUG-247](./bug-247-pricing-portal-failure-shows-checkout-error-copy.md) | Billing / pricing copy | P3 | Pricing-page "Manage Billing" portal failures redirect to `?checkout=error` and show "Checkout failed. Please try again." for an action that was never a checkout; the app-billing sibling already has correct portal-failure copy. |
 | [BUG-241](./bug-241-deploy-pipeline-has-no-migration-step.md) | CI/CD / deploy / migrations | P2 | Deploy pipeline has no migration step — schema PRs ship code without applying migrations to dev/prod, with green CI (CI migrates only its throwaway DB). Systemic cause of BUG-240; will recur for every future migration without a gate. |
 

--- a/src/adapters/jobs/drain-pending-stripe-cancellations.test.ts
+++ b/src/adapters/jobs/drain-pending-stripe-cancellations.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  FakeLogger,
+  FakePendingStripeCancellationRepository,
+} from '@/src/application/test-helpers/fakes';
+import { drainPendingStripeCancellations } from './drain-pending-stripe-cancellations';
+
+function alreadyCanceledError(): Error {
+  return Object.assign(new Error('No such subscription'), {
+    rawType: 'invalid_request_error',
+    code: 'resource_missing',
+  });
+}
+
+describe('drainPendingStripeCancellations', () => {
+  it('deletes a stale pending row when the Stripe customer cancellation succeeds', async () => {
+    const repo = new FakePendingStripeCancellationRepository(
+      () => new Date('2026-06-12T12:00:00.000Z'),
+    );
+    await repo.schedule('evt_stale', 'cus_stale');
+    const cancelStripeCustomerSubscriptions = vi.fn(async () => undefined);
+
+    const result = await drainPendingStripeCancellations(
+      {
+        olderThan: new Date('2026-06-12T12:15:00.000Z'),
+        dryRun: false,
+      },
+      {
+        pendingStripeCancellations: repo,
+        cancelStripeCustomerSubscriptions,
+        logger: new FakeLogger(),
+      },
+    );
+
+    expect(result).toEqual({
+      scanned: 1,
+      drained: 1,
+      failed: 0,
+      failures: [],
+      dryRun: false,
+    });
+    expect(cancelStripeCustomerSubscriptions).toHaveBeenCalledWith('cus_stale');
+    await expect(repo.findByEventId('evt_stale')).resolves.toBeNull();
+  });
+
+  it('keeps a stale pending row and logs the failure when cancellation fails', async () => {
+    const repo = new FakePendingStripeCancellationRepository(
+      () => new Date('2026-06-12T12:00:00.000Z'),
+    );
+    await repo.schedule('evt_stale', 'cus_stale');
+    const logger = new FakeLogger();
+    const cancelStripeCustomerSubscriptions = vi.fn(async () => {
+      throw new Error('stripe outage');
+    });
+
+    const result = await drainPendingStripeCancellations(
+      {
+        olderThan: new Date('2026-06-12T12:15:00.000Z'),
+        dryRun: false,
+      },
+      {
+        pendingStripeCancellations: repo,
+        cancelStripeCustomerSubscriptions,
+        logger,
+      },
+    );
+
+    expect(result).toEqual({
+      scanned: 1,
+      drained: 0,
+      failed: 1,
+      failures: [{ eventId: 'evt_stale', error: 'stripe outage' }],
+      dryRun: false,
+    });
+    await expect(repo.findByEventId('evt_stale')).resolves.toEqual({
+      stripeCustomerId: 'cus_stale',
+    });
+    expect(logger.errorCalls).toEqual([
+      {
+        context: { eventId: 'evt_stale', error: 'stripe outage' },
+        msg: 'Pending Stripe cancellation drain failed',
+      },
+    ]);
+  });
+
+  it('treats already-canceled Stripe errors as success and deletes the row', async () => {
+    const repo = new FakePendingStripeCancellationRepository(
+      () => new Date('2026-06-12T12:00:00.000Z'),
+    );
+    await repo.schedule('evt_stale', 'cus_stale');
+    const cancelStripeCustomerSubscriptions = vi.fn(async () => {
+      throw alreadyCanceledError();
+    });
+
+    const result = await drainPendingStripeCancellations(
+      {
+        olderThan: new Date('2026-06-12T12:15:00.000Z'),
+        dryRun: false,
+      },
+      {
+        pendingStripeCancellations: repo,
+        cancelStripeCustomerSubscriptions,
+        logger: new FakeLogger(),
+      },
+    );
+
+    expect(result.drained).toBe(1);
+    expect(result.failed).toBe(0);
+    await expect(repo.findByEventId('evt_stale')).resolves.toBeNull();
+  });
+
+  it('does not drain rows newer than the stale cutoff', async () => {
+    const repo = new FakePendingStripeCancellationRepository(
+      () => new Date('2026-06-12T12:20:00.000Z'),
+    );
+    await repo.schedule('evt_fresh', 'cus_fresh');
+    const cancelStripeCustomerSubscriptions = vi.fn(async () => undefined);
+
+    const result = await drainPendingStripeCancellations(
+      {
+        olderThan: new Date('2026-06-12T12:15:00.000Z'),
+        dryRun: false,
+      },
+      {
+        pendingStripeCancellations: repo,
+        cancelStripeCustomerSubscriptions,
+        logger: new FakeLogger(),
+      },
+    );
+
+    expect(result.scanned).toBe(0);
+    expect(cancelStripeCustomerSubscriptions).not.toHaveBeenCalled();
+    await expect(repo.findByEventId('evt_fresh')).resolves.toEqual({
+      stripeCustomerId: 'cus_fresh',
+    });
+  });
+
+  it('reports stale rows without canceling or deleting in dry-run mode', async () => {
+    const repo = new FakePendingStripeCancellationRepository(
+      () => new Date('2026-06-12T12:00:00.000Z'),
+    );
+    await repo.schedule('evt_stale', 'cus_stale');
+    const cancelStripeCustomerSubscriptions = vi.fn(async () => undefined);
+
+    const result = await drainPendingStripeCancellations(
+      {
+        olderThan: new Date('2026-06-12T12:15:00.000Z'),
+        dryRun: true,
+      },
+      {
+        pendingStripeCancellations: repo,
+        cancelStripeCustomerSubscriptions,
+        logger: new FakeLogger(),
+      },
+    );
+
+    expect(result).toEqual({
+      scanned: 1,
+      drained: 0,
+      failed: 0,
+      failures: [],
+      dryRun: true,
+    });
+    expect(cancelStripeCustomerSubscriptions).not.toHaveBeenCalled();
+    await expect(repo.findByEventId('evt_stale')).resolves.toEqual({
+      stripeCustomerId: 'cus_stale',
+    });
+  });
+});

--- a/src/adapters/jobs/drain-pending-stripe-cancellations.ts
+++ b/src/adapters/jobs/drain-pending-stripe-cancellations.ts
@@ -1,0 +1,108 @@
+import { isAlreadyCanceledError } from '@/src/adapters/gateways/stripe';
+import type { Logger } from '@/src/application/ports/logger';
+import type { PendingStripeCancellationRepository } from '@/src/application/ports/repositories';
+
+export const PENDING_STRIPE_CANCELLATION_STALE_AFTER_MINUTES = 15;
+
+type DrainPendingStripeCancellationsInput = {
+  olderThan: Date;
+  dryRun?: boolean;
+};
+
+type DrainPendingStripeCancellationsDeps = {
+  pendingStripeCancellations: PendingStripeCancellationRepository;
+  cancelStripeCustomerSubscriptions: (
+    stripeCustomerId: string,
+  ) => Promise<void>;
+  logger: Logger;
+};
+
+type DrainPendingStripeCancellationsFailure = {
+  eventId: string;
+  error: string;
+};
+
+export type DrainPendingStripeCancellationsOutput = {
+  scanned: number;
+  drained: number;
+  failed: number;
+  failures: DrainPendingStripeCancellationsFailure[];
+  dryRun: boolean;
+};
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message || error.name;
+  return String(error);
+}
+
+export async function drainPendingStripeCancellations(
+  input: DrainPendingStripeCancellationsInput,
+  deps: DrainPendingStripeCancellationsDeps,
+): Promise<DrainPendingStripeCancellationsOutput> {
+  const dryRun = input.dryRun ?? true;
+  const pendingRows = await deps.pendingStripeCancellations.listStale(
+    input.olderThan,
+  );
+
+  if (pendingRows.length > 0) {
+    deps.logger.warn(
+      {
+        count: pendingRows.length,
+        oldestCreatedAt: pendingRows[0]?.createdAt.toISOString(),
+        olderThan: input.olderThan.toISOString(),
+        dryRun,
+      },
+      dryRun
+        ? 'Detected stale pending Stripe cancellations (dry-run)'
+        : 'Draining stale pending Stripe cancellations',
+    );
+  }
+
+  if (dryRun) {
+    return {
+      scanned: pendingRows.length,
+      drained: 0,
+      failed: 0,
+      failures: [],
+      dryRun,
+    };
+  }
+
+  const failures: DrainPendingStripeCancellationsFailure[] = [];
+  let drained = 0;
+
+  for (const row of pendingRows) {
+    try {
+      try {
+        await deps.cancelStripeCustomerSubscriptions(row.stripeCustomerId);
+      } catch (error) {
+        if (isAlreadyCanceledError(error)) {
+          deps.logger.info(
+            { eventId: row.eventId },
+            'Pending Stripe cancellation already satisfied externally',
+          );
+        } else {
+          throw error;
+        }
+      }
+
+      await deps.pendingStripeCancellations.deleteByEventId(row.eventId);
+      drained += 1;
+    } catch (error) {
+      const message = toErrorMessage(error);
+      failures.push({ eventId: row.eventId, error: message });
+      deps.logger.error(
+        { eventId: row.eventId, error: message },
+        'Pending Stripe cancellation drain failed',
+      );
+    }
+  }
+
+  return {
+    scanned: pendingRows.length,
+    drained,
+    failed: failures.length,
+    failures,
+    dryRun,
+  };
+}

--- a/src/adapters/repositories/drizzle-pending-stripe-cancellation-repository.test.ts
+++ b/src/adapters/repositories/drizzle-pending-stripe-cancellation-repository.test.ts
@@ -88,4 +88,35 @@ describe('DrizzlePendingStripeCancellationRepository', () => {
     expect(deleteFn).toHaveBeenCalledWith(pendingStripeCancellations);
     expect(where).toHaveBeenCalledTimes(1);
   });
+
+  it('lists stale pending cancellations ordered by creation time', async () => {
+    const rows = [
+      {
+        eventId: 'evt_old',
+        stripeCustomerId: 'cus_old',
+        createdAt: new Date('2026-06-12T12:00:00.000Z'),
+      },
+    ];
+    const orderBy = vi.fn(async () => rows);
+    const where = vi.fn(() => ({ orderBy }));
+    const from = vi.fn(() => ({ where }));
+    const select = vi.fn(() => ({ from }));
+
+    const db = { select } as const;
+    const repo = new DrizzlePendingStripeCancellationRepository(
+      db as unknown as RepoDb,
+    );
+
+    await expect(
+      repo.listStale(new Date('2026-06-12T12:15:00.000Z')),
+    ).resolves.toEqual(rows);
+    expect(select).toHaveBeenCalledWith({
+      eventId: pendingStripeCancellations.eventId,
+      stripeCustomerId: pendingStripeCancellations.stripeCustomerId,
+      createdAt: pendingStripeCancellations.createdAt,
+    });
+    expect(from).toHaveBeenCalledWith(pendingStripeCancellations);
+    expect(where).toHaveBeenCalledTimes(1);
+    expect(orderBy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/adapters/repositories/drizzle-pending-stripe-cancellation-repository.ts
+++ b/src/adapters/repositories/drizzle-pending-stripe-cancellation-repository.ts
@@ -1,6 +1,9 @@
-import { eq } from 'drizzle-orm';
+import { asc, eq, lt } from 'drizzle-orm';
 import { pendingStripeCancellations } from '@/db/schema';
-import type { PendingStripeCancellationRepository } from '@/src/application/ports/repositories';
+import type {
+  PendingStripeCancellation,
+  PendingStripeCancellationRepository,
+} from '@/src/application/ports/repositories';
 import type { DrizzleDb } from '../shared/database-types';
 
 export class DrizzlePendingStripeCancellationRepository
@@ -37,5 +40,17 @@ export class DrizzlePendingStripeCancellationRepository
     await this.db
       .delete(pendingStripeCancellations)
       .where(eq(pendingStripeCancellations.eventId, eventId));
+  }
+
+  async listStale(olderThan: Date): Promise<PendingStripeCancellation[]> {
+    return this.db
+      .select({
+        eventId: pendingStripeCancellations.eventId,
+        stripeCustomerId: pendingStripeCancellations.stripeCustomerId,
+        createdAt: pendingStripeCancellations.createdAt,
+      })
+      .from(pendingStripeCancellations)
+      .where(lt(pendingStripeCancellations.createdAt, olderThan))
+      .orderBy(asc(pendingStripeCancellations.createdAt));
   }
 }

--- a/src/application/ports/pending-stripe-cancellation-repository.ts
+++ b/src/application/ports/pending-stripe-cancellation-repository.ts
@@ -1,5 +1,12 @@
+export type PendingStripeCancellation = {
+  eventId: string;
+  stripeCustomerId: string;
+  createdAt: Date;
+};
+
 export interface PendingStripeCancellationRepository {
   findByEventId(eventId: string): Promise<{ stripeCustomerId: string } | null>;
   schedule(eventId: string, stripeCustomerId: string): Promise<void>;
   deleteByEventId(eventId: string): Promise<void>;
+  listStale(olderThan: Date): Promise<PendingStripeCancellation[]>;
 }

--- a/src/application/test-helpers/fakes/fake-pending-stripe-cancellation-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-pending-stripe-cancellation-repository.test.ts
@@ -23,6 +23,25 @@ describe('FakePendingStripeCancellationRepository', () => {
     await expect(repo.findByEventId('evt_1')).resolves.toBeNull();
   });
 
+  it('lists only stale pending cancellations before the cutoff', async () => {
+    let now = new Date('2026-06-12T12:00:00.000Z');
+    const repo = new FakePendingStripeCancellationRepository(() => now);
+
+    await repo.schedule('evt_stale', 'cus_stale');
+    now = new Date('2026-06-12T12:20:00.000Z');
+    await repo.schedule('evt_fresh', 'cus_fresh');
+
+    await expect(
+      repo.listStale(new Date('2026-06-12T12:15:00.000Z')),
+    ).resolves.toEqual([
+      {
+        eventId: 'evt_stale',
+        stripeCustomerId: 'cus_stale',
+        createdAt: new Date('2026-06-12T12:00:00.000Z'),
+      },
+    ]);
+  });
+
   it('restores snapshots', async () => {
     const repo = new FakePendingStripeCancellationRepository();
     await repo.schedule('evt_1', 'cus_123');

--- a/src/application/test-helpers/fakes/fake-pending-stripe-cancellation-repository.ts
+++ b/src/application/test-helpers/fakes/fake-pending-stripe-cancellation-repository.ts
@@ -1,28 +1,50 @@
-import type { PendingStripeCancellationRepository } from '@/src/application/ports/repositories';
+import type {
+  PendingStripeCancellation,
+  PendingStripeCancellationRepository,
+} from '@/src/application/ports/repositories';
 
 type PendingStripeCancellationSnapshot = ReadonlyArray<
-  readonly [string, string]
+  readonly [string, { stripeCustomerId: string; createdAt: Date }]
 >;
 
 export class FakePendingStripeCancellationRepository
   implements PendingStripeCancellationRepository
 {
-  private readonly pendingByEventId = new Map<string, string>();
+  private readonly pendingByEventId = new Map<
+    string,
+    { stripeCustomerId: string; createdAt: Date }
+  >();
+
+  constructor(private readonly now: () => Date = () => new Date()) {}
 
   async findByEventId(
     eventId: string,
   ): Promise<{ stripeCustomerId: string } | null> {
-    const stripeCustomerId = this.pendingByEventId.get(eventId);
-    if (!stripeCustomerId) return null;
-    return { stripeCustomerId };
+    const pending = this.pendingByEventId.get(eventId);
+    if (!pending) return null;
+    return { stripeCustomerId: pending.stripeCustomerId };
   }
 
   async schedule(eventId: string, stripeCustomerId: string): Promise<void> {
-    this.pendingByEventId.set(eventId, stripeCustomerId);
+    this.pendingByEventId.set(eventId, {
+      stripeCustomerId,
+      createdAt: this.now(),
+    });
   }
 
   async deleteByEventId(eventId: string): Promise<void> {
     this.pendingByEventId.delete(eventId);
+  }
+
+  async listStale(olderThan: Date): Promise<PendingStripeCancellation[]> {
+    return [...this.pendingByEventId.entries()]
+      .filter(([, pending]) => pending.createdAt < olderThan)
+      .sort(([, a], [, b]) => a.createdAt.getTime() - b.createdAt.getTime())
+      .map(([eventId, pending]) => ({
+        eventId,
+        stripeCustomerId: pending.stripeCustomerId,
+        createdAt: pending.createdAt,
+      }));
   }
 
   snapshot(): PendingStripeCancellationSnapshot {
@@ -31,8 +53,8 @@ export class FakePendingStripeCancellationRepository
 
   restore(snapshot: PendingStripeCancellationSnapshot): void {
     this.pendingByEventId.clear();
-    for (const [eventId, stripeCustomerId] of snapshot) {
-      this.pendingByEventId.set(eventId, stripeCustomerId);
+    for (const [eventId, pending] of snapshot) {
+      this.pendingByEventId.set(eventId, pending);
     }
   }
 }

--- a/tests/integration/stripe-repositories.integration.test.ts
+++ b/tests/integration/stripe-repositories.integration.test.ts
@@ -1,11 +1,14 @@
 import { randomUUID } from 'node:crypto';
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { afterAll, afterEach, describe, expect, it } from 'vitest';
 import * as schema from '@/db/schema';
+import { drainPendingStripeCancellations } from '@/src/adapters/jobs/drain-pending-stripe-cancellations';
+import { DrizzlePendingStripeCancellationRepository } from '@/src/adapters/repositories/drizzle-pending-stripe-cancellation-repository';
 import { DrizzleStripeCustomerRepository } from '@/src/adapters/repositories/drizzle-stripe-customer-repository';
 import { DrizzleStripeEventRepository } from '@/src/adapters/repositories/drizzle-stripe-event-repository';
 import { DrizzleSubscriptionRepository } from '@/src/adapters/repositories/drizzle-subscription-repository';
 import { ApplicationError } from '@/src/application/errors';
+import { FakeLogger } from '@/src/application/test-helpers/fakes';
 import {
   cleanupAfterEach,
   closeConnection,
@@ -51,6 +54,73 @@ describe('Stripe repositories', () => {
       processedAt: null,
       error: 'boom',
     });
+  });
+
+  it('drains stale pending Stripe cancellations and leaves fresh rows untouched', async () => {
+    const staleEventId = `evt_${randomUUID().replaceAll('-', '')}`;
+    const freshEventId = `evt_${randomUUID().replaceAll('-', '')}`;
+    const repo = new DrizzlePendingStripeCancellationRepository(db);
+    const logger = new FakeLogger();
+    const canceledCustomerIds: string[] = [];
+
+    try {
+      await db.insert(schema.clerkEvents).values([
+        {
+          id: staleEventId,
+          type: 'user.deleted',
+          createdAt: new Date('2026-06-12T12:00:00.000Z'),
+        },
+        {
+          id: freshEventId,
+          type: 'user.deleted',
+          createdAt: new Date('2026-06-12T12:20:00.000Z'),
+        },
+      ]);
+
+      await db.insert(schema.pendingStripeCancellations).values([
+        {
+          eventId: staleEventId,
+          stripeCustomerId: 'cus_stale',
+          createdAt: new Date('2026-06-12T12:00:00.000Z'),
+        },
+        {
+          eventId: freshEventId,
+          stripeCustomerId: 'cus_fresh',
+          createdAt: new Date('2026-06-12T12:20:00.000Z'),
+        },
+      ]);
+
+      const result = await drainPendingStripeCancellations(
+        {
+          olderThan: new Date('2026-06-12T12:15:00.000Z'),
+          dryRun: false,
+        },
+        {
+          pendingStripeCancellations: repo,
+          cancelStripeCustomerSubscriptions: async (stripeCustomerId) => {
+            canceledCustomerIds.push(stripeCustomerId);
+          },
+          logger,
+        },
+      );
+
+      expect(result).toEqual({
+        scanned: 1,
+        drained: 1,
+        failed: 0,
+        failures: [],
+        dryRun: false,
+      });
+      expect(canceledCustomerIds).toEqual(['cus_stale']);
+      await expect(repo.findByEventId(staleEventId)).resolves.toBeNull();
+      await expect(repo.findByEventId(freshEventId)).resolves.toEqual({
+        stripeCustomerId: 'cus_fresh',
+      });
+    } finally {
+      await db
+        .delete(schema.clerkEvents)
+        .where(inArray(schema.clerkEvents.id, [staleEventId, freshEventId]));
+    }
   });
 
   it('upserts Stripe customers per user', async () => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/reconcile-stripe-subscriptions?dryRun=true",
+      "schedule": "0 8 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a Vercel cron entry for the Stripe reconciliation route, starting in `dryRun=true`.
- Adds a shared GET/POST cron handler that preserves auth/rate-limit ordering and returns reconciliation plus pending-cancellation drain results.
- Adds a pending Stripe cancellation drain job that lists stale rows, cancels by the stored Stripe customer id, deletes successful/already-canceled rows, and preserves/logs real failures.
- Extends the pending-cancellation repository port, Drizzle repo, and fake with `listStale`.
- Updates BUG-244/BUG-246 docs with the implemented decision and post-deploy dry-run flip checklist.

## Root Cause

- BUG-244: the hardened reconciliation job existed but had no scheduler invoking it.
- BUG-246: deleted-account Stripe cancellation failures could persist past Svix retries because the pending cancellation queue had no scheduled drain.

## Validation

- Red focused tests first: GET handler missing, drain job missing, `listStale` missing.
- Focused green: `pnpm test --run app/api/cron/reconcile-stripe-subscriptions/route.test.ts src/adapters/jobs/drain-pending-stripe-cancellations.test.ts src/application/test-helpers/fakes/fake-pending-stripe-cancellation-repository.test.ts src/adapters/repositories/drizzle-pending-stripe-cancellation-repository.test.ts`
- Focused integration green: `pnpm test:integration --run tests/integration/stripe-repositories.integration.test.ts`
- Full committed-tree gate: `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build`
- E2E committed-tree gate: `pnpm test:e2e` -> `36 passed`

## Post-Deploy Owner Step

- Vercel scheduled firing itself is not CI-verifiable. After deploy: observe one scheduled `dryRun=true` run in logs, review the reconciliation/drain report, then intentionally flip the cron path to `dryRun=false` in a follow-up once the report is accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated daily Stripe subscription reconciliation is now scheduled to run, starting in safe mode with manual verification before full activation.
  * Added pending Stripe cancellation draining to handle edge cases where cancellations were not processed.
  * Reconciliation endpoint now supports both request methods.

* **Documentation**
  * Updated documentation for completed billing-maintenance implementations and verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->