### PR TITLE
Fix BUG-251 (P2): exam abandon discards the session; file BUG-251/252

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -68,6 +68,8 @@ reviews:
         4. One concept per test, use Arrange-Act-Assert pattern
         5. Test behavior, not implementation details
         6. Use factories: createQuestion(), createChoice() from test-helpers/
+        7. Do NOT require dynamic import()/beforeAll loading in pure TypeScript *.test.ts suites.
+           That React 19 compatibility rule is scoped to **/*.test.tsx component tests.
 
     # React component tests - React 19 specific
     - path: "**/*.test.tsx"

--- a/app/(app)/app/practice/hooks/use-practice-incomplete-session.ts
+++ b/app/(app)/app/practice/hooks/use-practice-incomplete-session.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import {
+  discardPracticeSession,
   endPracticeSession,
   type GetIncompletePracticeSessionOutput,
   getIncompletePracticeSession,
@@ -49,7 +50,9 @@ export function usePracticeIncompleteSession(
 
     await abandonIncompleteSession({
       sessionId: incompleteSession.sessionId,
+      mode: incompleteSession.mode,
       endPracticeSessionFn: endPracticeSession,
+      discardPracticeSessionFn: discardPracticeSession,
       setIncompleteSessionStatus,
       setIncompleteSessionError,
       setIncompleteSession,

--- a/app/(app)/app/practice/hooks/use-practice-session-controls.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-controls.browser.spec.tsx
@@ -17,6 +17,9 @@ const getTags = vi.mocked(tagController.getTags);
 const countAvailableQuestions = vi.mocked(
   practiceController.countAvailableQuestions,
 );
+const discardPracticeSession = vi.mocked(
+  practiceController.discardPracticeSession,
+);
 const endPracticeSession = vi.mocked(practiceController.endPracticeSession);
 const getIncompletePracticeSession = vi.mocked(
   practiceController.getIncompletePracticeSession,
@@ -210,5 +213,39 @@ describe('usePracticeSessionControls (browser)', () => {
       sessionId,
       idempotencyKey: sessionId,
     });
+    expect(discardPracticeSession).not.toHaveBeenCalled();
+  });
+
+  it('uses discard instead of end when abandoning an incomplete exam session', async () => {
+    const sessionId = '11111111-1111-1111-1111-111111111112';
+
+    getTags.mockResolvedValue(ok({ rows: [] }));
+    getIncompletePracticeSession.mockResolvedValue(
+      ok({
+        sessionId,
+        mode: 'exam',
+        answeredCount: 0,
+        totalCount: 10,
+        startedAt: '2026-02-08T00:00:00.000Z',
+      }),
+    );
+    discardPracticeSession.mockResolvedValue(ok({ discarded: true }));
+    countAvailableQuestions.mockResolvedValue(ok({ count: 0 }));
+
+    const screen = await render(<PracticeSessionControlsHookProbe />);
+
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('idle');
+
+    await screen
+      .getByRole('button', { name: 'abandon-incomplete-session' })
+      .click();
+
+    expect(discardPracticeSession).toHaveBeenCalledWith({
+      sessionId,
+      idempotencyKey: sessionId,
+    });
+    expect(endPracticeSession).not.toHaveBeenCalled();
   });
 });

--- a/app/(app)/app/practice/practice-page-incomplete-session.test.ts
+++ b/app/(app)/app/practice/practice-page-incomplete-session.test.ts
@@ -135,15 +135,18 @@ describe('practice-page-incomplete-session', () => {
   });
 
   describe('abandonIncompleteSession', () => {
-    it('ends the session and clears local state on success', async () => {
+    it('ends a tutor session and clears local state on success', async () => {
       const setStatus = vi.fn();
       const setError = vi.fn();
       const setSession = vi.fn();
       const endPracticeSessionFn = vi.fn(async () => ok({}));
+      const discardPracticeSessionFn = vi.fn(async () => ok({}));
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        mode: 'tutor',
         endPracticeSessionFn,
+        discardPracticeSessionFn,
         setIncompleteSessionStatus: setStatus,
         setIncompleteSessionError: setError,
         setIncompleteSession: setSession,
@@ -154,6 +157,34 @@ describe('practice-page-incomplete-session', () => {
         sessionId: fixtureSession1Id,
         idempotencyKey: fixtureSession1Id,
       });
+      expect(discardPracticeSessionFn).not.toHaveBeenCalled();
+      expect(setSession).toHaveBeenCalledWith(null);
+      expect(setStatus).toHaveBeenLastCalledWith('idle');
+    });
+
+    it('discards an exam session and clears local state on success', async () => {
+      const setStatus = vi.fn();
+      const setError = vi.fn();
+      const setSession = vi.fn();
+      const endPracticeSessionFn = vi.fn(async () => ok({}));
+      const discardPracticeSessionFn = vi.fn(async () => ok({}));
+
+      await abandonIncompleteSession({
+        sessionId: fixtureSession1Id,
+        mode: 'exam',
+        endPracticeSessionFn,
+        discardPracticeSessionFn,
+        setIncompleteSessionStatus: setStatus,
+        setIncompleteSessionError: setError,
+        setIncompleteSession: setSession,
+        isMounted: () => true,
+      });
+
+      expect(discardPracticeSessionFn).toHaveBeenCalledWith({
+        sessionId: fixtureSession1Id,
+        idempotencyKey: fixtureSession1Id,
+      });
+      expect(endPracticeSessionFn).not.toHaveBeenCalled();
       expect(setSession).toHaveBeenCalledWith(null);
       expect(setStatus).toHaveBeenLastCalledWith('idle');
     });
@@ -166,10 +197,13 @@ describe('practice-page-incomplete-session', () => {
       const endPracticeSessionFn = vi.fn(async () => {
         throw error;
       });
+      const discardPracticeSessionFn = vi.fn(async () => ok({}));
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        mode: 'tutor',
         endPracticeSessionFn,
+        discardPracticeSessionFn,
         setIncompleteSessionStatus: setStatus,
         setIncompleteSessionError: setError,
         setIncompleteSession: setSession,
@@ -192,10 +226,13 @@ describe('practice-page-incomplete-session', () => {
       const endPracticeSessionFn = vi.fn(async () => {
         throw new Error('boom');
       });
+      const discardPracticeSessionFn = vi.fn(async () => ok({}));
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        mode: 'tutor',
         endPracticeSessionFn,
+        discardPracticeSessionFn,
         setIncompleteSessionStatus: setStatus,
         setIncompleteSessionError: setError,
         setIncompleteSession: setSession,
@@ -215,10 +252,13 @@ describe('practice-page-incomplete-session', () => {
       const endPracticeSessionFn = vi.fn(async () =>
         err('INTERNAL_ERROR', 'Nope'),
       );
+      const discardPracticeSessionFn = vi.fn(async () => ok({}));
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        mode: 'tutor',
         endPracticeSessionFn,
+        discardPracticeSessionFn,
         setIncompleteSessionStatus: setStatus,
         setIncompleteSessionError: setError,
         setIncompleteSession: setSession,

--- a/app/(app)/app/practice/practice-page-incomplete-session.ts
+++ b/app/(app)/app/practice/practice-page-incomplete-session.ts
@@ -63,7 +63,9 @@ export function createIncompleteSessionEffect<T>(input: {
 
 export async function abandonIncompleteSession<T>(input: {
   sessionId: string;
+  mode: 'tutor' | 'exam';
   endPracticeSessionFn: (input: unknown) => Promise<ActionResult<unknown>>;
+  discardPracticeSessionFn: (input: unknown) => Promise<ActionResult<unknown>>;
   setIncompleteSessionStatus: (status: IncompleteSessionStatus) => void;
   setIncompleteSessionError: (message: string | null) => void;
   setIncompleteSession: (session: T | null) => void;
@@ -74,10 +76,15 @@ export async function abandonIncompleteSession<T>(input: {
   input.setIncompleteSessionStatus('loading');
   input.setIncompleteSessionError(null);
 
-  let res: Awaited<ReturnType<typeof input.endPracticeSessionFn>>;
+  const abandonSessionFn =
+    input.mode === 'exam'
+      ? input.discardPracticeSessionFn
+      : input.endPracticeSessionFn;
+
+  let res: Awaited<ReturnType<typeof abandonSessionFn>>;
   try {
     res = await withTimeout(
-      input.endPracticeSessionFn({
+      abandonSessionFn({
         sessionId: input.sessionId,
         idempotencyKey: input.sessionId,
       }),

--- a/docs/bugs/bug-251-active-exam-abandon-bypasses-finalization.md
+++ b/docs/bugs/bug-251-active-exam-abandon-bypasses-finalization.md
@@ -1,0 +1,105 @@
+# BUG-251: Active Exam Abandon Completes Without Finalization
+
+**Status:** Open — filed, NOT fixed
+**Severity:** P2
+**Date:** 2026-06-18
+**Confirmed:** 2026-06-18
+**Component:** Practice Engine / Exam Lifecycle / Session Abandon
+
+---
+
+## Summary
+
+An in-progress exam session can be "abandoned" from the Practice page, but the abandon path calls the generic `endPracticeSession` action. That action marks the active exam as completed without running `finalizeExamAnswers`, so no final attempts are created for drafted or omitted answers.
+
+The exam is no longer active after this write, so this is not an active-exam secrecy leak under the canonical `mode === 'exam' && endedAt === null` policy. It is still a real lifecycle/data-integrity bug: UI copy promises to discard the in-progress session, but the system persists it as a completed reviewable exam with missing finalized attempts and dropped drafts.
+
+## Reproduction
+
+1. Start an exam session with at least one question.
+2. Leave `/app/practice/[sessionId]` and return to `/app/practice` while the exam is still incomplete.
+3. On the incomplete-session card, click **Abandon session** and confirm **Abandon anyway**.
+4. The UI calls `endPracticeSession({ sessionId, idempotencyKey: sessionId })` instead of `finalizeExamAnswers`.
+5. Open History → Sessions, expand the abandoned exam, or click the session row's review link.
+
+Expected:
+
+- An active exam cannot become a completed/reviewable session through the generic abandon path.
+- Either the exam is discarded in a non-reviewable state, or it is explicitly submitted through `finalizeExamAnswers`.
+
+Actual:
+
+- The active exam receives `endedAt` with no finalization.
+- Completed-session feedback treats the abandoned exam as reviewable because the only review gate is `session.endedAt !== null`.
+- History may show the exam as `0/N` or undercount answered/omitted questions because final attempts were never created.
+
+## Root Cause
+
+The incomplete-session abandon UI is mode-agnostic:
+
+- [`IncompleteSessionCard`](<../../app/(app)/app/practice/components/incomplete-session-card.tsx#L26>) renders the card for both exam and tutor sessions.
+- [`IncompleteSessionCard`](<../../app/(app)/app/practice/components/incomplete-session-card.tsx#L46>) exposes **Abandon session** for every incomplete session.
+- [`abandonIncompleteSession`](<../../app/(app)/app/practice/practice-page-incomplete-session.ts#L77>) calls the supplied `endPracticeSessionFn` with only `sessionId` and `idempotencyKey`.
+
+The server action and use case do not distinguish tutor end from exam finalization:
+
+- [`EndPracticeSessionInputSchema`](../../src/adapters/controllers/practice-schemas.ts#L47) accepts only `sessionId` and optional `idempotencyKey`; it has no mode or intent.
+- [`endPracticeSession`](../../src/adapters/controllers/practice-controller.ts#L244) directly calls `endPracticeSessionUseCase.execute(...)`.
+- [`EndPracticeSessionUseCase.execute`](../../src/application/use-cases/end-practice-session.ts#L21) directly calls `sessions.end(...)`; it does not reject active exam sessions or finalize drafts.
+- [`DrizzlePracticeSessionRepository.end`](../../src/adapters/repositories/drizzle-practice-session-repository.ts#L319) only sets `endedAt` when it is currently null.
+
+After that write, completed-session feedback trusts `endedAt` as the reveal boundary:
+
+- [`GetCompletedSessionQuestionsWithFeedbackUseCase.execute`](../../src/application/use-cases/get-completed-session-questions-with-feedback.ts#L100) only rejects sessions whose `endedAt` is null.
+- The same use case then returns answer-key fields at [`correctChoiceId`](../../src/application/use-cases/get-completed-session-questions-with-feedback.ts#L195), [`explanationMd`](../../src/application/use-cases/get-completed-session-questions-with-feedback.ts#L196), and [`choiceExplanations`](../../src/application/use-cases/get-completed-session-questions-with-feedback.ts#L198).
+- History links completed sessions to review routes at [`history-sessions-tab.tsx`](<../../app/(app)/app/history/components/history-sessions-tab.tsx#L172>) and renders the breakdown at [`history-sessions-tab.tsx`](<../../app/(app)/app/history/components/history-sessions-tab.tsx#L275>).
+
+## Impact
+
+This is a specific-flow lifecycle bug. A subscriber can turn an in-progress exam into a completed reviewable session through a UI action labeled as discard, and the resulting completed session has no finalized exam attempts. The user cannot peek and then submit the same exam later because `finalizeExamAnswers` rejects already-ended sessions, and overall attempt-based stats are not inflated. The harm is misleading session history/review state and loss of the drafted/omitted finalization record.
+
+## Proposed Fix
+
+Make generic `endPracticeSession` tutor-only for active sessions. If the loaded session is `mode === 'exam'` and `endedAt === null`, reject with a validation/conflict error and require `FinalizeExamAnswersUseCase` as the only path that can complete a reviewable exam.
+
+For the Practice page abandon UX, add a separate explicit exam-abandon action that discards or marks the incomplete exam as abandoned in a non-reviewable state. It must not set `endedAt` in a way that makes completed-session review readers reveal feedback. If the product wants "abandon" to mean "submit what I have," change the UI copy and route it through `finalizeExamAnswers`; do not silently finalize under discard wording.
+
+Rejected alternative: making `endPracticeSession` automatically call `finalizeExamAnswers` for exams. The UI says the action discards the in-progress session and starts over, so silently submitting would surprise users and still leave a dangerous generic action boundary.
+
+## Failing Test Sketch
+
+```ts
+import { FakePracticeSessionRepository } from '@/src/application/test-helpers/fakes';
+import { EndPracticeSessionUseCase } from './end-practice-session';
+
+it('rejects generic end for an active exam session', async () => {
+  const sessions = new FakePracticeSessionRepository([
+    createPracticeSession({
+      id: '11111111-1111-4111-8111-111111111111',
+      userId: '22222222-2222-4222-8222-222222222222',
+      mode: 'exam',
+      endedAt: null,
+      questionIds: ['33333333-3333-4333-8333-333333333333'],
+      questionStates: [
+        createPracticeSessionQuestionState({
+          questionId: '33333333-3333-4333-8333-333333333333',
+          draftSelectedChoiceId: null,
+          draftCumulativeMs: 15_000,
+        }),
+      ],
+    }),
+  ]);
+  const useCase = new EndPracticeSessionUseCase(sessions);
+
+  await expect(
+    useCase.execute({
+      userId: '22222222-2222-4222-8222-222222222222',
+      sessionId: '11111111-1111-4111-8111-111111111111',
+    }),
+  ).rejects.toMatchObject({
+    code: 'VALIDATION_ERROR',
+  });
+});
+```
+
+An integration-level regression should also assert that an active exam abandoned from the Practice page cannot make `getCompletedSessionQuestionsWithFeedback({ sessionId })` return `correctChoiceId` or explanations unless `finalizeExamAnswers` has run and created final attempts.

--- a/docs/bugs/bug-251-active-exam-abandon-bypasses-finalization.md
+++ b/docs/bugs/bug-251-active-exam-abandon-bypasses-finalization.md
@@ -1,6 +1,7 @@
 # BUG-251: Active Exam Abandon Completes Without Finalization
 
-**Status:** Fix implemented on `dev` (PR #464) — pending promotion to `main` + production verification before archival
+**Status:** Open
+**Resolution State:** Fix implemented on `dev` in PR #464; pending review, promotion to `main`, production verification, and archival.
 **Severity:** P2
 **Date:** 2026-06-18
 **Confirmed:** 2026-06-18

--- a/docs/bugs/bug-251-active-exam-abandon-bypasses-finalization.md
+++ b/docs/bugs/bug-251-active-exam-abandon-bypasses-finalization.md
@@ -60,11 +60,21 @@ This is a specific-flow lifecycle bug. A subscriber can turn an in-progress exam
 
 ## Proposed Fix
 
-Make generic `endPracticeSession` tutor-only for active sessions. If the loaded session is `mode === 'exam'` and `endedAt === null`, reject with a validation/conflict error and require `FinalizeExamAnswersUseCase` as the only path that can complete a reviewable exam.
+**Decision (2026-06-18, owner-approved): exam "Abandon" means TRUE DISCARD by deletion.**
 
-For the Practice page abandon UX, add a separate explicit exam-abandon action that discards or marks the incomplete exam as abandoned in a non-reviewable state. It must not set `endedAt` in a way that makes completed-session review readers reveal feedback. If the product wants "abandon" to mean "submit what I have," change the UI copy and route it through `finalizeExamAnswers`; do not silently finalize under discard wording.
+"Abandon" on an in-progress exam means *discard it as if it never happened* — matching the dialog copy ("This will discard the in-progress session and you will need to start over"). The owner confirmed there is **no need to retain or measure exam abandonment**, so the abandoned exam session is **hard-deleted**, not tombstoned. Deletion is chosen because it adds **no new lifecycle state** — and "a reader forgot to exclude a session state" is exactly this bug's failure mode, so introducing an `abandoned` state would re-create the bug class elsewhere. The discarded data is uncommitted exam drafts (an active exam has zero finalized attempts) — the lowest-value data in the system. If abandonment analytics are ever needed, a retain-and-hide model can be added then.
 
-Rejected alternative: making `endPracticeSession` automatically call `finalizeExamAnswers` for exams. The UI says the action discards the in-progress session and starts over, so silently submitting would surprise users and still leave a dangerous generic action boundary.
+Implementation (exam-specific):
+
+1. Add `DiscardPracticeSessionUseCase` + a `discardPracticeSession` server action that **deletes** the caller's incomplete session: `DELETE WHERE id = ? AND user_id = ? AND ended_at IS NULL`. Idempotent — a missing/already-discarded session resolves success (the abandon UI passes an idempotency key and may retry). Deletion frees the `PRACTICE_SESSIONS_USER_INCOMPLETE_UQ` partial unique index so the user can start a new session immediately.
+2. Guard `EndPracticeSessionUseCase` (defense in depth): reject `mode === 'exam' && endedAt === null` with `VALIDATION_ERROR`, so no caller can complete an active exam through the generic end path.
+3. Route the Practice-hub abandon to the new discard action for **exam** sessions. **Tutor** abandon is unchanged: tutor sessions accrue real graded attempts as they are answered, so `end()` legitimately completes them, and tutor mode has no answer secrecy.
+
+Rejected alternatives:
+
+- **Reject-only guard (no discard action):** would strand the user behind the one-incomplete-session constraint — they could neither end the exam nor start a new one. Kept only as defense-in-depth *alongside* the discard action, never alone.
+- **Auto-finalize on abandon (route to `finalizeExamAnswers`):** silently submits and grades drafts the user chose to throw away, contradicting the "discard" copy. If the product ever wants abandon-means-submit, re-label the dialog first; do not finalize under discard wording.
+- **Soft-delete / `abandoned_at` tombstone:** preserves an abandonment signal the owner does not want, and adds an `abandoned` state every lifecycle reader (history, completed-feedback, incomplete, stats) must remember to exclude — re-creating this bug's class. Over-engineered for the present need.
 
 ## Failing Test Sketch
 

--- a/docs/bugs/bug-251-active-exam-abandon-bypasses-finalization.md
+++ b/docs/bugs/bug-251-active-exam-abandon-bypasses-finalization.md
@@ -1,6 +1,6 @@
 # BUG-251: Active Exam Abandon Completes Without Finalization
 
-**Status:** Open — filed, NOT fixed
+**Status:** Fix implemented on `dev` (PR #464) — pending promotion to `main` + production verification before archival
 **Severity:** P2
 **Date:** 2026-06-18
 **Confirmed:** 2026-06-18

--- a/docs/bugs/bug-252-unanswered-exam-time-not-persisted.md
+++ b/docs/bugs/bug-252-unanswered-exam-time-not-persisted.md
@@ -1,0 +1,117 @@
+# BUG-252: Unanswered Exam Question Time Is Not Persisted Before Finalization
+
+**Status:** Open — filed, NOT fixed
+**Severity:** P3
+**Date:** 2026-06-18
+**Confirmed:** 2026-06-18
+**Component:** Practice Engine / Exam Draft Timing / Omitted Attempts
+
+---
+
+## Summary
+
+Exam mode tracks per-question elapsed time locally, but if the user leaves a question without selecting an answer, the client intentionally skips the server draft write. `FinalizeExamAnswersUseCase` later computes omitted attempts' `timeSpentSeconds` from server-side `draftCumulativeMs`, so unanswered questions that the user spent time on can be finalized with `timeSpentSeconds = 0`.
+
+This does not affect scoring and no current UI surfaces omitted-question timing. The bug is a narrow persistence-accuracy gap in the proposed stopwatch model: unanswered time is preserved only in browser state until the user later selects an answer.
+
+## Reproduction
+
+1. Start a two-question exam.
+2. On question 1, spend 15 seconds reading but do not choose an answer.
+3. Navigate to question 2.
+4. Submit the exam while question 1 remains unanswered.
+5. Inspect the finalized omitted attempt for question 1.
+
+Expected:
+
+- Question 1 is omitted and incorrect.
+- Its attempt records approximately `timeSpentSeconds = 15` because the user spent 15 seconds on that question.
+
+Actual:
+
+- Question 1 is omitted and incorrect.
+- Its attempt records `timeSpentSeconds = 0` because no server draft write ever persisted the local `15_000` ms.
+
+## Root Cause
+
+The interaction-contract doc labels the stopwatch behavior as a proposed model, and that model says cumulative time should be persisted on draft save and used during finalization:
+
+- [`interaction-contracts.md`](../practice-engine/interaction-contracts.md#L189) defines "On leave question: cumulativeMs += ...".
+- [`interaction-contracts.md`](../practice-engine/interaction-contracts.md#L192) says "On draft save: persist cumulativeMs alongside the draft choiceId".
+- [`interaction-contracts.md`](../practice-engine/interaction-contracts.md#L193) says "On finalize: timeSpentSeconds = Math.floor(cumulativeMs / 1000)".
+
+The client has an explicit no-selection early return:
+
+- [`maybeSaveDraftBeforeNavigation`](<../../app/(app)/app/practice/shared/question-flow-actions.ts#L174>) checks `if (!input.selectedChoiceId)`.
+- It calls `onSaved` with the local `cumulativeMs` at [`question-flow-actions.ts`](<../../app/(app)/app/practice/shared/question-flow-actions.ts#L175>), but returns without calling `saveExamDraftAnswerFn` at [`question-flow-actions.ts`](<../../app/(app)/app/practice/shared/question-flow-actions.ts#L180>).
+- The existing test suite locks in that behavior: [`question-flow-actions.test.ts`](<../../app/(app)/app/practice/shared/question-flow-actions.test.ts#L858>) asserts "tracks unanswered exam time locally" and [`question-flow-actions.test.ts`](<../../app/(app)/app/practice/shared/question-flow-actions.test.ts#L889>) expects `saveExamDraftAnswerFn` not to be called.
+
+The server/API shape also prevents persisting a time-only draft:
+
+- [`SaveExamDraftAnswerInputSchema`](../../src/adapters/controllers/practice-schemas.ts#L56) requires `selectedChoiceId: zUuid`.
+- [`SaveExamDraftAnswerInput`](../../src/application/use-cases/save-exam-draft-answer.ts#L10) requires `selectedChoiceId: string`.
+- [`PracticeSessionRepository.saveDraftAnswer`](../../src/application/ports/practice-session-repository.ts#L29) also requires `selectedChoiceId: string`.
+
+Finalization then trusts the server-side draft clock for omitted attempts:
+
+- [`FinalizeExamAnswersUseCase`](../../src/application/use-cases/finalize-exam-answers.ts#L95) loops every question state.
+- It computes `timeSpentSeconds` from `state.draftCumulativeMs` at [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L96).
+- For unanswered questions, it inserts the omitted attempt with that value at [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L102) and [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L112).
+
+Because unanswered cumulative time never leaves the browser until a choice is later selected, finalization writes an undercounted duration for questions that remain omitted.
+
+## Impact
+
+Exam scoring remains correct for the omitted answer, but persisted attempt timing is wrong for skipped/unanswered exam questions. The current user-facing impact is low because the app does not display per-question omitted timing. The durable risk is bad timing data for analytics, audits, or future study recommendations.
+
+## Proposed Fix
+
+Change the exam draft write contract to persist time-only drafts by allowing `selectedChoiceId: string | null` while keeping `latest*` finalized fields untouched. A narrow implementation direction:
+
+1. Rename or widen `saveExamDraftAnswer` to accept nullable `selectedChoiceId`.
+2. Validate nullable selected choice: if non-null, it must belong to the question; if null, only persist `draftCumulativeMs` and `draftSavedAt`.
+3. Update the repository port and `DrizzlePracticeSessionRepository.saveDraftAnswer` to set `draftSelectedChoiceId` to the nullable value and always persist monotonic `draftCumulativeMs`.
+4. Update `maybeSaveDraftBeforeNavigation` to call the server whenever cumulative time advances, even when no choice is selected.
+5. Keep `FinalizeExamAnswersUseCase` reading `draftCumulativeMs`; once server truth is correct, omitted attempts get the correct duration.
+
+Rejected alternative: store unanswered timing only in local component state or send all clocks during finalization. Local state is lost on refresh/navigation and would make finalization depend on client-supplied bulk timing instead of the existing session-state source of truth.
+
+## Failing Test Sketch
+
+```ts
+it('persists cumulative time for unanswered exam questions before navigation', async () => {
+  const saveExamDraftAnswerFn = vi.fn().mockResolvedValue(
+    ok({
+      questionId,
+      markedForReview: false,
+      latestSelectedChoiceId: null,
+      latestIsCorrect: null,
+      latestAnsweredAt: null,
+      draftSelectedChoiceId: null,
+      draftSavedAt: '2026-06-18T12:00:00.000Z',
+      draftCumulativeMs: 15_000,
+    }),
+  );
+
+  const shouldNavigate = await maybeSaveDraftBeforeNavigation({
+    sessionId,
+    question: { questionId, session: { mode: 'exam' } },
+    selectedChoiceId: null,
+    currentCumulativeMs: 15_000,
+    lastSavedDraftSelectedChoiceId: null,
+    lastSavedDraftCumulativeMs: 0,
+    saveExamDraftAnswerFn,
+    setLoadState: () => {},
+  });
+
+  expect(shouldNavigate).toBe(true);
+  expect(saveExamDraftAnswerFn).toHaveBeenCalledWith({
+    sessionId,
+    questionId,
+    selectedChoiceId: null,
+    cumulativeMs: 15_000,
+  });
+});
+```
+
+Add an application-level companion test using `FakePracticeSessionRepository`: save a nullable/time-only draft with `draftCumulativeMs: 15_000`, finalize the exam, and assert the omitted attempt for that question has `timeSpentSeconds === 15`.

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -1,7 +1,7 @@
 # Bug Reports
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-06-18 (BUG-250 resolved + archived — `csvCell` in the feedback export neutralizes spreadsheet-formula-capable cells before CSV quoting; fixed on `dev` (`b98306a6`), promoted to `main` via PR #460 (merge `d76a3516`), production deploy verified READY. Prior: BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`.)
+**Last Updated:** 2026-06-18 (Manual practice/quiz engine correctness sweep filed BUG-251..BUG-252. Prior: BUG-250 resolved + archived — `csvCell` in the feedback export neutralizes spreadsheet-formula-capable cells before CSV quoting; fixed on `dev` (`b98306a6`), promoted to `main` via PR #460 (merge `d76a3516`), production deploy verified READY. Prior: BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`.)
 
 ---
 
@@ -13,7 +13,11 @@ Bug reports document issues discovered in the codebase along with their root cau
 2. **Regression Prevention** — Ensure we don't reintroduce the same bugs
 3. **Knowledge Base** — Help future developers understand past issues
 
-**Next Bug ID:** BUG-251
+**Next Bug ID:** BUG-253
+
+**Latest manual report (2026-06-18) — Practice/quiz engine correctness sweep:**
+- BUG-251 (P2) filed: active exam abandon calls generic `endPracticeSession`, marks the exam completed without final attempts, and persists a discard action as a misleading reviewable session.
+- BUG-252 (P3) filed: unanswered exam-question elapsed time is tracked only in browser state and is not persisted, so final omitted attempts can record `timeSpentSeconds = 0`.
 
 **Latest archival (2026-06-18) — BUG-250 resolved (feedback CSV formula injection):**
 - BUG-250 (P3) verified fixed and archived to `docs/_archive/bugs/`. `csvCell` in `scripts/export-question-feedback.ts` now prefixes an apostrophe to spreadsheet-formula-capable cells (leading `=`/`+`/`-`/`@`, a raw leading tab/CR/LF, and leading-whitespace bypass forms) before delimiter quoting, and the existing `values.map(csvCell)` path applies it to every CSV column; the `--json` export path is untouched and still emits raw comment text. Fixed via TDD directly on `dev` (no feature branch): fix `b98306a6`, doc `523ae02d`. Full local gate green (typecheck, lint, unit 2859, build) and focused suite 19/19; owner-graded A. Promoted to `main` via PR #460 (merge `d76a3516`); production Vercel deploy for `d76a3516` verified READY; `main` and `dev` trees identical. This was the only active bug; **no active bugs remain.**
@@ -159,6 +163,8 @@ Bug reports document issues discovered in the codebase along with their root cau
 
 | ID | Title | Priority | Filed |
 |----|-------|----------|-------|
+| [BUG-251](./bug-251-active-exam-abandon-bypasses-finalization.md) | Active Exam Abandon Completes Without Finalization | P2 | 2026-06-18 |
+| [BUG-252](./bug-252-unanswered-exam-time-not-persisted.md) | Unanswered Exam Question Time Is Not Persisted Before Finalization | P3 | 2026-06-18 |
 | [BUG-250](./bug-250-question-feedback-csv-formula-injection.md) | Feedback Comment CSV Export Allows Spreadsheet Formula Injection | P3 | 2026-06-17 |
 
 ## Audit #21 — Stripe/Billing Deep Sweep (2026-06-11)

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -165,7 +165,6 @@ Bug reports document issues discovered in the codebase along with their root cau
 |----|-------|----------|-------|
 | [BUG-251](./bug-251-active-exam-abandon-bypasses-finalization.md) | Active Exam Abandon Completes Without Finalization | P2 | 2026-06-18 |
 | [BUG-252](./bug-252-unanswered-exam-time-not-persisted.md) | Unanswered Exam Question Time Is Not Persisted Before Finalization | P3 | 2026-06-18 |
-| [BUG-250](./bug-250-question-feedback-csv-formula-injection.md) | Feedback Comment CSV Export Allows Spreadsheet Formula Injection | P3 | 2026-06-17 |
 
 ## Audit #21 — Stripe/Billing Deep Sweep (2026-06-11)
 

--- a/lib/container.test.ts
+++ b/lib/container.test.ts
@@ -33,6 +33,7 @@ import {
   CountAvailableQuestionsUseCase,
   CreateCheckoutSessionUseCase,
   CreatePortalSessionUseCase,
+  DiscardPracticeSessionUseCase,
   EndPracticeSessionUseCase,
   GetAttemptedQuestionsUseCase,
   GetBookmarksUseCase,
@@ -382,6 +383,9 @@ describe('container factories', () => {
     );
     expect(practiceDeps.startPracticeSessionUseCase).toBeInstanceOf(
       StartPracticeSessionUseCase,
+    );
+    expect(practiceDeps.discardPracticeSessionUseCase).toBeInstanceOf(
+      DiscardPracticeSessionUseCase,
     );
     expect(practiceDeps.endPracticeSessionUseCase).toBeInstanceOf(
       EndPracticeSessionUseCase,

--- a/lib/container/controllers.ts
+++ b/lib/container/controllers.ts
@@ -99,6 +99,8 @@ export function createControllerFactories(input: {
       countAvailableQuestionsUseCase:
         useCases.createCountAvailableQuestionsUseCase(),
       startPracticeSessionUseCase: useCases.createStartPracticeSessionUseCase(),
+      discardPracticeSessionUseCase:
+        useCases.createDiscardPracticeSessionUseCase(),
       endPracticeSessionUseCase: useCases.createEndPracticeSessionUseCase(),
       finalizeExamAnswersUseCase: useCases.createFinalizeExamAnswersUseCase(),
       saveExamDraftAnswerUseCase: useCases.createSaveExamDraftAnswerUseCase(),

--- a/lib/container/types.ts
+++ b/lib/container/types.ts
@@ -35,6 +35,7 @@ import type {
   CountAvailableQuestionsUseCase,
   CreateCheckoutSessionUseCase,
   CreatePortalSessionUseCase,
+  DiscardPracticeSessionUseCase,
   EndPracticeSessionUseCase,
   FinalizeExamAnswersUseCase,
   GetAttemptedQuestionsUseCase,
@@ -117,6 +118,7 @@ export type UseCaseFactories = {
   createCheckoutSessionUseCase: () => CreateCheckoutSessionUseCase;
   createPortalSessionUseCase: () => CreatePortalSessionUseCase;
   createCountAvailableQuestionsUseCase: () => CountAvailableQuestionsUseCase;
+  createDiscardPracticeSessionUseCase: () => DiscardPracticeSessionUseCase;
   createEndPracticeSessionUseCase: () => EndPracticeSessionUseCase;
   createFinalizeExamAnswersUseCase: () => FinalizeExamAnswersUseCase;
   createSaveExamDraftAnswerUseCase: () => SaveExamDraftAnswerUseCase;

--- a/lib/container/use-cases.ts
+++ b/lib/container/use-cases.ts
@@ -3,6 +3,7 @@ import {
   CountAvailableQuestionsUseCase,
   CreateCheckoutSessionUseCase,
   CreatePortalSessionUseCase,
+  DiscardPracticeSessionUseCase,
   EndPracticeSessionUseCase,
   FinalizeExamAnswersUseCase,
   GetAttemptedQuestionsUseCase,
@@ -74,6 +75,10 @@ export function createUseCaseFactories(input: {
     createCountAvailableQuestionsUseCase: () =>
       new CountAvailableQuestionsUseCase(
         repositories.createQuestionRepository(),
+      ),
+    createDiscardPracticeSessionUseCase: () =>
+      new DiscardPracticeSessionUseCase(
+        repositories.createPracticeSessionRepository(),
       ),
     createEndPracticeSessionUseCase: () =>
       new EndPracticeSessionUseCase(

--- a/src/adapters/controllers/practice-controller-session-lifecycle.test.ts
+++ b/src/adapters/controllers/practice-controller-session-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { ApplicationError } from '@/src/application/errors';
 import { FakeRateLimiter } from '@/src/application/test-helpers/fakes';
 import type { FinalizeExamAnswersOutput } from '@/src/application/use-cases';
 import {
+  discardPracticeSession,
   endPracticeSession,
   finalizeExamAnswers,
   startPracticeSession,
@@ -366,6 +367,107 @@ describe('practice-controller', () => {
       });
       expect(second).toEqual(first);
       expect(deps.endPracticeSessionUseCase.inputs).toHaveLength(1);
+    });
+  });
+
+  describe('discardPracticeSession', () => {
+    it('returns VALIDATION_ERROR when input is invalid', async () => {
+      const deps = createDeps();
+
+      const result = await discardPracticeSession({ sessionId: 'bad' }, deps);
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          fieldErrors: { sessionId: expect.any(Array) },
+        },
+      });
+      expect(deps.discardPracticeSessionUseCase.inputs).toEqual([]);
+    });
+
+    it('returns UNAUTHENTICATED when unauthenticated', async () => {
+      const deps = createDeps({ user: null });
+
+      const result = await discardPracticeSession(
+        { sessionId: '11111111-1111-1111-1111-111111111111' },
+        deps,
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: 'UNAUTHENTICATED' },
+      });
+      expect(deps.discardPracticeSessionUseCase.inputs).toEqual([]);
+    });
+
+    it('returns UNSUBSCRIBED when not entitled', async () => {
+      const deps = createDeps({ isEntitled: false });
+
+      const result = await discardPracticeSession(
+        { sessionId: '11111111-1111-1111-1111-111111111111' },
+        deps,
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: 'UNSUBSCRIBED' },
+      });
+      expect(deps.discardPracticeSessionUseCase.inputs).toEqual([]);
+    });
+
+    it('returns RATE_LIMITED when rate limited', async () => {
+      const deps = createDeps({
+        rateLimiter: new FakeRateLimiter({
+          success: false,
+          limit: 20,
+          remaining: 0,
+          retryAfterSeconds: 60,
+        }),
+      });
+
+      const result = await discardPracticeSession(
+        { sessionId: '11111111-1111-1111-1111-111111111111' },
+        deps,
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: 'RATE_LIMITED' },
+      });
+      expect(deps.discardPracticeSessionUseCase.inputs).toEqual([]);
+    });
+
+    it('returns discard success when use case succeeds', async () => {
+      const deps = createDeps();
+
+      const result = await discardPracticeSession(
+        { sessionId: '11111111-1111-1111-1111-111111111111' },
+        deps,
+      );
+
+      expect(result).toEqual({ ok: true, data: { discarded: true } });
+      expect(deps.discardPracticeSessionUseCase.inputs).toEqual([
+        {
+          userId: deps._fixtures.userId,
+          sessionId: '11111111-1111-1111-1111-111111111111',
+        },
+      ]);
+    });
+
+    it('returns the cached discard success when idempotencyKey is reused', async () => {
+      const deps = createDeps();
+      const input = {
+        sessionId: '11111111-1111-1111-1111-111111111111',
+        idempotencyKey: '11111111-1111-1111-1111-111111111111',
+      } as const;
+
+      const first = await discardPracticeSession(input, deps);
+      const second = await discardPracticeSession(input, deps);
+
+      expect(first).toEqual({ ok: true, data: { discarded: true } });
+      expect(second).toEqual(first);
+      expect(deps.discardPracticeSessionUseCase.inputs).toHaveLength(1);
     });
   });
 

--- a/src/adapters/controllers/practice-controller-test-helpers.ts
+++ b/src/adapters/controllers/practice-controller-test-helpers.ts
@@ -2,6 +2,7 @@ import type { RateLimiter } from '@/src/application/ports/gateways';
 import {
   FakeAuthGateway,
   FakeCountAvailableQuestionsUseCase,
+  FakeDiscardPracticeSessionUseCase,
   FakeEndPracticeSessionUseCase,
   FakeFinalizeExamAnswersUseCase,
   FakeGetCompletedSessionQuestionsWithFeedbackUseCase,
@@ -18,6 +19,7 @@ import {
   FakeSubscriptionRepository,
 } from '@/src/application/test-helpers/fakes';
 import type {
+  DiscardPracticeSessionOutput,
   EndPracticeSessionOutput,
   FinalizeExamAnswersOutput,
   GetCompletedSessionQuestionsWithFeedbackOutput,
@@ -38,6 +40,7 @@ export type PracticeControllerTestDeps = PracticeControllerDeps & {
   getIncompletePracticeSessionUseCase: FakeGetIncompletePracticeSessionUseCase;
   getCompletedSessionQuestionsWithFeedbackUseCase: FakeGetCompletedSessionQuestionsWithFeedbackUseCase;
   startPracticeSessionUseCase: FakeStartPracticeSessionUseCase;
+  discardPracticeSessionUseCase: FakeDiscardPracticeSessionUseCase;
   endPracticeSessionUseCase: FakeEndPracticeSessionUseCase;
   finalizeExamAnswersUseCase: FakeFinalizeExamAnswersUseCase;
   saveExamDraftAnswerUseCase: FakeSaveExamDraftAnswerUseCase;
@@ -58,6 +61,8 @@ export function createDeps(overrides?: {
   startThrows?: unknown;
   countOutput?: { count: number };
   countThrows?: unknown;
+  discardOutput?: DiscardPracticeSessionOutput;
+  discardThrows?: unknown;
   endOutput?: EndPracticeSessionOutput;
   endThrows?: unknown;
   finalizeOutput?: FinalizeExamAnswersOutput;
@@ -130,6 +135,11 @@ export function createDeps(overrides?: {
   const countAvailableQuestionsUseCase = new FakeCountAvailableQuestionsUseCase(
     overrides?.countOutput ?? { count: 0 },
     overrides?.countThrows,
+  );
+
+  const discardPracticeSessionUseCase = new FakeDiscardPracticeSessionUseCase(
+    overrides?.discardOutput ?? { discarded: true },
+    overrides?.discardThrows,
   );
 
   const endPracticeSessionUseCase = new FakeEndPracticeSessionUseCase(
@@ -241,6 +251,7 @@ export function createDeps(overrides?: {
     getCompletedSessionQuestionsWithFeedbackUseCase,
     startPracticeSessionUseCase,
     countAvailableQuestionsUseCase,
+    discardPracticeSessionUseCase,
     endPracticeSessionUseCase,
     finalizeExamAnswersUseCase,
     saveExamDraftAnswerUseCase,

--- a/src/adapters/controllers/practice-controller.ts
+++ b/src/adapters/controllers/practice-controller.ts
@@ -2,7 +2,10 @@
 
 // WHY large-file: this controller is the server-action facade for the practice use-case cluster; splitting it would hide shared auth/rate-limit/action-result conventions.
 import { createDepsResolver, loadAppContainer } from '@/lib/controller-helpers';
-import { START_PRACTICE_SESSION_RATE_LIMIT } from '@/src/adapters/shared/rate-limits';
+import {
+  PRACTICE_SESSION_MUTATION_RATE_LIMIT,
+  START_PRACTICE_SESSION_RATE_LIMIT,
+} from '@/src/adapters/shared/rate-limits';
 import { ApplicationError } from '@/src/application/errors';
 import type {
   AuthGateway,
@@ -13,6 +16,8 @@ import type { IdempotencyKeyRepository } from '@/src/application/ports/repositor
 import type {
   CountAvailableQuestionsInput,
   CountAvailableQuestionsOutput,
+  DiscardPracticeSessionInput,
+  DiscardPracticeSessionOutput,
   EndPracticeSessionInput,
   EndPracticeSessionOutput,
   FinalizeExamAnswersInput,
@@ -39,6 +44,8 @@ import type { SaveExamDraftAnswerOutput } from './practice-schemas';
 import {
   CountAvailableQuestionsInputSchema,
   CountAvailableQuestionsOutputSchema,
+  DiscardPracticeSessionInputSchema,
+  DiscardPracticeSessionOutputSchema,
   EmptyInputSchema,
   EndPracticeSessionInputSchema,
   EndPracticeSessionOutputSchema,
@@ -63,6 +70,7 @@ import { executeIdempotent } from './shared/execute-idempotent';
 
 export type {
   CountAvailableQuestionsOutput,
+  DiscardPracticeSessionOutput,
   EndPracticeSessionOutput,
   FinalizeExamAnswersOutput,
   GetCompletedSessionQuestionsWithFeedbackOutput,
@@ -100,6 +108,11 @@ export type PracticeControllerDeps = {
     execute: (
       input: CountAvailableQuestionsInput,
     ) => Promise<CountAvailableQuestionsOutput>;
+  };
+  discardPracticeSessionUseCase: {
+    execute: (
+      input: DiscardPracticeSessionInput,
+    ) => Promise<DiscardPracticeSessionOutput>;
   };
   endPracticeSessionUseCase: {
     execute: (
@@ -257,6 +270,40 @@ export const endPracticeSession = createAction({
       outputSchema: EndPracticeSessionOutputSchema,
       execute: () =>
         d.endPracticeSessionUseCase.execute({
+          userId,
+          sessionId,
+        }),
+    });
+  },
+});
+
+export const discardPracticeSession = createAction({
+  schema: DiscardPracticeSessionInputSchema,
+  getDeps,
+  execute: async (input, d, meta) => {
+    const userId = await requireEntitledUserId(d, meta);
+
+    const rate = await d.rateLimiter.limit({
+      key: `practice:discardPracticeSession:${userId}`,
+      ...PRACTICE_SESSION_MUTATION_RATE_LIMIT,
+    });
+    if (!rate.success) {
+      throw new ApplicationError(
+        'RATE_LIMITED',
+        `Too many session mutations. Try again in ${rate.retryAfterSeconds}s.`,
+      );
+    }
+
+    const { sessionId, idempotencyKey } = input;
+
+    return executeIdempotent({
+      d,
+      userId,
+      action: 'practice:discardPracticeSession',
+      idempotencyKey,
+      outputSchema: DiscardPracticeSessionOutputSchema,
+      execute: () =>
+        d.discardPracticeSessionUseCase.execute({
           userId,
           sessionId,
         }),

--- a/src/adapters/controllers/practice-schemas.ts
+++ b/src/adapters/controllers/practice-schemas.ts
@@ -51,6 +51,7 @@ export const EndPracticeSessionInputSchema = z
   })
   .strict();
 
+export const DiscardPracticeSessionInputSchema = EndPracticeSessionInputSchema;
 export const FinalizeExamAnswersInputSchema = EndPracticeSessionInputSchema;
 
 export const SaveExamDraftAnswerInputSchema = z
@@ -152,6 +153,11 @@ export const PracticeSessionSummaryOutputSchema =
   EndPracticeSessionOutputSchema;
 export const FinalizeExamAnswersOutputSchema =
   PracticeSessionSummaryOutputSchema;
+export const DiscardPracticeSessionOutputSchema = z
+  .object({
+    discarded: z.literal(true),
+  })
+  .strict();
 
 export const SaveExamDraftAnswerOutputSchema = z
   .object({

--- a/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { PRACTICE_SESSIONS_USER_INCOMPLETE_UQ } from '@/db/schema';
+import {
+  PRACTICE_SESSIONS_USER_INCOMPLETE_UQ,
+  practiceSessions,
+} from '@/db/schema';
 import { ApplicationError } from '@/src/application/errors';
 import { DrizzlePracticeSessionRepository } from './drizzle-practice-session-repository';
 import { restoreDrizzlePracticeSessionRepositoryTestMocks } from './drizzle-practice-session-repository-test-helpers';
@@ -232,6 +235,38 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
     await expect(
       repo.create({ userId: userId, mode: 'tutor', paramsJson }),
     ).rejects.toMatchObject({ code: 'INTERNAL_ERROR' });
+  });
+
+  it('discards an incomplete practice session by deleting the session row', async () => {
+    const deleteWhere = vi.fn(async () => undefined);
+    const deleteFrom = vi.fn(() => ({ where: deleteWhere }));
+
+    const db = {
+      delete: deleteFrom,
+      insert: () => {
+        throw new Error('unexpected insert');
+      },
+      query: {
+        practiceSessions: {
+          findFirst: async () => {
+            throw new Error('unexpected findFirst');
+          },
+        },
+      },
+      update: () => {
+        throw new Error('unexpected update');
+      },
+    } as const;
+
+    type RepoDb = ConstructorParameters<
+      typeof DrizzlePracticeSessionRepository
+    >[0];
+    const repo = new DrizzlePracticeSessionRepository(db as unknown as RepoDb);
+
+    await expect(repo.discard(sessionId, userId)).resolves.toBeUndefined();
+
+    expect(deleteFrom).toHaveBeenCalledWith(practiceSessions);
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
   });
 
   it('ends an active practice session', async () => {

--- a/src/adapters/repositories/drizzle-practice-session-repository.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository.ts
@@ -316,6 +316,18 @@ export class DrizzlePracticeSessionRepository
     });
   }
 
+  async discard(id: string, userId: string): Promise<void> {
+    await this.db
+      .delete(practiceSessions)
+      .where(
+        and(
+          eq(practiceSessions.id, id),
+          eq(practiceSessions.userId, userId),
+          isNull(practiceSessions.endedAt),
+        ),
+      );
+  }
+
   async end(id: string, userId: string) {
     const existing = await this.findByIdAndUserId(id, userId);
     if (!existing) {

--- a/src/adapters/shared/rate-limits.ts
+++ b/src/adapters/shared/rate-limits.ts
@@ -39,6 +39,11 @@ export const START_PRACTICE_SESSION_RATE_LIMIT = {
   windowMs: ONE_MINUTE_MS,
 } as const;
 
+export const PRACTICE_SESSION_MUTATION_RATE_LIMIT = {
+  limit: 60,
+  windowMs: ONE_MINUTE_MS,
+} as const;
+
 export const BOOKMARK_MUTATION_RATE_LIMIT = {
   limit: 60,
   windowMs: ONE_MINUTE_MS,

--- a/src/application/ports/practice-session-repository.ts
+++ b/src/application/ports/practice-session-repository.ts
@@ -55,5 +55,6 @@ export interface PracticeSessionRepository {
     questionId: string;
     markedForReview: boolean;
   }): Promise<PracticeSessionQuestionState>;
+  discard(id: string, userId: string): Promise<void>;
   end(id: string, userId: string): Promise<PracticeSession>;
 }

--- a/src/application/test-helpers/fakes/fake-practice-session-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-practice-session-repository.test.ts
@@ -63,6 +63,51 @@ describe('FakePracticeSessionRepository', () => {
     );
   });
 
+  it('discards only incomplete sessions owned by the caller', async () => {
+    const endedAt = new Date('2026-02-01T00:00:00Z');
+    const repo = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: 'active-owned',
+        userId: 'user-1',
+        mode: 'exam',
+        endedAt: null,
+      }),
+      createPracticeSession({
+        id: 'active-other',
+        userId: 'user-2',
+        mode: 'exam',
+        endedAt: null,
+      }),
+      createPracticeSession({
+        id: 'ended-owned',
+        userId: 'user-1',
+        mode: 'exam',
+        endedAt,
+      }),
+    ]);
+
+    await expect(repo.discard('active-owned', 'user-1')).resolves.toBe(
+      undefined,
+    );
+    await expect(repo.discard('missing', 'user-1')).resolves.toBe(undefined);
+    await expect(repo.discard('active-other', 'user-1')).resolves.toBe(
+      undefined,
+    );
+    await expect(repo.discard('ended-owned', 'user-1')).resolves.toBe(
+      undefined,
+    );
+
+    await expect(
+      repo.findByIdAndUserId('active-owned', 'user-1'),
+    ).resolves.toBeNull();
+    await expect(
+      repo.findByIdAndUserId('active-other', 'user-2'),
+    ).resolves.toMatchObject({ id: 'active-other' });
+    await expect(
+      repo.findByIdAndUserId('ended-owned', 'user-1'),
+    ).resolves.toMatchObject({ id: 'ended-owned', endedAt });
+  });
+
   it('normalizes missing draft fields when creating a session from legacy params', async () => {
     const repo = new FakePracticeSessionRepository();
 

--- a/src/application/test-helpers/fakes/fake-practice-session-repository.ts
+++ b/src/application/test-helpers/fakes/fake-practice-session-repository.ts
@@ -372,6 +372,17 @@ export class FakePracticeSessionRepository
     return updatedState;
   }
 
+  async discard(id: string, userId: string): Promise<void> {
+    this.sessions = this.sessions.filter(
+      (session) =>
+        !(
+          session.id === id &&
+          session.userId === userId &&
+          session.endedAt === null
+        ),
+    );
+  }
+
   async end(id: string, userId: string): Promise<PracticeSession> {
     const existing = await this.findByIdAndUserId(id, userId);
     if (!existing) {

--- a/src/application/test-helpers/fakes/fake-use-cases.ts
+++ b/src/application/test-helpers/fakes/fake-use-cases.ts
@@ -44,6 +44,10 @@ export class FakeCountAvailableQuestionsUseCase extends FakeUseCase<
   U.CountAvailableQuestionsInput,
   U.CountAvailableQuestionsOutput
 > {}
+export class FakeDiscardPracticeSessionUseCase extends FakeUseCase<
+  U.DiscardPracticeSessionInput,
+  U.DiscardPracticeSessionOutput
+> {}
 export class FakeEndPracticeSessionUseCase extends FakeUseCase<
   U.EndPracticeSessionInput,
   U.EndPracticeSessionOutput

--- a/src/application/test-helpers/fakes/index.ts
+++ b/src/application/test-helpers/fakes/index.ts
@@ -22,6 +22,7 @@ export {
   FakeCountAvailableQuestionsUseCase,
   FakeCreateCheckoutSessionUseCase,
   FakeCreatePortalSessionUseCase,
+  FakeDiscardPracticeSessionUseCase,
   FakeEndPracticeSessionUseCase,
   FakeFinalizeExamAnswersUseCase,
   FakeGetAttemptedQuestionsUseCase,

--- a/src/application/use-cases/discard-practice-session.test.ts
+++ b/src/application/use-cases/discard-practice-session.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FakeAttemptRepository,
+  FakeLogger,
+  FakePracticeSessionRepository,
+  FakeQuestionRepository,
+} from '@/src/application/test-helpers/fakes';
+import {
+  createChoice,
+  createPracticeSession,
+  createQuestion,
+} from '@/src/domain/test-helpers';
+import { DiscardPracticeSessionUseCase } from './discard-practice-session';
+import { GetCompletedSessionQuestionsWithFeedbackUseCase } from './get-completed-session-questions-with-feedback';
+import { GetSessionHistoryUseCase } from './get-session-history';
+import { StartPracticeSessionUseCase } from './start-practice-session';
+
+describe('DiscardPracticeSessionUseCase', () => {
+  it('removes the caller incomplete session and makes it non-reviewable', async () => {
+    const userId = 'user-1';
+    const sessionId = 'session-exam';
+    const question = createQuestion({
+      id: 'question-1',
+      slug: 'question-1',
+      choices: [
+        createChoice({
+          id: 'choice-1',
+          questionId: 'question-1',
+          isCorrect: true,
+        }),
+      ],
+    });
+    const sessions = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: sessionId,
+        userId,
+        mode: 'exam',
+        questionIds: ['question-1'],
+        questionStates: [
+          {
+            questionId: 'question-1',
+            markedForReview: false,
+            latestSelectedChoiceId: null,
+            latestIsCorrect: null,
+            latestAnsweredAt: null,
+            draftSelectedChoiceId: 'choice-1',
+            draftSavedAt: new Date('2026-02-01T00:01:00.000Z'),
+            draftCumulativeMs: 15_000,
+          },
+        ],
+        endedAt: null,
+      }),
+    ]);
+
+    await new DiscardPracticeSessionUseCase(sessions).execute({
+      userId,
+      sessionId,
+    });
+
+    await expect(
+      sessions.findByIdAndUserId(sessionId, userId),
+    ).resolves.toBeNull();
+    await expect(
+      sessions.findCompletedByUserId(userId, 10, 0, 'exam'),
+    ).resolves.toEqual({ rows: [], total: 0 });
+
+    const history = new GetSessionHistoryUseCase(
+      sessions,
+      new FakeQuestionRepository([question]),
+    );
+    await expect(
+      history.execute({ userId, limit: 10, offset: 0, mode: 'exam' }),
+    ).resolves.toMatchObject({ rows: [], total: 0 });
+
+    const feedback = new GetCompletedSessionQuestionsWithFeedbackUseCase(
+      sessions,
+      new FakeQuestionRepository([question]),
+      new FakeAttemptRepository([]),
+      new FakeLogger(),
+    );
+    await expect(feedback.execute({ userId, sessionId })).rejects.toMatchObject(
+      {
+        code: 'NOT_FOUND',
+      },
+    );
+  });
+
+  it('is idempotent when the session is missing or already discarded', async () => {
+    const sessions = new FakePracticeSessionRepository([]);
+    const useCase = new DiscardPracticeSessionUseCase(sessions);
+
+    await expect(
+      useCase.execute({ userId: 'user-1', sessionId: 'missing' }),
+    ).resolves.toEqual({ discarded: true });
+    await expect(
+      useCase.execute({ userId: 'user-1', sessionId: 'missing' }),
+    ).resolves.toEqual({ discarded: true });
+  });
+
+  it('does not discard another user session', async () => {
+    const session = createPracticeSession({
+      id: 'session-1',
+      userId: 'owner-user',
+      mode: 'exam',
+      endedAt: null,
+    });
+    const sessions = new FakePracticeSessionRepository([session]);
+
+    await new DiscardPracticeSessionUseCase(sessions).execute({
+      userId: 'other-user',
+      sessionId: 'session-1',
+    });
+
+    await expect(
+      sessions.findByIdAndUserId('session-1', 'owner-user'),
+    ).resolves.toMatchObject({ id: 'session-1' });
+  });
+
+  it('does not discard completed sessions', async () => {
+    const endedAt = new Date('2026-02-01T00:10:00.000Z');
+    const session = createPracticeSession({
+      id: 'session-ended',
+      userId: 'user-1',
+      mode: 'exam',
+      endedAt,
+    });
+    const sessions = new FakePracticeSessionRepository([session]);
+
+    await new DiscardPracticeSessionUseCase(sessions).execute({
+      userId: 'user-1',
+      sessionId: 'session-ended',
+    });
+
+    await expect(
+      sessions.findByIdAndUserId('session-ended', 'user-1'),
+    ).resolves.toMatchObject({ id: 'session-ended', endedAt });
+  });
+
+  it('frees the incomplete-session slot so the user can start over', async () => {
+    const userId = 'user-1';
+    const question = createQuestion({
+      id: 'question-1',
+      difficulty: 'easy',
+      choices: [
+        createChoice({
+          id: 'choice-1',
+          questionId: 'question-1',
+          isCorrect: true,
+        }),
+      ],
+    });
+    const sessions = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: 'session-old',
+        userId,
+        mode: 'exam',
+        questionIds: ['question-1'],
+        endedAt: null,
+      }),
+    ]);
+
+    await new DiscardPracticeSessionUseCase(sessions).execute({
+      userId,
+      sessionId: 'session-old',
+    });
+
+    await expect(
+      new StartPracticeSessionUseCase(
+        new FakeQuestionRepository([question]),
+        sessions,
+      ).execute({
+        userId,
+        mode: 'exam',
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+      }),
+    ).resolves.toMatchObject({
+      requestedCount: 1,
+      actualCount: 1,
+    });
+  });
+});

--- a/src/application/use-cases/discard-practice-session.test.ts
+++ b/src/application/use-cases/discard-practice-session.test.ts
@@ -136,6 +136,28 @@ describe('DiscardPracticeSessionUseCase', () => {
     ).resolves.toMatchObject({ id: 'session-ended', endedAt });
   });
 
+  it('rejects discarding a tutor session and leaves it intact', async () => {
+    const sessions = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: 'session-tutor',
+        userId: 'user-1',
+        mode: 'tutor',
+        endedAt: null,
+      }),
+    ]);
+
+    await expect(
+      new DiscardPracticeSessionUseCase(sessions).execute({
+        userId: 'user-1',
+        sessionId: 'session-tutor',
+      }),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    await expect(
+      sessions.findByIdAndUserId('session-tutor', 'user-1'),
+    ).resolves.toMatchObject({ id: 'session-tutor' });
+  });
+
   it('frees the incomplete-session slot so the user can start over', async () => {
     const userId = 'user-1';
     const question = createQuestion({

--- a/src/application/use-cases/discard-practice-session.ts
+++ b/src/application/use-cases/discard-practice-session.ts
@@ -1,3 +1,4 @@
+import { ApplicationError } from '../errors';
 import type { PracticeSessionRepository } from '../ports/repositories';
 
 export type DiscardPracticeSessionInput = {
@@ -15,6 +16,26 @@ export class DiscardPracticeSessionUseCase {
   async execute(
     input: DiscardPracticeSessionInput,
   ): Promise<DiscardPracticeSessionOutput> {
+    const existing = await this.sessions.findByIdAndUserId(
+      input.sessionId,
+      input.userId,
+    );
+
+    // Idempotent: an absent (already-discarded, or not-owned) session is a no-op success.
+    if (!existing) {
+      return { discarded: true };
+    }
+
+    // Discard is the exam-only terminal transition. Tutor sessions hold real graded
+    // attempts and must complete via end(), never be deleted (BUG-251 decision). Enforce
+    // the invariant server-side so a direct action call cannot bypass the UI's mode routing.
+    if (existing.mode !== 'exam') {
+      throw new ApplicationError(
+        'VALIDATION_ERROR',
+        'Only exam sessions can be discarded; tutor sessions must be ended',
+      );
+    }
+
     await this.sessions.discard(input.sessionId, input.userId);
     return { discarded: true };
   }

--- a/src/application/use-cases/discard-practice-session.ts
+++ b/src/application/use-cases/discard-practice-session.ts
@@ -1,0 +1,21 @@
+import type { PracticeSessionRepository } from '../ports/repositories';
+
+export type DiscardPracticeSessionInput = {
+  userId: string;
+  sessionId: string;
+};
+
+export type DiscardPracticeSessionOutput = {
+  discarded: true;
+};
+
+export class DiscardPracticeSessionUseCase {
+  constructor(private readonly sessions: PracticeSessionRepository) {}
+
+  async execute(
+    input: DiscardPracticeSessionInput,
+  ): Promise<DiscardPracticeSessionOutput> {
+    await this.sessions.discard(input.sessionId, input.userId);
+    return { discarded: true };
+  }
+}

--- a/src/application/use-cases/end-practice-session.test.ts
+++ b/src/application/use-cases/end-practice-session.test.ts
@@ -54,7 +54,7 @@ describe('EndPracticeSessionUseCase', () => {
     });
   }
 
-  it('returns exam accuracy using total question count denominator when calculating session metrics', async () => {
+  it('rejects generic end for an active exam session', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-02-01T00:10:00Z'));
 
@@ -66,16 +66,9 @@ describe('EndPracticeSessionUseCase', () => {
 
     await expect(
       useCase.execute({ userId: 'user-1', sessionId: 'session-exam' }),
-    ).resolves.toMatchObject({
-      sessionId: 'session-exam',
-      mode: 'exam',
-      questionCount: 3,
-      totals: {
-        answered: 1,
-        correct: 1,
-        accuracy: 1 / 3,
-      },
-    });
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    } satisfies Partial<ApplicationError>);
   });
 
   it('returns tutor accuracy using total question count denominator when calculating session metrics', async () => {

--- a/src/application/use-cases/end-practice-session.ts
+++ b/src/application/use-cases/end-practice-session.ts
@@ -18,6 +18,23 @@ export class EndPracticeSessionUseCase {
   async execute(
     input: EndPracticeSessionInput,
   ): Promise<EndPracticeSessionOutput> {
+    const existing = await this.sessions.findByIdAndUserId(
+      input.sessionId,
+      input.userId,
+    );
+    if (!existing) {
+      throw new ApplicationError('NOT_FOUND', 'Practice session not found');
+    }
+    if (existing.endedAt) {
+      throw new ApplicationError('CONFLICT', 'Practice session already ended');
+    }
+    if (existing.mode === 'exam') {
+      throw new ApplicationError(
+        'VALIDATION_ERROR',
+        'Active exam sessions must be finalized or discarded, not ended',
+      );
+    }
+
     const session = await this.sessions.end(input.sessionId, input.userId);
 
     const endedAt = session.endedAt;

--- a/src/application/use-cases/index.ts
+++ b/src/application/use-cases/index.ts
@@ -19,6 +19,11 @@ export {
   CreatePortalSessionUseCase,
 } from './create-portal-session';
 export {
+  type DiscardPracticeSessionInput,
+  type DiscardPracticeSessionOutput,
+  DiscardPracticeSessionUseCase,
+} from './discard-practice-session';
+export {
   type EndPracticeSessionInput,
   type EndPracticeSessionOutput,
   EndPracticeSessionUseCase,

--- a/tests/integration/bug-regression-exam-draft-bounds.integration.test.ts
+++ b/tests/integration/bug-regression-exam-draft-bounds.integration.test.ts
@@ -13,6 +13,7 @@ import { DrizzleQuestionRepository } from '@/src/adapters/repositories/drizzle-q
 import {
   FakeAuthGateway,
   FakeCountAvailableQuestionsUseCase,
+  FakeDiscardPracticeSessionUseCase,
   FakeEndPracticeSessionUseCase,
   FakeFinalizeExamAnswersUseCase,
   FakeGetCompletedSessionQuestionsWithFeedbackUseCase,
@@ -107,6 +108,9 @@ function createPracticeControllerDepsForBug238(input: {
     }),
     countAvailableQuestionsUseCase: new FakeCountAvailableQuestionsUseCase({
       count: 1,
+    }),
+    discardPracticeSessionUseCase: new FakeDiscardPracticeSessionUseCase({
+      discarded: true,
     }),
     endPracticeSessionUseCase: new FakeEndPracticeSessionUseCase({
       sessionId: '11111111-1111-1111-1111-111111111111',


### PR DESCRIPTION
## Summary

Promotes the **BUG-251 fix** plus the **BUG-251/252 filings** from the practice/quiz-engine correctness sweep. 29-file delta over `main` (`c5c88873`).

## BUG-251 (P2) — FIXED

The Practice-hub "Abandon" dialog promises to *discard* an in-progress session, but the handler called generic `endPracticeSession`, which set `endedAt` **without** `finalizeExamAnswers`. For an exam that meant a discarded session persisted as a reviewable "completed" exam (in History, with the full answer key exposed by the completed-feedback reader) and with no finalized attempts.

Owner-decided fix (recorded in the bug doc's Proposed Fix): **exam "Abandon" = true discard by deletion.**

- New `DiscardPracticeSessionUseCase` + `discardPracticeSession` server action → repo `discard()` does `DELETE WHERE id = ? AND user_id = ? AND ended_at IS NULL`. Idempotent; frees the one-incomplete-session unique index so the user can start over (a reject-only guard would have stranded them).
- `EndPracticeSessionUseCase` now rejects `mode === 'exam' && endedAt === null` (VALIDATION_ERROR) as defense in depth. The guard is in the **use-case**, so `finalizeExamAnswers` (which calls the repo `end()` directly) is unaffected.
- Practice-hub abandon routes **exam → discard**, **tutor → end** (tutor accrues real graded attempts and legitimately completes; tutor has no answer secrecy).
- Deletion was chosen over a tombstone because it adds **no new lifecycle state** (so it can't re-create this bug's "a reader forgot to exclude a state" failure mode), the owner does not want an abandonment signal, and the discarded data is uncommitted drafts (an active exam has zero finalized attempts).

Not a secrecy bug: the canonical secrecy boundary is `endedAt` (exam-answer-secrecy-policy §1/§5), and `finalizeExamAnswers` already rejects ended sessions, so there was never a peek-then-submit. This was a lifecycle/data-integrity fix.

## BUG-252 (P3) — filed only (not fixed here)

Unanswered-but-time-spent exam questions skip the server draft write, so finalize records `timeSpentSeconds = 0` for omitted attempts. Scoring unaffected; no UI surfaces the value. Documented as a narrow persistence-accuracy gap; deferred.

## Verification

- Full gate green on `dev` (typecheck, lint, 2873 unit, 298 browser, integration 111, build).
- Independent re-verification: focused BUG-251 suites 68/68 green; `tsc --noEmit` clean.
- Regression proof (use-case test against real `GetSessionHistory` + `GetCompletedSessionQuestionsWithFeedback`): a discarded exam is absent from history and the feedback reader throws `NOT_FOUND` — no answer-key reveal. Plus idempotency, cross-user safety, completed-session protection, no-stranding.
- `attempts.practice_session_id` FK confirmed `onDelete: set null` — discard can never cascade-destroy attempts.

## Known non-blocking notes (for reviewer awareness)

1. Repo `discard` has mocked-db unit coverage rather than a dedicated Postgres integration test; semantics are covered by the fake + use-case tests, and the `and/eq/isNull` pattern is integration-proven across the repo.
2. `discard` is mode-agnostic; the UI only routes exam→discard, but a direct action call could discard one's own incomplete tutor session (attempts survive via set-null; not cross-user). Optional defense-in-depth later.

## Promotion

Merge with a merge commit (protected `main`). Moving `main` triggers a production deploy.

https://claude.ai/code/session_01RhHv6rK1YVBaE8WmPNpGXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed abandoning active **exam** practice sessions so they are truly **discarded** (not ended as completed) and no longer bypass exam finalization.
  * Added safeguards preventing active **exam** sessions from being finalized through the generic “end” flow.
* **New Features**
  * Added an idempotent **discard** action for incomplete practice sessions, with mode-dependent behavior.
* **Tests**
  * Expanded coverage for abandoning incomplete sessions in **tutor** and **exam** modes across controller and page/integration paths.
* **Documentation**
  * Updated and added bug reports for the exam abandon behavior and unanswered exam timing persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->