### PR TITLE
Promote dev→main: BUG-241 deploy-migration (Vercel buildCommand)

### DIFF
--- a/docs/bugs/bug-241-deploy-pipeline-has-no-migration-step.md
+++ b/docs/bugs/bug-241-deploy-pipeline-has-no-migration-step.md
@@ -1,57 +1,119 @@
 # BUG-241: Deploy Pipeline Has No Migration Step — Schema PRs Ship Code Without Applying Migrations (Green CI, Broken Runtime)
 
 **Status:** Open
+**Resolution State:** Fixed on branch in `vercel.json` (`buildCommand`); pending preview-deploy verification and archival
 **Priority:** P2 (systemic process/infra gap; latent outage for every schema-bearing PR; high blast radius)
 **Date:** 2026-06-03
 **Family:** CI/CD / deploy / migrations
-**Related:** [BUG-240](../_archive/bugs/bug-240-question-feedback-migrations-not-applied-to-dev-prod.md) (the first outage this gap produced; remediated and archived)
+**Related:** [BUG-240](../_archive/bugs/bug-240-question-feedback-migrations-not-applied-to-dev-prod.md) (the first outage this gap produced; remediated and archived), [DEBT-391](../_archive/debt/debt-391-local-e2e-schema-drift-preflight.md) (resolved local/E2E migration-ledger drift primitive to reuse)
 
 ---
 
 ## Description
 
-Applying migrations to the deployed databases is a **manual, documented-but-unenforced** operator step. There is no automated step that applies Drizzle migrations to the dev or production database on deploy, and nothing *gates* a deploy on migrations having been applied. As a result, a PR can add a migration, pass all of CI, merge, and deploy code that references a table/column that does not exist in dev/prod — with a fully green pipeline.
+When BUG-241 was filed, applying migrations to deployed databases was a **manual, documented-but-unenforced** operator step. There was no automated deploy step that applied Drizzle migrations to the Vercel-targeted Neon branches, and nothing gated a deployment on the target database having the repo's migration journal applied. A PR could add a migration, pass all required CI, merge through the protected `main` flow, and deploy code that referenced a table or column that did not exist in the deployed database.
 
-**The documentation is not the gap.** The runbook already exists and even names this exact failure:
-- `docs/dev/deployment-procedure.md` §5 Pre-Deployment Checklist requires *"If schema changed: `pnpm db:migrate` run against the target deployed database immediately after deploy (forgetting this causes silent write failures)."*
-- `docs/dev/deployment-environments.md` documents the symptom under **"Missing Database Migration Causes Silent Write Failures."**
+**The runbook was not the gap.** The pre-fix `docs/dev/deployment-procedure.md` checklist told operators to run `pnpm db:migrate` against the target deployed database when schema changed, and `docs/dev/deployment-environments.md` documented the exact symptom under **"Missing Database Migration Causes Silent Write Failures."** The gap was that the runbook step was not enforced by CI or Vercel. This branch reconciles those runbooks to the Build Command migration contract.
 
-The gap is that this is a **human checklist item with no automated enforcement** — exactly the kind of step that gets skipped under delivery pressure. [BUG-240](../_archive/bugs/bug-240-question-feedback-migrations-not-applied-to-dev-prod.md) is the first confirmed outage from skipping it (SPEC-041's `question_feedback` table was never applied to dev/prod). Adjacent: [DEBT-391](../debt/debt-391-local-e2e-schema-drift-preflight.md) (local/e2e schema-drift preflight) is related drift-detection momentum that could be extended to deploy.
+[BUG-240](../_archive/bugs/bug-240-question-feedback-migrations-not-applied-to-dev-prod.md) is the first confirmed outage from this class: SPEC-041's `question_feedback` table was present in repo migrations but had not been applied to deployed dev/preview or production databases before code reached those environments.
+
+## Verified Evidence
+
+| Claim | Verified artifact | Result / correction |
+|---|---|---|
+| CI uses throwaway Postgres, not a deployed Neon branch. | `.github/workflows/ci.yml:35-37` sets the CI job's local `DATABASE_URL`; `.github/workflows/ci.yml:20-28` defines the Postgres service. | Confirmed. Do not treat CI migration success as deploy-target migration. |
+| CI proves migrations apply cleanly only against that throwaway DB. | `.github/workflows/ci.yml:105-106` runs `pnpm db:migrate`; `.github/workflows/ci.yml:108-111` seeds placeholder content. | Confirmed. |
+| The GitHub `deploy` job does not deploy or migrate. | `.github/workflows/ci.yml:218-224` defines `deploy` and only echoes that Vercel Git integration handles production deploys. | Corrected from the prior stale deploy-job citation. |
+| The package build path is only Next build. | `package.json:9-10` defines `build` as `next build`; `package.json:24-25` defines `db:migrate` as a separate manual script. | Confirmed. There is no package-level deploy hook. |
+| Vercel cloud project had no dashboard Build Command override, Install Command override, or Ignored Build Step before this branch's repo-level fix. | Redacted Vercel project metadata audit on 2026-06-16. | Confirmed without printing project identifiers, hostnames, or env values. Before `vercel.json` added `buildCommand`, Vercel fell back to the package build script. |
+| Vercel has `DATABASE_URL` scoped in Production, Preview, and Development. | Redacted Vercel env metadata audit on 2026-06-16. | Confirmed presence only: one `DATABASE_URL` entry in each scope, with no git-branch-specific override observed. A value-free host comparison verified Production is isolated from the shared Preview/Development non-production database. |
+| Vercel Build Step has scoped env available. | `lib/env.ts:101-118` documents `VERCEL_ENV` availability during the Build Step and function execution; `DATABASE_URL` is required by `lib/env.ts:38-40`. | Confirmed. A Vercel Build Command migration is viable from the repo's env-loading perspective. |
+| The migration ledger table and comparison primitive already exist in test helpers. | `tests/e2e/helpers/credential-health-check.ts:161-174` has `computeMissingMigrations()`, `:176-180` has `formatSchemaDriftMessage()`, and `:200-238` has `verifyMigrationLedger(sql)`. | Confirmed. Reuse this shipped primitive for the drift gate instead of inventing a second comparison. |
+| The ledger comparison is precise. | `tests/e2e/helpers/credential-health-check.ts:205-214` queries `drizzle.__drizzle_migrations.created_at`; `db/migrations/meta/_journal.json:4-152` stores journal `entries[].when`; `drizzle.config.ts:14-21` leaves Drizzle migration schema/table defaults in place. | Confirmed. Compare journal `entries[].when` to `drizzle.__drizzle_migrations.created_at`, then map missing `when` values back to journal tags for messages. |
+| Local test DBs are isolated from deploy DBs. | `scripts/e2e-local-orchestrator.ts:65-94` starts, migrates, seeds, and runs E2E against a resolver-scoped Docker target; `scripts/resolve-local-test-target.ts:32-39` derives per-worktree local DB ports from base `55400`; `docker-compose.yml:13` keeps `5434` only as the raw Compose fallback when `DB_TEST_PORT` is unset. | Corrected from stale fixed-local-port wording. CI still uses service port `5432`; normal local wrappers use resolver-scoped Docker targets. |
+| No PR-template checkbox exists today. | `.github/` currently contains only `dependabot.yml` and `workflows/ci.yml`. | Confirmed. Any PR-template attestation would have to be created as implementation work; it is not an existing control. |
+
+## Deployment Topology
+
+Disambiguate the three "dev" surfaces:
+
+| Surface | Source | Database target contract | Pre-fix migration behavior |
+|---|---|---|---|
+| Local app runtime | Local checkout with `.env.local` | Expected to match Vercel Development and the Neon `dev` branch. Verify the provider target before any manual mutation. | Manual when intentionally targeting this database. |
+| Local integration / normal local E2E | Local checkout via `scripts/resolve-local-test-target.ts` | Resolver-scoped Docker Postgres, never a deployed Neon branch unless the operator explicitly opts into an existing database. | E2E wrapper starts, migrates, and seeds automatically; integration wrapper uses the resolver-scoped local target. |
+| CI | GitHub Actions `test` job | Throwaway Postgres service on the CI runner. | CI runs `pnpm db:migrate` and seed against the throwaway DB only. |
+| Git `dev` branch / feature branches | Vercel Preview | Shared non-production Neon `dev` branch DB by documented contract; value-free host comparison verified it is isolated from Production. | No deploy migration step. Fixed on this branch by `vercel.json` `buildCommand`. |
+| Vercel Development env | `vercel env pull` / local Vercel development scope | Shared non-production Neon `dev` branch DB by documented contract; value-free host comparison verified it matches Preview and is isolated from Production. | No deploy migration step. Fixed on this branch by `vercel.json` `buildCommand` for Vercel builds. |
+| Git `main` branch | Vercel Production | Neon `main` branch DB by documented contract; value-free host comparison verified it is isolated from Preview/Development. | No deploy migration step. Fixed on this branch by `vercel.json` `buildCommand` once merged to `main`. |
+
+`main` is protected by an active GitHub `main-protection` ruleset requiring PRs and the `test` status check before merge. The local `origin/dev` and `origin/main` refs currently have identical trees, although `main` has merge commits on top of `dev`. Any fix must preserve this protected-main flow and must not rely on bypassing it.
 
 ## Root Cause
 
-- **CI migrates only a throwaway DB.** `.github/workflows/ci.yml:106` runs `pnpm db:migrate`, but `DATABASE_URL` for that job is the ephemeral CI Postgres `postgresql://postgres:postgres@localhost:5432/addiction_boards_test` (`.github/workflows/ci.yml:37`). It proves the migrations *apply cleanly*; it never touches dev or prod.
-- **The deploy job is a no-op placeholder.** `.github/workflows/ci.yml:206-212` (`deploy`) only runs `echo "Production deploy is handled by Vercel Git integration on main."`. There is no `db:migrate` invocation against any real environment.
-- **Vercel build does not migrate.** Production is built via Vercel Git integration running `next build` (`package.json` `build` script). There is no `predeploy`/`postinstall`/build hook that runs `pnpm db:migrate`. (`package.json` has only `db:migrate` as a manual script; no deploy wiring.)
-- **Net effect:** applying migrations to dev/prod is an undocumented, manual, easily-forgotten human step. Local/CI tests migrate their own local DBs (:5434 / CI :5432), so they stay green and hide the omission until a user hits the live feature.
+- **CI migrates only a throwaway DB.** `.github/workflows/ci.yml:105-106` runs `pnpm db:migrate` with the CI-local `DATABASE_URL` from `.github/workflows/ci.yml:35-37`. It proves the migration files apply; it never touches Vercel Preview, Vercel Development, or Vercel Production databases.
+- **The GitHub `deploy` job is a no-op placeholder.** `.github/workflows/ci.yml:218-224` only emits a message that production deployment is handled by Vercel Git integration. It cannot block Vercel's git-triggered deployment with a migration.
+- **Vercel previously built only the app.** Before this branch's `vercel.json` fix, the Vercel project had no dashboard Build Command override, no Install Command override, and no Ignored Build Step. With `package.json:9-10`, the build was `next build`; with `package.json:24-25`, `pnpm db:migrate` remained a separate manual script.
+- **The pre-fix docs relied on human memory.** The old deployment runbook correctly described manual migration, but the merge/deploy path did not enforce it.
 
-## Impact
+## Fix (Implemented)
 
-- Every PR that adds a migration is a latent dev/prod outage that CI cannot detect.
-- The failure mode is invisible until a user exercises the new schema in the running app (exactly how [BUG-240](../_archive/bugs/bug-240-question-feedback-migrations-not-applied-to-dev-prod.md) surfaced).
-- Risk scales with migration cadence and with how decoupled the code deploy is from the schema change.
+The fix is **Vercel release-phase migration in the Build Command**, configured in `vercel.json` as the project `buildCommand`:
 
-## Expected Fix (options — pick per ops constraints; do it safely)
+```bash
+pnpm db:migrate && pnpm build
+```
 
-The goal: **a schema change cannot reach users before its migration is applied**, and the application is automated rather than relying on memory. Candidate approaches, roughly in order of robustness:
+This is set as `buildCommand` in `vercel.json` (overriding Vercel's default `next build`), so it applies to Production and Preview builds. It is live on Preview/Development builds immediately and on Production once this change is on `main`. The Install Command is left unset, and no Ignored Build Step is configured, so every deploy build runs the migration; if an ignore rule is ever added it must explicitly refuse to skip builds when `db/migrations/**` or `db/schema.ts` changes.
 
-1. **Release-phase migration in the deploy pipeline.** Add an explicit, authenticated `pnpm db:migrate` step against the real target DB as part of the deploy (e.g. a Vercel deploy hook / GitHub Actions `deploy` job step that holds the prod `DATABASE_URL` as a secret), gated to run **before** the new code serves traffic. Forward-only, additive migrations make this safe for the common case; expand-then-contract for breaking changes.
-2. **Pre-deploy migration gate / check.** A required step that verifies the target DB's `drizzle.__drizzle_migrations` head matches the repo's newest journal entry, failing the deploy if migrations are pending. (Detects drift even if step 1 isn't adopted.)
-3. **Surface the existing runbook at the point of decision.** The release checklist already exists (`deployment-procedure.md` §5) but lives in a doc nobody opens at merge time. Add a **PR-template checkbox** that triggers when `db/migrations/` changed ("schema migration applied to dev/preview AND production after deploy"), and/or a CI warning that fails/annotates a PR touching `db/migrations/` until a human attests the deploy-time migration. This converts the forgettable checklist item into an in-flow gate. (This is the floor; options 1–2 are the durable fix.)
+This mechanism is the accepted fix because Vercel already owns the traffic switch for both Preview and Production git deployments. Running `pnpm db:migrate` in the Vercel Build Command uses the environment-scoped `DATABASE_URL` that Vercel injects for the build, applies migrations to the same Neon branch the deployment will use, and fails the deployment closed before the new build can serve traffic if migration fails. The mechanism works in the Vercel build because `drizzle-kit` is installed for the build and `drizzle.config.ts` loads env files with `override: false`, so Vercel's injected environment-scoped `DATABASE_URL` wins over local file fallbacks. GitHub Actions cannot currently provide that ordering because the existing `deploy` job does not trigger or block Vercel's git integration.
 
-Whichever is chosen:
-- **Never `drizzle-kit push`** in any environment — migration files only, recorded in `drizzle.__drizzle_migrations`.
-- Migrations must run with an **explicit, host-verified `DATABASE_URL`** per environment, never implicit `.env.local` resolution for prod.
-- Keep migrations **forward-only and additive** where possible; use expand/contract for destructive changes so code and schema can deploy independently.
+Required implementation constraints:
+
+1. Use the Vercel-scoped `DATABASE_URL` for the build target. **Verified 2026-06-16** by a value-free Vercel host comparison (booleans only; no connection strings or hostnames recorded): the **Production** `DATABASE_URL` host is distinct from **Preview** and **Development**, and Preview and Development share one non-production host. A Preview or Development build therefore migrates the shared non-production (Neon `dev`) database, never production — the catastrophic failure mode (a Preview build resolving to the production database) is ruled out. Re-run the same value-free host comparison if Vercel env scoping or the Neon integration is ever reconfigured.
+2. Never use `drizzle-kit push` in any environment. Use checked-in migration files only.
+3. Treat migrations as forward-only. Additive migrations are the norm; destructive changes must use expand/contract so the currently served deployment remains compatible if the migration succeeds but a later build step fails.
+4. Rely on Drizzle's migration ledger for idempotency. Re-runs must be no-ops when `drizzle.__drizzle_migrations.created_at` already contains the journal `entries[].when` values.
+5. Accept the concurrency caveat explicitly: all Preview builds use the shared Neon `dev` branch, so every Preview build can attempt the same pending migration; two quick `main` merges can also run two Production builds against Neon `main`. Recorded migrations prevent normal double-apply on rerun, but there is no repo-verified global lock across concurrent Preview or Production builds. This is acceptable only with the forward-only/additive and idempotent rules above.
+6. Keep the protected-main flow intact: PR → required `test` check → merge to `main` → Vercel Production build runs migration, then build.
+
+### Floor Fallback
+
+If the Build Command migration cannot be enabled immediately, the minimum acceptable fallback is a **required deploy-target drift gate** that reuses the DEBT-391 helper primitive:
+
+- Read expected migrations from `db/migrations/meta/_journal.json`.
+- Query the target database's `drizzle.__drizzle_migrations.created_at`.
+- Use `computeMissingMigrations()` and `formatSchemaDriftMessage()` from `tests/e2e/helpers/credential-health-check.ts` rather than writing a second comparison.
+- Fail closed when any journal `entries[].when` value is missing from the target ledger.
+- Print only missing migration tags and remediation text; never print `DATABASE_URL`, hostnames, passwords, Drizzle hashes, or provider identifiers.
+
+This floor detects drift but does not apply migrations. It is a stopgap until the Vercel Build Command migration exists, not the final fix.
+
+### Rejected Alternatives
+
+- **GitHub Actions `deploy` job migration as the primary fix.** Rejected because Vercel's git integration deploys independently on `main` pushes. The current GitHub `deploy` job cannot order a migration before Vercel serves traffic, and adding deploy DB secrets to GitHub would increase secret surface without solving Preview/Production ordering.
+- **Drift gate as the primary fix.** Rejected because it only detects pending migrations. It still leaves a human to apply them and would preserve the exact manual step that caused BUG-240. It is acceptable only as the floor fallback above.
+- **PR-template checkbox / CI annotation as the floor.** Rejected as the enforcement floor because no PR template exists today, a checkbox does not inspect the target database, and human attestation is the weakest control for a step already known to be skipped. A template may be added later as supplemental release hygiene, but it cannot close BUG-241.
+- **Keep the manual runbook only.** Rejected because the current runbook already existed when BUG-240 occurred.
 
 ## Verification
 
-- [ ] A deliberately-added test migration on a throwaway branch is *not* deployable to a target environment without the migration being applied (the gate fails closed), OR the release-phase step applies it automatically and records it.
-- [ ] Re-running the chosen mechanism is idempotent (no error when migrations are already applied).
-- [ ] `docs/dev/` documents the mechanism and the manual fallback (host-verified explicit `DATABASE_URL`, never `push`).
-- [x] [BUG-240](../_archive/bugs/bug-240-question-feedback-migrations-not-applied-to-dev-prod.md) remediation (dev + prod migrated) is complete so the live regression is closed independently of this gate.
+- [x] Vercel Project Build Command is set to `pnpm db:migrate && pnpm build` for git-triggered Preview and Production builds (set as `buildCommand` in `vercel.json`; live on Preview immediately, on Production when merged to `main`).
+- [x] Redacted provider audit confirms `DATABASE_URL` is present in Production, Preview, and Development scopes (verified 2026-06-16); a value-free host comparison confirmed Production is isolated from the shared Preview/Development non-production host, with no connection strings or hostnames recorded.
+- [ ] A throwaway additive migration on a test branch is not servable before migration: the Preview build either applies and records it before `pnpm build`, or fails closed before the deployment reaches READY.
+- [ ] Re-running the same Vercel build or redeploy is idempotent: Drizzle sees the matching `drizzle.__drizzle_migrations.created_at` values and does not re-apply already-recorded migrations.
+- [ ] A deliberately invalid migration fails the Vercel build before the new deployment serves traffic.
+- [ ] The floor drift gate, if implemented before the Build Command change, reports missing tags by comparing `db/migrations/meta/_journal.json` `entries[].when` to `drizzle.__drizzle_migrations.created_at` without logging secrets or hostnames.
+- [x] `docs/dev/deployment-procedure.md` and `docs/dev/deployment-environments.md` consistently state the Vercel Build Command migration is the deploy contract, with `pnpm db:seed` and any out-of-band migration remaining the documented manual fallback.
+- [x] [BUG-240](../_archive/bugs/bug-240-question-feedback-migrations-not-applied-to-dev-prod.md) remediation is complete so the live regression is closed independently of this gate.
 
 ## Surfaces Confirmed
 
-- The migration **files** themselves are correct and apply cleanly (CI proves this against its ephemeral DB). The gap is strictly *where* `db:migrate` is (not) run, not *what* it would do.
-- This is an infra/process bug, not an application code bug; no `src/**` change is required to close it.
+- Migration files exist under `db/migrations/`, and the repo journal is `db/migrations/meta/_journal.json`.
+- CI applies the current migration journal to a throwaway Postgres service.
+- The migration-ledger comparison primitive shipped with resolved [DEBT-391](../_archive/debt/debt-391-local-e2e-schema-drift-preflight.md).
+- This remains an infra/process bug. No `src/**` change is required to specify the fix.
+
+## Operator-Must-Verify Facts
+
+- **Resolved 2026-06-16** (was a hard precondition before implementation): a value-free Vercel host comparison confirmed the Production `DATABASE_URL` host is distinct from Preview/Development and that Preview and Development share one non-production host, so production is isolated from preview/development builds. The literal Neon branch *names* (`main` for production, `dev` for the shared non-production branch) are confirmable in the Neon/Vercel dashboards but are not safety-critical given the verified isolation. Re-verify with the same value-free comparison if Vercel/Neon scoping is reconfigured.
+- Whether Preview Deployment Protection beyond Git fork protection is enabled. The available redacted Vercel protection metadata exposed Git fork protection, but not a clear Preview Standard Protection boolean.

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -1,7 +1,7 @@
 # Bug Reports
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-06-14 (AUDIT-012 BUG-248 and BUG-249 resolved + archived — the `main-protection` ruleset is active and Dependabot vulnerability alerts + automated security fixes are enabled; the only active bug is now BUG-241. Prior: AUDIT-012 filed BUG-248/249 on 2026-06-13; BUG-247 resolved + archived via PR #424.)
+**Last Updated:** 2026-06-16 (BUG-241 entry citations refreshed, including deploy job `ci.yml:206-212` → `ci.yml:218-224`, and the accepted fix recorded as Vercel Build Command release-phase migration with a DEBT-391-style drift-gate floor. Prior: AUDIT-012 BUG-248 and BUG-249 resolved + archived — the `main-protection` ruleset is active and Dependabot vulnerability alerts + automated security fixes are enabled; the only active bug is now BUG-241.)
 
 ---
 
@@ -34,7 +34,7 @@ Bug reports document issues discovered in the codebase along with their root cau
 - BUG-240 verified fixed and archived: migrations `0019_illegal_warbound` and `0020_fat_ironclad` were applied to the deployed dev/preview and production DBs with `DATABASE_URL=<env> pnpm db:migrate`; read-only verification confirms the `question_feedback` table, all 3 enums, 7 indexes, and migration head `0020`. PR #391 merged with green CI/CodeRabbit, and dev/main are aligned at `704eabbf`.
 
 **Manual report (2026-06-03) — deploy migration enforcement gap remains open:**
-- BUG-241 filed (P2): systemic cause — the deploy pipeline has no migration step. CI migrates only its throwaway DB (`ci.yml:37,106`); the `deploy` job only `echo`s (`ci.yml:206-212`); Vercel build runs `next build` with no `db:migrate`. So every schema-bearing PR can ship code referencing tables that don't exist in dev/prod with fully green CI. BUG-240 was the first outage from this gap.
+- BUG-241 filed (P2): systemic cause — the deploy pipeline had no migration step. CI migrates only its throwaway DB (`ci.yml:37,106`); the `deploy` job is a no-op placeholder (`ci.yml:218-224`); before this PR's `vercel.json` `buildCommand`, Vercel fell back to `package.json` `build=next build` with no `db:migrate`. So every schema-bearing PR could ship code referencing tables that did not exist in the deployed Preview/Development or Production database with fully green CI. BUG-240 was the first outage from this gap; the accepted fix is Vercel Build Command release-phase migration with a DEBT-391-style drift-gate floor.
 
 **Latest archival (2026-04-25) — BUG-238 active-exam draft timing bound:**
 - BUG-238 verified fixed (PR #287, merged dev `ee1f801e`): `saveExamDraftAnswer` now rejects oversized `cumulativeMs` at the controller boundary, clamps non-controller use-case calls, and caps legacy oversized drafts during exam finalization. Archived to `docs/_archive/bugs/`.
@@ -153,7 +153,7 @@ Bug reports document issues discovered in the codebase along with their root cau
 
 | Bug | Family | Priority | Summary |
 |-----|--------|----------|---------|
-| [BUG-241](./bug-241-deploy-pipeline-has-no-migration-step.md) | CI/CD / deploy / migrations | P2 | Deploy pipeline has no migration step — schema PRs ship code without applying migrations to dev/prod, with green CI (CI migrates only its throwaway DB). Systemic cause of BUG-240; will recur for every future migration without a gate. |
+| [BUG-241](./bug-241-deploy-pipeline-has-no-migration-step.md) | CI/CD / deploy / migrations | P2 | Deploy pipeline has no migration step — schema PRs ship code without applying migrations to deployed Preview/Development or Production databases, with green CI (CI migrates only its throwaway DB). Systemic cause of BUG-240; will recur for every future migration without a gate. |
 
 ## Audit #21 — Stripe/Billing Deep Sweep (2026-06-11)
 
@@ -257,9 +257,9 @@ Focused follow-up sweep across mutation-oriented form actions and the interactiv
 
 | Bug | Family | Priority | Summary |
 |-----|--------|----------|---------|
-| [BUG-231](./bug-231-remove-bookmark-action-missing-idempotency.md) | Bookmarks / server actions | P4 | Remove-bookmark form posts are not replay-safe and can toggle the bookmark back on under duplicate submit |
-| [BUG-232](./bug-232-manage-billing-actions-drop-portal-idempotency.md) | Billing / server actions / Stripe | P4 | Manage Billing UI entry points still cannot reach the controller's portal-session idempotency path |
-| [BUG-233](./bug-233-practice-session-start-stale-response-after-config-change.md) | Practice / client async state | P3 | Session-start requests can still commit stale navigation or stale error state after visible configuration changes |
+| [BUG-231](../_archive/bugs/bug-231-remove-bookmark-action-missing-idempotency.md) | Bookmarks / server actions | P4 | Remove-bookmark form posts are not replay-safe and can toggle the bookmark back on under duplicate submit |
+| [BUG-232](../_archive/bugs/bug-232-manage-billing-actions-drop-portal-idempotency.md) | Billing / server actions / Stripe | P4 | Manage Billing UI entry points still cannot reach the controller's portal-session idempotency path |
+| [BUG-233](../_archive/bugs/bug-233-practice-session-start-stale-response-after-config-change.md) | Practice / client async state | P3 | Session-start requests can still commit stale navigation or stale error state after visible configuration changes |
 
 **Surfaces confirmed clean:**
 - Pricing checkout forms already emit an `IdempotencyKeyField` and forward it through `subscribeMonthlyAction` / `subscribeAnnualAction`.

--- a/docs/dev/deployment-environments.md
+++ b/docs/dev/deployment-environments.md
@@ -1,6 +1,6 @@
 # Deployment Environments: Source of Truth
 
-**Last Reviewed (code/docs):** 2026-06-12
+**Last Reviewed (code/docs):** 2026-06-16
 
 This document is the repo-backed source of truth for environment scoping and the operator checklist around Clerk, Stripe, Postgres/Neon, and Vercel.
 
@@ -30,7 +30,13 @@ The current Vercel + Neon setup uses one Neon project with isolated database bra
 - Vercel **Preview** and **Development** target the Neon `dev` branch.
 - Local `.env.local` should be pulled from or kept equivalent to the Vercel Development environment for local app runtime. Normal authenticated local E2E uses the resolver-scoped Docker database; use `E2E_USE_EXISTING_DATABASE=true` only for deliberate deploy-target E2E checks.
 
+Redacted Vercel metadata checked on 2026-06-16 confirms a `DATABASE_URL` entry exists in Production, Preview, and Development scopes, with no git-branch-specific override observed. A value-free host comparison on 2026-06-16 (each scope's `DATABASE_URL` pulled to a temp directory outside the repo, compared by host, booleans only — no connection strings or hostnames recorded) confirmed that the **Production** host is distinct from both **Preview** and **Development**, and that **Preview** and **Development** resolve to the **same** non-production host. This matches the contract above: production is isolated from the shared non-production database. The literal Neon branch *names* behind each value are confirmable in the Neon/Vercel dashboards; the safety-critical isolation is verified in-repo here without recording any secret.
+
 Do not hard-code branch hostnames, account ids, passwords, or connection strings in the repo. Verify those values through the Vercel Storage dashboard, Vercel environment variables, or a local redacted host check before running migrations.
+
+### Deploy Migration Contract
+
+[BUG-241](../bugs/bug-241-deploy-pipeline-has-no-migration-step.md) is fixed: the Vercel Build Command (`buildCommand` in `vercel.json`) runs `pnpm db:migrate && pnpm build`, so checked-in Drizzle migrations apply to the environment-scoped `DATABASE_URL` before a deployment can serve. This is live on Preview/Development builds immediately and on Production once the change is on `main`. A failed migration fails the build closed, leaving the current deployment serving. Schema migrations are therefore no longer a manual operator step; `pnpm db:seed` (content) remains manual.
 
 ---
 
@@ -137,8 +143,9 @@ When code references a newly added column but the target database has not had `p
 
 - Inspect Vercel function logs or local server logs.
 - Look for the real Postgres error behind the generic controller error handling.
+- Compare the repo migration journal to the target DB ledger. Reuse the DEBT-391 primitive: `db/migrations/meta/_journal.json` `entries[].when` must be present in `drizzle.__drizzle_migrations.created_at`.
 
-**Fix**
+**Fix (manual fallback — the Vercel Build Command now applies deploy migrations automatically)**
 
 Run migrations against the exact database backing the failing environment:
 
@@ -168,6 +175,10 @@ E2E_USE_EXISTING_DATABASE=true DATABASE_URL="$LOCAL_E2E_DATABASE_URL" pnpm test:
 
 Do not run migrations by relying on implicit `.env.local` resolution. Every database mutation should pass an explicit `DATABASE_URL` for the intended target.
 
+**Prevention**
+
+The Vercel Build Command runs `pnpm db:migrate && pnpm build` for git-triggered Preview and Production builds (set in `vercel.json`), so a deployment cannot serve against a database that is behind the repo migration journal. Keep migrations forward-only and additive where possible; use expand/contract for destructive changes.
+
 Historical example: PR #169 added `claimed_at` to `idempotency_keys`; the code deployed before the non-production database was migrated, which broke write paths until `pnpm db:migrate` was run.
 
 Historical example: SPEC-040 added `attempts.is_omitted` plus two CHECK constraints in migrations `0017` and `0018`; deploy-target E2E answer-submission flows failed with "Failed to insert attempt" until the Neon `dev` branch was migrated.
@@ -189,7 +200,7 @@ When changing environment configuration, verify all of the following:
 3. Production and non-production databases are isolated.
 4. `NEXT_PUBLIC_APP_URL` matches the environment actually serving the app.
 5. Preview webhook targets are publicly reachable.
-6. Any schema change is followed by `pnpm db:migrate` on the target database.
+6. Any schema change is applied by the Vercel Build Command migration on deploy; verify the build ran the migration for the target deployment before it serves (the build fails closed otherwise).
 7. Any content change that affects seeded data is followed by `pnpm db:seed` on the target database.
 8. Auth and payment flows have been smoke-tested on the target environment after changes.
 

--- a/docs/dev/deployment-procedure.md
+++ b/docs/dev/deployment-procedure.md
@@ -1,19 +1,26 @@
 # Deployment Procedure
 
 > **Parent:** [Deployment Environments](./deployment-environments.md)
-> **Last Updated:** 2026-05-23
+> **Last Updated:** 2026-06-16
 
 ---
 
-## 1. Key Fact: Vercel Does Not Run Migrations or Seeds
+## 1. Migration Contract: Build-Command Migration
 
-Vercel deploys **code only**. It does not automatically:
+[BUG-241](../bugs/bug-241-deploy-pipeline-has-no-migration-step.md) is fixed. The Vercel Build Command is set in `vercel.json` (`buildCommand`) to run:
 
-- Run `pnpm db:migrate` (schema changes)
-- Run `pnpm db:seed` (content data)
-- Execute any SQL scripts
+```bash
+pnpm db:migrate && pnpm build
+```
 
-These are always manual operator steps, run from a local machine with the appropriate `DATABASE_URL`.
+so Vercel applies checked-in Drizzle migrations to the environment-scoped `DATABASE_URL` before a deployment can serve. This is live on Preview/Development builds immediately and on Production once the change is on `main`. A failed migration fails the build closed, so the currently-serving deployment stays up.
+
+Vercel still does **not** automatically run:
+
+- `pnpm db:seed` (content data) — seeds remain a manual operator step
+- Any other SQL script
+
+For seeds, and for any manual deploy-target migration fallback, use an explicit, host-verified `DATABASE_URL`.
 
 ---
 
@@ -33,16 +40,16 @@ These are always manual operator steps, run from a local machine with the approp
    └─ Must pass before merge
 
 2. Vercel (automatic on push/merge)
-   └─ Builds and deploys the application code
+   └─ buildCommand (vercel.json): pnpm db:migrate && pnpm build
    └─ Preview: any non-main branch
    └─ Production: main branch
 
-3. Operator (manual, post-deploy)
-   └─ DATABASE_URL="<target>" pnpm db:migrate   # if schema changed
-   └─ DATABASE_URL="<target>" pnpm db:seed      # if content changed
+3. Operator
+   └─ Verify the Vercel build ran the migration before serving; manual migrate only as fallback
+   └─ DATABASE_URL="<target>" pnpm db:seed                                    # if content changed
 ```
 
-**Important:** CI never migrates or seeds the actual Preview/Production database used by Vercel. It only validates migrations and seed logic against the CI database. Target-environment migrations and reseeds are still manual operator steps.
+**Important:** CI never migrates or seeds the actual Preview/Production database used by Vercel. It only validates migrations and seed logic against the CI database. Target-environment schema migration runs via the Vercel Build Command (`pnpm db:migrate && pnpm build`); reseeding remains a manual operator step.
 
 ---
 
@@ -88,7 +95,7 @@ If you are using Neon, fetch the connection string for the intended branch first
 
 **Caution:** Always double-check which database/branch you're targeting. Running migrations or seeds against the wrong environment can corrupt data. Production operations should be done deliberately and verified immediately.
 
-**Optional helper:** `pnpm db:seed:all -- --plan` pulls Vercel Development, Preview, and Production env files into a temp directory, compares them with local `.env.local`, and shows the unique seed targets without writing data. `pnpm db:seed:all` then imports drafts as published and seeds each unique `DATABASE_URL` once. It does **not** run migrations; keep using `pnpm db:migrate` separately when schema changes are involved.
+**Optional helper:** `pnpm db:seed:all -- --plan` pulls Vercel Development, Preview, and Production env files into a temp directory, compares them with local `.env.local`, and shows the unique seed targets without writing data. `pnpm db:seed:all` then imports drafts as published and seeds each unique `DATABASE_URL` once. It does **not** run migrations; deploy-time schema changes are handled by the Vercel Build Command migration. Use `pnpm db:migrate` manually only for an out-of-band or fallback migration against an explicit `DATABASE_URL`.
 
 Normal local authenticated E2E uses the resolver-scoped Docker database and runs migrations automatically through `pnpm test:e2e`. For an intentional deploy-target E2E check, confirm the host without printing credentials, migrate that target deliberately, then run the suite with `E2E_USE_EXISTING_DATABASE=true`:
 
@@ -118,7 +125,7 @@ Before merging to `main` (production deploy):
 - [ ] `pnpm test:e2e` passes when local auth/billing env is available (CI enforces this on pushes and same-repo PRs)
 - [ ] CodeRabbit review completed and feedback addressed
 - [ ] If schema changed: migration tested on local + preview DB first
-- [ ] If schema changed: `pnpm db:migrate` run against the target deployed database **immediately after deploy** (forgetting this causes silent write failures — see [Known Gotchas](./deployment-environments.md#missing-database-migration-causes-silent-write-failures))
+- [ ] If schema changed: confirm the Vercel build ran the Build Command migration (`pnpm db:migrate`) before `pnpm build` — the deploy fails closed otherwise, so a READY deployment means the migration applied (see [Known Gotchas](./deployment-environments.md#missing-database-migration-causes-silent-write-failures))
 - [ ] If content changed: seed tested on local + preview DB first
 
 ---

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm db:migrate && pnpm build",
   "crons": [
     {
       "path": "/api/cron/reconcile-stripe-subscriptions?dryRun=false",


### PR DESCRIPTION
Sync `main` to `dev`. Carries the BUG-241 fix already reviewed and merged via #453: `vercel.json` `buildCommand` = `pnpm db:migrate && pnpm build` (every Vercel deploy applies Drizzle migrations to its scoped Neon branch before serving, fail-closed), plus the reconciled deployment runbooks and the value-free Neon-isolation verification.

Identical diff was CodeRabbit-APPROVED on #453 (0 actionable). Mechanism proven on the #453 preview build (migrations applied successfully before next build). Merging to `main` activates auto-migration on the Production deploy against Neon `main` (no-op today — prod is at migration head 0020 — and fail-closed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment pipeline to automatically execute database migrations during the build phase, ensuring schema changes are applied before reaching production or preview environments.

* **Documentation**
  * Updated deployment documentation to reflect automatic migration execution during builds, including updated operator verification procedures and deployment environment clarifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->