### PR TITLE
Promote dev to main: archive BUG-252 (docs-only)

### DIFF
--- a/docs/_archive/bugs/bug-252-unanswered-exam-time-not-persisted.md
+++ b/docs/_archive/bugs/bug-252-unanswered-exam-time-not-persisted.md
@@ -1,7 +1,7 @@
 # BUG-252: Unanswered Exam Question Time Is Not Persisted Before Finalization
 
-**Status:** Open — branch fix landed, pending PR review / merge / production verification
-**Resolution State:** Implementation commit `902fc4d4` on branch `bug/252-persist-unanswered-exam-time` widens exam draft saves to accept `selectedChoiceId: string | null`, persists time-only unanswered drafts, and leaves `FinalizeExamAnswersUseCase` unchanged. Full local gate passed on 2026-06-19: typecheck, lint, unit 2883, browser 298, integration 112, build, and e2e 36. Keep open until PR review/merge, promotion to `main`, and production deploy READY verification are complete.
+**Status:** Resolved — fixed, merged, promoted to `main`, and production-verified
+**Resolution State:** Fixed via PR #472 (squash `2916f416` on `dev`), promoted to `main` via PR #473 (merge `d2f96d61`; the promotion merged under an owner-authorized override of CodeRabbit's review-rate-limit cooldown, justified by #472's APPROVED review of the byte-identical tree). Production Vercel deploy for `d2f96d61` verified READY on 2026-06-20. The exam draft write contract now accepts `selectedChoiceId: string | null`, so unanswered time-only drafts persist `draftCumulativeMs`; `FinalizeExamAnswersUseCase` is unchanged and reads the now-correct server-side draft timing. BUG-238 cumulative bounds preserved (schema `.max`, use-case clamp, repo monotonic guard, finalize cap). CodeRabbit APPROVED on the exact head of PR #472 (`08787944`, 0 actionable, 0 threads); full gate green (typecheck, lint, unit 2883, browser 298, integration 112, build, e2e 36). `main` and `dev` trees identical.
 **Severity:** P3
 **Date:** 2026-06-18
 **Confirmed:** 2026-06-18
@@ -13,7 +13,7 @@
 
 Before implementation commit `902fc4d4`, exam mode tracked per-question elapsed time locally, but if the user left a question without selecting an answer, the client intentionally skipped the server draft write. `FinalizeExamAnswersUseCase` later computed omitted attempts' `timeSpentSeconds` from server-side `draftCumulativeMs`, so unanswered questions that the user spent time on could be finalized with `timeSpentSeconds = 0`.
 
-This does not affect scoring and no current UI surfaces omitted-question timing. Until the branch fix is reviewed, merged, promoted, and production-verified, BUG-252 remains a narrow persistence-accuracy gap in the proposed stopwatch model: unanswered time is preserved only in browser state until the user later selects an answer.
+This did not affect scoring and no UI surfaced omitted-question timing. Before the fix, BUG-252 was a narrow persistence-accuracy gap in the proposed stopwatch model: unanswered time was preserved only in browser state until the user later selected an answer.
 
 ## Reproduction
 
@@ -35,37 +35,37 @@ Pre-fix actual:
 
 ## Root Cause
 
-The root-cause evidence below describes the pre-fix state verified at filing. Commit `902fc4d4` changes the live branch behavior, but BUG-252 remains open until the fix is reviewed, merged/promoted, and production-verified.
+The root-cause evidence below describes the pre-fix state verified at filing. The fix shipped to production (PR #472 → `dev`, PR #473 merge `d2f96d61` → `main`, deploy READY 2026-06-20); this section is retained as the historical pre-fix record.
 
 The interaction-contract doc labels the stopwatch behavior as a proposed model, and that model says cumulative time should be persisted on draft save and used during finalization:
 
-- [`interaction-contracts.md`](../practice-engine/interaction-contracts.md#L191) defines "On leave question: cumulativeMs += ...".
-- [`interaction-contracts.md`](../practice-engine/interaction-contracts.md#L192) says "On draft save: persist cumulativeMs alongside the draft choiceId".
-- [`interaction-contracts.md`](../practice-engine/interaction-contracts.md#L193) says "On finalize: timeSpentSeconds = Math.floor(cumulativeMs / 1000)".
+- [`interaction-contracts.md`](../../practice-engine/interaction-contracts.md#L191) defines "On leave question: cumulativeMs += ...".
+- [`interaction-contracts.md`](../../practice-engine/interaction-contracts.md#L192) says "On draft save: persist cumulativeMs alongside the draft choiceId".
+- [`interaction-contracts.md`](../../practice-engine/interaction-contracts.md#L193) says "On finalize: timeSpentSeconds = Math.floor(cumulativeMs / 1000)".
 
 The pre-fix client had an explicit no-selection early return:
 
-- [`maybeSaveDraftBeforeNavigation`](<../../app/(app)/app/practice/shared/question-flow-actions.ts#L174>) checks `if (!input.selectedChoiceId)`.
-- It calls `onSaved` with the local `cumulativeMs` at [`question-flow-actions.ts`](<../../app/(app)/app/practice/shared/question-flow-actions.ts#L175>), but returns without calling `saveExamDraftAnswerFn` at [`question-flow-actions.ts`](<../../app/(app)/app/practice/shared/question-flow-actions.ts#L180>).
-- The existing test suite locks in that behavior: [`question-flow-actions.test.ts`](<../../app/(app)/app/practice/shared/question-flow-actions.test.ts#L858>) asserts "tracks unanswered exam time locally" and [`question-flow-actions.test.ts`](<../../app/(app)/app/practice/shared/question-flow-actions.test.ts#L889>) expects `saveExamDraftAnswerFn` not to be called.
+- [`maybeSaveDraftBeforeNavigation`](<../../../app/(app)/app/practice/shared/question-flow-actions.ts#L174>) checks `if (!input.selectedChoiceId)`.
+- It calls `onSaved` with the local `cumulativeMs` at [`question-flow-actions.ts`](<../../../app/(app)/app/practice/shared/question-flow-actions.ts#L175>), but returns without calling `saveExamDraftAnswerFn` at [`question-flow-actions.ts`](<../../../app/(app)/app/practice/shared/question-flow-actions.ts#L180>).
+- The existing test suite locks in that behavior: [`question-flow-actions.test.ts`](<../../../app/(app)/app/practice/shared/question-flow-actions.test.ts#L858>) asserts "tracks unanswered exam time locally" and [`question-flow-actions.test.ts`](<../../../app/(app)/app/practice/shared/question-flow-actions.test.ts#L889>) expects `saveExamDraftAnswerFn` not to be called.
 
 The pre-fix server/API shape also prevented persisting a time-only draft:
 
-- [`SaveExamDraftAnswerInputSchema`](../../src/adapters/controllers/practice-schemas.ts#L61) requires `selectedChoiceId: zUuid`.
-- [`SaveExamDraftAnswerInput`](../../src/application/use-cases/save-exam-draft-answer.ts#L14) requires `selectedChoiceId: string`.
-- [`PracticeSessionRepository.saveDraftAnswer`](../../src/application/ports/practice-session-repository.ts#L33) also requires `selectedChoiceId: string`.
+- [`SaveExamDraftAnswerInputSchema`](../../../src/adapters/controllers/practice-schemas.ts#L61) requires `selectedChoiceId: zUuid`.
+- [`SaveExamDraftAnswerInput`](../../../src/application/use-cases/save-exam-draft-answer.ts#L14) requires `selectedChoiceId: string`.
+- [`PracticeSessionRepository.saveDraftAnswer`](../../../src/application/ports/practice-session-repository.ts#L33) also requires `selectedChoiceId: string`.
 
 Finalization then trusts the server-side draft clock for omitted attempts:
 
-- [`FinalizeExamAnswersUseCase`](../../src/application/use-cases/finalize-exam-answers.ts#L95) loops every question state.
-- It caps `state.draftCumulativeMs` and computes `timeSpentSeconds` from that value at [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L96-L100).
-- For unanswered questions, it inserts the omitted attempt with that value at [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L106) and [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L112).
+- [`FinalizeExamAnswersUseCase`](../../../src/application/use-cases/finalize-exam-answers.ts#L95) loops every question state.
+- It caps `state.draftCumulativeMs` and computes `timeSpentSeconds` from that value at [`finalize-exam-answers.ts`](../../../src/application/use-cases/finalize-exam-answers.ts#L96-L100).
+- For unanswered questions, it inserts the omitted attempt with that value at [`finalize-exam-answers.ts`](../../../src/application/use-cases/finalize-exam-answers.ts#L106) and [`finalize-exam-answers.ts`](../../../src/application/use-cases/finalize-exam-answers.ts#L112).
 
 Before `902fc4d4`, unanswered cumulative time never left the browser until a choice was later selected, so finalization wrote an undercounted duration for questions that remained omitted.
 
 ## Impact
 
-Exam scoring remains correct for the omitted answer, but persisted attempt timing is wrong for skipped/unanswered exam questions until the branch fix is deployed. The current user-facing impact is low because the app does not display per-question omitted timing. The durable risk is bad timing data for analytics, audits, or future study recommendations.
+Exam scoring remained correct for the omitted answer, but persisted attempt timing was wrong for skipped/unanswered exam questions before the fix shipped. The user-facing impact was low because the app does not display per-question omitted timing. The durable risk addressed was bad timing data for analytics, audits, or future study recommendations.
 
 ## Proposed Fix
 

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -1,7 +1,7 @@
 # Bug Reports
 
 **Project:** Naltrexone University
-**Last Updated:** 2026-06-19 (BUG-252 branch fix landed in `902fc4d4` on `bug/252-persist-unanswered-exam-time`; full local gate green, PR review/promotion/prod verification pending, so BUG-252 remains open. Prior: BUG-251 resolved + archived — exam "Abandon" now hard-deletes the incomplete session (`DiscardPracticeSessionUseCase`) instead of completing it; promoted to `main` via PR #464 (merge `d5568288`), production deploy verified READY. Prior: practice/quiz-engine sweep filed BUG-251..BUG-252. Prior: BUG-250 resolved + archived — `csvCell` in the feedback export neutralizes spreadsheet-formula-capable cells before CSV quoting; fixed on `dev` (`b98306a6`), promoted to `main` via PR #460 (merge `d76a3516`), production deploy verified READY. Prior: BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`.)
+**Last Updated:** 2026-06-20 (BUG-252 resolved + archived — exam draft saves now accept nullable `selectedChoiceId`, so unanswered time-only drafts persist `draftCumulativeMs`; `FinalizeExamAnswersUseCase` unchanged and BUG-238 cumulative bounds intact. Fixed via PR #472 (squash `2916f416` on `dev`), promoted to `main` via PR #473 (merge `d2f96d61`), production deploy verified READY; `main` and `dev` trees identical. **No active bugs remain.** Prior: BUG-251 resolved + archived — exam "Abandon" now hard-deletes the incomplete session (`DiscardPracticeSessionUseCase`) instead of completing it; promoted to `main` via PR #464 (merge `d5568288`), production deploy verified READY. Prior: BUG-250 resolved + archived — `csvCell` in the feedback export neutralizes spreadsheet-formula-capable cells before CSV quoting; fixed on `dev` (`b98306a6`), promoted to `main` via PR #460 (merge `d76a3516`), production deploy verified READY. Prior: BUG-241 resolved + archived — `vercel.json` `buildCommand` runs `pnpm db:migrate && pnpm build` on every Vercel deploy, verified live on Preview→Neon `dev` and Production→Neon `main`; merged via #453 → `dev` and #454 → `main`.)
 
 ---
 
@@ -15,8 +15,8 @@ Bug reports document issues discovered in the codebase along with their root cau
 
 **Next Bug ID:** BUG-253
 
-**Latest branch fix (2026-06-19) — BUG-252 implementation pending review:**
-- BUG-252 (P3) has a branch fix in implementation commit `902fc4d4` on `bug/252-persist-unanswered-exam-time`: exam draft saves now accept nullable `selectedChoiceId`, unanswered time-only drafts persist `draftCumulativeMs`, BUG-238 cumulative bounds remain intact, and finalization continues to read capped server-side draft timing. Full local gate passed (typecheck, lint, unit 2883, browser 298, integration 112, build, e2e 36). **BUG-252 remains open** pending PR review, merge to `dev`, promotion to `main`, and production deploy READY verification.
+**Latest archival (2026-06-20) — BUG-252 resolved (unanswered exam draft timing):**
+- BUG-252 (P3) verified fixed and archived to `docs/_archive/bugs/`. The exam draft write contract now accepts nullable `selectedChoiceId`, so unanswered time-only drafts persist `draftCumulativeMs` (the client now does a server round-trip on navigation whenever cumulative time advances, even with no choice selected); `FinalizeExamAnswersUseCase` is unchanged and reads the now-correct capped server-side draft timing. BUG-238 cumulative bounds preserved (schema `.max`, use-case clamp, repo monotonic guard, finalize cap); the null-save path cannot null an existing draft choice because the UI selection is hydrated from `draftSelectedChoiceId` on load and exam radios have no deselect. Fixed via PR #472 (squash `2916f416` on `dev`) after a CodeRabbit `APPROVED` review on the exact head (`08787944`, 0 actionable, 0 threads) and full gate green (typecheck, lint, unit 2883, browser 298, integration 112, build, e2e 36); promoted to `main` via PR #473 (merge `d2f96d61`, merged under an owner-authorized override of CodeRabbit's review-rate-limit cooldown justified by #472's approval of the byte-identical tree); production deploy for `d2f96d61` verified READY; `main` and `dev` trees identical. This was the last active bug; **no active bugs remain.**
 
 **Latest archival (2026-06-19) — BUG-251 resolved (exam abandon discard lifecycle):**
 - BUG-251 (P2) verified fixed and archived to `docs/_archive/bugs/`. Exam "Abandon" now means true discard: a new `DiscardPracticeSessionUseCase` + `discardPracticeSession` action hard-deletes the incomplete exam session (`DELETE WHERE id / user_id / ended_at IS NULL`, idempotent, exam-only) instead of routing through generic `endPracticeSession`, so a discarded exam no longer persists as a misleading reviewable "completed" session. `EndPracticeSessionUseCase` rejects active-exam ends (defense in depth); tutor abandon is unchanged. Fixed on `dev`, promoted to `main` via PR #464 (merge `d5568288`) after a CodeRabbit `APPROVED` review on the exact head (CHANGES_REQUESTED → fixes → APPROVED) and full gate green (typecheck, lint, unit 2874, browser 298, integration 111, build, e2e 36); production deploy for `d5568288` verified READY; `main` and `dev` trees identical. **BUG-252 (P3) remains open** (deferred — narrow omitted-question timing-accuracy gap).
@@ -167,9 +167,7 @@ Bug reports document issues discovered in the codebase along with their root cau
 
 ## Active Bugs
 
-| ID | Title | Priority | Filed |
-|----|-------|----------|-------|
-| [BUG-252](./bug-252-unanswered-exam-time-not-persisted.md) | Unanswered Exam Question Time Is Not Persisted Before Finalization | P3 | 2026-06-18 |
+_No active bugs. All filed bugs are resolved and archived to `docs/_archive/bugs/`._
 
 ## Audit #21 — Stripe/Billing Deep Sweep (2026-06-11)
 


### PR DESCRIPTION
Docs-only promotion to keep main and dev synced after the BUG-252 archival. Single commit b2d29ca7 moves the resolved BUG-252 bug doc to docs/_archive/bugs/ (Status set to Resolved, relative links re-depthed for the archive path, root-cause/impact reframed to past tense) and clears the Active Bugs table. The BUG-252 code fix already shipped to production via PR #473 (merge d2f96d61, deploy READY). No source/test/config changes. Intended to merge under the docs-override path once the required test check passes.

https://claude.ai/code/session_01RhHv6rK1YVBaE8WmPNpGXQ