### PR TITLE
Add CSP guardrail comment (do not flip reportOnly — DEBT-420)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -205,6 +205,14 @@ async function getClerkMiddleware(): Promise<NextMiddleware> {
       contentSecurityPolicy: {
         directives: CLERK_CSP_DIRECTIVES,
         strict: true,
+        // ⚠️ Keep `reportOnly: true`. Do NOT flip to `false` (enforcing).
+        // Clerk strict mode uses a per-request nonce + 'strict-dynamic', which is
+        // fundamentally incompatible with this app's Next 16 PPR / Cache Components:
+        // prerendered static-shell <script> tags cannot carry the per-request nonce,
+        // so enforcing blocks first-party /_next/static/chunks and breaks the app
+        // (verified via live Sentry + a production-build experiment + Next/Clerk docs).
+        // Real enforcement would require a separate non-nonce host-allowlist policy.
+        // See docs/_archive/debt/debt-420-csp-enforcing-mode-flip.md.
         reportOnly: true,
         ...(sentrySecurityHeaderEndpoint
           ? { reportTo: sentrySecurityHeaderEndpoint }


### PR DESCRIPTION
One-line guardrail. Adds an inline `⚠️` comment at `proxy.ts` `reportOnly: true` warning not to flip it to enforcing, pointing at archived DEBT-420.

**Why:** the abandoned enforce flip nearly shipped because there was no warning at the temptation point. Clerk strict nonce + `'strict-dynamic'` CSP is incompatible with this app's Next 16 PPR/Cache Components (prerendered shell scripts can't carry the per-request nonce → enforcing blocks first-party `_next/static/chunks`).

Comment-only — no behavior change. CSP stays report-only. Full gate green (typecheck, lint, 33/33 proxy tests, build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifying comments to configuration code for improved maintainability and future development clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->