### PR TITLE
Promote dev → main: CI action-setup bump + Playwright apt-flake hardening (#446)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.8
+        uses: pnpm/action-setup@v6.0.9
         with:
           version: 11.3.0
           run_install: false
@@ -118,7 +118,14 @@ jobs:
 
       - name: Install Playwright browsers
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-        run: pnpm exec playwright install --with-deps
+        run: |
+          # GitHub's ubuntu-24.04 image ships Microsoft/Azure apt repos that
+          # intermittently return 403, which fails `apt-get update` inside
+          # `playwright install --with-deps` and reds an otherwise-green run.
+          # Playwright's system libs come from the Ubuntu archive, not these
+          # repos, so drop any Microsoft apt source before installing.
+          sudo find /etc/apt/sources.list.d -type f -exec grep -lE 'packages\.microsoft\.com' {} + 2>/dev/null | sudo xargs -r rm -f || true
+          pnpm exec playwright install --with-deps
 
       - name: Browser tests with coverage
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)


### PR DESCRIPTION
Promotes the merged #446 to main.

**Contents (1 commit, `b5fc4056`):**
- Bump `pnpm/action-setup` v6.0.8 → v6.0.9 (re-applied from dependabot #441 on a dev-based branch).
- Harden the CI `Install Playwright browsers` step: drop any `packages.microsoft.com` apt source before `--with-deps` so a transient Microsoft-repo 403 can't red an otherwise-green run.

Both CI-green and CodeRabbit-approved on #446 (bump + hardening reviewed separately). Merge-commit promotion keeps dev an ancestor of main.