### PR TITLE
Promote to main: BUG-255 exam finalization end time cap (#490)

### DIFF
--- a/docs/bugs/bug-255-review-submit-screen-stops-exam-timer.md
+++ b/docs/bugs/bug-255-review-submit-screen-stops-exam-timer.md
@@ -10,11 +10,11 @@
 
 ## Summary
 
-The active exam timer is disabled once the user enters the Review & Submit screen. If the deadline passes while the user remains on that screen, the exam is not auto-finalized. The user can submit later, and the session `endedAt`/summary duration are recorded from the late submit time rather than the exam deadline.
+The active exam timer is disabled once the user enters the Review & Submit screen. If the deadline passes while the user remains on that screen, the exam is not auto-finalized. The user can submit later, and the session `endedAt` plus `durationSeconds` are recorded from the late submit time rather than the exam deadline.
 
 This is a timer-enforcement gap in a normal exam workflow: reviewing answers before final submit.
 
-**Scope (why P4):** the only effect is an inflated recorded `durationSeconds`/`endedAt`. Answers cannot be changed after the deadline — every draft save routes through `SaveExamDraftAnswerUseCase`, which rejects post-deadline saves with `CONFLICT: Exam time has expired` ([`save-exam-draft-answer.ts`](../../src/application/use-cases/save-exam-draft-answer.ts#L55)). There is no score or data-integrity impact; the recorded duration stat is the entire harm.
+**Scope (why P4):** the durable effect is an inflated recorded `endedAt` and `durationSeconds`, which then display in summary/history surfaces and can affect completed-session ordering. Verified answer-mutation paths do not make this a scoring bug: draft persistence still routes through `SaveExamDraftAnswerUseCase`, which rejects post-deadline saves with `CONFLICT: Exam time has expired` ([`save-exam-draft-answer.ts`](../../src/application/use-cases/save-exam-draft-answer.ts#L55)); opening a question from review returns to the active exam question UI ([`use-practice-session-review-stage-state.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.ts#L141>)), whose production exam action bar has navigation/review controls but no per-question submit button ([`practice-view.tsx`](<../../app/(app)/app/practice/components/practice-view.tsx#L350>)); and even if the synthetic probe calls the per-question submit path, `SubmitAnswerUseCase` rejects active exam sessions with `VALIDATION_ERROR` ([`submit-answer.ts`](../../src/application/use-cases/submit-answer.ts#L182)). BUG-254's finalization flush remains bounded to a single current question within `FINALIZE_FLUSH_DEADLINE_GRACE_MS` and is not a general post-deadline draft-save bypass ([`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L38)).
 
 ## Reproduction
 
@@ -38,60 +38,116 @@ Actual:
 
 Entering Review & Submit loads review state and clears active question state:
 
-- [`use-practice-session-review-stage.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.ts#L196>) starts the exam review transition.
+- [`use-practice-session-review-stage.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.ts#L204>) starts the `onEndSession` path that saves the current draft before entering review.
+- [`use-practice-session-review-stage-state.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.ts#L160>) loads review state for exam sessions instead of immediately finalizing.
 - [`use-practice-session-review-stage-state.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.ts#L123>) stores the active exam review.
 - [`use-practice-session-review-stage-state.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.ts#L128>) resets question state.
 
 The page model disables the timer while review state exists:
 
-- [`use-practice-session-page-model.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts#L178>) computes `isTimerActive`.
-- [`use-practice-session-page-model.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts#L182>) requires `!reviewStage.review`, so Review & Submit turns the timer off.
+- [`use-practice-session-page-model.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts#L186>) computes `isTimerActive`.
+- [`use-practice-session-page-model.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts#L188>) requires a current `questionFlow.sessionInfo.deadlineAt`, which review entry clears via `resetQuestionState`.
+- [`use-practice-session-page-model.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts#L190>) also requires `!reviewStage.review`, so Review & Submit turns the timer off even though the active exam is not ended.
+- [`use-practice-session-page-model.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts#L193>) is the only `useExamTimer` wiring for the session page; with `isTimerActive === false`, no expiry callback runs from the Review & Submit screen.
 
 The Review & Submit UI still allows a late manual submit:
 
 - [`exam-review-view.tsx`](<../../app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx#L238>) renders the Submit exam action.
 - [`exam-review-view.tsx`](<../../app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx#L272>) invokes `onFinalizeReview()`.
-- [`use-practice-session-review-stage.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.ts#L238>) finalizes the exam review.
+- [`use-practice-session-review-stage.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.ts#L251>) finalizes the exam review.
 
-Finalization records wall-clock end time:
+Pre-fix finalization reached the session end boundary without an explicit exam deadline timestamp, so summary/history projected duration from the repository's wall-clock default:
 
-- [`drizzle-practice-session-repository.ts`](../../src/adapters/repositories/drizzle-practice-session-repository.ts#L341) sets `endedAt = this.now()`.
+- [`use-practice-session-review-stage.ts`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.ts#L142>) calls the same `endSession(...)` helper used by finalization, but the Review & Submit path does not pass a `finalDraftAnswer`.
+- [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L252) calls `tx.sessions.end(...)`.
+- [`drizzle-practice-session-repository.ts`](../../src/adapters/repositories/drizzle-practice-session-repository.ts#L341) defaults to `this.now()` when callers do not provide an explicit `endedAt`.
 - [`practice-session-summary.ts`](../../src/application/use-cases/practice-session-summary.ts#L47) computes duration from `startedAt` to that `endedAt`.
+- [`get-session-history.ts`](../../src/application/use-cases/get-session-history.ts#L91) recomputes completed-session `durationSeconds` from persisted `startedAt`/`endedAt` for history.
+- [`drizzle-practice-session-repository.ts`](../../src/adapters/repositories/drizzle-practice-session-repository.ts#L142) orders completed sessions by `endedAt` descending.
 
 ## Impact
 
-A user who spends time on Review & Submit can end up with an exam session whose recorded `durationSeconds` exceeds the allowed exam duration, and the app does not auto-submit while the review screen is open. This is a stat-integrity issue only: the answers themselves are locked at the deadline (the server rejects all post-deadline draft saves), so scores and graded outcomes are unaffected.
+A user who spends time on Review & Submit can end up with an exam session whose recorded `durationSeconds` exceeds the allowed exam duration, and whose `endedAt` reflects when they eventually clicked Submit exam instead of when time expired. This can show an impossible duration in the summary/history UI and can make the completed session sort/date as later than the exam deadline. No score or graded-outcome impact was found in the normal Review & Submit flow: post-deadline draft saves are rejected, active-exam per-question submit is not exposed in production UI and is server-rejected, and BUG-254's final flush is a bounded expiry-only single-question path rather than a general answer map.
 
 ## Proposed Fix
 
-Keep the exam timer active until the exam is actually ended, including Review & Submit. Implementation options:
+**Verdict: FIX.** Accepting this as won't-fix would leave persisted exam timestamps/durations visibly impossible for a normal workflow. The harm is low, but the correct fix is small and belongs at the server-authoritative finalization boundary rather than relying on a client timer.
 
-1. Preserve `deadlineAt` in review state and feed it to `useExamTimer` while `reviewStage.review` is active.
-2. On expiry from Review & Submit, call the same finalization path used by active-question expiry.
-3. Defense in depth: cap exam `endedAt`/summary duration at `computeExamDeadline(session)` during finalization, or expose a repository method that can end an expired exam at the deadline rather than at late wall-clock submit time.
+Committed path:
+
+1. In `FinalizeExamAnswersUseCase`, compute the server-side exam deadline with `computeExamDeadline(session)` and choose an effective end time of `deadline === null ? now : min(now, max(deadline, latestAnsweredAt))` for active exam finalization. Manual submit before the deadline still ends at `now`; submit after the deadline ends at the deadline unless BUG-254's accepted finalization flush records an attempt inside the grace window after the deadline, in which case `endedAt` must not be earlier than that attempt's `answeredAt`.
+2. Persist that effective end time through the `PracticeSessionRepository` boundary ([`practice-session-repository.ts`](../../src/application/ports/practice-session-repository.ts#L59)) instead of allowing `DrizzlePracticeSessionRepository.end(...)` to always stamp `this.now()` for exam finalization. Keep the generic tutor `EndPracticeSessionUseCase` behavior unchanged.
+3. Return the summary projected from the same persisted effective `endedAt`, so `endedAt`, summary `durationSeconds`, and history `durationSeconds` share one source of truth.
+4. Do not relax `SaveExamDraftAnswerUseCase` and do not broaden BUG-254's finalization flush. The cap happens after the existing `applyFinalDraftAnswer(...)` grace-window validation, so `FINALIZE_FLUSH_DEADLINE_GRACE_MS` still only controls whether the single current-question expiry flush may be accepted; when such a flush is accepted after the deadline, the persisted exam end time may extend only as far as that validated attempt's `answeredAt` so the session does not end before its own recorded attempt.
+
+Rejected alternatives:
+
+- **Accept as won't-fix P4:** rejected because impossible exam durations and late completion timestamps are visible and persisted, not merely transient UI copy.
+- **Client-only timer restoration on Review & Submit:** rejected as the primary fix because review entry currently clears `deadlineAt`, browser timers can be throttled or clock-skewed, and a client-only change cannot guarantee the persisted `endedAt` is capped. It may be added as a UX guard later, but it must not be the source of truth.
+- **Cap only the returned summary duration:** rejected because it hides one projection while leaving persisted `endedAt`, history duration, history date, and ordering inconsistent.
+- **Relax post-deadline draft saves:** rejected because it would let ordinary answer changes persist after time expires and would violate the exam deadline invariant.
 
 ## Failing Test Sketch
 
-```tsx
-it('keeps the exam timer active while the Review & Submit screen is open', async () => {
+Primary red test goes in [`finalize-exam-answers.test.ts`](../../src/application/use-cases/finalize-exam-answers.test.ts), which already uses `FakePracticeSessionRepository`, `FakeAttemptRepository`, `FakeQuestionRepository`, `createPracticeSession`, and `createQuestion`.
+
+```ts
+it('caps expired exam finalization endedAt and duration at the server deadline', async () => {
   vi.useFakeTimers();
-  vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
-  mockActiveTimedExam('2026-05-22T12:00:01.000Z');
-  mockReviewResponse();
-  mockFinalizeSummary();
+  vi.setSystemTime(new Date('2026-03-17T12:05:00.000Z'));
 
-  const screen = await render(<PracticeSessionPageModelReviewProbe />);
-  await screen.getByRole('button', { name: 'review-answers' }).click();
-  await expect.element(screen.getByTestId('active-view')).toHaveTextContent('review');
+  const questions = new FakeQuestionRepository([
+    createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+  ]);
+  const attempts = new FakeAttemptRepository();
+  const sessions = new FakePracticeSessionRepository([
+    createPracticeSession({
+      id: 'session-1',
+      userId: 'user-1',
+      mode: 'exam',
+      questionIds: ['q1'],
+      startedAt: new Date('2026-03-17T12:00:00.000Z'),
+      questionStates: [
+        {
+          questionId: 'q1',
+          markedForReview: false,
+          latestSelectedChoiceId: null,
+          latestIsCorrect: null,
+          latestAnsweredAt: null,
+          draftSelectedChoiceId: 'q1-correct',
+          draftSavedAt: new Date('2026-03-17T12:10:00.000Z'),
+          draftCumulativeMs: 30_000,
+        },
+      ],
+    }),
+  ]);
+  const useCase = new FinalizeExamAnswersUseCase(
+    questions,
+    attempts,
+    sessions,
+    passthroughTransaction(questions, attempts, sessions),
+    () => new Date(),
+  );
 
-  await vi.advanceTimersByTimeAsync(1_000);
+  const summary = await useCase.execute({
+    userId: 'user-1',
+    sessionId: 'session-1',
+  });
 
-  expect(finalizeExamAnswersMock).toHaveBeenCalledTimes(1);
+  expect(summary.endedAt).toBe('2026-03-17T12:01:12.000Z');
+  expect(summary.totals.durationSeconds).toBe(72);
+  await expect(sessions.findByIdAndUserId('session-1', 'user-1')).resolves.toMatchObject({
+    endedAt: new Date('2026-03-17T12:01:12.000Z'),
+  });
 });
 ```
+
+Secondary browser coverage is feasible if the implementation also restores visible timer behavior on the Review & Submit screen: [`PracticeSessionPageModelReviewProbe`](<../../app/(app)/app/practice/[sessionId]/hooks/practice-session-page-model.browser.probes.tsx#L181>) and the timer spec helpers in [`use-practice-session-page-model-timer.browser.spec.tsx`](<../../app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-timer.browser.spec.tsx#L28>) already exist. Do not make that browser test the only proof; the persisted end-time invariant belongs in the use-case/repository tests.
 
 ## Prior Bug Cross-Refs
 
 - BUG-251: active exam abandon lifecycle, fixed. Not this bug.
 - BUG-252: draft timing persistence, fixed. Not this bug.
+- BUG-254: expiry final draft flush, fixed. Compatible: this bug's proposed end-time cap must not widen `FINALIZE_FLUSH_DEADLINE_GRACE_MS` or accept more than the one validated current-question draft.
+- BUG-237: active exam per-question submit is fixed/rejected server-side. Relevant to severity: the synthetic `allowExamCommit` probe is not a production answer-mutation path.
 - No prior bug found for timer deactivation on Review & Submit.

--- a/src/adapters/repositories/drizzle-attempt-repository.test.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.test.ts
@@ -326,6 +326,43 @@ describe('DrizzleAttemptRepository', () => {
       });
     });
 
+    it('passes an explicit answeredAt timestamp when provided', async () => {
+      const db = createDbMock();
+      const answeredAt = new Date('2026-02-01T00:00:00Z');
+      const explicitAnsweredAt = new Date('2026-02-01T00:00:42Z');
+      db._mocks.insertReturning.mockResolvedValue([
+        {
+          id: attemptId,
+          userId: userId,
+          questionId: questionId,
+          practiceSessionId: sessionId,
+          selectedChoiceId: selectedChoiceId,
+          isOmitted: false,
+          isCorrect: true,
+          timeSpentSeconds: 42,
+          answeredAt,
+        },
+      ]);
+
+      const repo = new DrizzleAttemptRepository(db as unknown as RepoDb);
+
+      await repo.insert({
+        userId: userId,
+        questionId: questionId,
+        practiceSessionId: sessionId,
+        outcome: answeredOutcome(selectedChoiceId),
+        isCorrect: true,
+        timeSpentSeconds: 42,
+        answeredAt: explicitAnsweredAt,
+      });
+
+      expect(db._mocks.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          answeredAt: explicitAnsweredAt,
+        }),
+      );
+    });
+
     it('returns an inserted omitted attempt', async () => {
       const db = createDbMock();
       const answeredAt = new Date('2026-02-01T00:00:00Z');

--- a/src/adapters/repositories/drizzle-attempt-repository.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.ts
@@ -23,14 +23,14 @@ import type {
   AttemptedQuestionSummary,
   AttemptedQuestionsFilters,
   AttemptedQuestionsSort,
+  AttemptInsertInput,
   AttemptMostRecentAnsweredAt,
   AttemptRepository,
   PageOptions,
   RecentAttempt,
 } from '@/src/application/ports/repositories';
-import type { Attempt, AttemptRetryOrigin } from '@/src/domain/entities';
+import type { Attempt } from '@/src/domain/entities';
 import {
-  type AnswerOutcome,
   isOmittedOutcome,
   selectedChoiceIdOrNull,
 } from '@/src/domain/value-objects';
@@ -164,17 +164,7 @@ export class DrizzleAttemptRepository implements AttemptRepository {
     ];
   }
 
-  async insert(input: {
-    userId: string;
-    questionId: string;
-    practiceSessionId: string | null;
-    outcome: AnswerOutcome;
-    isCorrect: boolean;
-    timeSpentSeconds: number;
-    retryOfAttemptId?: string | null;
-    retryOrigin?: AttemptRetryOrigin | null;
-    retrySessionId?: string | null;
-  }) {
+  async insert(input: AttemptInsertInput) {
     let row: (typeof attempts)['$inferSelect'] | undefined;
     try {
       [row] = await this.db
@@ -187,6 +177,7 @@ export class DrizzleAttemptRepository implements AttemptRepository {
           isOmitted: isOmittedOutcome(input.outcome),
           isCorrect: input.isCorrect,
           timeSpentSeconds: input.timeSpentSeconds,
+          ...(input.answeredAt ? { answeredAt: input.answeredAt } : {}),
           retryOfAttemptId: input.retryOfAttemptId ?? null,
           retryOrigin: input.retryOrigin ?? null,
           retrySessionId: input.retrySessionId ?? null,

--- a/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
@@ -347,6 +347,64 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
         ?.latestAnsweredAt,
     ).toEqual(new Date('2026-02-01T00:00:01.000Z'));
     expect(nowFn).toHaveBeenCalledTimes(1);
+    expect(updateSet).toHaveBeenCalledWith({ endedAt: now });
+  });
+
+  it('uses an explicit endedAt when ending a practice session', async () => {
+    const explicitEndedAt = new Date('2026-02-01T00:10:00.000Z');
+    const nowFn = vi.fn((): Date => {
+      throw new Error('unexpected clock call');
+    });
+
+    const row = {
+      id: sessionId,
+      userId: userId,
+      mode: 'exam',
+      paramsJson: {
+        count: 1,
+        tagSlugs: [],
+        difficulties: [],
+        questionIds: [firstQuestionId],
+      },
+      startedAt: new Date('2026-02-01T00:00:00.000Z'),
+      endedAt: null,
+    } as const;
+
+    const updateReturning = vi.fn(async () => [
+      {
+        ...row,
+        endedAt: explicitEndedAt,
+      },
+    ]);
+    const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+    const updateSet = vi.fn(() => ({ where: updateWhere }));
+    const update = vi.fn(() => ({ set: updateSet }));
+
+    const db = {
+      query: {
+        practiceSessions: {
+          findFirst: async () => row,
+        },
+      },
+      update,
+      insert: () => {
+        throw new Error('unexpected insert');
+      },
+    } as const;
+
+    type RepoDb = ConstructorParameters<
+      typeof DrizzlePracticeSessionRepository
+    >[0];
+    const repo = new DrizzlePracticeSessionRepository(
+      db as unknown as RepoDb,
+      nowFn,
+    );
+
+    const ended = await repo.end(sessionId, userId, explicitEndedAt);
+
+    expect(ended).toMatchObject({ id: sessionId, endedAt: explicitEndedAt });
+    expect(updateSet).toHaveBeenCalledWith({ endedAt: explicitEndedAt });
+    expect(nowFn).not.toHaveBeenCalled();
   });
 
   it('throws CONFLICT when the practice session is already ended', async () => {

--- a/src/adapters/repositories/drizzle-practice-session-repository.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository.ts
@@ -328,7 +328,7 @@ export class DrizzlePracticeSessionRepository
       );
   }
 
-  async end(id: string, userId: string) {
+  async end(id: string, userId: string, explicitEndedAt?: Date) {
     const existing = await this.findByIdAndUserId(id, userId);
     if (!existing) {
       throw new ApplicationError('NOT_FOUND', 'Practice session not found');
@@ -338,7 +338,7 @@ export class DrizzlePracticeSessionRepository
       throw new ApplicationError('CONFLICT', 'Practice session already ended');
     }
 
-    const endedAt = this.now();
+    const endedAt = explicitEndedAt ?? this.now();
     const [updated] = await this.db
       .update(practiceSessions)
       .set({ endedAt })

--- a/src/application/ports/attempt-repository.ts
+++ b/src/application/ports/attempt-repository.ts
@@ -17,6 +17,7 @@ export type AttemptInsertInput = {
   outcome: AnswerOutcome;
   isCorrect: boolean;
   timeSpentSeconds: number;
+  answeredAt?: Date;
   retryOfAttemptId?: string | null;
   retryOrigin?: AttemptRetryOrigin | null;
   retrySessionId?: string | null;

--- a/src/application/ports/practice-session-repository.ts
+++ b/src/application/ports/practice-session-repository.ts
@@ -56,5 +56,5 @@ export interface PracticeSessionRepository {
     markedForReview: boolean;
   }): Promise<PracticeSessionQuestionState>;
   discard(id: string, userId: string): Promise<void>;
-  end(id: string, userId: string): Promise<PracticeSession>;
+  end(id: string, userId: string, endedAt?: Date): Promise<PracticeSession>;
 }

--- a/src/application/test-helpers/fakes/fake-attempt-repository.ts
+++ b/src/application/test-helpers/fakes/fake-attempt-repository.ts
@@ -3,20 +3,14 @@ import type {
   AttemptedQuestionSummary,
   AttemptedQuestionsFilters,
   AttemptedQuestionsSort,
+  AttemptInsertInput,
   AttemptMostRecentAnsweredAt,
   AttemptRepository,
   PageOptions,
 } from '@/src/application/ports/repositories';
-import type {
-  Attempt,
-  AttemptRetryOrigin,
-  Question,
-} from '@/src/domain/entities';
+import type { Attempt, Question } from '@/src/domain/entities';
 import { createAttempt } from '@/src/domain/entities/attempt';
-import {
-  type AnswerOutcome,
-  isOmittedOutcome,
-} from '@/src/domain/value-objects';
+import { isOmittedOutcome } from '@/src/domain/value-objects';
 
 type InMemoryAttempt = Attempt & {
   practiceSessionId: string | null;
@@ -38,17 +32,7 @@ export class FakeAttemptRepository implements AttemptRepository {
       : null;
   }
 
-  async insert(input: {
-    userId: string;
-    questionId: string;
-    practiceSessionId: string | null;
-    outcome: AnswerOutcome;
-    isCorrect: boolean;
-    timeSpentSeconds: number;
-    retryOfAttemptId?: string | null;
-    retryOrigin?: AttemptRetryOrigin | null;
-    retrySessionId?: string | null;
-  }): Promise<Attempt> {
+  async insert(input: AttemptInsertInput): Promise<Attempt> {
     // BUG-105: Enforce session+question uniqueness (mirrors DB partial unique index)
     if (input.practiceSessionId !== null) {
       const duplicate = this.attempts.find(
@@ -82,7 +66,7 @@ export class FakeAttemptRepository implements AttemptRepository {
       retryOfAttemptId: input.retryOfAttemptId ?? null,
       retryOrigin: input.retryOrigin ?? null,
       retrySessionId: input.retrySessionId ?? null,
-      answeredAt: new Date(),
+      answeredAt: input.answeredAt ?? new Date(),
     });
     const storedAttempt = {
       ...attempt,

--- a/src/application/test-helpers/fakes/fake-practice-session-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-practice-session-repository.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ApplicationError } from '@/src/application/errors';
 import { createPracticeSession } from '@/src/domain/test-helpers';
 import { omittedOutcome } from '@/src/domain/value-objects';
 import { FakePracticeSessionRepository } from './fake-practice-session-repository';
 
 describe('FakePracticeSessionRepository', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('normalizes missing draft fields for seeded legacy sessions', async () => {
     const legacySession = {
       ...createPracticeSession({
@@ -61,6 +65,37 @@ describe('FakePracticeSessionRepository', () => {
     await expect(repo.end('session-1', 'user-1')).rejects.toEqual(
       new ApplicationError('CONFLICT', 'Practice session already ended'),
     );
+  });
+
+  it('honors explicit endedAt while preserving the default clock path', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-01T00:10:00.000Z'));
+    const explicitEndedAt = new Date('2026-02-01T00:05:00.000Z');
+    const repo = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: 'explicit-session',
+        userId: 'user-1',
+        mode: 'exam',
+        endedAt: null,
+      }),
+      createPracticeSession({
+        id: 'default-session',
+        userId: 'user-1',
+        mode: 'tutor',
+        endedAt: null,
+      }),
+    ]);
+
+    await expect(
+      repo.end('explicit-session', 'user-1', explicitEndedAt),
+    ).resolves.toMatchObject({
+      id: 'explicit-session',
+      endedAt: explicitEndedAt,
+    });
+    await expect(repo.end('default-session', 'user-1')).resolves.toMatchObject({
+      id: 'default-session',
+      endedAt: new Date('2026-02-01T00:10:00.000Z'),
+    });
   });
 
   it('discards only incomplete sessions owned by the caller', async () => {

--- a/src/application/test-helpers/fakes/fake-practice-session-repository.ts
+++ b/src/application/test-helpers/fakes/fake-practice-session-repository.ts
@@ -383,7 +383,11 @@ export class FakePracticeSessionRepository
     );
   }
 
-  async end(id: string, userId: string): Promise<PracticeSession> {
+  async end(
+    id: string,
+    userId: string,
+    explicitEndedAt?: Date,
+  ): Promise<PracticeSession> {
     const existing = await this.findByIdAndUserId(id, userId);
     if (!existing) {
       throw new ApplicationError('NOT_FOUND', 'Practice session not found');
@@ -393,7 +397,10 @@ export class FakePracticeSessionRepository
       throw new ApplicationError('CONFLICT', 'Practice session already ended');
     }
 
-    const ended: PracticeSession = { ...existing, endedAt: new Date() };
+    const ended: PracticeSession = {
+      ...existing,
+      endedAt: explicitEndedAt ?? new Date(),
+    };
     this.updateSession(id, () => ended);
     return ended;
   }

--- a/src/application/use-cases/finalize-exam-answers.test.ts
+++ b/src/application/use-cases/finalize-exam-answers.test.ts
@@ -6,13 +6,17 @@ import {
   FakePracticeSessionRepository,
   FakeQuestionRepository,
 } from '@/src/application/test-helpers/fakes';
-import { MS_PER_SECOND } from '@/src/domain/services';
+import {
+  EXAM_SECONDS_PER_QUESTION,
+  MS_PER_SECOND,
+} from '@/src/domain/services';
 import {
   createChoice,
   createPracticeSession,
   createQuestion,
 } from '@/src/domain/test-helpers';
 import {
+  computeFinalExamEndedAt,
   FINALIZE_FLUSH_DEADLINE_GRACE_MS,
   FinalizeExamAnswersUseCase,
   type FinalizeExamAnswersWriteTransaction,
@@ -146,6 +150,10 @@ describe('FinalizeExamAnswersUseCase', () => {
       sessions,
       passthroughTransaction(questions, attempts, sessions),
     );
+    const examDeadline = new Date(
+      new Date('2026-03-17T12:00:00.000Z').getTime() +
+        4 * EXAM_SECONDS_PER_QUESTION * MS_PER_SECOND,
+    );
 
     await expect(
       useCase.execute({
@@ -156,12 +164,12 @@ describe('FinalizeExamAnswersUseCase', () => {
       sessionId: 'session-1',
       mode: 'exam',
       questionCount: 4,
-      endedAt: '2026-03-17T12:30:00.000Z',
+      endedAt: examDeadline.toISOString(),
       totals: {
         answered: 3,
         correct: 2,
         accuracy: 0.5,
-        durationSeconds: 1800,
+        durationSeconds: 4 * EXAM_SECONDS_PER_QUESTION,
       },
     });
 
@@ -208,7 +216,7 @@ describe('FinalizeExamAnswersUseCase', () => {
     await expect(
       sessions.findByIdAndUserId('session-1', 'user-1'),
     ).resolves.toMatchObject({
-      endedAt: new Date('2026-03-17T12:30:00.000Z'),
+      endedAt: examDeadline,
       questionStates: [
         {
           questionId: 'q1',
@@ -553,6 +561,136 @@ describe('FinalizeExamAnswersUseCase', () => {
         'Finalize exam is only available in exam mode',
       ),
     );
+  });
+
+  describe('exam end timestamp cap (BUG-255)', () => {
+    const STARTED_AT = new Date('2026-03-17T12:00:00.000Z');
+    const ONE_QUESTION_DEADLINE = new Date(
+      STARTED_AT.getTime() + EXAM_SECONDS_PER_QUESTION * MS_PER_SECOND,
+    );
+
+    function createTimedExamUseCase(input: { now: Date }) {
+      const questions = new FakeQuestionRepository([
+        createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+      ]);
+      const attempts = new FakeAttemptRepository();
+      const sessions = new FakePracticeSessionRepository([
+        createPracticeSession({
+          id: 'session-1',
+          userId: 'user-1',
+          mode: 'exam',
+          questionIds: ['q1'],
+          startedAt: STARTED_AT,
+          questionStates: [
+            {
+              questionId: 'q1',
+              markedForReview: false,
+              latestSelectedChoiceId: null,
+              latestIsCorrect: null,
+              latestAnsweredAt: null,
+              draftSelectedChoiceId: 'q1-correct',
+              draftSavedAt: new Date(STARTED_AT.getTime() + 30_000),
+              draftCumulativeMs: 30_000,
+            },
+          ],
+        }),
+      ]);
+      const useCase = new FinalizeExamAnswersUseCase(
+        questions,
+        attempts,
+        sessions,
+        passthroughTransaction(questions, attempts, sessions),
+        () => input.now,
+      );
+
+      return { attempts, sessions, useCase };
+    }
+
+    it('caps late exam finalization endedAt and duration at the server deadline', async () => {
+      const { attempts, sessions, useCase } = createTimedExamUseCase({
+        now: new Date('2026-03-17T12:05:00.000Z'),
+      });
+
+      const summary = await useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+      });
+
+      expect(summary).toMatchObject({
+        endedAt: ONE_QUESTION_DEADLINE.toISOString(),
+        totals: {
+          durationSeconds: EXAM_SECONDS_PER_QUESTION,
+        },
+      });
+      await expect(
+        sessions.findByIdAndUserId('session-1', 'user-1'),
+      ).resolves.toMatchObject({
+        endedAt: ONE_QUESTION_DEADLINE,
+      });
+      await expect(
+        attempts.findBySessionId('session-1', 'user-1'),
+      ).resolves.toMatchObject([{ answeredAt: ONE_QUESTION_DEADLINE }]);
+    });
+
+    it('keeps early exam finalization endedAt at now', async () => {
+      const earlyNow = new Date(STARTED_AT.getTime() + 30_000);
+      const { sessions, useCase } = createTimedExamUseCase({ now: earlyNow });
+
+      const summary = await useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+      });
+
+      expect(summary).toMatchObject({
+        endedAt: earlyNow.toISOString(),
+        totals: {
+          durationSeconds: 30,
+        },
+      });
+      await expect(
+        sessions.findByIdAndUserId('session-1', 'user-1'),
+      ).resolves.toMatchObject({ endedAt: earlyNow });
+    });
+
+    it('uses now when the exam deadline is unavailable', () => {
+      const now = new Date('2026-03-17T12:05:00.000Z');
+
+      expect(
+        computeFinalExamEndedAt({
+          now,
+          deadline: null,
+          latestAnsweredAt: null,
+        }),
+      ).toEqual(now);
+    });
+
+    it('does not cap below a BUG-254 grace-window attempt answered after the deadline', async () => {
+      vi.useFakeTimers();
+      const graceAnsweredAt = new Date(
+        ONE_QUESTION_DEADLINE.getTime() + FINALIZE_FLUSH_DEADLINE_GRACE_MS,
+      );
+      vi.setSystemTime(graceAnsweredAt);
+      const { attempts, sessions, useCase } = createTimedExamUseCase({
+        now: graceAnsweredAt,
+      });
+
+      const summary = await useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+        finalDraftAnswer: {
+          questionId: 'q1',
+          selectedChoiceId: 'q1-correct',
+          cumulativeMs: 30_000,
+        },
+      });
+      const [attempt] = await attempts.findBySessionId('session-1', 'user-1');
+
+      expect(attempt?.answeredAt).toEqual(graceAnsweredAt);
+      expect(summary.endedAt).toBe(graceAnsweredAt.toISOString());
+      await expect(
+        sessions.findByIdAndUserId('session-1', 'user-1'),
+      ).resolves.toMatchObject({ endedAt: graceAnsweredAt });
+    });
   });
 
   describe('finalDraftAnswer expiry flush (BUG-254)', () => {

--- a/src/application/use-cases/finalize-exam-answers.ts
+++ b/src/application/use-cases/finalize-exam-answers.ts
@@ -59,6 +59,23 @@ export type FinalizeExamAnswersWriteTransaction = <T>(
   }) => Promise<T>,
 ) => Promise<T>;
 
+export function computeFinalExamEndedAt(input: {
+  now: Date;
+  deadline: Date | null;
+  latestAnsweredAt: Date | null;
+}): Date {
+  const { now, deadline, latestAnsweredAt } = input;
+  if (deadline === null) {
+    return now;
+  }
+
+  const latestAnsweredAtMs =
+    latestAnsweredAt?.getTime() ?? Number.NEGATIVE_INFINITY;
+  return new Date(
+    Math.min(now.getTime(), Math.max(deadline.getTime(), latestAnsweredAtMs)),
+  );
+}
+
 export class FinalizeExamAnswersUseCase {
   constructor(
     private readonly questions: QuestionRepository,
@@ -116,6 +133,8 @@ export class FinalizeExamAnswersUseCase {
         );
       }
 
+      const finalizationNow = this.now();
+
       // BUG-254: apply the single-question expiry flush BEFORE grading so the
       // selection visible on-screen at expiry is graded instead of omitted.
       // Grading below stays server-authoritative; this only persists the
@@ -125,8 +144,31 @@ export class FinalizeExamAnswersUseCase {
             tx,
             loadedSession,
             input.finalDraftAnswer,
+            finalizationNow,
           )
         : loadedSession;
+      const deadline = computeExamDeadline(activeSession);
+      const finalDraftFlushAfterDeadline =
+        input.finalDraftAnswer !== undefined &&
+        deadline !== null &&
+        finalizationNow.getTime() >= deadline.getTime();
+      const finalAttemptAnsweredAt = finalDraftFlushAfterDeadline
+        ? finalizationNow
+        : computeFinalExamEndedAt({
+            now: finalizationNow,
+            deadline,
+            latestAnsweredAt: null,
+          });
+      let latestAnsweredAt: Date | null = null;
+      const trackAnsweredAt = (answeredAt: Date | null) => {
+        if (!answeredAt) return;
+        if (
+          latestAnsweredAt === null ||
+          answeredAt.getTime() > latestAnsweredAt.getTime()
+        ) {
+          latestAnsweredAt = answeredAt;
+        }
+      };
 
       const draftedStates = activeSession.questionStates.filter(
         (state) => state.draftSelectedChoiceId !== null,
@@ -137,6 +179,8 @@ export class FinalizeExamAnswersUseCase {
       );
 
       for (const state of activeSession.questionStates) {
+        trackAnsweredAt(state.latestAnsweredAt);
+
         const cappedCumulativeMs = Math.min(
           state.draftCumulativeMs,
           SAVE_EXAM_DRAFT_MAX_CUMULATIVE_MS,
@@ -154,7 +198,9 @@ export class FinalizeExamAnswersUseCase {
             outcome,
             isCorrect: false,
             timeSpentSeconds,
+            answeredAt: finalAttemptAnsweredAt,
           });
+          trackAnsweredAt(attempt.answeredAt);
 
           await tx.sessions.finalizeDraftAnswer({
             sessionId: input.sessionId,
@@ -181,7 +227,9 @@ export class FinalizeExamAnswersUseCase {
           outcome,
           isCorrect: grade.isCorrect,
           timeSpentSeconds,
+          answeredAt: finalAttemptAnsweredAt,
         });
+        trackAnsweredAt(attempt.answeredAt);
 
         await tx.sessions.finalizeDraftAnswer({
           sessionId: input.sessionId,
@@ -193,7 +241,12 @@ export class FinalizeExamAnswersUseCase {
         });
       }
 
-      return tx.sessions.end(input.sessionId, input.userId);
+      const effectiveEndedAt = computeFinalExamEndedAt({
+        now: finalizationNow,
+        deadline,
+        latestAnsweredAt,
+      });
+      return tx.sessions.end(input.sessionId, input.userId, effectiveEndedAt);
     });
 
     const endedAt = endedSession.endedAt;
@@ -214,6 +267,7 @@ export class FinalizeExamAnswersUseCase {
     },
     session: PracticeSession,
     finalDraftAnswer: FinalizeExamFinalDraftAnswer,
+    now: Date,
   ): Promise<PracticeSession> {
     const questionState = session.questionStates.find(
       (state) => state.questionId === finalDraftAnswer.questionId,
@@ -226,7 +280,7 @@ export class FinalizeExamAnswersUseCase {
     }
 
     const deadline = computeExamDeadline(session);
-    const nowMs = this.now().getTime();
+    const nowMs = now.getTime();
     const isWithinGraceWindow =
       deadline !== null &&
       nowMs >= deadline.getTime() &&

--- a/tests/integration/exam-timer.integration.test.ts
+++ b/tests/integration/exam-timer.integration.test.ts
@@ -46,6 +46,7 @@ function createFinalizeExamAnswersUseCase(input: { now: () => Date }) {
           sessions: new DrizzlePracticeSessionRepository(tx, input.now),
         }),
       ),
+    input.now,
   );
 }
 


### PR DESCRIPTION
Promotes the BUG-255 fix from \`dev\` to \`main\` (fires the production deploy).

## What ships
- **BUG-255 (P4):** Exam finalization after the deadline (e.g. sitting on Review & Submit past expiry) no longer records a wall-clock \`endedAt\`/inflated \`durationSeconds\`. The server now caps the persisted end time at \`deadline === null ? now : min(now, max(deadline, latestAnsweredAt))\`, so the cap never precedes a BUG-254 grace-window flush attempt. Summary + history duration project from the single persisted value.
- Optional \`endedAt?\`/\`answeredAt?\` params threaded through the session + attempt repository ports, defaulting to the repo clock — tutor \`EndPracticeSessionUseCase\` behavior unchanged.

## Verification
- Fix PR #490 squash-merged to \`dev\` (\`2a8d1a64\`); CodeRabbit APPROVED on the exact head with 0 unresolved threads; full gate green (unit 2911, typecheck, lint, build, integration).
- \`main\`/\`dev\` trees were identical before this promotion; this PR carries exactly the one BUG-255 commit.

Bug doc stays \`Status: Open\` — it will be archived only after this production deploy is verified READY.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where reviewing and submitting exam answers after the deadline incorrectly recorded inflated end times and durations. Exam finalization now properly caps timestamps to the server deadline.

* **Documentation**
  * Expanded bug documentation with detailed root cause analysis, impact assessment, and fix verification criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->