### PR TITLE
Promote dev→main: archive BUG-250 (resolved, verified in prod)

### DIFF
--- a/docs/_archive/bugs/bug-250-question-feedback-csv-formula-injection.md
+++ b/docs/_archive/bugs/bug-250-question-feedback-csv-formula-injection.md
@@ -1,11 +1,12 @@
 # BUG-250: Feedback Comment CSV Export Allows Spreadsheet Formula Injection
 
-**Status:** Open
+**Status:** Resolved
 **Priority:** P3
 **Date:** 2026-06-17
 **Confirmed:** 2026-06-17
+**Resolved:** 2026-06-18
 **Component:** Question Feedback / Ops Export / Output Encoding
-**Resolution State:** Fixed on `dev` in commit `b98306a6`; pending PR #460 promotion to `main`, post-merge verification, and archival.
+**Resolution State:** Fixed on `dev` in commit `b98306a6`, promoted to `main` via PR #460 (merge `d76a3516`), production deploy verified READY, and archived.
 
 ---
 
@@ -40,8 +41,8 @@ This is not a web XSS bug and does not affect the default export. It requires an
 
 The export script makes comment export an explicit supported mode:
 
-- [`package.json`](../../package.json#L28): `"export:feedback": "tsx scripts/export-question-feedback.ts"`
-- [`docs/dev/question-feedback-analytics.md`](../dev/question-feedback-analytics.md#L17): `pnpm --silent export:feedback -- --include-comments > question-feedback-comments.csv`
+- [`package.json`](../../../package.json#L28): `"export:feedback": "tsx scripts/export-question-feedback.ts"`
+- [`docs/dev/question-feedback-analytics.md`](../../dev/question-feedback-analytics.md#L17): `pnpm --silent export:feedback -- --include-comments > question-feedback-comments.csv`
 
 The script copies the persisted subscriber comment into the record when `--include-comments` is set:
 
@@ -51,7 +52,7 @@ if (options.includeComments) {
 }
 ```
 
-Location: [`scripts/export-question-feedback.ts`](../../scripts/export-question-feedback.ts#L235)
+Location: [`scripts/export-question-feedback.ts`](../../../scripts/export-question-feedback.ts#L235)
 
 Before the `b98306a6` fix, the CSV writer only escaped CSV delimiters, not spreadsheet formula prefixes:
 
@@ -63,7 +64,7 @@ function csvCell(value: string | null): string {
 }
 ```
 
-The current `dev` implementation fixes the same [`csvCell` boundary](../../scripts/export-question-feedback.ts#L297) by neutralizing before delimiter quoting.
+The current `dev` implementation fixes the same [`csvCell` boundary](../../../scripts/export-question-feedback.ts#L297) by neutralizing before delimiter quoting.
 
 In the vulnerable version, because the payload contained double quotes, `csvCell` wrapped and doubled quotes. After CSV parsing, the cell value still began with `=`, so spreadsheet software treated it as a formula rather than inert text.
 
@@ -71,9 +72,9 @@ The vector did not even require the quoting path: `csvCell`'s guard only matched
 
 The comment input is bounded but intentionally free text:
 
-- Client textarea: [`components/question/question-report-dialog.tsx`](../../components/question/question-report-dialog.tsx#L145) sets `maxLength={MAX_QUESTION_FEEDBACK_COMMENT_LENGTH}`.
-- Server action: [`src/adapters/controllers/question-feedback-controller.ts`](../../src/adapters/controllers/question-feedback-controller.ts#L40) trims and caps comments with `.max(MAX_QUESTION_FEEDBACK_COMMENT_LENGTH)`.
-- Database: [`db/schema.ts`](../../db/schema.ts#L603) enforces `char_length(comment) <= 2000`.
+- Client textarea: [`components/question/question-report-dialog.tsx`](../../../components/question/question-report-dialog.tsx#L145) sets `maxLength={MAX_QUESTION_FEEDBACK_COMMENT_LENGTH}`.
+- Server action: [`src/adapters/controllers/question-feedback-controller.ts`](../../../src/adapters/controllers/question-feedback-controller.ts#L40) trims and caps comments with `.max(MAX_QUESTION_FEEDBACK_COMMENT_LENGTH)`.
+- Database: [`db/schema.ts`](../../../db/schema.ts#L603) enforces `char_length(comment) <= 2000`.
 
 Those bounds prevent storage DoS, but they do not neutralize formula-capable text at input or storage time.
 
@@ -95,9 +96,9 @@ Minimal fix:
 
 Do not remove `--include-comments`; the workflow is legitimate. The bug is output encoding for the CSV format.
 
-## Implementation State
+## Resolution
 
-Implemented on `dev` in commit `b98306a6` (`Fix BUG-250: neutralize CSV formula injection in feedback export`).
+Fixed on `dev` in commit `b98306a6` (`Fix BUG-250: neutralize CSV formula injection in feedback export`), promoted to `main` via PR #460 (merge `d76a3516`), and verified live (production Vercel deploy READY).
 
 `csvCell` now neutralizes spreadsheet-formula-capable values before CSV delimiter quoting, and the existing `values.map(csvCell)` serialization path applies that protection to every CSV column. The JSON export branch remains unchanged and continues to emit raw comment text.
 
@@ -113,11 +114,11 @@ Implemented on `dev` in commit `b98306a6` (`Fix BUG-250: neutralize CSV formula 
 - [x] `pnpm lint` passed.
 - [x] `pnpm test --run` passed (350 files, 2859 tests).
 - [x] `pnpm build` passed.
-- [ ] PR #460 promoted the fix to `main`.
-- [ ] Post-merge verification completed.
-- [ ] Archived to `docs/_archive/bugs/` after verification.
+- [x] PR #460 promoted the fix to `main` (merge `d76a3516`).
+- [x] Post-merge verification completed — production Vercel deploy for `d76a3516` reached READY.
+- [x] Archived to `docs/_archive/bugs/`.
 
 ## Related Clean Surfaces
 
-- Markdown rendering remains clean: [`components/markdown/markdown.tsx`](../../components/markdown/markdown.tsx#L71) uses `ReactMarkdown` with `rehypeSanitize` and `skipHtml`.
+- Markdown rendering remains clean: [`components/markdown/markdown.tsx`](../../../components/markdown/markdown.tsx#L71) uses `ReactMarkdown` with `rehypeSanitize` and `skipHtml`.
 - Stored report comments are not rendered in the first-party web UI; they are submitted, stored, and exported for editorial analysis.

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -1,7 +1,7 @@
 # Bug Reports
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-06-17 (BUG-250 fixed on `dev` and pending `main` promotion verification — `csvCell` in the feedback export now neutralizes spreadsheet-formula-capable cells before CSV quoting; fix `b98306a6`, dev→main promotion PR #460 open. Prior: BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`.)
+**Last Updated:** 2026-06-18 (BUG-250 resolved + archived — `csvCell` in the feedback export neutralizes spreadsheet-formula-capable cells before CSV quoting; fixed on `dev` (`b98306a6`), promoted to `main` via PR #460 (merge `d76a3516`), production deploy verified READY. Prior: BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`.)
 
 ---
 
@@ -15,8 +15,8 @@ Bug reports document issues discovered in the codebase along with their root cau
 
 **Next Bug ID:** BUG-251
 
-**Latest active bug update (2026-06-17) — BUG-250 fixed on `dev`, pending promotion verification:**
-- BUG-250 (P3) is fixed on `dev` but remains active until PR #460 promotes the fix to `main` and post-merge verification is complete. `csvCell` in `scripts/export-question-feedback.ts` now prefixes an apostrophe to spreadsheet-formula-capable cells (leading `=`/`+`/`-`/`@`, a raw leading tab/CR/LF, and leading-whitespace bypass forms) before delimiter quoting, and the existing `values.map(csvCell)` path applies it to every CSV column; the `--json` export path is untouched and still emits raw comment text. Fixed via TDD directly on `dev` (no feature branch): fix `b98306a6`. Full local gate green (typecheck, lint, unit 2859, build) and focused suite 19/19; owner-graded A. BUG-250 is the only active bug.
+**Latest archival (2026-06-18) — BUG-250 resolved (feedback CSV formula injection):**
+- BUG-250 (P3) verified fixed and archived to `docs/_archive/bugs/`. `csvCell` in `scripts/export-question-feedback.ts` now prefixes an apostrophe to spreadsheet-formula-capable cells (leading `=`/`+`/`-`/`@`, a raw leading tab/CR/LF, and leading-whitespace bypass forms) before delimiter quoting, and the existing `values.map(csvCell)` path applies it to every CSV column; the `--json` export path is untouched and still emits raw comment text. Fixed via TDD directly on `dev` (no feature branch): fix `b98306a6`, doc `523ae02d`. Full local gate green (typecheck, lint, unit 2859, build) and focused suite 19/19; owner-graded A. Promoted to `main` via PR #460 (merge `d76a3516`); production Vercel deploy for `d76a3516` verified READY; `main` and `dev` trees identical. This was the only active bug; **no active bugs remain.**
 
 **Latest archival (2026-06-16) — BUG-241 resolved (deploy migration enforcement):**
 - BUG-241 (P2) verified fixed and archived to `docs/_archive/bugs/`. The fix adds `"buildCommand": "pnpm db:migrate && pnpm build"` to `vercel.json`, so every git-triggered Vercel deploy applies checked-in Drizzle migrations to its environment-scoped Neon branch before serving, failing the build closed on migration error. Merged via PR #453 (squash `ff46fbda` → `dev`) and promoted to `main` via PR #454 (merge `daed8479`); `main` and `dev` trees are identical. Verified live on real Vercel builds: the Preview deploy migrated Neon `dev` and the Production deploy migrated Neon `main`, each logging `[✓] migrations applied successfully!` before `next build`. Neon branch isolation (Production vs shared Preview/Development) was confirmed by a value-free host comparison. `pnpm db:seed` (content) remains a documented manual step. This was the last active bug; **no active bugs remain.**


### PR DESCRIPTION
## Promotion: close out BUG-250 — archive as resolved

Docs-only close-out. The BUG-250 fix already shipped to `main`/production via **PR #460** (merge `d76a3516`) and the production deploy is **verified READY**. This PR promotes the archival bookkeeping so `main` and `dev` stay in sync.

### Change (1 commit, `4f9b2d3f`)
- Move `bug-250-…md` → `docs/_archive/bugs/` (relative links re-deepened to `../../../`, all verified resolving).
- Flip `Status: Open` → `Resolved`; tick the promotion / post-merge-verification / archived checklist boxes.
- Index: BUG-250 entry → "resolved + archived"; **no active bugs remain**.

### No code change
Documentation only — no `scripts/`, app, or runtime change. The fix itself was promoted and verified under #460.

### Verification
Full local gate green (typecheck, lint, unit 2859, build). Archive links verified resolving from the new depth.

### Merge process (per dev→main convention)
- Merge via **merge commit** (not squash).
- Gate: `test` check + CodeRabbit review (owner has pre-authorized the close-out).
- Do **not** delete `dev`.