### PR TITLE
Promote BUG-256 fix to main (expired exam resume -> summary)

### DIFF
--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-init-load.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-init-load.browser.spec.tsx
@@ -20,7 +20,9 @@ import {
   getPracticeSessionSummaryMock,
   mockBookmarksAndReview,
   PracticeSessionPageModelHookProbe,
+  PracticeSessionPageModelNavigationProbe,
   PracticeSessionPageModelSummaryProbe,
+  PracticeSessionPageModelViewProbe,
   setupPracticeSessionPageModelBrowserSpec,
 } from './use-practice-session-page-model-test-helpers';
 
@@ -171,6 +173,204 @@ describe('usePracticeSessionPageModel (browser)', () => {
       .element(screen.getByTestId('question-id'))
       .toHaveTextContent(BROWSER_QUESTION_1_ID);
     expect(callOrder).toEqual(['summary', 'question']);
+  });
+
+  it('shows the summary when resuming an exam that expires during getNextQuestion', async () => {
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockResolvedValueOnce(
+        ok({
+          sessionId: BROWSER_SESSION_ID,
+          endedAt: '2026-02-07T00:20:00.000Z',
+          mode: 'exam',
+          questionCount: 2,
+          totals: {
+            answered: 2,
+            correct: 1,
+            accuracy: 0.5,
+            durationSeconds: 1200,
+          },
+        }),
+      );
+    getNextQuestionMock.mockResolvedValue(ok(null));
+    getPracticeSessionReviewMock.mockResolvedValue(
+      ok(
+        createReviewResponse({
+          mode: 'exam',
+          totalCount: 2,
+          answeredCount: 2,
+          markedCount: 0,
+          rows: [
+            createReviewRow({ questionId: BROWSER_QUESTION_1_ID, order: 1 }),
+          ],
+        }),
+      ),
+    );
+
+    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
+
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    await expect
+      .element(screen.getByTestId('summary-mode'))
+      .toHaveTextContent('exam');
+    await expect
+      .element(screen.getByTestId('summary-session-id'))
+      .toHaveTextContent(BROWSER_SESSION_ID);
+    await expect
+      .element(screen.getByTestId('question-id'))
+      .toHaveTextContent('');
+  });
+
+  it('keeps the generic empty state when expired-exam recovery still reports an active session', async () => {
+    getPracticeSessionSummaryMock.mockResolvedValue(
+      errorResult('CONFLICT', 'Practice session has not ended'),
+    );
+    getNextQuestionMock.mockResolvedValue(ok(null));
+
+    const screen = await render(<PracticeSessionPageModelViewProbe />);
+
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('');
+    await expect
+      .element(screen.getByText('No more questions found.'))
+      .toBeVisible();
+  });
+
+  it('keeps the generic empty state when expired-exam recovery summary re-read throws', async () => {
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockRejectedValueOnce(new Error('Summary recovery failed'));
+    getNextQuestionMock.mockResolvedValue(ok(null));
+
+    const screen = await render(<PracticeSessionPageModelViewProbe />);
+
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('');
+    await expect
+      .element(screen.getByText('No more questions found.'))
+      .toBeVisible();
+  });
+
+  it('does not commit expired-exam recovery results after unmount', async () => {
+    const recoverySummary = createDeferred<ActionResult<unknown>>();
+
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockImplementationOnce(() => recoverySummary.promise);
+    getNextQuestionMock.mockResolvedValue(ok(null));
+
+    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
+
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('summary-session-id'))
+      .toHaveTextContent('');
+    await expect
+      .element(screen.getByTestId('summary-mode'))
+      .toHaveTextContent('');
+
+    screen.unmount();
+    recoverySummary.resolve(
+      ok({
+        sessionId: BROWSER_SESSION_ID,
+        endedAt: '2026-02-07T00:20:00.000Z',
+        mode: 'exam',
+        questionCount: 2,
+        totals: {
+          answered: 2,
+          correct: 1,
+          accuracy: 0.5,
+          durationSeconds: 1200,
+        },
+      }),
+    );
+    await expect
+      .poll(() => document.querySelector('[data-testid="active-view"]'))
+      .toBeNull();
+    await expect
+      .poll(() => document.querySelector('[data-testid="summary-session-id"]'))
+      .toBeNull();
+    await expect
+      .poll(() => document.querySelector('[data-testid="summary-mode"]'))
+      .toBeNull();
+    await expect
+      .poll(() => document.body.textContent ?? '')
+      .not.toContain(BROWSER_SESSION_ID);
+  });
+
+  it('does not re-read the summary when normal in-session navigation returns no question', async () => {
+    getPracticeSessionSummaryMock.mockResolvedValue(
+      errorResult('CONFLICT', 'Practice session has not ended'),
+    );
+    getNextQuestionMock
+      .mockResolvedValueOnce(
+        ok(
+          createQuestionResponse({
+            questionId: BROWSER_QUESTION_1_ID,
+            session: {
+              mode: 'tutor',
+              deadlineAt: null,
+              index: 0,
+              total: 1,
+              isMarkedForReview: false,
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(ok(null));
+    mockBookmarksAndReview(
+      createReviewResponse({
+        mode: 'tutor',
+        totalCount: 1,
+        answeredCount: 0,
+        markedCount: 0,
+        rows: [
+          createReviewRow({ questionId: BROWSER_QUESTION_1_ID, order: 1 }),
+        ],
+      }),
+    );
+
+    const screen = await render(<PracticeSessionPageModelNavigationProbe />);
+
+    await expect
+      .element(screen.getByTestId('question-id'))
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
+
+    await screen.getByRole('button', { name: 'next-question' }).click();
+
+    await expect
+      .element(screen.getByTestId('load-status'))
+      .toHaveTextContent('ready');
+    await expect
+      .element(screen.getByTestId('question-id'))
+      .toHaveTextContent('');
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(2);
+    expect(getPracticeSessionSummaryMock).toHaveBeenCalledTimes(1);
   });
 
   it('recovers a summary when ending an active tutor session returns CONFLICT', async () => {

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
@@ -25,6 +25,7 @@ import { withTimeout } from '@/lib/with-timeout';
 import {
   endPracticeSession,
   finalizeExamAnswers,
+  type GetPracticeSessionSummaryOutput,
   getCompletedSessionQuestionsWithFeedback,
   getPracticeSessionReview,
   getPracticeSessionSummary,
@@ -201,6 +202,51 @@ export function usePracticeSessionPageModel(
       })
     : undefined;
 
+  const applyBootstrapSummary = useCallback(
+    (summary: GetPracticeSessionSummaryOutput) => {
+      reviewStage.setSummary(summary);
+      questionFlow.setSessionMode(summary.mode);
+      questionFlow.resetQuestionState();
+      questionFlow.setLoadState({ status: 'ready' });
+    },
+    [
+      questionFlow.resetQuestionState,
+      questionFlow.setLoadState,
+      questionFlow.setSessionMode,
+      reviewStage.setSummary,
+    ],
+  );
+
+  const recoverBootstrapSummaryAfterNullQuestion = useCallback(
+    async (requestId: number): Promise<boolean> => {
+      let result: Awaited<ReturnType<typeof getPracticeSessionSummary>>;
+      try {
+        result = await withTimeout(
+          getPracticeSessionSummary({ sessionId }),
+          BOOTSTRAP_SUMMARY_TIMEOUT_MS,
+        );
+      } catch (error) {
+        if (isMounted()) {
+          reportClientError(error, {
+            component: 'UsePracticeSessionPageModel',
+            action: 'recoverBootstrapSummaryAfterNullQuestion',
+          });
+        }
+        return false;
+      }
+
+      if (requestId !== bootstrapRequestIdRef.current || !isMounted()) {
+        return true;
+      }
+      if (!result.ok) return false;
+
+      setShouldRetryBootstrap(false);
+      applyBootstrapSummary(result.data);
+      return true;
+    },
+    [applyBootstrapSummary, isMounted, sessionId],
+  );
+
   const bootstrapSessionSummary = useCallback(() => {
     const requestId = bootstrapRequestIdRef.current + 1;
     bootstrapRequestIdRef.current = requestId;
@@ -216,15 +262,15 @@ export function usePracticeSessionPageModel(
         if (requestId !== bootstrapRequestIdRef.current || !isMounted()) return;
 
         if (result.ok) {
-          reviewStage.setSummary(result.data);
-          questionFlow.setSessionMode(result.data.mode);
-          questionFlow.resetQuestionState();
-          questionFlow.setLoadState({ status: 'ready' });
+          applyBootstrapSummary(result.data);
           return;
         }
 
         if (result.error.code === 'CONFLICT') {
-          questionFlow.onTryAgain();
+          questionFlow.onTryAgain({
+            recoverNullQuestion: () =>
+              recoverBootstrapSummaryAfterNullQuestion(requestId),
+          });
           return;
         }
 
@@ -249,10 +295,10 @@ export function usePracticeSessionPageModel(
   }, [
     sessionId,
     isMounted,
+    applyBootstrapSummary,
     questionFlow.onTryAgain,
-    questionFlow.resetQuestionState,
     questionFlow.setLoadState,
-    questionFlow.setSessionMode,
+    recoverBootstrapSummaryAfterNullQuestion,
     reviewStage.setSummary,
   ]);
 

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.ts
@@ -8,7 +8,10 @@ import {
   submitAnswerForQuestion,
 } from '@/app/(app)/app/practice/[sessionId]/practice-session-page-logic';
 import type { LoadState } from '@/app/(app)/app/practice/practice-page-logic';
-import { maybeSaveDraftBeforeNavigation } from '@/app/(app)/app/practice/shared/question-flow-actions';
+import {
+  maybeSaveDraftBeforeNavigation,
+  type NullQuestionRecovery,
+} from '@/app/(app)/app/practice/shared/question-flow-actions';
 import { useQuestionFlowCore } from '@/app/(app)/app/practice/shared/use-question-flow-core';
 import { runTransitionedAsyncAction } from '@/app/(app)/app/shared/transitioned-async-action';
 import { reportClientError } from '@/lib/report-client-error';
@@ -34,6 +37,10 @@ type SubmitOptions = {
   allowExamCommit?: boolean;
 };
 
+type TryAgainOptions = {
+  recoverNullQuestion?: NullQuestionRecovery | undefined;
+};
+
 export type UsePracticeSessionQuestionFlowOutput = {
   sessionInfo: NextQuestion['session'];
   sessionMode: 'tutor' | 'exam' | null;
@@ -52,7 +59,7 @@ export type UsePracticeSessionQuestionFlowOutput = {
   setSessionMode: (mode: 'tutor' | 'exam' | null) => void;
   setLoadState: (state: LoadState) => void;
   resetQuestionState: () => void;
-  onTryAgain: () => void;
+  onTryAgain: (options?: TryAgainOptions) => void;
   onNextQuestion: () => void;
   onNavigateQuestion: (questionId: string) => void;
   onSelectChoice: (choiceId: string) => void;

--- a/app/(app)/app/practice/[sessionId]/practice-session-page-logic.ts
+++ b/app/(app)/app/practice/[sessionId]/practice-session-page-logic.ts
@@ -1,6 +1,6 @@
 import type { LoadState } from '@/app/(app)/app/practice/practice-page-logic';
 import {
-  createTransitionedLoadAction,
+  type NullQuestionRecovery,
   runLoadQuestionFlow,
   runSubmitAnswerFlow,
 } from '@/app/(app)/app/practice/shared/question-flow-actions';
@@ -32,6 +32,9 @@ import type { SubmitAnswerOutput } from '@/src/application/use-cases/submit-answ
 const END_SESSION_TIMEOUT_MS = STANDARD_MUTATION_TIMEOUT_MS;
 const SESSION_REVIEW_TIMEOUT_MS = STANDARD_READ_TIMEOUT_MS;
 type SessionIdInput = { sessionId: string };
+type LoadNextQuestionOptions = {
+  recoverNullQuestion?: NullQuestionRecovery | undefined;
+};
 type FinalExamDraftAnswer = {
   questionId: string;
   selectedChoiceId: string | null;
@@ -62,6 +65,7 @@ export async function loadNextQuestion(input: {
   setQuestionLoadedAt: (loadedAtMs: number | null) => void;
   setQuestion: (question: NextQuestion | null) => void;
   setSessionInfo: (info: NextQuestion['session']) => void;
+  recoverNullQuestion?: NullQuestionRecovery | undefined;
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
@@ -89,6 +93,7 @@ export async function loadNextQuestion(input: {
       if (!question?.session) return;
       input.setSessionInfo(question.session);
     },
+    recoverNullQuestion: input.recoverNullQuestion,
     createRequestSequenceId: input.createRequestSequenceId,
     isLatestRequest: input.isLatestRequest,
     isMounted: input.isMounted,
@@ -114,11 +119,15 @@ export function createLoadNextQuestionAction(input: {
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
-}): () => void {
-  return createTransitionedLoadAction({
-    startTransition: input.startTransition,
-    run: () => loadNextQuestion(input),
-  });
+}): (options?: LoadNextQuestionOptions) => void {
+  return (options) => {
+    input.startTransition(() => {
+      void loadNextQuestion({
+        ...input,
+        recoverNullQuestion: options?.recoverNullQuestion,
+      });
+    });
+  };
 }
 
 export async function submitAnswerForQuestion(input: {

--- a/app/(app)/app/practice/shared/question-flow-actions.test.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions.test.ts
@@ -201,6 +201,94 @@ describe('question-flow-actions', () => {
     expect(onLoaded).toHaveBeenCalledWith({ questionId: fixtureQuestion1Id });
   });
 
+  it('does not commit the generic empty state when null-question recovery handles the load', async () => {
+    const setLoadState = vi.fn();
+    const setQuestion = vi.fn();
+    const onLoaded = vi.fn();
+    const recoverNullQuestion = vi.fn(async () => true);
+
+    await runLoadQuestionFlow({
+      requestInput: {},
+      getQuestionFn: async () => ({
+        ok: true,
+        data: null,
+      }),
+      createIdempotencyKey: () => 'idemp_new',
+      nowMs: () => 9999,
+      setLoadState,
+      setSelectedChoiceId: () => undefined,
+      setSubmitResult: () => undefined,
+      setSubmitIdempotencyKey: () => undefined,
+      setQuestionLoadedAt: () => undefined,
+      setQuestion,
+      onLoaded,
+      recoverNullQuestion,
+    });
+
+    expect(recoverNullQuestion).toHaveBeenCalledOnce();
+    expect(setQuestion).not.toHaveBeenCalled();
+    expect(onLoaded).not.toHaveBeenCalled();
+    expect(setLoadState).toHaveBeenCalledOnce();
+    expect(setLoadState).toHaveBeenCalledWith({ status: 'loading' });
+  });
+
+  it('commits the generic empty state when null-question recovery declines the load', async () => {
+    let loadState: AsyncLoadStateWithIdle = { status: 'idle' };
+    let question: unknown = { questionId: fixtureQuestionOldId };
+    const onLoaded = vi.fn();
+    const recoverNullQuestion = vi.fn(async () => false);
+
+    await runLoadQuestionFlow({
+      requestInput: {},
+      getQuestionFn: async () => ({
+        ok: true,
+        data: null,
+      }),
+      createIdempotencyKey: () => 'idemp_new',
+      nowMs: () => 9999,
+      setLoadState: (next) => {
+        loadState = next;
+      },
+      setSelectedChoiceId: () => undefined,
+      setSubmitResult: () => undefined,
+      setSubmitIdempotencyKey: () => undefined,
+      setQuestionLoadedAt: () => undefined,
+      setQuestion: (next) => {
+        question = next;
+      },
+      onLoaded,
+      recoverNullQuestion,
+    });
+
+    expect(recoverNullQuestion).toHaveBeenCalledOnce();
+    expect(loadState).toEqual({ status: 'ready' });
+    expect(question).toBeNull();
+    expect(onLoaded).toHaveBeenCalledWith(null);
+  });
+
+  it('does not invoke null-question recovery when a real question loads', async () => {
+    const recoverNullQuestion = vi.fn(async () => true);
+
+    await runLoadQuestionFlow({
+      requestInput: {},
+      getQuestionFn: async () => ({
+        ok: true,
+        data: { questionId: fixtureQuestion1Id },
+      }),
+      createIdempotencyKey: () => 'idemp_new',
+      nowMs: () => 9999,
+      setLoadState: () => undefined,
+      setSelectedChoiceId: () => undefined,
+      setSubmitResult: () => undefined,
+      setSubmitIdempotencyKey: () => undefined,
+      setQuestionLoadedAt: () => undefined,
+      setQuestion: () => undefined,
+      recoverNullQuestion,
+    });
+
+    expect(recoverNullQuestion).not.toHaveBeenCalled();
+  });
+
   it('uses the standard read timeout tier when loading questions', async () => {
     vi.useFakeTimers();
     try {

--- a/app/(app)/app/practice/shared/question-flow-actions.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions.ts
@@ -22,6 +22,8 @@ export type RequestSequencingHooks = {
   isLatestRequest: (requestId: number) => boolean;
 };
 
+export type NullQuestionRecovery = () => Promise<boolean>;
+
 function assertRequestSequencingHooks(input: {
   createRequestSequenceId?:
     | RequestSequencingHooks['createRequestSequenceId']
@@ -61,6 +63,7 @@ export async function runLoadQuestionFlow<TQuestion>(input: {
   setQuestionLoadedAt: (loadedAtMs: number | null) => void;
   setQuestion: (question: TQuestion | null) => void;
   onLoaded?: ((question: TQuestion | null) => void) | undefined;
+  recoverNullQuestion?: NullQuestionRecovery | undefined;
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
@@ -115,6 +118,12 @@ export async function runLoadQuestionFlow<TQuestion>(input: {
     input.setQuestionLoadedAt(null);
     input.onLoaded?.(null);
     return;
+  }
+
+  if (res.data === null && input.recoverNullQuestion) {
+    const handled = await input.recoverNullQuestion();
+    if (!canCommit()) return;
+    if (handled) return;
   }
 
   input.setQuestion(res.data);

--- a/docs/bugs/bug-256-expired-exam-resume-shows-empty-question-state.md
+++ b/docs/bugs/bug-256-expired-exam-resume-shows-empty-question-state.md
@@ -32,15 +32,15 @@ Actual:
 
 The session page bootstraps by asking for the summary first:
 
-- [`use-practice-session-page-model.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts#L204>) calls `getPracticeSessionSummary`.
-- If the session is not yet ended, [`use-practice-session-page-model.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts#L219>) falls back to `questionFlow.onTryAgain()`.
+- [`use-practice-session-page-model.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts#L212>) calls `getPracticeSessionSummary`.
+- If the session is not yet ended, [`use-practice-session-page-model.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts#L227>) falls back to `questionFlow.onTryAgain()`.
 
 The fallback `getNextQuestion` path finalizes expired exams but returns no summary:
 
 - [`get-next-question.ts`](../../src/application/use-cases/get-next-question.ts#L178) checks expiry.
 - [`get-next-question.ts`](../../src/application/use-cases/get-next-question.ts#L185) executes the expired exam finalizer.
 - [`get-next-question.ts`](../../src/application/use-cases/get-next-question.ts#L186) returns `null`.
-- Existing coverage locks this contract at [`get-next-question-navigation.test.ts`](../../src/application/use-cases/get-next-question-navigation.test.ts#L306).
+- Existing coverage starts at [`get-next-question-navigation.test.ts`](../../src/application/use-cases/get-next-question-navigation.test.ts#L306) and asserts `getNextQuestion.execute(...)` resolves to `null` at [`get-next-question-navigation.test.ts`](../../src/application/use-cases/get-next-question-navigation.test.ts#L333).
 
 The shared load flow commits the `null` question as a ready state:
 
@@ -58,13 +58,29 @@ A subscriber returning to an expired exam briefly sees an incorrect state ("No m
 
 ## Proposed Fix
 
-Make the expired-finalization path converge to the same result surface as normal finalization.
+Make the expired-finalization path converge to the same result surface as normal finalization with a client-side summary recovery in the session page bootstrap fallback.
 
-Possible implementation:
+Committed path:
 
-1. Change the expired exam finalizer pathway to return `FinalizeExamAnswersOutput` or a typed "finalized" result instead of overloading `null`.
-2. In the client fallback path, if `getNextQuestion` returns `null` for a session request, immediately call `getPracticeSessionSummary({ sessionId })` before rendering the empty state.
-3. Add a browser/page-model regression that resumes an expired exam and expects the summary view, not "No more questions found."
+1. Keep `GetNextQuestionUseCase` unchanged: when an active exam is already expired, it may finalize the exam server-side and return `null`.
+2. Add an optional async null-question recovery hook to the app-layer load path (`usePracticeSessionQuestionFlow` → `loadNextQuestion` → `runLoadQuestionFlow`). It must run only when the question load returns `ok(null)`, and it must run before `setQuestion(null)` / `setLoadState({ status: 'ready' })` commits the generic empty state.
+3. In `usePracticeSessionPageModel`, enable that hook only for the bootstrap-summary `CONFLICT` fallback before calling `questionFlow.onTryAgain()`.
+4. For that bootstrap-only `null`, immediately re-read the server-authoritative summary with `getPracticeSessionSummary({ sessionId })`.
+5. If the summary read succeeds, set the page-model summary state through the same ended-session bootstrap path and reset the question state; if it still returns `CONFLICT`, preserve the existing generic no-question behavior.
+6. Add a browser/page-model regression that resumes an expired exam and expects the summary view, not "No more questions found."
+
+Rationale:
+
+- Smallest blast radius: the fix stays in the app/page-model load orchestration and does not change domain, application use-case, controller schema, or persisted state contracts.
+- Server authority is preserved: the server still performs finalization and grading; the client only re-reads the summary after that server-side state transition.
+- Idempotency is preserved: the recovery adds no second finalize/end mutation, only a read after the existing expired-exam finalizer has run.
+- Existing `getNextQuestion` `null` semantics remain valid for ordinary no-question states, so current application-layer navigation coverage does not need to be rewritten.
+
+Rejected alternatives:
+
+- Return `FinalizeExamAnswersOutput` or a new typed "finalized" union from `getNextQuestion`: broader cross-layer output/schema change for one bootstrap edge, and it weakens the stable question-load contract.
+- Call `endPracticeSession` or `finalizeExamAnswers` again from the client after `getNextQuestion` returns `null`: unnecessary duplicate mutation and a larger idempotency/race surface because the reachable server path already finalized the exam.
+- Render results from client-held question/load state without re-reading the summary: would trust stale/incomplete client state instead of the server-authoritative finalized session.
 
 ## Failing Test Sketch
 
@@ -72,12 +88,27 @@ Possible implementation:
 it('shows the summary when resuming an exam that expires during getNextQuestion', async () => {
   getPracticeSessionSummaryMock
     .mockResolvedValueOnce(errorResult('CONFLICT', 'Practice session has not ended'))
-    .mockResolvedValueOnce(ok(finalizedExamSummary));
+    .mockResolvedValueOnce(
+      ok({
+        sessionId: BROWSER_SESSION_ID,
+        endedAt: '2026-02-07T00:20:00.000Z',
+        mode: 'exam',
+        questionCount: 2,
+        totals: {
+          answered: 2,
+          correct: 1,
+          accuracy: 0.5,
+          durationSeconds: 1200,
+        },
+      }),
+    );
   getNextQuestionMock.mockResolvedValue(ok(null));
 
-  const screen = await render(<PracticeSessionPageModelReviewProbe />);
+  const screen = await render(<PracticeSessionPageModelSummaryProbe />);
 
+  await expect.poll(() => getPracticeSessionSummaryMock.mock.calls.length).toBe(2);
   await expect.element(screen.getByTestId('active-view')).toHaveTextContent('summary');
+  await expect.element(screen.getByTestId('summary-mode')).toHaveTextContent('exam');
 });
 ```
 


### PR DESCRIPTION
Promotes the BUG-256 fix from dev to main (fires prod deploy).

What ships: an app-layer null-question recovery hook so resuming an expired exam re-reads the server-authoritative summary instead of showing 'No more questions found'. Read-only/idempotent; scoped to the bootstrap CONFLICT fallback; normal-navigation nulls unchanged. App layer only - no domain/application/controller change.

Already on dev via #479 (squash b848a778): CodeRabbit APPROVED on 4b480784, test check green, browser + unit coverage. Bug doc stays Open (archival follows prod-verify).

https://claude.ai/code/session_01RhHv6rK1YVBaE8WmPNpGXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exam recovery by displaying the exam summary view when an exam expires during session usage, instead of showing an empty question state and ensuring users see accurate session information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->