### PR TITLE
CI: bump pnpm/action-setup to 6.0.9 + harden Playwright install against apt 403 flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.8
+        uses: pnpm/action-setup@v6.0.9
         with:
           version: 11.3.0
           run_install: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,14 @@ jobs:
 
       - name: Install Playwright browsers
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-        run: pnpm exec playwright install --with-deps
+        run: |
+          # GitHub's ubuntu-24.04 image ships Microsoft/Azure apt repos that
+          # intermittently return 403, which fails `apt-get update` inside
+          # `playwright install --with-deps` and reds an otherwise-green run.
+          # Playwright's system libs come from the Ubuntu archive, not these
+          # repos, so drop any Microsoft apt source before installing.
+          sudo find /etc/apt/sources.list.d -type f -exec grep -lE 'packages\.microsoft\.com' {} + 2>/dev/null | sudo xargs -r rm -f || true
+          pnpm exec playwright install --with-deps
 
       - name: Browser tests with coverage
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)


### PR DESCRIPTION
## Problem
Dependabot opened #441 to bump `pnpm/action-setup` v6.0.8 → v6.0.9, but it targeted `main` directly off an old main-only merge commit. Merging it as-is would put a commit on `main` that `dev` lacks, breaking our "dev is ancestor of main / trees identical" invariant. CodeRabbit also skips bot PRs, so #441 would merge unreviewed.

## Solution
Re-apply the identical one-line change on a `dev`-based branch so:
- `dev` stays an ancestor of `main` (promote via dev→main as usual)
- CodeRabbit reviews the change
- The CI `test` check (the meaningful gate for a workflow change) validates it

## Change
`.github/workflows/ci.yml`: `pnpm/action-setup@v6.0.8` → `@v6.0.9` (sole occurrence). pnpm pin (`version: 11.3.0`) unchanged.

Closes #441 (will close that PR once this lands via dev→main promotion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->