### PR TITLE
Fix BUG-247 pricing portal failure copy

### DIFF
--- a/app/pricing/manage-billing-action.test.ts
+++ b/app/pricing/manage-billing-action.test.ts
@@ -53,7 +53,7 @@ describe('runManageBillingAction', () => {
     });
   });
 
-  it('returns redirect to /pricing?checkout=error when portal session creation fails', async () => {
+  it('returns redirect to /pricing?portal=error when portal session creation fails', async () => {
     const redirectFn = (url: string): never => {
       throw new RedirectError(url);
     };
@@ -71,7 +71,7 @@ describe('runManageBillingAction', () => {
       });
 
     await expect(action()).rejects.toMatchObject({
-      url: '/pricing?checkout=error',
+      url: '/pricing?portal=error',
     });
   });
 
@@ -95,7 +95,7 @@ describe('runManageBillingAction', () => {
         });
 
       await expect(action()).rejects.toMatchObject({
-        url: '/pricing?checkout=error',
+        url: '/pricing?portal=error',
       });
     } finally {
       vi.unstubAllEnvs();
@@ -118,7 +118,7 @@ describe('runManageBillingAction', () => {
       });
 
     await expect(action()).rejects.toMatchObject({
-      url: '/pricing?checkout=error',
+      url: '/pricing?portal=error',
     });
     expect(logger.errorCalls).toHaveLength(1);
   });

--- a/app/pricing/manage-billing-action.ts
+++ b/app/pricing/manage-billing-action.ts
@@ -15,7 +15,7 @@ export async function runManageBillingAction(deps: {
   return runManageBillingActionCore({
     ...deps,
     redirects: {
-      failure: `${ROUTES.PRICING}?checkout=error`,
+      failure: `${ROUTES.PRICING}?portal=error`,
       unauthenticated: ROUTES.SIGN_UP,
     },
   });

--- a/app/pricing/page.test.tsx
+++ b/app/pricing/page.test.tsx
@@ -498,6 +498,13 @@ describe('app/pricing', () => {
     });
   });
 
+  it('builds the portal error banner when portal=error', async () => {
+    expect(getPricingBanner({ portal: 'error' })).toMatchObject({
+      tone: 'error',
+      message: "Couldn't open the billing portal. Please try again.",
+    });
+  });
+
   it('builds the checkout error banner when checkout is a repeated query param', async () => {
     expect(getPricingBanner({ checkout: ['error', 'cancel'] })).toMatchObject({
       tone: 'error',

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -64,6 +64,7 @@ export async function loadPricingData(
 
 type PricingSearchParams = {
   checkout?: string | string[] | undefined;
+  portal?: string | string[] | undefined;
   reason?: string | string[] | undefined;
   plan?: string;
 };
@@ -77,6 +78,7 @@ export function getPricingBanner(
   trialContext?: PricingTrialContext,
 ): PricingBanner | null {
   const checkout = normalizeSearchParam(searchParams.checkout);
+  const portal = normalizeSearchParam(searchParams.portal);
   const reason = normalizeSearchParam(searchParams.reason);
 
   if (checkout === 'rate_limited') {
@@ -97,6 +99,13 @@ export function getPricingBanner(
     return {
       tone: 'info',
       message: 'Checkout canceled.',
+    };
+  }
+
+  if (portal === 'error') {
+    return {
+      tone: 'error',
+      message: "Couldn't open the billing portal. Please try again.",
     };
   }
 

--- a/docs/bugs/bug-247-pricing-portal-failure-shows-checkout-error-copy.md
+++ b/docs/bugs/bug-247-pricing-portal-failure-shows-checkout-error-copy.md
@@ -1,6 +1,7 @@
 # BUG-247: Pricing-Page "Manage Billing" Portal Failures Show Checkout-Failure Copy ("Checkout failed. Please try again.")
 
 **Status:** Open
+**Resolution State:** Fixed on branch `fix/bug-247-pricing-portal-failure-copy`; pending PR review, merge verification, and archival.
 **Priority:** P3 (wrong but recoverable user-facing copy on a real recovery path; the sibling route already has the correct copy)
 **Date:** 2026-06-11
 **Family:** Billing / pricing copy / portal failure handling
@@ -17,7 +18,7 @@ This lands a payment-troubled user (e.g. an `unpaid`/`paused` subscriber redirec
 ## Steps to Reproduce
 
 1. Be a signed-in user with a non-entitled-but-recoverable subscription (e.g. `unpaid` with an active period) → app layout redirects to `/pricing?reason=manage_billing`.
-2. Click **Manage Billing** while Stripe portal-session creation fails (transient Stripe 5xx → `STRIPE_ERROR`, or `RATE_LIMITED` after >20 portal attempts/min).
+2. Click **Manage Billing** while Stripe portal-session creation fails (`STRIPE_ERROR` from a missing portal-session URL or an already-open Stripe circuit; `INTERNAL_ERROR` from an exhausted raw Stripe/network failure handled by `createAction`; `RATE_LIMITED` after >20 portal attempts/min; or `NOT_FOUND` when no Stripe customer mapping exists).
 3. Observe redirect to `/pricing?checkout=error` and the banner "Checkout failed. Please try again." above the "Subscription needs attention" card.
 
 ## Root Cause
@@ -26,7 +27,7 @@ This lands a payment-troubled user (e.g. an `unpaid`/`paused` subscriber redirec
 2. `app/pricing/page.tsx:175-177` — `buildPricingPresentation` sets `showManageBillingAction = true` for `manage_billing`/`payment_processing`, passing `manageBillingAction` into `PricingView`.
 3. `app/pricing/pricing-view.tsx:62-73` (banner button) and `:103-118` ("Subscription needs attention" card) submit `action={manageBillingAction}`.
 4. `app/pricing/manage-billing-actions.ts` → `app/pricing/manage-billing-action.ts:15-21` — the pricing wrapper hardcodes `redirects.failure = ${ROUTES.PRICING}?checkout=error` (only `UNAUTHENTICATED` is special-cased → `/sign-up`).
-5. `lib/manage-billing/manage-billing-core.ts:46-52` — any thrown error or any non-ok result whose code is not `UNAUTHENTICATED` (`STRIPE_ERROR`; `RATE_LIMITED` from `PORTAL_SESSION_RATE_LIMIT`, `billing-controller.ts:157-166`; `NOT_FOUND` from `create-portal-session.ts:23-25`) redirects to that failure URL.
+5. `lib/manage-billing/manage-billing-core.ts:46-52` — any thrown error redirects to the configured failure URL, and any non-ok result whose code is not `UNAUTHENTICATED` also redirects there. Real production codes that reach this branch include `INTERNAL_ERROR` from raw thrown Stripe/network failures converted by `createAction`/`handleError` (`src/adapters/controllers/create-action.ts:53-69`, `src/adapters/controllers/action-result.ts:51-61`), `STRIPE_ERROR` from a missing portal-session URL (`src/adapters/gateways/stripe/stripe-portal.ts:41-45`) or already-open Stripe circuit (`src/adapters/gateways/stripe/stripe-retry.ts:8-16`, `src/adapters/shared/circuit-breaker.ts:115-119`), `RATE_LIMITED` from `PORTAL_SESSION_RATE_LIMIT` (`billing-controller.ts:157-166`), and `NOT_FOUND` from a missing Stripe customer mapping (`create-portal-session.ts:23-25`).
 6. `app/pricing/page.tsx:89-94` — `getPricingBanner` maps `checkout === 'error'` to the error-tone banner **"Checkout failed. Please try again."**
 7. Contrast (intended copy exists): `app/(app)/app/billing/manage-billing-action.ts:17-19` redirects the identical failure to `/app/billing?error=portal_failed`, and `app/(app)/app/billing/page.tsx:126-130` renders **"Couldn't open the billing portal. Please try again."**
 
@@ -35,16 +36,20 @@ This lands a payment-troubled user (e.g. an `unpaid`/`paused` subscriber redirec
 - A user actively trying to fix a billing problem is told their *checkout* failed — misleading and slightly alarming, on the exact path where clarity matters most (payment recovery).
 - Recoverable in one retry, and only triggers when portal creation actually fails, so impact is bounded — hence P3, not higher.
 
-## Expected Fix (options)
+## Expected Fix
 
-1. **Pricing-specific portal-failure copy (preferred).** Give pricing-side portal failures their own param (e.g. `/pricing?portal=error`) and add a `getPricingBanner` branch rendering "Couldn't open the billing portal. Please try again." Keep `UNAUTHENTICATED → /sign-up` unchanged.
-2. **Redirect pricing portal failures to the app billing error surface.** For users who already have a subscription row, redirect portal failures to `/app/billing?error=portal_failed` (reusing the correct existing copy) instead of `/pricing?checkout=error`.
+Use the pricing-specific portal-failure bucket.
 
-Either way, the `checkout=error` banner should remain reserved for actual subscribe/checkout failures (its BUG-114 origin).
+1. Change the pricing-side manage-billing wrapper's configured failure redirect from `/pricing?checkout=error` to `/pricing?portal=error`.
+2. Extend `PricingSearchParams` in `app/pricing/page.tsx:65-69` with `portal?: string | string[] | undefined`, normalize `searchParams.portal` inside `getPricingBanner` (`:75-94`), and add a branch rendering "Couldn't open the billing portal. Please try again." for `portal === 'error'`.
+3. Keep `UNAUTHENTICATED → /sign-up` unchanged.
+4. Keep `checkout=error` reserved for actual subscribe/checkout failures (its BUG-114 origin).
+
+Do **not** redirect the pricing failure to `/app/billing?error=portal_failed` for this fix. The app-billing route remains the sibling proof of intended portal-failure copy, but the pricing page should own its own portal-failure banner because the failure starts from pricing-page recovery CTAs.
 
 ## Verification
 
-- [ ] Test: pricing Manage Billing failure (`STRIPE_ERROR`/`RATE_LIMITED`/`NOT_FOUND`) renders portal-failure copy, not checkout-failure copy.
+- [ ] Test: pricing Manage Billing failure (`INTERNAL_ERROR`/`STRIPE_ERROR`/`RATE_LIMITED`/`NOT_FOUND`) renders portal-failure copy, not checkout-failure copy.
 - [ ] Test: subscribe-action failures still render "Checkout failed. Please try again." (no regression of the `checkout=error` bucket).
 - [ ] Test: `UNAUTHENTICATED` portal failure still redirects to `/sign-up`.
 - [ ] `pnpm test --run` green.


### PR DESCRIPTION
## Summary
- Route pricing-page Manage Billing portal failures to `/pricing?portal=error` instead of the checkout failure bucket.
- Add a pricing banner branch for portal failures using the same copy as `/app/billing`: "Couldn't open the billing portal. Please try again."
- Preserve `checkout=error` for subscribe/checkout failures and keep unauthenticated portal failures on `/sign-up`.
- Correct the BUG-247 spec provenance/expected-fix wording so the doc matches the verified implementation plan.

## Verification
- `pnpm test --run app/pricing` red first: 4 expected failures, then green: 5 files / 82 tests passed.
- `pnpm db:test:up && pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build && pnpm test:e2e`
- Pre-push hook also passed: `pnpm typecheck && pnpm test --run`.

## Scope
- Touches only `app/pricing/*` plus the BUG-247 spec doc.
- Does not touch `lib/manage-billing/*`, app billing, route constants, or BUG-245 surfaces.

Refs: docs/bugs/bug-247-pricing-portal-failure-shows-checkout-error-copy.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Billing portal failures now redirect to a portal-specific error state and display an error banner: "Couldn't open the billing portal. Please try again." (replaces generic checkout error messaging).
* **Documentation**
  * Updated bug report and resolution notes to reflect the portal-failure routing and updated banner messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->