### PR TITLE
Promote dev→main: resolve BUG-250 (CSV formula injection in feedback export)

### DIFF
--- a/docs/_archive/bugs/bug-250-question-feedback-csv-formula-injection.md
+++ b/docs/_archive/bugs/bug-250-question-feedback-csv-formula-injection.md
@@ -39,8 +39,8 @@ This is not a web XSS bug and does not affect the default export. It requires an
 
 The export script makes comment export an explicit supported mode:
 
-- [`package.json`](../../package.json#L28): `"export:feedback": "tsx scripts/export-question-feedback.ts"`
-- [`docs/dev/question-feedback-analytics.md`](../dev/question-feedback-analytics.md#L17): `pnpm --silent export:feedback -- --include-comments > question-feedback-comments.csv`
+- [`package.json`](../../../package.json#L28): `"export:feedback": "tsx scripts/export-question-feedback.ts"`
+- [`docs/dev/question-feedback-analytics.md`](../../dev/question-feedback-analytics.md#L17): `pnpm --silent export:feedback -- --include-comments > question-feedback-comments.csv`
 
 The script copies the persisted subscriber comment into the record when `--include-comments` is set:
 
@@ -50,7 +50,7 @@ if (options.includeComments) {
 }
 ```
 
-Location: [`scripts/export-question-feedback.ts`](../../scripts/export-question-feedback.ts#L232)
+Location: [`scripts/export-question-feedback.ts`](../../../scripts/export-question-feedback.ts#L232)
 
 The CSV writer only escapes CSV delimiters, not spreadsheet formula prefixes:
 
@@ -62,7 +62,7 @@ function csvCell(value: string | null): string {
 }
 ```
 
-Location: [`scripts/export-question-feedback.ts`](../../scripts/export-question-feedback.ts#L294)
+Location: [`scripts/export-question-feedback.ts`](../../../scripts/export-question-feedback.ts#L294)
 
 Because the payload contains double quotes, `csvCell` wraps and doubles quotes. After CSV parsing, the cell value still begins with `=`, so spreadsheet software treats it as a formula rather than inert text.
 
@@ -70,9 +70,9 @@ The vector does not even require the quoting path: `csvCell`'s guard only matche
 
 The comment input is bounded but intentionally free text:
 
-- Client textarea: [`components/question/question-report-dialog.tsx`](../../components/question/question-report-dialog.tsx#L145) sets `maxLength={MAX_QUESTION_FEEDBACK_COMMENT_LENGTH}`.
-- Server action: [`src/adapters/controllers/question-feedback-controller.ts`](../../src/adapters/controllers/question-feedback-controller.ts#L40) trims and caps comments with `.max(MAX_QUESTION_FEEDBACK_COMMENT_LENGTH)`.
-- Database: [`db/schema.ts`](../../db/schema.ts#L603) enforces `char_length(comment) <= 2000`.
+- Client textarea: [`components/question/question-report-dialog.tsx`](../../../components/question/question-report-dialog.tsx#L145) sets `maxLength={MAX_QUESTION_FEEDBACK_COMMENT_LENGTH}`.
+- Server action: [`src/adapters/controllers/question-feedback-controller.ts`](../../../src/adapters/controllers/question-feedback-controller.ts#L40) trims and caps comments with `.max(MAX_QUESTION_FEEDBACK_COMMENT_LENGTH)`.
+- Database: [`db/schema.ts`](../../../db/schema.ts#L603) enforces `char_length(comment) <= 2000`.
 
 Those bounds prevent storage DoS, but they do not change the first character of the exported CSV cell.
 
@@ -115,5 +115,5 @@ Implemented in fix commit `Fix BUG-250: neutralize CSV formula injection in feed
 
 ## Related Clean Surfaces
 
-- Markdown rendering remains clean: [`components/markdown/markdown.tsx`](../../components/markdown/markdown.tsx#L71) uses `ReactMarkdown` with `rehypeSanitize` and `skipHtml`.
+- Markdown rendering remains clean: [`components/markdown/markdown.tsx`](../../../components/markdown/markdown.tsx#L71) uses `ReactMarkdown` with `rehypeSanitize` and `skipHtml`.
 - Stored report comments are not rendered in the first-party web UI; they are submitted, stored, and exported for editorial analysis.

--- a/docs/bugs/bug-250-question-feedback-csv-formula-injection.md
+++ b/docs/bugs/bug-250-question-feedback-csv-formula-injection.md
@@ -1,16 +1,17 @@
 # BUG-250: Feedback Comment CSV Export Allows Spreadsheet Formula Injection
 
-**Status:** Resolved
+**Status:** Open
 **Priority:** P3
 **Date:** 2026-06-17
 **Confirmed:** 2026-06-17
 **Component:** Question Feedback / Ops Export / Output Encoding
+**Resolution State:** Fixed on `dev` in commit `b98306a6`; pending PR #460 promotion to `main`, post-merge verification, and archival.
 
 ---
 
 ## Description
 
-Subscriber-controlled question report comments can be exported into a CSV cell that begins with a spreadsheet formula prefix. CSV quoting protects delimiters, but it does not neutralize formulas after a spreadsheet parses the cell. An editorial operator who follows the documented `--include-comments` CSV workflow can therefore open an exported comment as an executable spreadsheet formula.
+Subscriber-controlled question report comments can be exported into a CSV cell that begins with a spreadsheet formula prefix on branches that do not include the `b98306a6` fix. CSV quoting protects delimiters, but it does not neutralize formulas after a spreadsheet parses the cell. An editorial operator who follows the documented `--include-comments` CSV workflow can therefore open an exported comment as an executable spreadsheet formula.
 
 This is not a web XSS bug and does not affect the default export. It requires an operator to opt into comment export and open the resulting CSV in spreadsheet software, so the severity is P3.
 
@@ -39,8 +40,8 @@ This is not a web XSS bug and does not affect the default export. It requires an
 
 The export script makes comment export an explicit supported mode:
 
-- [`package.json`](../../../package.json#L28): `"export:feedback": "tsx scripts/export-question-feedback.ts"`
-- [`docs/dev/question-feedback-analytics.md`](../../dev/question-feedback-analytics.md#L17): `pnpm --silent export:feedback -- --include-comments > question-feedback-comments.csv`
+- [`package.json`](../../package.json#L28): `"export:feedback": "tsx scripts/export-question-feedback.ts"`
+- [`docs/dev/question-feedback-analytics.md`](../dev/question-feedback-analytics.md#L17): `pnpm --silent export:feedback -- --include-comments > question-feedback-comments.csv`
 
 The script copies the persisted subscriber comment into the record when `--include-comments` is set:
 
@@ -50,9 +51,9 @@ if (options.includeComments) {
 }
 ```
 
-Location: [`scripts/export-question-feedback.ts`](../../../scripts/export-question-feedback.ts#L232)
+Location: [`scripts/export-question-feedback.ts`](../../scripts/export-question-feedback.ts#L235)
 
-The CSV writer only escapes CSV delimiters, not spreadsheet formula prefixes:
+Before the `b98306a6` fix, the CSV writer only escaped CSV delimiters, not spreadsheet formula prefixes:
 
 ```ts
 function csvCell(value: string | null): string {
@@ -62,19 +63,19 @@ function csvCell(value: string | null): string {
 }
 ```
 
-Location: [`scripts/export-question-feedback.ts`](../../../scripts/export-question-feedback.ts#L294)
+The current `dev` implementation fixes the same [`csvCell` boundary](../../scripts/export-question-feedback.ts#L297) by neutralizing before delimiter quoting.
 
-Because the payload contains double quotes, `csvCell` wraps and doubles quotes. After CSV parsing, the cell value still begins with `=`, so spreadsheet software treats it as a formula rather than inert text.
+In the vulnerable version, because the payload contained double quotes, `csvCell` wrapped and doubled quotes. After CSV parsing, the cell value still began with `=`, so spreadsheet software treated it as a formula rather than inert text.
 
-The vector does not even require the quoting path: `csvCell`'s guard only matches `/[",\n\r]/`, so a quote/comma/newline-free payload such as `=1+1` (or one led by `+`, `-`, `@`, tab, CR, or LF) is emitted **verbatim and unquoted** and is still parsed as a formula. Every column is serialized through `csvCell` (`values.map(csvCell)`), so the neutralization fix below must apply to all cells, not only `comment` — though `comment` is the only subscriber-controlled free-text column today (the others are UUIDs, enums, ISO dates, or the admin-authored `question_slug`).
+The vector did not even require the quoting path: `csvCell`'s guard only matched `/[",\n\r]/`, so a quote/comma/newline-free payload such as `=1+1` (or one led by `+`, `-`, `@`, tab, CR, or LF) was emitted **verbatim and unquoted** and was still parsed as a formula. Every column is serialized through `csvCell` (`values.map(csvCell)`), so the neutralization fix below must apply to all cells, not only `comment` — though `comment` is the only subscriber-controlled free-text column today (the others are UUIDs, enums, ISO dates, or the admin-authored `question_slug`).
 
 The comment input is bounded but intentionally free text:
 
-- Client textarea: [`components/question/question-report-dialog.tsx`](../../../components/question/question-report-dialog.tsx#L145) sets `maxLength={MAX_QUESTION_FEEDBACK_COMMENT_LENGTH}`.
-- Server action: [`src/adapters/controllers/question-feedback-controller.ts`](../../../src/adapters/controllers/question-feedback-controller.ts#L40) trims and caps comments with `.max(MAX_QUESTION_FEEDBACK_COMMENT_LENGTH)`.
-- Database: [`db/schema.ts`](../../../db/schema.ts#L603) enforces `char_length(comment) <= 2000`.
+- Client textarea: [`components/question/question-report-dialog.tsx`](../../components/question/question-report-dialog.tsx#L145) sets `maxLength={MAX_QUESTION_FEEDBACK_COMMENT_LENGTH}`.
+- Server action: [`src/adapters/controllers/question-feedback-controller.ts`](../../src/adapters/controllers/question-feedback-controller.ts#L40) trims and caps comments with `.max(MAX_QUESTION_FEEDBACK_COMMENT_LENGTH)`.
+- Database: [`db/schema.ts`](../../db/schema.ts#L603) enforces `char_length(comment) <= 2000`.
 
-Those bounds prevent storage DoS, but they do not change the first character of the exported CSV cell.
+Those bounds prevent storage DoS, but they do not neutralize formula-capable text at input or storage time.
 
 ## Impact
 
@@ -94,9 +95,9 @@ Minimal fix:
 
 Do not remove `--include-comments`; the workflow is legitimate. The bug is output encoding for the CSV format.
 
-## Resolution
+## Implementation State
 
-Implemented in fix commit `Fix BUG-250: neutralize CSV formula injection in feedback export`.
+Implemented on `dev` in commit `b98306a6` (`Fix BUG-250: neutralize CSV formula injection in feedback export`).
 
 `csvCell` now neutralizes spreadsheet-formula-capable values before CSV delimiter quoting, and the existing `values.map(csvCell)` serialization path applies that protection to every CSV column. The JSON export branch remains unchanged and continues to emit raw comment text.
 
@@ -112,8 +113,11 @@ Implemented in fix commit `Fix BUG-250: neutralize CSV formula injection in feed
 - [x] `pnpm lint` passed.
 - [x] `pnpm test --run` passed (350 files, 2859 tests).
 - [x] `pnpm build` passed.
+- [ ] PR #460 promoted the fix to `main`.
+- [ ] Post-merge verification completed.
+- [ ] Archived to `docs/_archive/bugs/` after verification.
 
 ## Related Clean Surfaces
 
-- Markdown rendering remains clean: [`components/markdown/markdown.tsx`](../../../components/markdown/markdown.tsx#L71) uses `ReactMarkdown` with `rehypeSanitize` and `skipHtml`.
+- Markdown rendering remains clean: [`components/markdown/markdown.tsx`](../../components/markdown/markdown.tsx#L71) uses `ReactMarkdown` with `rehypeSanitize` and `skipHtml`.
 - Stored report comments are not rendered in the first-party web UI; they are submitted, stored, and exported for editorial analysis.

--- a/docs/bugs/bug-250-question-feedback-csv-formula-injection.md
+++ b/docs/bugs/bug-250-question-feedback-csv-formula-injection.md
@@ -1,0 +1,106 @@
+# BUG-250: Feedback Comment CSV Export Allows Spreadsheet Formula Injection
+
+**Status:** Open
+**Priority:** P3
+**Date:** 2026-06-17
+**Confirmed:** 2026-06-17
+**Component:** Question Feedback / Ops Export / Output Encoding
+
+---
+
+## Description
+
+Subscriber-controlled question report comments can be exported into a CSV cell that begins with a spreadsheet formula prefix. CSV quoting protects delimiters, but it does not neutralize formulas after a spreadsheet parses the cell. An editorial operator who follows the documented `--include-comments` CSV workflow can therefore open an exported comment as an executable spreadsheet formula.
+
+This is not a web XSS bug and does not affect the default export. It requires an operator to opt into comment export and open the resulting CSV in spreadsheet software, so the severity is P3.
+
+## Trigger / Repro
+
+1. As any subscribed user with access to question feedback, submit a question report with a comment such as:
+
+   ```text
+   =HYPERLINK("https://example.invalid","click")
+   ```
+
+2. An operator follows the documented comment-export workflow:
+
+   ```bash
+   DATABASE_URL="$TEST_DATABASE_URL" pnpm --silent export:feedback -- --include-comments > question-feedback-comments.csv
+   ```
+
+3. The generated CSV contains the formula as the first character of the `comment` cell:
+
+   ```csv
+   feedback_id,question_id,question_slug,attempt_id,practice_session_id,kind,rating,category,created_at,user_id,has_comment,comment
+   11111111-1111-4111-8111-111111111111,33333333-3333-4333-8333-333333333333,safe-question,,,report,,other,2026-06-17T00:00:00.000Z,[redacted],true,"=HYPERLINK(""https://example.invalid"",""click"")"
+   ```
+
+## Proof
+
+The export script makes comment export an explicit supported mode:
+
+- [`package.json`](../../package.json#L28): `"export:feedback": "tsx scripts/export-question-feedback.ts"`
+- [`docs/dev/question-feedback-analytics.md`](../dev/question-feedback-analytics.md#L17): `pnpm --silent export:feedback -- --include-comments > question-feedback-comments.csv`
+
+The script copies the persisted subscriber comment into the record when `--include-comments` is set:
+
+```ts
+if (options.includeComments) {
+  record.comment = row.comment;
+}
+```
+
+Location: [`scripts/export-question-feedback.ts`](../../scripts/export-question-feedback.ts#L232)
+
+The CSV writer only escapes CSV delimiters, not spreadsheet formula prefixes:
+
+```ts
+function csvCell(value: string | null): string {
+  if (value === null) return '';
+  if (!/[",\n\r]/.test(value)) return value;
+  return `"${value.replaceAll('"', '""')}"`;
+}
+```
+
+Location: [`scripts/export-question-feedback.ts`](../../scripts/export-question-feedback.ts#L294)
+
+Because the payload contains double quotes, `csvCell` wraps and doubles quotes. After CSV parsing, the cell value still begins with `=`, so spreadsheet software treats it as a formula rather than inert text.
+
+The vector does not even require the quoting path: `csvCell`'s guard only matches `/[",\n\r]/`, so a quote/comma/newline-free payload such as `=1+1` (or one led by `+`, `-`, `@`, tab, CR, or LF) is emitted **verbatim and unquoted** and is still parsed as a formula. Every column is serialized through `csvCell` (`values.map(csvCell)`), so the neutralization fix below must apply to all cells, not only `comment` — though `comment` is the only subscriber-controlled free-text column today (the others are UUIDs, enums, ISO dates, or the admin-authored `question_slug`).
+
+The comment input is bounded but intentionally free text:
+
+- Client textarea: [`components/question/question-report-dialog.tsx`](../../components/question/question-report-dialog.tsx#L145) sets `maxLength={MAX_QUESTION_FEEDBACK_COMMENT_LENGTH}`.
+- Server action: [`src/adapters/controllers/question-feedback-controller.ts`](../../src/adapters/controllers/question-feedback-controller.ts#L40) trims and caps comments with `.max(MAX_QUESTION_FEEDBACK_COMMENT_LENGTH)`.
+- Database: [`db/schema.ts`](../../db/schema.ts#L603) enforces `char_length(comment) <= 2000`.
+
+Those bounds prevent storage DoS, but they do not change the first character of the exported CSV cell.
+
+## Impact
+
+A malicious subscriber can plant a formula in a feedback report. If an editorial/admin operator exports comments as CSV and opens the file in a spreadsheet, the comment cell can execute as a spreadsheet formula. Depending on the spreadsheet product and operator interaction, formulas can create deceptive links or make outbound requests that expose adjacent exported data.
+
+Blast radius is limited to opted-in local editorial analysis exports; the default export excludes comments, JSON output is not a spreadsheet formula sink, and the first-party web UI does not render stored report comments.
+
+## Expected Fix
+
+Neutralize spreadsheet formulas before CSV serialization for every string cell, with coverage for comments specifically.
+
+Minimal fix:
+
+1. Add a helper before `csvCell` that prefixes an apostrophe to values whose raw first character is tab/CR/LF or whose first non-space/tab/CR/LF character is a spreadsheet formula prefix (`=`, `+`, `-`, `@`).
+2. Apply that helper before delimiter quoting, so a comment like `=HYPERLINK(...)` exports as a literal text cell.
+3. Add unit coverage in `scripts/export-question-feedback.test.ts` for `--include-comments` with formula-prefixed comments, quoted formulas, leading-whitespace bypass forms, and at least one non-formula value to preserve normal CSV output.
+
+Do not remove `--include-comments`; the workflow is legitimate. The bug is output encoding for the CSV format.
+
+## Verification
+
+- [x] Code-level tracer bullet verified on 2026-06-17.
+- [x] Formatter probe confirmed a formula-prefixed comment survives as the first character of the CSV cell.
+- [x] Existing focused audit suite passed: `pnpm test --run components/markdown/markdown.test.tsx src/adapters/controllers/question-feedback-controller.test.ts src/adapters/controllers/question-controller.test.ts src/adapters/controllers/question-view-controller.test.ts src/adapters/controllers/review-controller.test.ts proxy.test.ts app/(marketing)/checkout/success/page.test.ts app/(marketing)/checkout/success/checkout-success-assertions.test.ts app/pricing/subscribe-actions.test.ts app/pricing/manage-billing-action.test.ts app/(app)/app/billing/manage-billing-action.test.ts` (168 tests).
+
+## Related Clean Surfaces
+
+- Markdown rendering remains clean: [`components/markdown/markdown.tsx`](../../components/markdown/markdown.tsx#L71) uses `ReactMarkdown` with `rehypeSanitize` and `skipHtml`.
+- Stored report comments are not rendered in the first-party web UI; they are submitted, stored, and exported for editorial analysis.

--- a/docs/bugs/bug-250-question-feedback-csv-formula-injection.md
+++ b/docs/bugs/bug-250-question-feedback-csv-formula-injection.md
@@ -1,6 +1,6 @@
 # BUG-250: Feedback Comment CSV Export Allows Spreadsheet Formula Injection
 
-**Status:** Open
+**Status:** Resolved
 **Priority:** P3
 **Date:** 2026-06-17
 **Confirmed:** 2026-06-17
@@ -94,11 +94,24 @@ Minimal fix:
 
 Do not remove `--include-comments`; the workflow is legitimate. The bug is output encoding for the CSV format.
 
+## Resolution
+
+Implemented in fix commit `Fix BUG-250: neutralize CSV formula injection in feedback export`.
+
+`csvCell` now neutralizes spreadsheet-formula-capable values before CSV delimiter quoting, and the existing `values.map(csvCell)` serialization path applies that protection to every CSV column. The JSON export branch remains unchanged and continues to emit raw comment text.
+
 ## Verification
 
 - [x] Code-level tracer bullet verified on 2026-06-17.
 - [x] Formatter probe confirmed a formula-prefixed comment survives as the first character of the CSV cell.
 - [x] Existing focused audit suite passed: `pnpm test --run components/markdown/markdown.test.tsx src/adapters/controllers/question-feedback-controller.test.ts src/adapters/controllers/question-controller.test.ts src/adapters/controllers/question-view-controller.test.ts src/adapters/controllers/review-controller.test.ts proxy.test.ts app/(marketing)/checkout/success/page.test.ts app/(marketing)/checkout/success/checkout-success-assertions.test.ts app/pricing/subscribe-actions.test.ts app/pricing/manage-billing-action.test.ts app/(app)/app/billing/manage-billing-action.test.ts` (168 tests).
+- [x] Implemented fix in `scripts/export-question-feedback.ts`: CSV cells are neutralized before delimiter quoting; JSON exports are untouched.
+- [x] Added unit coverage in `scripts/export-question-feedback.test.ts` for bare formulas, quoted formulas, leading-whitespace/control bypasses, preservation/idempotency cases, all-column CSV coverage, JSON untouched behavior, and the BUG-250 `=HYPERLINK(...)` repro.
+- [x] `pnpm test --run scripts/export-question-feedback.test.ts` passed (19 tests).
+- [x] `pnpm typecheck` passed.
+- [x] `pnpm lint` passed.
+- [x] `pnpm test --run` passed (350 files, 2859 tests).
+- [x] `pnpm build` passed.
 
 ## Related Clean Surfaces
 

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -1,7 +1,7 @@
 # Bug Reports
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-06-16 (BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`. No active bugs remain. Prior: AUDIT-012 BUG-248 and BUG-249 resolved + archived — the `main-protection` ruleset is active and Dependabot vulnerability alerts + automated security fixes are enabled.)
+**Last Updated:** 2026-06-17 (BUG-250 filed — feedback comment CSV export allows spreadsheet formula injection when an operator opts into `--include-comments` and opens the CSV in spreadsheet software. Prior: BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`.)
 
 ---
 
@@ -13,7 +13,7 @@ Bug reports document issues discovered in the codebase along with their root cau
 2. **Regression Prevention** — Ensure we don't reintroduce the same bugs
 3. **Knowledge Base** — Help future developers understand past issues
 
-**Next Bug ID:** BUG-250
+**Next Bug ID:** BUG-251
 
 **Latest archival (2026-06-16) — BUG-241 resolved (deploy migration enforcement):**
 - BUG-241 (P2) verified fixed and archived to `docs/_archive/bugs/`. The fix adds `"buildCommand": "pnpm db:migrate && pnpm build"` to `vercel.json`, so every git-triggered Vercel deploy applies checked-in Drizzle migrations to its environment-scoped Neon branch before serving, failing the build closed on migration error. Merged via PR #453 (squash `ff46fbda` → `dev`) and promoted to `main` via PR #454 (merge `daed8479`); `main` and `dev` trees are identical. Verified live on real Vercel builds: the Preview deploy migrated Neon `dev` and the Production deploy migrated Neon `main`, each logging `[✓] migrations applied successfully!` before `next build`. Neon branch isolation (Production vs shared Preview/Development) was confirmed by a value-free host comparison. `pnpm db:seed` (content) remains a documented manual step. This was the last active bug; **no active bugs remain.**
@@ -154,7 +154,9 @@ Bug reports document issues discovered in the codebase along with their root cau
 
 ## Active Bugs
 
-_No active bugs._ BUG-241 — the last active bug — was resolved and archived on 2026-06-16 (see the archival note above and [docs/_archive/bugs/bug-241-deploy-pipeline-has-no-migration-step.md](../_archive/bugs/bug-241-deploy-pipeline-has-no-migration-step.md)).
+| ID | Title | Priority | Filed |
+|----|-------|----------|-------|
+| [BUG-250](./bug-250-question-feedback-csv-formula-injection.md) | Feedback Comment CSV Export Allows Spreadsheet Formula Injection | P3 | 2026-06-17 |
 
 ## Audit #21 — Stripe/Billing Deep Sweep (2026-06-11)
 

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -1,7 +1,7 @@
 # Bug Reports
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-06-17 (BUG-250 resolved + archived — `csvCell` in the feedback export now neutralizes spreadsheet-formula-capable cells before CSV quoting; fix `b98306a6` + doc `523ae02d` on `dev`, dev→main promotion PR open for CodeRabbit review. Prior: BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`.)
+**Last Updated:** 2026-06-17 (BUG-250 fixed on `dev` and pending `main` promotion verification — `csvCell` in the feedback export now neutralizes spreadsheet-formula-capable cells before CSV quoting; fix `b98306a6`, dev→main promotion PR #460 open. Prior: BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`.)
 
 ---
 
@@ -15,8 +15,8 @@ Bug reports document issues discovered in the codebase along with their root cau
 
 **Next Bug ID:** BUG-251
 
-**Latest archival (2026-06-17) — BUG-250 resolved (feedback CSV formula injection):**
-- BUG-250 (P3) verified fixed and archived to `docs/_archive/bugs/`. `csvCell` in `scripts/export-question-feedback.ts` now prefixes an apostrophe to spreadsheet-formula-capable cells (leading `=`/`+`/`-`/`@`, a raw leading tab/CR/LF, and leading-whitespace bypass forms) before delimiter quoting, and the existing `values.map(csvCell)` path applies it to every CSV column; the `--json` export path is untouched and still emits raw comment text. Fixed via TDD directly on `dev` (no feature branch): fix `b98306a6`, bug doc `523ae02d`. Full local gate green (typecheck, lint, unit 2859, build) and focused suite 19/19; owner-graded A. Promotion to `main` is via the dev→main promotion PR for this change (CodeRabbit review pending; not yet merged). This was the only active bug; **no active bugs remain.**
+**Latest active bug update (2026-06-17) — BUG-250 fixed on `dev`, pending promotion verification:**
+- BUG-250 (P3) is fixed on `dev` but remains active until PR #460 promotes the fix to `main` and post-merge verification is complete. `csvCell` in `scripts/export-question-feedback.ts` now prefixes an apostrophe to spreadsheet-formula-capable cells (leading `=`/`+`/`-`/`@`, a raw leading tab/CR/LF, and leading-whitespace bypass forms) before delimiter quoting, and the existing `values.map(csvCell)` path applies it to every CSV column; the `--json` export path is untouched and still emits raw comment text. Fixed via TDD directly on `dev` (no feature branch): fix `b98306a6`. Full local gate green (typecheck, lint, unit 2859, build) and focused suite 19/19; owner-graded A. BUG-250 is the only active bug.
 
 **Latest archival (2026-06-16) — BUG-241 resolved (deploy migration enforcement):**
 - BUG-241 (P2) verified fixed and archived to `docs/_archive/bugs/`. The fix adds `"buildCommand": "pnpm db:migrate && pnpm build"` to `vercel.json`, so every git-triggered Vercel deploy applies checked-in Drizzle migrations to its environment-scoped Neon branch before serving, failing the build closed on migration error. Merged via PR #453 (squash `ff46fbda` → `dev`) and promoted to `main` via PR #454 (merge `daed8479`); `main` and `dev` trees are identical. Verified live on real Vercel builds: the Preview deploy migrated Neon `dev` and the Production deploy migrated Neon `main`, each logging `[✓] migrations applied successfully!` before `next build`. Neon branch isolation (Production vs shared Preview/Development) was confirmed by a value-free host comparison. `pnpm db:seed` (content) remains a documented manual step. This was the last active bug; **no active bugs remain.**

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -1,7 +1,7 @@
 # Bug Reports
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-06-17 (BUG-250 filed — feedback comment CSV export allows spreadsheet formula injection when an operator opts into `--include-comments` and opens the CSV in spreadsheet software. Prior: BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`.)
+**Last Updated:** 2026-06-17 (BUG-250 resolved + archived — `csvCell` in the feedback export now neutralizes spreadsheet-formula-capable cells before CSV quoting; fix `b98306a6` + doc `523ae02d` on `dev`, dev→main promotion PR open for CodeRabbit review. Prior: BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`.)
 
 ---
 
@@ -14,6 +14,9 @@ Bug reports document issues discovered in the codebase along with their root cau
 3. **Knowledge Base** — Help future developers understand past issues
 
 **Next Bug ID:** BUG-251
+
+**Latest archival (2026-06-17) — BUG-250 resolved (feedback CSV formula injection):**
+- BUG-250 (P3) verified fixed and archived to `docs/_archive/bugs/`. `csvCell` in `scripts/export-question-feedback.ts` now prefixes an apostrophe to spreadsheet-formula-capable cells (leading `=`/`+`/`-`/`@`, a raw leading tab/CR/LF, and leading-whitespace bypass forms) before delimiter quoting, and the existing `values.map(csvCell)` path applies it to every CSV column; the `--json` export path is untouched and still emits raw comment text. Fixed via TDD directly on `dev` (no feature branch): fix `b98306a6`, bug doc `523ae02d`. Full local gate green (typecheck, lint, unit 2859, build) and focused suite 19/19; owner-graded A. Promotion to `main` is via the dev→main promotion PR for this change (CodeRabbit review pending; not yet merged). This was the only active bug; **no active bugs remain.**
 
 **Latest archival (2026-06-16) — BUG-241 resolved (deploy migration enforcement):**
 - BUG-241 (P2) verified fixed and archived to `docs/_archive/bugs/`. The fix adds `"buildCommand": "pnpm db:migrate && pnpm build"` to `vercel.json`, so every git-triggered Vercel deploy applies checked-in Drizzle migrations to its environment-scoped Neon branch before serving, failing the build closed on migration error. Merged via PR #453 (squash `ff46fbda` → `dev`) and promoted to `main` via PR #454 (merge `daed8479`); `main` and `dev` trees are identical. Verified live on real Vercel builds: the Preview deploy migrated Neon `dev` and the Production deploy migrated Neon `main`, each logging `[✓] migrations applied successfully!` before `next build`. Neon branch isolation (Production vs shared Preview/Development) was confirmed by a value-free host comparison. `pnpm db:seed` (content) remains a documented manual step. This was the last active bug; **no active bugs remain.**

--- a/scripts/export-question-feedback.test.ts
+++ b/scripts/export-question-feedback.test.ts
@@ -72,6 +72,147 @@ describe('formatQuestionFeedbackExport', () => {
     );
   });
 
+  it('neutralizes bare spreadsheet formulas in CSV comments', () => {
+    const csv = formatQuestionFeedbackExport(
+      ['=1+1', '+1+1', '-2+3', '@SUM(A1)'].map((comment, index) =>
+        rowWithComment(comment, { id: `feedback-formula-${index + 1}` }),
+      ),
+      {
+        format: 'csv',
+        includeUserId: false,
+        includeComments: true,
+      },
+    );
+
+    expect(csv).toContain(",true,'=1+1\n");
+    expect(csv).toContain(",true,'+1+1\n");
+    expect(csv).toContain(",true,'-2+3\n");
+    expect(csv).toContain(",true,'@SUM(A1)\n");
+  });
+
+  it('neutralizes quoted spreadsheet formulas before CSV delimiter quoting', () => {
+    const csv = formatQuestionFeedbackExport(
+      [rowWithComment('=HYPERLINK("https://example.invalid","c")')],
+      {
+        format: 'csv',
+        includeUserId: false,
+        includeComments: true,
+      },
+    );
+
+    expect(csv).toContain(
+      `,true,"'=HYPERLINK(""https://example.invalid"",""c"")"\n`,
+    );
+  });
+
+  it('neutralizes leading-whitespace and control-character formula bypasses in CSV comments', () => {
+    const cases = [
+      { comment: ' =1+1', expected: ",true,' =1+1\n" },
+      { comment: '\t=1+1', expected: ",true,'\t=1+1\n" },
+      { comment: '\r=1', expected: `,true,"'\r=1"\n` },
+      { comment: '\n=1', expected: `,true,"'\n=1"\n` },
+    ];
+
+    for (const { comment, expected } of cases) {
+      const csv = formatQuestionFeedbackExport([rowWithComment(comment)], {
+        format: 'csv',
+        includeUserId: false,
+        includeComments: true,
+      });
+
+      expect(csv).toContain(expected);
+    }
+  });
+
+  it('preserves non-formula CSV cells and existing delimiter quoting', () => {
+    const csv = formatQuestionFeedbackExport(
+      [
+        rowWithComment('normal comment', {
+          id: '11111111-1111-4111-8111-111111111111',
+          questionId: '33333333-3333-4333-8333-333333333333',
+          attemptId: '44444444-4444-4444-8444-444444444444',
+          createdAt: '2026-06-17T12:00:00.000Z',
+        }),
+        rowWithComment('Contains comma, "quote", and newline\ntext', {
+          id: '22222222-2222-4222-8222-222222222222',
+          questionId: '33333333-3333-4333-8333-333333333333',
+          attemptId: '44444444-4444-4444-8444-444444444444',
+          createdAt: '2026-06-17T12:00:00.000Z',
+        }),
+        rowWithComment("'=already-text", {
+          id: '33333333-3333-4333-8333-333333333333',
+          questionId: '33333333-3333-4333-8333-333333333333',
+          attemptId: '44444444-4444-4444-8444-444444444444',
+          createdAt: '2026-06-17T12:00:00.000Z',
+        }),
+        rowWithComment('', {
+          id: '44444444-4444-4444-8444-444444444444',
+          questionId: '33333333-3333-4333-8333-333333333333',
+          attemptId: '44444444-4444-4444-8444-444444444444',
+          createdAt: '2026-06-17T12:00:00.000Z',
+        }),
+        rowWithComment(null, {
+          id: '55555555-5555-4555-8555-555555555555',
+          questionId: '33333333-3333-4333-8333-333333333333',
+          attemptId: '44444444-4444-4444-8444-444444444444',
+          createdAt: '2026-06-17T12:00:00.000Z',
+        }),
+      ],
+      {
+        format: 'csv',
+        includeUserId: false,
+        includeComments: true,
+      },
+    );
+
+    expect(csv).toBe(
+      [
+        'feedback_id,question_id,question_slug,attempt_id,practice_session_id,kind,rating,category,created_at,user_id,has_comment,comment',
+        '11111111-1111-4111-8111-111111111111,33333333-3333-4333-8333-333333333333,question-slug-1,44444444-4444-4444-8444-444444444444,,report,,ambiguous_wording,2026-06-17T12:00:00.000Z,[redacted],true,normal comment',
+        '22222222-2222-4222-8222-222222222222,33333333-3333-4333-8333-333333333333,question-slug-1,44444444-4444-4444-8444-444444444444,,report,,ambiguous_wording,2026-06-17T12:00:00.000Z,[redacted],true,"Contains comma, ""quote"", and newline\ntext"',
+        "33333333-3333-4333-8333-333333333333,33333333-3333-4333-8333-333333333333,question-slug-1,44444444-4444-4444-8444-444444444444,,report,,ambiguous_wording,2026-06-17T12:00:00.000Z,[redacted],true,'=already-text",
+        '44444444-4444-4444-8444-444444444444,33333333-3333-4333-8333-333333333333,question-slug-1,44444444-4444-4444-8444-444444444444,,report,,ambiguous_wording,2026-06-17T12:00:00.000Z,[redacted],false,',
+        '55555555-5555-4555-8555-555555555555,33333333-3333-4333-8333-333333333333,question-slug-1,44444444-4444-4444-8444-444444444444,,report,,ambiguous_wording,2026-06-17T12:00:00.000Z,[redacted],false,',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('neutralizes formula-capable values in every CSV column', () => {
+    const csv = formatQuestionFeedbackExport(
+      [
+        rowWithComment('normal comment', {
+          questionSlug: '=formula-slug',
+          userId: '+spreadsheet-user',
+        }),
+      ],
+      {
+        format: 'csv',
+        includeUserId: true,
+        includeComments: true,
+      },
+    );
+
+    expect(csv).toContain(",'=formula-slug,");
+    expect(csv).toContain(",'+spreadsheet-user,");
+  });
+
+  it('keeps formula-prefixed comments raw in JSON exports', () => {
+    const json = formatQuestionFeedbackExport([rowWithComment('=1+1')], {
+      format: 'json',
+      includeUserId: false,
+      includeComments: true,
+    });
+
+    expect(JSON.parse(json)).toEqual([
+      expect.objectContaining({
+        comment: '=1+1',
+      }),
+    ]);
+    expect(json).toContain('"comment": "=1+1"');
+    expect(json).not.toContain("'=1+1");
+  });
+
   it('formats JSON with ISO timestamps and omits comment bodies by default', () => {
     const json = formatQuestionFeedbackExport([BASE_ROW], {
       format: 'json',
@@ -96,6 +237,17 @@ describe('formatQuestionFeedbackExport', () => {
     ]);
   });
 });
+
+function rowWithComment(
+  comment: string | null,
+  overrides: Partial<QuestionFeedbackExportRow> = {},
+): QuestionFeedbackExportRow {
+  return {
+    ...BASE_ROW,
+    comment,
+    ...overrides,
+  };
+}
 
 describe('parseQuestionFeedbackExportArgs', () => {
   it('defaults to CSV with privacy-preserving output', () => {

--- a/scripts/export-question-feedback.ts
+++ b/scripts/export-question-feedback.ts
@@ -64,6 +64,9 @@ const DEFAULT_OPTIONS: QuestionFeedbackExportOptions = {
   includeUserId: false,
   includeComments: false,
 };
+const CSV_FORMULA_PREFIXES = new Set(['=', '+', '-', '@']);
+const CSV_LEADING_IGNORED_CHARS = new Set([' ', '\t', '\r', '\n']);
+const CSV_RAW_CONTROL_PREFIXES = new Set(['\t', '\r', '\n']);
 
 const DEFAULT_DEPS: QuestionFeedbackExportDeps<
   ReturnType<typeof postgres>,
@@ -293,8 +296,21 @@ function csvRecordLine(
 
 function csvCell(value: string | null): string {
   if (value === null) return '';
-  if (!/[",\n\r]/.test(value)) return value;
-  return `"${value.replaceAll('"', '""')}"`;
+  const safeValue = neutralizeSpreadsheetFormula(value);
+  if (!/[",\n\r]/.test(safeValue)) return safeValue;
+  return `"${safeValue.replaceAll('"', '""')}"`;
+}
+
+function neutralizeSpreadsheetFormula(value: string): string {
+  if (value.startsWith("'")) return value;
+  if (CSV_RAW_CONTROL_PREFIXES.has(value.charAt(0))) return `'${value}`;
+
+  let index = 0;
+  while (CSV_LEADING_IGNORED_CHARS.has(value.charAt(index))) {
+    index += 1;
+  }
+
+  return CSV_FORMULA_PREFIXES.has(value.charAt(index)) ? `'${value}` : value;
 }
 
 function toIsoString(value: Date | string): string {


### PR DESCRIPTION
## Promotion: resolve BUG-250 (P3) — CSV/spreadsheet formula injection in the ops feedback export

Promotes the complete BUG-250 resolution from `dev` to `main`/production.

### Commits
- `523ae02d` — Document BUG-250 (bug doc)
- `b98306a6` — Fix BUG-250: neutralize CSV formula injection in feedback export
- `060e5b6f` — Archive BUG-250 (resolved) + update bug index

### The bug
A subscriber-submitted question-feedback `comment` beginning with a spreadsheet formula prefix (`=` `+` `-` `@`, a leading tab/CR/LF, or a leading-whitespace bypass) was written verbatim into the `--include-comments` CSV output of `scripts/export-question-feedback.ts`. An operator opening that CSV in Excel/Sheets could have the cell evaluated as a formula (e.g. `=HYPERLINK(...)`).

### The fix
`csvCell` now prefixes an apostrophe to formula-capable cells **before** delimiter quoting, applied to every column via the existing `values.map(csvCell)` path. The `--json` export path is untouched (JSON is not a spreadsheet sink). TDD coverage: bare + quoted formulas, leading-whitespace/control bypasses, per-column coverage, JSON-stays-raw, idempotency, and the `=HYPERLINK(...)` repro.

### Verification (local)
- Focused suite 19/19; full unit suite 2859 passed; `typecheck` + `lint` + `build` green.
- Owner-graded A.

### Severity / scope
P3: ops script only, operator-in-the-loop, opt-in `--include-comments`. The script is not part of the Next build/runtime, so there is no web or production-runtime behavior change — this promotion is a docs + ops-script change.

### Merge process (per dev→main convention)
- Merge via **merge commit** (not squash).
- Requires the `test` check + CodeRabbit review before merge. **Do not merge until CodeRabbit has reviewed and the owner approves.**
- Do **not** delete `dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV exports of question feedback are now protected against spreadsheet formula injection when opened in spreadsheet applications.

* **Documentation**
  * Updated bug register to document the spreadsheet formula injection vulnerability and its mitigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->