### PR TITLE
Promote dev to main: BUG-252 unanswered exam draft timing persistence

### DIFF
--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.browser.spec.tsx
@@ -220,7 +220,8 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
     });
   });
 
-  it('navigates without saving when exam next is used with no selection', async () => {
+  it('navigates without saving when exam next is used with no selection and no elapsed time', async () => {
+    vi.spyOn(Date, 'now').mockImplementation(() => 1_000);
     const getNextQuestionFn = vi
       .fn<(input: unknown) => Promise<ActionResult<NextQuestion | null>>>()
       .mockResolvedValueOnce(
@@ -390,7 +391,7 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
             'selectedChoiceId' in input &&
             typeof input.selectedChoiceId === 'string'
               ? input.selectedChoiceId
-              : fixtureChoice2Id,
+              : null,
           draftSavedAt: '2026-02-01T00:00:00.000Z',
           draftCumulativeMs:
             typeof input === 'object' &&
@@ -449,6 +450,12 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
       cumulativeMs: 30_000,
     });
     expect(saveExamDraftAnswerFn).toHaveBeenNthCalledWith(2, {
+      sessionId: fixtureSession1Id,
+      questionId: fixtureQ2Id,
+      selectedChoiceId: null,
+      cumulativeMs: 500,
+    });
+    expect(saveExamDraftAnswerFn).toHaveBeenNthCalledWith(3, {
       sessionId: fixtureSession1Id,
       questionId: fixtureQ1Id,
       selectedChoiceId: fixtureChoice2Id,
@@ -591,7 +598,13 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
     await expect
       .poll(() => harness.result.current.question?.questionId)
       .toBe(fixtureQ2Id);
-    expect(saveExamDraftAnswerFn).not.toHaveBeenCalled();
+    expect(saveExamDraftAnswerFn).toHaveBeenCalledTimes(1);
+    expect(saveExamDraftAnswerFn).toHaveBeenCalledWith({
+      sessionId: fixtureSession1Id,
+      questionId: fixtureQ1Id,
+      selectedChoiceId: null,
+      cumulativeMs: 30_000,
+    });
 
     nowMs = 31_500;
     harness.result.current.onNavigateQuestion(fixtureQ1Id);
@@ -610,8 +623,14 @@ describe('usePracticeSessionQuestionFlow (browser)', () => {
       .poll(() => harness.result.current.question?.questionId)
       .toBe(fixtureQ2Id);
 
-    expect(saveExamDraftAnswerFn).toHaveBeenCalledTimes(1);
-    expect(saveExamDraftAnswerFn).toHaveBeenCalledWith({
+    expect(saveExamDraftAnswerFn).toHaveBeenCalledTimes(3);
+    expect(saveExamDraftAnswerFn).toHaveBeenNthCalledWith(2, {
+      sessionId: fixtureSession1Id,
+      questionId: fixtureQ2Id,
+      selectedChoiceId: null,
+      cumulativeMs: 500,
+    });
+    expect(saveExamDraftAnswerFn).toHaveBeenNthCalledWith(3, {
       sessionId: fixtureSession1Id,
       questionId: fixtureQ1Id,
       selectedChoiceId: fixtureChoice2Id,

--- a/app/(app)/app/practice/shared/question-flow-actions.test.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions.test.ts
@@ -855,11 +855,23 @@ describe('question-flow-actions', () => {
     });
   });
 
-  it('tracks unanswered exam time locally when no exam selection exists', async () => {
-    const saveExamDraftAnswerFn =
-      vi.fn<
+  it('persists cumulative time for unanswered exam questions before navigation', async () => {
+    const saveExamDraftAnswerFn = vi
+      .fn<
         (input: unknown) => Promise<ActionResult<SaveExamDraftAnswerOutput>>
-      >();
+      >()
+      .mockResolvedValue(
+        ok({
+          questionId: fixtureQuestion1Id,
+          markedForReview: false,
+          latestSelectedChoiceId: null,
+          latestIsCorrect: null,
+          latestAnsweredAt: null,
+          draftSelectedChoiceId: null,
+          draftSavedAt: '2026-02-01T00:00:00.000Z',
+          draftCumulativeMs: 15_000,
+        }),
+      );
     const onSaved = vi.fn();
 
     const shouldNavigate = await maybeSaveDraftBeforeNavigation({
@@ -886,12 +898,52 @@ describe('question-flow-actions', () => {
     });
 
     expect(shouldNavigate).toBe(true);
-    expect(saveExamDraftAnswerFn).not.toHaveBeenCalled();
+    expect(saveExamDraftAnswerFn).toHaveBeenCalledWith({
+      sessionId: fixtureSession1Id,
+      questionId: fixtureQuestion1Id,
+      selectedChoiceId: null,
+      cumulativeMs: 15_000,
+    });
     expect(onSaved).toHaveBeenCalledWith({
       questionId: fixtureQuestion1Id,
       selectedChoiceId: null,
       cumulativeMs: 15_000,
     });
+  });
+
+  it('does not save a time-only exam draft when cumulative time did not advance', async () => {
+    const saveExamDraftAnswerFn =
+      vi.fn<
+        (input: unknown) => Promise<ActionResult<SaveExamDraftAnswerOutput>>
+      >();
+    const onSaved = vi.fn();
+
+    const shouldNavigate = await maybeSaveDraftBeforeNavigation({
+      sessionId: fixtureSession1Id,
+      question: {
+        questionId: fixtureQuestion1Id,
+        session: {
+          sessionId: fixtureSession1Id,
+          mode: 'exam',
+
+          deadlineAt: '2099-05-22T12:02:24.000Z',
+
+          index: 0,
+          total: 2,
+        },
+      },
+      selectedChoiceId: null,
+      currentCumulativeMs: 15_000,
+      lastSavedDraftSelectedChoiceId: null,
+      lastSavedDraftCumulativeMs: 15_000,
+      saveExamDraftAnswerFn,
+      setLoadState: () => {},
+      onSaved,
+    });
+
+    expect(shouldNavigate).toBe(true);
+    expect(saveExamDraftAnswerFn).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
   });
 
   it('blocks navigation and sets load error when draft save fails', async () => {

--- a/app/(app)/app/practice/shared/question-flow-actions.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions.ts
@@ -171,15 +171,6 @@ export async function maybeSaveDraftBeforeNavigation<
     return true;
   }
 
-  if (!input.selectedChoiceId) {
-    input.onSaved?.({
-      questionId: input.question.questionId,
-      selectedChoiceId: null,
-      cumulativeMs: input.currentCumulativeMs,
-    });
-    return true;
-  }
-
   let res: ActionResult<SaveExamDraftAnswerOutput>;
   try {
     res = await withTimeout(

--- a/docs/bugs/bug-252-unanswered-exam-time-not-persisted.md
+++ b/docs/bugs/bug-252-unanswered-exam-time-not-persisted.md
@@ -1,6 +1,7 @@
 # BUG-252: Unanswered Exam Question Time Is Not Persisted Before Finalization
 
-**Status:** Open — filed, NOT fixed
+**Status:** Open — branch fix landed, pending PR review / merge / production verification
+**Resolution State:** Implementation commit `902fc4d4` on branch `bug/252-persist-unanswered-exam-time` widens exam draft saves to accept `selectedChoiceId: string | null`, persists time-only unanswered drafts, and leaves `FinalizeExamAnswersUseCase` unchanged. Full local gate passed on 2026-06-19: typecheck, lint, unit 2883, browser 298, integration 112, build, and e2e 36. Keep open until PR review/merge, promotion to `main`, and production deploy READY verification are complete.
 **Severity:** P3
 **Date:** 2026-06-18
 **Confirmed:** 2026-06-18
@@ -10,9 +11,9 @@
 
 ## Summary
 
-Exam mode tracks per-question elapsed time locally, but if the user leaves a question without selecting an answer, the client intentionally skips the server draft write. `FinalizeExamAnswersUseCase` later computes omitted attempts' `timeSpentSeconds` from server-side `draftCumulativeMs`, so unanswered questions that the user spent time on can be finalized with `timeSpentSeconds = 0`.
+Before implementation commit `902fc4d4`, exam mode tracked per-question elapsed time locally, but if the user left a question without selecting an answer, the client intentionally skipped the server draft write. `FinalizeExamAnswersUseCase` later computed omitted attempts' `timeSpentSeconds` from server-side `draftCumulativeMs`, so unanswered questions that the user spent time on could be finalized with `timeSpentSeconds = 0`.
 
-This does not affect scoring and no current UI surfaces omitted-question timing. The bug is a narrow persistence-accuracy gap in the proposed stopwatch model: unanswered time is preserved only in browser state until the user later selects an answer.
+This does not affect scoring and no current UI surfaces omitted-question timing. Until the branch fix is reviewed, merged, promoted, and production-verified, BUG-252 remains a narrow persistence-accuracy gap in the proposed stopwatch model: unanswered time is preserved only in browser state until the user later selects an answer.
 
 ## Reproduction
 
@@ -27,12 +28,14 @@ Expected:
 - Question 1 is omitted and incorrect.
 - Its attempt records approximately `timeSpentSeconds = 15` because the user spent 15 seconds on that question.
 
-Actual:
+Pre-fix actual:
 
 - Question 1 is omitted and incorrect.
 - Its attempt records `timeSpentSeconds = 0` because no server draft write ever persisted the local `15_000` ms.
 
 ## Root Cause
+
+The root-cause evidence below describes the pre-fix state verified at filing. Commit `902fc4d4` changes the live branch behavior, but BUG-252 remains open until the fix is reviewed, merged/promoted, and production-verified.
 
 The interaction-contract doc labels the stopwatch behavior as a proposed model, and that model says cumulative time should be persisted on draft save and used during finalization:
 
@@ -40,13 +43,13 @@ The interaction-contract doc labels the stopwatch behavior as a proposed model, 
 - [`interaction-contracts.md`](../practice-engine/interaction-contracts.md#L192) says "On draft save: persist cumulativeMs alongside the draft choiceId".
 - [`interaction-contracts.md`](../practice-engine/interaction-contracts.md#L193) says "On finalize: timeSpentSeconds = Math.floor(cumulativeMs / 1000)".
 
-The client has an explicit no-selection early return:
+The pre-fix client had an explicit no-selection early return:
 
 - [`maybeSaveDraftBeforeNavigation`](<../../app/(app)/app/practice/shared/question-flow-actions.ts#L174>) checks `if (!input.selectedChoiceId)`.
 - It calls `onSaved` with the local `cumulativeMs` at [`question-flow-actions.ts`](<../../app/(app)/app/practice/shared/question-flow-actions.ts#L175>), but returns without calling `saveExamDraftAnswerFn` at [`question-flow-actions.ts`](<../../app/(app)/app/practice/shared/question-flow-actions.ts#L180>).
 - The existing test suite locks in that behavior: [`question-flow-actions.test.ts`](<../../app/(app)/app/practice/shared/question-flow-actions.test.ts#L858>) asserts "tracks unanswered exam time locally" and [`question-flow-actions.test.ts`](<../../app/(app)/app/practice/shared/question-flow-actions.test.ts#L889>) expects `saveExamDraftAnswerFn` not to be called.
 
-The server/API shape also prevents persisting a time-only draft:
+The pre-fix server/API shape also prevented persisting a time-only draft:
 
 - [`SaveExamDraftAnswerInputSchema`](../../src/adapters/controllers/practice-schemas.ts#L61) requires `selectedChoiceId: zUuid`.
 - [`SaveExamDraftAnswerInput`](../../src/application/use-cases/save-exam-draft-answer.ts#L14) requires `selectedChoiceId: string`.
@@ -58,11 +61,11 @@ Finalization then trusts the server-side draft clock for omitted attempts:
 - It caps `state.draftCumulativeMs` and computes `timeSpentSeconds` from that value at [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L96-L100).
 - For unanswered questions, it inserts the omitted attempt with that value at [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L106) and [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L112).
 
-Because unanswered cumulative time never leaves the browser until a choice is later selected, finalization writes an undercounted duration for questions that remain omitted.
+Before `902fc4d4`, unanswered cumulative time never left the browser until a choice was later selected, so finalization wrote an undercounted duration for questions that remained omitted.
 
 ## Impact
 
-Exam scoring remains correct for the omitted answer, but persisted attempt timing is wrong for skipped/unanswered exam questions. The current user-facing impact is low because the app does not display per-question omitted timing. The durable risk is bad timing data for analytics, audits, or future study recommendations.
+Exam scoring remains correct for the omitted answer, but persisted attempt timing is wrong for skipped/unanswered exam questions until the branch fix is deployed. The current user-facing impact is low because the app does not display per-question omitted timing. The durable risk is bad timing data for analytics, audits, or future study recommendations.
 
 ## Proposed Fix
 

--- a/docs/bugs/bug-252-unanswered-exam-time-not-persisted.md
+++ b/docs/bugs/bug-252-unanswered-exam-time-not-persisted.md
@@ -36,7 +36,7 @@ Actual:
 
 The interaction-contract doc labels the stopwatch behavior as a proposed model, and that model says cumulative time should be persisted on draft save and used during finalization:
 
-- [`interaction-contracts.md`](../practice-engine/interaction-contracts.md#L189) defines "On leave question: cumulativeMs += ...".
+- [`interaction-contracts.md`](../practice-engine/interaction-contracts.md#L191) defines "On leave question: cumulativeMs += ...".
 - [`interaction-contracts.md`](../practice-engine/interaction-contracts.md#L192) says "On draft save: persist cumulativeMs alongside the draft choiceId".
 - [`interaction-contracts.md`](../practice-engine/interaction-contracts.md#L193) says "On finalize: timeSpentSeconds = Math.floor(cumulativeMs / 1000)".
 
@@ -48,15 +48,15 @@ The client has an explicit no-selection early return:
 
 The server/API shape also prevents persisting a time-only draft:
 
-- [`SaveExamDraftAnswerInputSchema`](../../src/adapters/controllers/practice-schemas.ts#L56) requires `selectedChoiceId: zUuid`.
-- [`SaveExamDraftAnswerInput`](../../src/application/use-cases/save-exam-draft-answer.ts#L10) requires `selectedChoiceId: string`.
-- [`PracticeSessionRepository.saveDraftAnswer`](../../src/application/ports/practice-session-repository.ts#L29) also requires `selectedChoiceId: string`.
+- [`SaveExamDraftAnswerInputSchema`](../../src/adapters/controllers/practice-schemas.ts#L61) requires `selectedChoiceId: zUuid`.
+- [`SaveExamDraftAnswerInput`](../../src/application/use-cases/save-exam-draft-answer.ts#L14) requires `selectedChoiceId: string`.
+- [`PracticeSessionRepository.saveDraftAnswer`](../../src/application/ports/practice-session-repository.ts#L33) also requires `selectedChoiceId: string`.
 
 Finalization then trusts the server-side draft clock for omitted attempts:
 
 - [`FinalizeExamAnswersUseCase`](../../src/application/use-cases/finalize-exam-answers.ts#L95) loops every question state.
-- It computes `timeSpentSeconds` from `state.draftCumulativeMs` at [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L96).
-- For unanswered questions, it inserts the omitted attempt with that value at [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L102) and [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L112).
+- It caps `state.draftCumulativeMs` and computes `timeSpentSeconds` from that value at [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L96-L100).
+- For unanswered questions, it inserts the omitted attempt with that value at [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L106) and [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L112).
 
 Because unanswered cumulative time never leaves the browser until a choice is later selected, finalization writes an undercounted duration for questions that remain omitted.
 

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -1,7 +1,7 @@
 # Bug Reports
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-06-19 (BUG-251 resolved + archived — exam "Abandon" now hard-deletes the incomplete session (`DiscardPracticeSessionUseCase`) instead of completing it; promoted to `main` via PR #464 (merge `d5568288`), production deploy verified READY. Prior: practice/quiz-engine sweep filed BUG-251..BUG-252, BUG-252 (P3) still open. Prior: BUG-250 resolved + archived — `csvCell` in the feedback export neutralizes spreadsheet-formula-capable cells before CSV quoting; fixed on `dev` (`b98306a6`), promoted to `main` via PR #460 (merge `d76a3516`), production deploy verified READY. Prior: BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`.)
+**Last Updated:** 2026-06-19 (BUG-252 branch fix landed in `902fc4d4` on `bug/252-persist-unanswered-exam-time`; full local gate green, PR review/promotion/prod verification pending, so BUG-252 remains open. Prior: BUG-251 resolved + archived — exam "Abandon" now hard-deletes the incomplete session (`DiscardPracticeSessionUseCase`) instead of completing it; promoted to `main` via PR #464 (merge `d5568288`), production deploy verified READY. Prior: practice/quiz-engine sweep filed BUG-251..BUG-252. Prior: BUG-250 resolved + archived — `csvCell` in the feedback export neutralizes spreadsheet-formula-capable cells before CSV quoting; fixed on `dev` (`b98306a6`), promoted to `main` via PR #460 (merge `d76a3516`), production deploy verified READY. Prior: BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`.)
 
 ---
 
@@ -14,6 +14,9 @@ Bug reports document issues discovered in the codebase along with their root cau
 3. **Knowledge Base** — Help future developers understand past issues
 
 **Next Bug ID:** BUG-253
+
+**Latest branch fix (2026-06-19) — BUG-252 implementation pending review:**
+- BUG-252 (P3) has a branch fix in implementation commit `902fc4d4` on `bug/252-persist-unanswered-exam-time`: exam draft saves now accept nullable `selectedChoiceId`, unanswered time-only drafts persist `draftCumulativeMs`, BUG-238 cumulative bounds remain intact, and finalization continues to read capped server-side draft timing. Full local gate passed (typecheck, lint, unit 2883, browser 298, integration 112, build, e2e 36). **BUG-252 remains open** pending PR review, merge to `dev`, promotion to `main`, and production deploy READY verification.
 
 **Latest archival (2026-06-19) — BUG-251 resolved (exam abandon discard lifecycle):**
 - BUG-251 (P2) verified fixed and archived to `docs/_archive/bugs/`. Exam "Abandon" now means true discard: a new `DiscardPracticeSessionUseCase` + `discardPracticeSession` action hard-deletes the incomplete exam session (`DELETE WHERE id / user_id / ended_at IS NULL`, idempotent, exam-only) instead of routing through generic `endPracticeSession`, so a discarded exam no longer persists as a misleading reviewable "completed" session. `EndPracticeSessionUseCase` rejects active-exam ends (defense in depth); tutor abandon is unchanged. Fixed on `dev`, promoted to `main` via PR #464 (merge `d5568288`) after a CodeRabbit `APPROVED` review on the exact head (CHANGES_REQUESTED → fixes → APPROVED) and full gate green (typecheck, lint, unit 2874, browser 298, integration 111, build, e2e 36); production deploy for `d5568288` verified READY; `main` and `dev` trees identical. **BUG-252 (P3) remains open** (deferred — narrow omitted-question timing-accuracy gap).

--- a/src/adapters/controllers/practice-controller-exam-draft.test.ts
+++ b/src/adapters/controllers/practice-controller-exam-draft.test.ts
@@ -99,6 +99,47 @@ describe('practice-controller', () => {
       ]);
     });
 
+    it('accepts a time-only draft save with null selectedChoiceId', async () => {
+      const saveDraftOutput = {
+        questionId: '22222222-2222-2222-2222-222222222222',
+        markedForReview: false,
+        latestSelectedChoiceId: null,
+        latestIsCorrect: null,
+        latestAnsweredAt: null,
+        draftSelectedChoiceId: null,
+        draftSavedAt: new Date('2026-02-01T00:00:00.000Z'),
+        draftCumulativeMs: 15_000,
+      } as const;
+      const deps = createDeps({ saveDraftOutput });
+
+      const result = await saveExamDraftAnswer(
+        {
+          sessionId: '11111111-1111-1111-1111-111111111111',
+          questionId: '22222222-2222-2222-2222-222222222222',
+          selectedChoiceId: null,
+          cumulativeMs: 15_000,
+        },
+        deps,
+      );
+
+      expect(result).toEqual({
+        ok: true,
+        data: {
+          ...saveDraftOutput,
+          draftSavedAt: '2026-02-01T00:00:00.000Z',
+        },
+      });
+      expect(deps.saveExamDraftAnswerUseCase.inputs).toEqual([
+        {
+          userId: deps._fixtures.userId,
+          sessionId: '11111111-1111-1111-1111-111111111111',
+          questionId: '22222222-2222-2222-2222-222222222222',
+          selectedChoiceId: null,
+          cumulativeMs: 15_000,
+        },
+      ]);
+    });
+
     it('returns UNAUTHENTICATED when unauthenticated', async () => {
       const deps = createDeps({ user: null });
 

--- a/src/adapters/controllers/practice-schemas.test.ts
+++ b/src/adapters/controllers/practice-schemas.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_DRAFT_CUMULATIVE_MS } from '@/src/adapters/shared/validation-limits';
+import { SaveExamDraftAnswerInputSchema } from './practice-schemas';
+
+describe('SaveExamDraftAnswerInputSchema', () => {
+  it('accepts a nullable selectedChoiceId for time-only exam drafts', () => {
+    const input = {
+      sessionId: crypto.randomUUID(),
+      questionId: crypto.randomUUID(),
+      selectedChoiceId: null,
+      cumulativeMs: 15_000,
+    };
+
+    expect(SaveExamDraftAnswerInputSchema.parse(input)).toEqual(input);
+  });
+
+  it('keeps cumulativeMs bounded for time-only exam drafts', () => {
+    const result = SaveExamDraftAnswerInputSchema.safeParse({
+      sessionId: crypto.randomUUID(),
+      questionId: crypto.randomUUID(),
+      selectedChoiceId: null,
+      cumulativeMs: MAX_DRAFT_CUMULATIVE_MS + 1,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.cumulativeMs).toEqual(
+      expect.any(Array),
+    );
+  });
+
+  it('keeps the draft input strict', () => {
+    const result = SaveExamDraftAnswerInputSchema.safeParse({
+      sessionId: crypto.randomUUID(),
+      questionId: crypto.randomUUID(),
+      selectedChoiceId: null,
+      cumulativeMs: 15_000,
+      unexpected: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'unrecognized_keys',
+          keys: ['unexpected'],
+        }),
+      ]),
+    );
+  });
+});

--- a/src/adapters/controllers/practice-schemas.ts
+++ b/src/adapters/controllers/practice-schemas.ts
@@ -58,7 +58,7 @@ export const SaveExamDraftAnswerInputSchema = z
   .object({
     sessionId: zUuid,
     questionId: zUuid,
-    selectedChoiceId: zUuid,
+    selectedChoiceId: zUuid.nullable(),
     cumulativeMs: z.number().int().min(0).max(MAX_DRAFT_CUMULATIVE_MS),
   })
   .strict();

--- a/src/adapters/repositories/drizzle-practice-session-repository.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository.ts
@@ -239,7 +239,7 @@ export class DrizzlePracticeSessionRepository
     sessionId: string;
     userId: string;
     questionId: string;
-    selectedChoiceId: string;
+    selectedChoiceId: string | null;
     cumulativeMs: number;
   }): Promise<PracticeSessionQuestionState> {
     const savedAt = this.now();

--- a/src/application/ports/practice-session-repository.ts
+++ b/src/application/ports/practice-session-repository.ts
@@ -30,7 +30,7 @@ export interface PracticeSessionRepository {
     sessionId: string;
     userId: string;
     questionId: string;
-    selectedChoiceId: string;
+    selectedChoiceId: string | null;
     cumulativeMs: number;
   }): Promise<PracticeSessionQuestionState>;
   finalizeDraftAnswer(input: {

--- a/src/application/test-helpers/fakes/fake-practice-session-repository.ts
+++ b/src/application/test-helpers/fakes/fake-practice-session-repository.ts
@@ -224,7 +224,7 @@ export class FakePracticeSessionRepository
     sessionId: string;
     userId: string;
     questionId: string;
-    selectedChoiceId: string;
+    selectedChoiceId: string | null;
     cumulativeMs: number;
   }): Promise<PracticeSession['questionStates'][number]> {
     const session = await this.getActiveSession(input.sessionId, input.userId);

--- a/src/application/use-cases/finalize-exam-answers.test.ts
+++ b/src/application/use-cases/finalize-exam-answers.test.ts
@@ -16,7 +16,10 @@ import {
   type FinalizeExamAnswersWriteTransaction,
 } from './finalize-exam-answers';
 import { projectPracticeSessionSummary } from './practice-session-summary';
-import { SAVE_EXAM_DRAFT_MAX_CUMULATIVE_MS } from './save-exam-draft-answer';
+import {
+  SAVE_EXAM_DRAFT_MAX_CUMULATIVE_MS,
+  SaveExamDraftAnswerUseCase,
+} from './save-exam-draft-answer';
 
 function passthroughTransaction(
   questions: FakeQuestionRepository,
@@ -243,6 +246,67 @@ describe('FinalizeExamAnswersUseCase', () => {
         },
       ],
     });
+  });
+
+  it('finalizes a saved time-only draft as an omitted attempt with the saved duration', async () => {
+    const questions = new FakeQuestionRepository([
+      createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+    ]);
+    const attempts = new FakeAttemptRepository();
+    const sessions = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: 'session-1',
+        userId: 'user-1',
+        mode: 'exam',
+        questionIds: ['q1'],
+        startedAt: new Date('2026-03-17T12:00:00.000Z'),
+      }),
+    ]);
+    const saveDraft = new SaveExamDraftAnswerUseCase(
+      questions,
+      sessions,
+      () => new Date('2026-03-17T12:00:30.000Z'),
+    );
+    const finalize = new FinalizeExamAnswersUseCase(
+      questions,
+      attempts,
+      sessions,
+      passthroughTransaction(questions, attempts, sessions),
+    );
+
+    await saveDraft.execute({
+      userId: 'user-1',
+      sessionId: 'session-1',
+      questionId: 'q1',
+      selectedChoiceId: null,
+      cumulativeMs: 15_000,
+    });
+
+    await expect(
+      finalize.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+      }),
+    ).resolves.toMatchObject({
+      sessionId: 'session-1',
+      mode: 'exam',
+      questionCount: 1,
+      totals: {
+        answered: 0,
+        correct: 0,
+      },
+    });
+
+    await expect(
+      attempts.findBySessionId('session-1', 'user-1'),
+    ).resolves.toMatchObject([
+      {
+        questionId: 'q1',
+        outcome: { kind: 'omitted' },
+        isCorrect: false,
+        timeSpentSeconds: 15,
+      },
+    ]);
   });
 
   it('does not treat a malformed empty draft choice id as an omitted answer', async () => {

--- a/src/application/use-cases/save-exam-draft-answer.test.ts
+++ b/src/application/use-cases/save-exam-draft-answer.test.ts
@@ -110,6 +110,109 @@ describe('SaveExamDraftAnswerUseCase', () => {
     });
   });
 
+  it('saves a time-only draft when no choice is selected', async () => {
+    const sessions = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: 'session-1',
+        userId: 'user-1',
+        mode: 'exam',
+        questionIds: ['q1'],
+      }),
+    ]);
+    const questions = new FakeQuestionRepository([
+      createQuestion({
+        id: 'q1',
+        choices: [
+          createChoice({ id: 'choice-1', questionId: 'q1', label: 'A' }),
+          createChoice({ id: 'choice-2', questionId: 'q1', label: 'B' }),
+        ],
+      }),
+    ]);
+    const useCase = new SaveExamDraftAnswerUseCase(questions, sessions);
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+        questionId: 'q1',
+        selectedChoiceId: null,
+        cumulativeMs: 15_000,
+      }),
+    ).resolves.toMatchObject({
+      questionId: 'q1',
+      latestSelectedChoiceId: null,
+      latestIsCorrect: null,
+      latestAnsweredAt: null,
+      draftSelectedChoiceId: null,
+      draftCumulativeMs: 15_000,
+      draftSavedAt: expect.any(Date),
+    });
+
+    const persisted = await sessions.findByIdAndUserId('session-1', 'user-1');
+    expect(persisted?.questionStates[0]?.draftSelectedChoiceId).toBeNull();
+    expect(persisted?.questionStates[0]?.draftCumulativeMs).toBe(15_000);
+  });
+
+  it('clamps oversized cumulativeMs for time-only drafts', async () => {
+    const sessions = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: 'session-1',
+        userId: 'user-1',
+        mode: 'exam',
+        questionIds: ['q1'],
+      }),
+    ]);
+    const questions = new FakeQuestionRepository([
+      createQuestion({
+        id: 'q1',
+        choices: [
+          createChoice({ id: 'choice-1', questionId: 'q1', label: 'A' }),
+          createChoice({ id: 'choice-2', questionId: 'q1', label: 'B' }),
+        ],
+      }),
+    ]);
+    const useCase = new SaveExamDraftAnswerUseCase(questions, sessions);
+
+    await useCase.execute({
+      userId: 'user-1',
+      sessionId: 'session-1',
+      questionId: 'q1',
+      selectedChoiceId: null,
+      cumulativeMs: SAVE_EXAM_DRAFT_MAX_CUMULATIVE_MS + 1,
+    });
+
+    const persisted = await sessions.findByIdAndUserId('session-1', 'user-1');
+    expect(persisted?.questionStates[0]?.draftSelectedChoiceId).toBeNull();
+    expect(persisted?.questionStates[0]?.draftCumulativeMs).toBe(
+      SAVE_EXAM_DRAFT_MAX_CUMULATIVE_MS,
+    );
+  });
+
+  it('still rejects time-only drafts for unpublished or missing questions', async () => {
+    const sessions = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: 'session-1',
+        userId: 'user-1',
+        mode: 'exam',
+        questionIds: ['missing-question'],
+      }),
+    ]);
+    const useCase = new SaveExamDraftAnswerUseCase(
+      new FakeQuestionRepository([]),
+      sessions,
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+        questionId: 'missing-question',
+        selectedChoiceId: null,
+        cumulativeMs: 15_000,
+      }),
+    ).rejects.toEqual(new ApplicationError('NOT_FOUND', 'Question not found'));
+  });
+
   it('clamps cumulativeMs at SAVE_EXAM_DRAFT_MAX_CUMULATIVE_MS when input exceeds the bound', async () => {
     const sessions = new FakePracticeSessionRepository([
       createPracticeSession({

--- a/src/application/use-cases/save-exam-draft-answer.ts
+++ b/src/application/use-cases/save-exam-draft-answer.ts
@@ -11,7 +11,7 @@ export type SaveExamDraftAnswerInput = {
   userId: string;
   sessionId: string;
   questionId: string;
-  selectedChoiceId: string;
+  selectedChoiceId: string | null;
   cumulativeMs: number;
 };
 
@@ -61,10 +61,10 @@ export class SaveExamDraftAnswerUseCase {
       throw new ApplicationError('NOT_FOUND', 'Question not found');
     }
 
-    const selectedChoice = question.choices.find(
-      (choice) => choice.id === input.selectedChoiceId,
-    );
-    if (!selectedChoice) {
+    const selectedChoiceBelongsToQuestion =
+      input.selectedChoiceId === null ||
+      question.choices.some((choice) => choice.id === input.selectedChoiceId);
+    if (!selectedChoiceBelongsToQuestion) {
       throw new ApplicationError(
         'VALIDATION_ERROR',
         'Selected choice does not belong to the question',

--- a/tests/integration/bug-regression-exam-draft-bounds.integration.test.ts
+++ b/tests/integration/bug-regression-exam-draft-bounds.integration.test.ts
@@ -286,3 +286,58 @@ describe('BUG-238: Exam draft cumulativeMs is bounded', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// BUG-252: Time-only exam drafts are persisted
+// ---------------------------------------------------------------------------
+
+describe('BUG-252: unanswered exam draft time is persisted', () => {
+  it('round-trips a nullable draft choice and preserves the monotonic guard', async () => {
+    const user = await createUser(db, cleanup);
+    const question = await createQuestion(db, cleanup, {
+      slug: `it-bug252-time-only-draft-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const questions = new DrizzleQuestionRepository(db);
+    const sessions = new DrizzlePracticeSessionRepository(db);
+    const saveDraft = new SaveExamDraftAnswerUseCase(questions, sessions);
+    const session = await sessions.create({
+      userId: user.id,
+      mode: 'exam',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [question.id],
+      },
+    });
+
+    await saveDraft.execute({
+      userId: user.id,
+      sessionId: session.id,
+      questionId: question.id,
+      selectedChoiceId: null,
+      cumulativeMs: 15_000,
+    });
+
+    await sessions.saveDraftAnswer({
+      userId: user.id,
+      sessionId: session.id,
+      questionId: question.id,
+      selectedChoiceId: question.correctChoiceId,
+      cumulativeMs: 10_000,
+    });
+
+    const persisted = await sessions.findByIdAndUserId(session.id, user.id);
+    const state = persisted?.questionStates.find(
+      (questionState) => questionState.questionId === question.id,
+    );
+    expect(state).toMatchObject({
+      questionId: question.id,
+      draftSelectedChoiceId: null,
+      draftCumulativeMs: 15_000,
+    });
+    expect(state?.draftSavedAt).toEqual(expect.any(Date));
+  });
+});


### PR DESCRIPTION
Promotes dev to main to keep the trees synced (main mirrors dev). Two commits ride this promotion, both BUG-252-related:

1. 2916f416 — Fix BUG-252: persist unanswered exam draft timing. Widens exam draft selectedChoiceId to nullable so unanswered time-only drafts persist draftCumulativeMs; finalize unchanged; BUG-238 bounds preserved (schema max, use-case clamp, monotonic guard, finalize cap). CodeRabbit APPROVED on the exact head of PR #472; full gate green (typecheck, lint, unit 2883, browser 298, integration 112, build, e2e 36).
2. 26b29f2e — Fix BUG-252 doc citation line numbers after BUG-251 code drift (docs-only).

Merge strategy: merge commit (main-sync convention). BUG-252 stays open until this promotion deploys to production and is verified READY, then it is archived.

https://claude.ai/code/session_01RhHv6rK1YVBaE8WmPNpGXQ