### PR TITLE
Promote dev → main: actions/checkout 6.0.3 (#428)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## What
Promotion PR to sync `main` with `dev` under the new `main-protection` ruleset (direct fast-forward pushes to `main` are now blocked; main requires a PR + passing `test` check).

## Contents
Exactly one commit ahead of `main`:
- `d9b895de` — chore(deps): bump actions/checkout 6.0.2 → 6.0.3 (#428)

`#428` was already CI-green and CodeRabbit-clean on `dev` before merge. This PR carries that single, already-reviewed dependency bump to `main`.

## Why a PR (not FF)
The `main-protection` ruleset (intentional) blocks non-fast-forward and direct pushes, requires a PR, and requires the `test` status check. This promotion PR is the sanctioned path to keep `main` in parity with `dev`.