### PR TITLE
Fix BUG-257: tolerate publication-state changes in active exam writes

### DIFF
--- a/docs/bugs/bug-257-active-session-finalization-depends-on-current-published-question.md
+++ b/docs/bugs/bug-257-active-session-finalization-depends-on-current-published-question.md
@@ -1,6 +1,7 @@
 # BUG-257: Active Exam Finalization Depends on Current Question Publication State
 
 **Status:** Open
+**Resolution State:** Fixed on PR #494 (`fix/bug-257-active-session-finalization`); pending owner grade, merge, production verification, and archival.
 **Severity:** P4
 **Date:** 2026-06-20
 **Confirmed:** 2026-06-20 (mechanism only — see Reachability)
@@ -10,9 +11,9 @@
 
 ## Summary
 
-Practice sessions store only question IDs and draft choice IDs. Draft save and finalization then refetch question data through `findPublishedById(s)`. If a question is unpublished, archived, or otherwise absent from the published-question repository after the session starts but before the user saves/finalizes, the active exam can no longer save or finalize that answered question.
+Practice sessions store only question IDs and draft choice IDs. Before the fix on PR #494, draft save and finalization refetched question data through `findPublishedById(s)`. If a question was unpublished, archived, or otherwise absent from the published-question repository after the session started but before the user saved/finalized, the active exam could no longer save or finalize that answered question.
 
-Read models already tolerate unavailable questions after completion, but the write path for active sessions does not.
+Read models already tolerate unavailable questions after completion. PR #494 brings active-session write paths into alignment by using session-owned question lookups after membership is proven.
 
 ## Reachability (why P4, not P3)
 
@@ -29,37 +30,37 @@ Expected:
 
 - The active session finalizes against session-owned question/choice data even if the question is no longer publicly published, without stranding the whole session solely because publication status changed.
 
-Actual:
+Actual before PR #494:
 
 - Draft save rejects with `NOT_FOUND: Question not found`.
 - Finalization rejects when it cannot refetch the drafted question from the published-only repository.
 - The user must abandon the exam or wait for content to be restored.
 
-## Root Cause
+## Root Cause and Current Fix Seams
 
-The question repository only returns currently published rows:
+The public question repository methods intentionally return only currently published rows:
 
-- [`drizzle-question-repository.ts`](../../src/adapters/repositories/drizzle-question-repository.ts#L95) filters `findPublishedById` by `questions.status = 'published'`.
+- [`drizzle-question-repository.ts`](../../src/adapters/repositories/drizzle-question-repository.ts#L107) filters `findPublishedById` by `questions.status = 'published'`.
 - [`drizzle-question-repository.ts`](../../src/adapters/repositories/drizzle-question-repository.ts#L131) does the same for `findPublishedByIds`.
 
-Draft save depends on the current published row:
+Before the fix, active-session write paths reused those public reads. Current PR #494 seams:
 
-- [`save-exam-draft-answer.ts`](../../src/application/use-cases/save-exam-draft-answer.ts#L59) calls `findPublishedById(input.questionId)`.
-- [`save-exam-draft-answer.ts`](../../src/application/use-cases/save-exam-draft-answer.ts#L61) throws `NOT_FOUND` if it is absent.
-- Existing coverage asserts that missing/unpublished draft saves are rejected at [`save-exam-draft-answer.test.ts`](../../src/application/use-cases/save-exam-draft-answer.test.ts#L191).
+- [`save-exam-draft-answer.ts`](../../src/application/use-cases/save-exam-draft-answer.ts#L59) proves `input.questionId` is in the loaded session before the non-public lookup.
+- [`save-exam-draft-answer.ts`](../../src/application/use-cases/save-exam-draft-answer.ts#L66) calls `findByIdForSession(input.questionId)` after that membership gate.
+- Coverage accepts session-owned archived questions at [`save-exam-draft-answer.test.ts`](../../src/application/use-cases/save-exam-draft-answer.test.ts#L156), rejects archived questions outside the session at [`save-exam-draft-answer.test.ts`](../../src/application/use-cases/save-exam-draft-answer.test.ts#L192), and still rejects genuinely missing session-owned rows at [`save-exam-draft-answer.test.ts`](../../src/application/use-cases/save-exam-draft-answer.test.ts#L262).
 
-Finalization depends on current published rows for drafted answers:
+Finalization now uses session-owned reads for drafted answers:
 
 - [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L173) collects drafted states.
-- [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L176) fetches those questions through [`fetchQuestionsById`](../../src/application/shared/fetch-questions-by-id.ts#L11), which calls `findPublishedByIds`.
+- [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L176) fetches those questions through [`fetchSessionOwnedQuestionsById`](../../src/application/shared/fetch-session-owned-questions-by-id.ts#L4), which calls `findByIdsForSession`.
 - [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L216) reads the fetched question.
-- [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L218) throws `NOT_FOUND` when the published row is unavailable.
-- The BUG-254 final on-screen draft flush has the same dependency: [`applyFinalDraftAnswer`](../../src/application/use-cases/finalize-exam-answers.ts#L296) validates the flushed question through `findPublishedById`, and [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L300) throws `NOT_FOUND` if that published row is unavailable.
+- [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L218) still throws `NOT_FOUND` only if the session-owned row is genuinely absent.
+- The BUG-254 final on-screen draft flush uses the same session-owned boundary: [`applyFinalDraftAnswer`](../../src/application/use-cases/finalize-exam-answers.ts#L296) validates the flushed question through `findByIdForSession`, and [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L300) throws `NOT_FOUND` only if that session-owned row is genuinely absent.
 
 Completed/read-side review already has an unavailable-row model:
 
-- [`get-practice-session-review.ts`](../../src/application/use-cases/get-practice-session-review.ts#L160) returns `isAvailable: false` rows for missing questions.
-- [`get-completed-session-questions-with-feedback.ts`](../../src/application/use-cases/get-completed-session-questions-with-feedback.ts#L207) does the same after completion.
+- [`get-practice-session-review.ts`](../../src/application/use-cases/get-practice-session-review.ts#L161) returns `isAvailable: false` rows for missing questions.
+- [`get-completed-session-questions-with-feedback.ts`](../../src/application/use-cases/get-completed-session-questions-with-feedback.ts#L208) does the same after completion.
 
 ## Impact
 
@@ -126,7 +127,7 @@ it('finalizes a drafted exam answer even if the question is no longer published'
 });
 ```
 
-The current implementation still throws `ApplicationError('NOT_FOUND', 'Question not found')` because `FakeQuestionRepository.findPublishedByIds` filters out the archived question. The concrete test will need the existing `passthroughTransaction(questions, attempts, sessions)` helper shape from `finalize-exam-answers.test.ts`.
+The pre-fix implementation threw `ApplicationError('NOT_FOUND', 'Question not found')` because `FakeQuestionRepository.findPublishedByIds` filtered out the archived question. PR #494's concrete regression test uses the existing `passthroughTransaction(questions, attempts, sessions)` helper shape from `finalize-exam-answers.test.ts`.
 
 ## Prior Bug Cross-Refs
 

--- a/docs/bugs/bug-257-active-session-finalization-depends-on-current-published-question.md
+++ b/docs/bugs/bug-257-active-session-finalization-depends-on-current-published-question.md
@@ -16,7 +16,7 @@ Read models already tolerate unavailable questions after completion, but the wri
 
 ## Reachability (why P4, not P3)
 
-This is a **latent robustness gap, not an in-app-reachable bug**. There is no application flow that unpublishes or deletes a published question: `QuestionRepository` exposes only reads (no `create`/`update`/`delete`/`insert`/`save`), there are no admin/content routes that mutate questions, and `questions.status` is written only via schema/migrations/seed. Triggering this requires an **out-of-band** content operation (a migration, re-seed, or manual DB edit that removes or unpublishes a question) to land **during a short, timed active exam** that already contains that question. No user action causes it. The genuine, verified observation is the read/write asymmetry — the read side tolerates missing rows with `isAvailable: false`, while the active-session write path throws `NOT_FOUND`. Tracked at P4 (hardening) until there is evidence of a content-change pathway that can actually hit an active session.
+This is a **latent robustness gap, not an in-app-reachable bug**. There is no application flow that unpublishes or deletes a published question: `QuestionRepository` exposes only reads (no `create`/`update`/`delete`/`insert`/`save`), there are no admin/content routes that mutate questions, and database writes to question publication state are limited to schema/migrations/seed tooling. Triggering this requires an **out-of-band** content operation (a migration, re-seed, seed archiving, or manual DB edit that removes a question from the published set) to land **during a short, timed active exam** that already contains that question. No user action causes it. The genuine, verified observation is the read/write asymmetry — the read side tolerates missing rows with `isAvailable: false`, while the active-session write path throws `NOT_FOUND`. Tracked at P4 (hardening) until there is evidence of a content-change pathway that can actually hit an active session.
 
 ## Reproduction
 
@@ -27,7 +27,7 @@ This is a **latent robustness gap, not an in-app-reachable bug**. There is no ap
 
 Expected:
 
-- The active session finalizes against the question/choice snapshot that was valid when the session was created, or gracefully omits/unavailable-marks the affected row without stranding the whole session.
+- The active session finalizes against session-owned question/choice data even if the question is no longer publicly published, without stranding the whole session solely because publication status changed.
 
 Actual:
 
@@ -39,8 +39,8 @@ Actual:
 
 The question repository only returns currently published rows:
 
-- [`drizzle-question-repository.ts`](../../src/adapters/repositories/drizzle-question-repository.ts#L93) filters `findPublishedById` by `questions.status = 'published'`.
-- [`drizzle-question-repository.ts`](../../src/adapters/repositories/drizzle-question-repository.ts#L125) does the same for `findPublishedByIds`.
+- [`drizzle-question-repository.ts`](../../src/adapters/repositories/drizzle-question-repository.ts#L95) filters `findPublishedById` by `questions.status = 'published'`.
+- [`drizzle-question-repository.ts`](../../src/adapters/repositories/drizzle-question-repository.ts#L131) does the same for `findPublishedByIds`.
 
 Draft save depends on the current published row:
 
@@ -50,10 +50,11 @@ Draft save depends on the current published row:
 
 Finalization depends on current published rows for drafted answers:
 
-- [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L87) collects drafted states.
-- [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L90) fetches those questions.
-- [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L126) reads the fetched question.
-- [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L128) throws `NOT_FOUND` when the published row is unavailable.
+- [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L173) collects drafted states.
+- [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L176) fetches those questions through [`fetchQuestionsById`](../../src/application/shared/fetch-questions-by-id.ts#L11), which calls `findPublishedByIds`.
+- [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L216) reads the fetched question.
+- [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L218) throws `NOT_FOUND` when the published row is unavailable.
+- The BUG-254 final on-screen draft flush has the same dependency: [`applyFinalDraftAnswer`](../../src/application/use-cases/finalize-exam-answers.ts#L296) validates the flushed question through `findPublishedById`, and [`finalize-exam-answers.ts`](../../src/application/use-cases/finalize-exam-answers.ts#L300) throws `NOT_FOUND` if that published row is unavailable.
 
 Completed/read-side review already has an unavailable-row model:
 
@@ -62,21 +63,33 @@ Completed/read-side review already has an unavailable-row model:
 
 ## Impact
 
-If an out-of-band content operation removes/unpublishes a drafted question during an active exam (no in-app flow does this today), the user loses the ability to save or submit that in-progress exam until the content is restored. Low probability and not user-triggerable, hence P4.
+If an out-of-band content operation removes a drafted question from the published set during an active exam (no in-app flow does this today), the user loses the ability to save or submit that in-progress exam until the content is restored. Low probability and not user-triggerable, hence P4.
 
 ## Proposed Fix
 
-Make active sessions snapshot-safe. Good implementation options:
+Make active-session writes publication-state tolerant without relaxing public question discovery. Add a `QuestionRepository` method for session-owned question lookup that fetches by ID regardless of current `questions.status`, and use it only after the loaded practice session proves the `questionId` is already part of that session. Thread that method through `SaveExamDraftAnswerUseCase`, `FinalizeExamAnswersUseCase` drafted-state grading, and the BUG-254 `finalDraftAnswer` flush validation; keep public browsing, standalone question loading, and new-session candidate selection on the existing `findPublished*`/`listPublishedCandidateIds` methods.
 
-1. Store immutable question/choice grading snapshot data in `practice_sessions.params_json` at session start, at least `{ questionId, choiceIds, correctChoiceId }`.
-2. Add a repository method for session-owned questions that can fetch by ID regardless of current publication status, and use it only for sessions that already contain the question ID.
-3. For finalization, if a question is unavailable and no grading snapshot exists, finalize the affected drafted answer through a documented fallback instead of failing the whole session.
-4. Keep public question browsing and new-session candidate selection restricted to published questions.
+This is the smallest sound Clean Architecture change for the verified mechanism. `practice_sessions.params_json` already exists, but today it stores only filters, ordered `questionIds`, and mutable question state; adding grading snapshots would require extending the strict params schema and changing session creation to fetch/store choice/correct-answer data that finalization can already obtain from the persisted question rows. Finalization needs the full question choices to validate membership and `gradeAnswer(question, selectedChoiceId)`, and archived/unpublished rows still satisfy the existing attempts/choices foreign keys, so a session-scoped non-public read fixes the published-state dependency while preserving the published-only boundary for user-facing discovery.
+
+Rejected alternatives:
+
+- **Snapshot grading data in `params_json`:** robust but more invasive than necessary for this P4 because session creation currently selects only IDs and params parsing is strict.
+- **Relax `findPublishedById(s)` globally:** would leak archived/draft questions into browsing and candidate selection.
+- **Finalize missing rows through a fallback without fetching question data:** prevents stranding only by giving up grading; keep it as a later hard-delete fallback if product wants to tolerate actual row deletion.
+- **Do nothing / accept:** low reachability, but a small port-level hardening keeps active sessions independent of later publication-state flips.
 
 ## Failing Test Sketch
 
 ```ts
 it('finalizes a drafted exam answer even if the question is no longer published', async () => {
+  const archivedQuestion = createQuestion({
+    id: 'q1',
+    status: 'archived',
+    choices: [
+      createChoice({ id: 'c1', questionId: 'q1', label: 'A', isCorrect: true }),
+      createChoice({ id: 'c2', questionId: 'q1', label: 'B', sortOrder: 2 }),
+    ],
+  });
   const sessions = new FakePracticeSessionRepository([
     createPracticeSession({
       id: 'session-1',
@@ -84,20 +97,26 @@ it('finalizes a drafted exam answer even if the question is no longer published'
       mode: 'exam',
       questionIds: ['q1'],
       questionStates: [
-        createPracticeSessionQuestionState({
+        {
           questionId: 'q1',
+          markedForReview: false,
+          latestSelectedChoiceId: null,
+          latestIsCorrect: null,
+          latestAnsweredAt: null,
           draftSelectedChoiceId: 'c1',
+          draftSavedAt: null,
           draftCumulativeMs: 12_000,
-        }),
+        },
       ],
     }),
   ]);
   const attempts = new FakeAttemptRepository();
-  const questions = new FakeQuestionRepository([]);
+  const questions = new FakeQuestionRepository([archivedQuestion]);
+  const writeTransaction = passthroughTransaction(questions, attempts, sessions);
   const useCase = new FinalizeExamAnswersUseCase(
-    sessions,
     questions,
     attempts,
+    sessions,
     writeTransaction,
   );
 
@@ -107,7 +126,7 @@ it('finalizes a drafted exam answer even if the question is no longer published'
 });
 ```
 
-The current implementation throws `ApplicationError('NOT_FOUND', 'Question not found')`.
+The current implementation still throws `ApplicationError('NOT_FOUND', 'Question not found')` because `FakeQuestionRepository.findPublishedByIds` filters out the archived question. The concrete test will need the existing `passthroughTransaction(questions, attempts, sessions)` helper shape from `finalize-exam-answers.test.ts`.
 
 ## Prior Bug Cross-Refs
 

--- a/lib/cached-reads-coverage.test.ts
+++ b/lib/cached-reads-coverage.test.ts
@@ -1,0 +1,82 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { FakeQuestionRepository } from '@/src/application/test-helpers/fakes';
+import { createQuestion } from '@/src/domain/test-helpers';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('react', () => ({
+  cache<TArgs extends readonly unknown[], TResult>(
+    fn: (...args: TArgs) => TResult,
+  ) {
+    const results = new Map<string, TResult>();
+
+    return (...args: TArgs): TResult => {
+      const cacheKey = JSON.stringify(args);
+      if (!results.has(cacheKey)) {
+        results.set(cacheKey, fn(...args));
+      }
+
+      return results.get(cacheKey) as TResult;
+    };
+  },
+}));
+
+let createRequestCachedQuestionRepository: typeof import('./cached-reads').createRequestCachedQuestionRepository;
+
+beforeAll(async () => {
+  ({ createRequestCachedQuestionRepository } = await import('./cached-reads'));
+});
+
+describe('cached-reads coverage seam', () => {
+  it('deduplicates session-owned id reads through the request cache wrapper', async () => {
+    class CountingQuestionRepository extends FakeQuestionRepository {
+      findByIdForSessionCallCount = 0;
+
+      override async findByIdForSession(id: string) {
+        this.findByIdForSessionCallCount += 1;
+        return super.findByIdForSession(id);
+      }
+    }
+
+    const rawRepository = new CountingQuestionRepository([
+      createQuestion({
+        id: 'question-1',
+        slug: 'question-1',
+        status: 'archived',
+      }),
+    ]);
+    const repository = createRequestCachedQuestionRepository(rawRepository);
+
+    const first = await repository.findByIdForSession('question-1');
+    const second = await repository.findByIdForSession('question-1');
+
+    expect(rawRepository.findByIdForSessionCallCount).toBe(1);
+    expect(first?.status).toBe('archived');
+    expect(second?.status).toBe('archived');
+  });
+
+  it('normalizes session-owned batch reads while preserving caller order', async () => {
+    class CountingQuestionRepository extends FakeQuestionRepository {
+      findByIdsForSessionCallCount = 0;
+
+      override async findByIdsForSession(ids: readonly string[]) {
+        this.findByIdsForSessionCallCount += 1;
+        return super.findByIdsForSession(ids);
+      }
+    }
+
+    const rawRepository = new CountingQuestionRepository([
+      createQuestion({ id: 'a', slug: 'question-a', status: 'archived' }),
+      createQuestion({ id: 'b', slug: 'question-b', status: 'draft' }),
+    ]);
+    const repository = createRequestCachedQuestionRepository(rawRepository);
+
+    const first = await repository.findByIdsForSession(['b', 'a', 'a']);
+    const second = await repository.findByIdsForSession(['a', 'b']);
+
+    expect(rawRepository.findByIdsForSessionCallCount).toBe(1);
+    expect(rawRepository.findByIdsForSessionCalls).toEqual([['a', 'b']]);
+    expect(first.map((question) => question.id)).toEqual(['b', 'a', 'a']);
+    expect(second.map((question) => question.id)).toEqual(['a', 'b']);
+  });
+});

--- a/lib/cached-reads.test.ts
+++ b/lib/cached-reads.test.ts
@@ -262,6 +262,166 @@ console.log(
     });
   });
 
+  it('deduplicates session-owned question reads by id within a single server render', () => {
+    const result = runReactServerScript<{
+      findByIdForSessionCallCount: number;
+      firstStatus: string;
+      secondStatus: string;
+    }>(`
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const React = require('react');
+const { renderToReadableStream } = require('next/dist/compiled/react-server-dom-webpack/server.node');
+const { createRequestCachedQuestionRepository } = require('./lib/cached-reads.ts');
+const { FakeQuestionRepository } = require('./src/application/test-helpers/fakes/fake-question-repository.ts');
+const { createQuestion } = require('./src/domain/test-helpers/index.ts');
+
+class CountingQuestionRepository extends FakeQuestionRepository {
+  findByIdForSessionCallCount = 0;
+
+  async findByIdForSession(id) {
+    this.findByIdForSessionCallCount++;
+    return super.findByIdForSession(id);
+  }
+}
+
+async function drain(stream) {
+  const reader = stream.getReader();
+  while (true) {
+    const { done } = await reader.read();
+    if (done) break;
+  }
+}
+
+const rawRepository = new CountingQuestionRepository([
+  createQuestion({ id: 'question-1', slug: 'question-1', status: 'archived' }),
+]);
+const repository = createRequestCachedQuestionRepository(rawRepository);
+
+let firstStatus = 'missing';
+let secondStatus = 'missing';
+
+async function FirstCaller() {
+  const question = await repository.findByIdForSession('question-1');
+  firstStatus = question?.status ?? 'missing';
+  return React.createElement('div', null, firstStatus);
+}
+
+async function SecondCaller() {
+  const question = await repository.findByIdForSession('question-1');
+  secondStatus = question?.status ?? 'missing';
+  return React.createElement('div', null, secondStatus);
+}
+
+async function App() {
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement(FirstCaller),
+    React.createElement(SecondCaller),
+  );
+}
+
+await drain(await renderToReadableStream(React.createElement(App), null));
+console.log(
+  JSON.stringify({
+    findByIdForSessionCallCount: rawRepository.findByIdForSessionCallCount,
+    firstStatus,
+    secondStatus,
+  }),
+);
+`);
+
+    expect(result).toEqual({
+      findByIdForSessionCallCount: 1,
+      firstStatus: 'archived',
+      secondStatus: 'archived',
+    });
+  });
+
+  it('normalizes session-owned question batch reads while preserving caller order', () => {
+    const result = runReactServerScript<{
+      findByIdsForSessionCallCount: number;
+      findByIdsForSessionCalls: string[][];
+      firstResultIds: string[];
+      secondResultIds: string[];
+    }>(`
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const React = require('react');
+const { renderToReadableStream } = require('next/dist/compiled/react-server-dom-webpack/server.node');
+const { createRequestCachedQuestionRepository } = require('./lib/cached-reads.ts');
+const { FakeQuestionRepository } = require('./src/application/test-helpers/fakes/fake-question-repository.ts');
+const { createQuestion } = require('./src/domain/test-helpers/index.ts');
+
+class CountingQuestionRepository extends FakeQuestionRepository {
+  findByIdsForSessionCallCount = 0;
+
+  async findByIdsForSession(ids) {
+    this.findByIdsForSessionCallCount++;
+    return super.findByIdsForSession(ids);
+  }
+}
+
+async function drain(stream) {
+  const reader = stream.getReader();
+  while (true) {
+    const { done } = await reader.read();
+    if (done) break;
+  }
+}
+
+const rawRepository = new CountingQuestionRepository([
+  createQuestion({ id: 'a', slug: 'question-a', status: 'archived' }),
+  createQuestion({ id: 'b', slug: 'question-b', status: 'draft' }),
+]);
+const repository = createRequestCachedQuestionRepository(rawRepository);
+
+let firstResultIds = [];
+let secondResultIds = [];
+
+async function FirstCaller() {
+  const questions = await repository.findByIdsForSession(['b', 'a', 'a']);
+  firstResultIds = questions.map((question) => question.id);
+  return React.createElement('div', null, firstResultIds.join(','));
+}
+
+async function SecondCaller() {
+  const questions = await repository.findByIdsForSession(['a', 'b']);
+  secondResultIds = questions.map((question) => question.id);
+  return React.createElement('div', null, secondResultIds.join(','));
+}
+
+async function App() {
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement(FirstCaller),
+    React.createElement(SecondCaller),
+  );
+}
+
+await drain(await renderToReadableStream(React.createElement(App), null));
+console.log(
+  JSON.stringify({
+    findByIdsForSessionCallCount: rawRepository.findByIdsForSessionCallCount,
+    findByIdsForSessionCalls: rawRepository.findByIdsForSessionCalls,
+    firstResultIds,
+    secondResultIds,
+  }),
+);
+`);
+
+    expect(result).toEqual({
+      findByIdsForSessionCallCount: 1,
+      findByIdsForSessionCalls: [['a', 'b']],
+      firstResultIds: ['b', 'a', 'a'],
+      secondResultIds: ['a', 'b'],
+    });
+  });
+
   it('deduplicates tag list reads within a single server render', () => {
     const result = runReactServerScript(`
 import { createRequire } from 'node:module';

--- a/lib/cached-reads.ts
+++ b/lib/cached-reads.ts
@@ -32,6 +32,14 @@ export function createRequestCachedQuestionRepository(
       deserializeQuestionIds(serializedIds),
     ),
   );
+  const findByIdForSession = cache(async (id: string) =>
+    questionRepository.findByIdForSession(id),
+  );
+  const findByNormalizedIdsForSession = cache(async (serializedIds: string) =>
+    questionRepository.findByIdsForSession(
+      deserializeQuestionIds(serializedIds),
+    ),
+  );
 
   return {
     findPublishedById,
@@ -43,6 +51,24 @@ export function createRequestCachedQuestionRepository(
       if (normalizedIds.length === 0) return [];
 
       const questions = await findPublishedByNormalizedIds(
+        serializeQuestionIds(normalizedIds),
+      );
+      const questionById = new Map(
+        questions.map((question) => [question.id, question]),
+      );
+
+      return ids
+        .map((id) => questionById.get(id))
+        .filter((question): question is Question => question !== undefined);
+    },
+    findByIdForSession,
+    async findByIdsForSession(
+      ids: readonly string[],
+    ): Promise<readonly Question[]> {
+      const normalizedIds = getSortedUniqueQuestionIds(ids);
+      if (normalizedIds.length === 0) return [];
+
+      const questions = await findByNormalizedIdsForSession(
         serializeQuestionIds(normalizedIds),
       );
       const questionById = new Map(

--- a/src/adapters/controllers/question-view-controller.test.ts
+++ b/src/adapters/controllers/question-view-controller.test.ts
@@ -72,6 +72,8 @@ function createThrowingQuestionRepository(
       throw new Error(errorMessage);
     },
     findPublishedByIds: async () => [],
+    findByIdForSession: async () => null,
+    findByIdsForSession: async () => [],
     listPublishedCandidateIds: async () => [],
     countPublishedCandidateIds: async () => 0,
   };

--- a/src/adapters/controllers/question-view-controller.test.ts
+++ b/src/adapters/controllers/question-view-controller.test.ts
@@ -67,15 +67,27 @@ function createThrowingQuestionRepository(
   errorMessage = 'QuestionRepository should not be called',
 ): QuestionRepository {
   return {
-    findPublishedById: async () => null,
+    findPublishedById: async () => {
+      throw new Error(errorMessage);
+    },
     findPublishedBySlug: async () => {
       throw new Error(errorMessage);
     },
-    findPublishedByIds: async () => [],
-    findByIdForSession: async () => null,
-    findByIdsForSession: async () => [],
-    listPublishedCandidateIds: async () => [],
-    countPublishedCandidateIds: async () => 0,
+    findPublishedByIds: async () => {
+      throw new Error(errorMessage);
+    },
+    findByIdForSession: async () => {
+      throw new Error(errorMessage);
+    },
+    findByIdsForSession: async () => {
+      throw new Error(errorMessage);
+    },
+    listPublishedCandidateIds: async () => {
+      throw new Error(errorMessage);
+    },
+    countPublishedCandidateIds: async () => {
+      throw new Error(errorMessage);
+    },
   };
 }
 

--- a/src/adapters/repositories/drizzle-question-repository.test.ts
+++ b/src/adapters/repositories/drizzle-question-repository.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { practiceSessions } from '@/db/schema';
+import { practiceSessions, questions as questionsTable } from '@/db/schema';
 import { ApplicationError } from '@/src/application/errors';
 import type { QuestionProgressStatus } from '@/src/domain/value-objects';
 import { DrizzleQuestionRepository } from './drizzle-question-repository';
@@ -117,6 +117,28 @@ function createQuestionRow(
 
 describe('DrizzleQuestionRepository', () => {
   describe('findPublishedById', () => {
+    it('keeps a status predicate on the public id lookup', async () => {
+      let capturedWhere: unknown;
+      const db = {
+        query: {
+          questions: {
+            findFirst: async (config: { where: unknown }) => {
+              capturedWhere = config.where;
+              return null;
+            },
+          },
+        },
+      } as const;
+
+      const repo = new DrizzleQuestionRepository(db as unknown as RepoDb);
+
+      await repo.findPublishedById(questionId);
+
+      const columns = collectColumnNamesForTable(capturedWhere, questionsTable);
+      expect(columns).toContain('id');
+      expect(columns).toContain('status');
+    });
+
     it('returns null when no row exists', async () => {
       const db = {
         query: {
@@ -192,6 +214,32 @@ describe('DrizzleQuestionRepository', () => {
     });
   });
 
+  describe('findByIdForSession', () => {
+    it('maps a non-published question without adding a status predicate', async () => {
+      let capturedWhere: unknown;
+      const row = createQuestionRow({ status: 'archived' });
+      const db = {
+        query: {
+          questions: {
+            findFirst: async (config: { where: unknown }) => {
+              capturedWhere = config.where;
+              return row;
+            },
+          },
+        },
+      } as const;
+
+      const repo = new DrizzleQuestionRepository(db as unknown as RepoDb);
+
+      const result = await repo.findByIdForSession(row.id);
+
+      expect(result).toMatchObject({ id: row.id, status: 'archived' });
+      const columns = collectColumnNamesForTable(capturedWhere, questionsTable);
+      expect(columns).toContain('id');
+      expect(columns).not.toContain('status');
+    });
+  });
+
   describe('findPublishedBySlug', () => {
     it('returns the mapped question when found', async () => {
       const row = createQuestionRow({ slug: 'slug-1' });
@@ -229,6 +277,28 @@ describe('DrizzleQuestionRepository', () => {
       await expect(repo.findPublishedByIds([])).resolves.toEqual([]);
     });
 
+    it('keeps a status predicate on the public ids lookup', async () => {
+      let capturedWhere: unknown;
+      const db = {
+        query: {
+          questions: {
+            findMany: async (config: { where: unknown }) => {
+              capturedWhere = config.where;
+              return [];
+            },
+          },
+        },
+      } as const;
+
+      const repo = new DrizzleQuestionRepository(db as unknown as RepoDb);
+
+      await repo.findPublishedByIds([questionId]);
+
+      const columns = collectColumnNamesForTable(capturedWhere, questionsTable);
+      expect(columns).toContain('id');
+      expect(columns).toContain('status');
+    });
+
     it('returns results ordered by requested ids and filters missing', async () => {
       const row1 = createQuestionRow({
         id: requestedFirstQuestionId,
@@ -258,6 +328,49 @@ describe('DrizzleQuestionRepository', () => {
         requestedThirdQuestionId,
         requestedFirstQuestionId,
       ]);
+    });
+  });
+
+  describe('findByIdsForSession', () => {
+    it('preserves requested order for non-published questions without adding a status predicate', async () => {
+      let capturedWhere: unknown;
+      const archived = createQuestionRow({
+        id: requestedFirstQuestionId,
+        slug: requestedFirstQuestionId,
+        status: 'archived',
+      });
+      const draft = createQuestionRow({
+        id: requestedThirdQuestionId,
+        slug: requestedThirdQuestionId,
+        status: 'draft',
+      });
+      const db = {
+        query: {
+          questions: {
+            findMany: async (config: { where: unknown }) => {
+              capturedWhere = config.where;
+              return [archived, draft];
+            },
+          },
+        },
+      } as const;
+
+      const repo = new DrizzleQuestionRepository(db as unknown as RepoDb);
+
+      const result = await repo.findByIdsForSession([
+        requestedThirdQuestionId,
+        missingQuestionId,
+        requestedFirstQuestionId,
+      ]);
+
+      expect(result.map((q) => q.id)).toEqual([
+        requestedThirdQuestionId,
+        requestedFirstQuestionId,
+      ]);
+      expect(result.map((q) => q.status)).toEqual(['draft', 'archived']);
+      const columns = collectColumnNamesForTable(capturedWhere, questionsTable);
+      expect(columns).toContain('id');
+      expect(columns).not.toContain('status');
     });
   });
 

--- a/src/adapters/repositories/drizzle-question-repository.ts
+++ b/src/adapters/repositories/drizzle-question-repository.ts
@@ -37,6 +37,20 @@ function isNonEmptyArray<T>(
   return values.length > 0;
 }
 
+const questionRelations = {
+  choices: true,
+  questionTags: {
+    with: {
+      tag: true,
+    },
+  },
+} as const;
+
+type QuestionRowWithRelations = Question & {
+  choices: Choice[];
+  questionTags: Array<QuestionTag & { tag: Tag }>;
+};
+
 export class DrizzleQuestionRepository implements QuestionRepository {
   constructor(private readonly db: DrizzleDb) {}
 
@@ -93,14 +107,7 @@ export class DrizzleQuestionRepository implements QuestionRepository {
   async findPublishedById(id: string) {
     const row = await this.db.query.questions.findFirst({
       where: and(eq(questions.id, id), eq(questions.status, 'published')),
-      with: {
-        choices: true,
-        questionTags: {
-          with: {
-            tag: true,
-          },
-        },
-      },
+      with: questionRelations,
     });
 
     return row ? this.toDomain(row) : null;
@@ -109,14 +116,7 @@ export class DrizzleQuestionRepository implements QuestionRepository {
   async findPublishedBySlug(slug: string) {
     const row = await this.db.query.questions.findFirst({
       where: and(eq(questions.slug, slug), eq(questions.status, 'published')),
-      with: {
-        choices: true,
-        questionTags: {
-          with: {
-            tag: true,
-          },
-        },
-      },
+      with: questionRelations,
     });
 
     return row ? this.toDomain(row) : null;
@@ -130,14 +130,30 @@ export class DrizzleQuestionRepository implements QuestionRepository {
         inArray(questions.id, [...ids]),
         eq(questions.status, 'published'),
       ),
-      with: {
-        choices: true,
-        questionTags: {
-          with: {
-            tag: true,
-          },
-        },
-      },
+      with: questionRelations,
+    });
+
+    const byId = new Map(rows.map((row) => [row.id, this.toDomain(row)]));
+    return ids
+      .map((id) => byId.get(id))
+      .filter((q): q is NonNullable<typeof q> => !!q);
+  }
+
+  async findByIdForSession(id: string) {
+    const row = await this.db.query.questions.findFirst({
+      where: eq(questions.id, id),
+      with: questionRelations,
+    });
+
+    return row ? this.toDomain(row) : null;
+  }
+
+  async findByIdsForSession(ids: readonly string[]) {
+    if (ids.length === 0) return [];
+
+    const rows = await this.db.query.questions.findMany({
+      where: inArray(questions.id, [...ids]),
+      with: questionRelations,
     });
 
     const byId = new Map(rows.map((row) => [row.id, this.toDomain(row)]));
@@ -267,12 +283,7 @@ export class DrizzleQuestionRepository implements QuestionRepository {
     }
   }
 
-  private toDomain(
-    row: Question & {
-      choices: Choice[];
-      questionTags: Array<QuestionTag & { tag: Tag }>;
-    },
-  ) {
+  private toDomain(row: QuestionRowWithRelations) {
     const mappedChoices = row.choices.map((c) => {
       if (!isValidChoiceLabel(c.label)) {
         throw new ApplicationError(

--- a/src/application/ports/question-repository.ts
+++ b/src/application/ports/question-repository.ts
@@ -26,6 +26,24 @@ export interface QuestionRepository {
   findPublishedByIds(ids: readonly string[]): Promise<readonly Question[]>;
 
   /**
+   * Returns a question by id regardless of `questions.status`.
+   *
+   * Callers MUST prove the id is part of the caller's owned practice session
+   * before using this. This deliberately bypasses the published boundary and
+   * must never back public browsing or candidate selection.
+   */
+  findByIdForSession(id: string): Promise<Question | null>;
+
+  /**
+   * Returns questions by id regardless of `questions.status`.
+   *
+   * Callers MUST prove these ids are part of the caller's owned practice
+   * session before using this. This deliberately bypasses the published
+   * boundary and must never back public browsing or candidate selection.
+   */
+  findByIdsForSession(ids: readonly string[]): Promise<readonly Question[]>;
+
+  /**
    * Return candidate question ids for "next question" selection.
    *
    * Requirements:

--- a/src/application/shared/fetch-session-owned-questions-by-id.ts
+++ b/src/application/shared/fetch-session-owned-questions-by-id.ts
@@ -1,0 +1,13 @@
+import type { QuestionRepository } from '@/src/application/ports/repositories';
+import type { Question } from '@/src/domain/entities';
+
+export async function fetchSessionOwnedQuestionsById(
+  repo: QuestionRepository,
+  ids: readonly string[],
+): Promise<Map<string, Question>> {
+  const uniqueIds = [...new Set(ids)];
+  if (uniqueIds.length === 0) return new Map();
+
+  const questions = await repo.findByIdsForSession(uniqueIds);
+  return new Map(questions.map((question) => [question.id, question]));
+}

--- a/src/application/test-helpers/fakes/fake-question-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-question-repository.test.ts
@@ -4,6 +4,33 @@ import { createQuestion } from '@/src/domain/test-helpers';
 import { FakeQuestionRepository } from './fake-question-repository';
 
 describe('FakeQuestionRepository', () => {
+  it('keeps published lookups public-only while session-owned lookups ignore publication status', async () => {
+    const published = createQuestion({
+      id: 'q-published',
+      status: 'published',
+    });
+    const archived = createQuestion({ id: 'q-archived', status: 'archived' });
+    const draft = createQuestion({ id: 'q-draft', status: 'draft' });
+    const repo = new FakeQuestionRepository([published, archived, draft]);
+
+    await expect(repo.findPublishedById('q-archived')).resolves.toBeNull();
+    await expect(
+      repo.findPublishedByIds(['q-draft', 'q-published', 'q-archived']),
+    ).resolves.toEqual([published]);
+
+    await expect(repo.findByIdForSession('q-archived')).resolves.toEqual(
+      archived,
+    );
+    await expect(
+      repo.findByIdsForSession([
+        'q-draft',
+        'q-missing',
+        'q-published',
+        'q-archived',
+      ]),
+    ).resolves.toEqual([draft, published, archived]);
+  });
+
   it('throws VALIDATION_ERROR when status filters are provided without userId', async () => {
     const repo = new FakeQuestionRepository([createQuestion({ id: 'q1' })]);
 

--- a/src/application/test-helpers/fakes/fake-question-repository.ts
+++ b/src/application/test-helpers/fakes/fake-question-repository.ts
@@ -33,6 +33,7 @@ function validateStatusFilterInvariant(filters: QuestionFilters): void {
 export class FakeQuestionRepository implements QuestionRepository {
   private readonly questions: readonly Question[];
   readonly findPublishedByIdsCalls: string[][] = [];
+  readonly findByIdsForSessionCalls: string[][] = [];
   readonly listPublishedCandidateIdsCalls: QuestionFilters[] = [];
   readonly countPublishedCandidateIdsCalls: QuestionFilters[] = [];
 
@@ -63,6 +64,18 @@ export class FakeQuestionRepository implements QuestionRepository {
         .filter((q) => q.status === 'published')
         .map((q) => [q.id, q]),
     );
+    return ids.map((id) => byId.get(id)).filter((q): q is Question => !!q);
+  }
+
+  async findByIdForSession(id: string): Promise<Question | null> {
+    return this.questions.find((q) => q.id === id) ?? null;
+  }
+
+  async findByIdsForSession(
+    ids: readonly string[],
+  ): Promise<readonly Question[]> {
+    this.findByIdsForSessionCalls.push([...ids]);
+    const byId = new Map(this.questions.map((q) => [q.id, q]));
     return ids.map((id) => byId.get(id)).filter((q): q is Question => !!q);
   }
 

--- a/src/application/use-cases/finalize-exam-answers.test.ts
+++ b/src/application/use-cases/finalize-exam-answers.test.ts
@@ -44,6 +44,7 @@ function createFinalizeQuestion(
   questionId: string,
   correctChoiceId: string,
   incorrectChoiceId?: string,
+  overrides: Partial<ReturnType<typeof createQuestion>> = {},
 ) {
   const wrongId = incorrectChoiceId ?? `${questionId}-wrong`;
   return createQuestion({
@@ -65,6 +66,7 @@ function createFinalizeQuestion(
         isCorrect: false,
       }),
     ],
+    ...overrides,
   });
 }
 
@@ -256,6 +258,124 @@ describe('FinalizeExamAnswersUseCase', () => {
         },
       ],
     });
+  });
+
+  it('finalizes and grades a drafted session-owned question after it leaves the published set', async () => {
+    const questions = new FakeQuestionRepository([
+      createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong', {
+        status: 'archived',
+      }),
+    ]);
+    const attempts = new FakeAttemptRepository();
+    const sessions = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: 'session-1',
+        userId: 'user-1',
+        mode: 'exam',
+        questionIds: ['q1'],
+        startedAt: new Date('2026-03-17T12:00:00.000Z'),
+        questionStates: [
+          {
+            questionId: 'q1',
+            markedForReview: false,
+            latestSelectedChoiceId: null,
+            latestIsCorrect: null,
+            latestAnsweredAt: null,
+            draftSelectedChoiceId: 'q1-correct',
+            draftSavedAt: new Date('2026-03-17T12:00:30.000Z'),
+            draftCumulativeMs: 30_000,
+          },
+        ],
+      }),
+    ]);
+    const useCase = new FinalizeExamAnswersUseCase(
+      questions,
+      attempts,
+      sessions,
+      passthroughTransaction(questions, attempts, sessions),
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+      }),
+    ).resolves.toMatchObject({
+      sessionId: 'session-1',
+      mode: 'exam',
+      questionCount: 1,
+      totals: {
+        answered: 1,
+        correct: 1,
+      },
+    });
+    await expect(
+      attempts.findBySessionId('session-1', 'user-1'),
+    ).resolves.toMatchObject([
+      {
+        questionId: 'q1',
+        outcome: {
+          kind: 'answered',
+          selectedChoiceId: 'q1-correct',
+        },
+        isCorrect: true,
+      },
+    ]);
+  });
+
+  it('finalizes an omitted session-owned question after it leaves the published set without fetching it for grading', async () => {
+    const questions = new FakeQuestionRepository([
+      createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong', {
+        status: 'archived',
+      }),
+    ]);
+    const attempts = new FakeAttemptRepository();
+    const sessions = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: 'session-1',
+        userId: 'user-1',
+        mode: 'exam',
+        questionIds: ['q1'],
+        startedAt: new Date('2026-03-17T12:00:00.000Z'),
+        questionStates: [
+          {
+            questionId: 'q1',
+            markedForReview: false,
+            latestSelectedChoiceId: null,
+            latestIsCorrect: null,
+            latestAnsweredAt: null,
+            draftSelectedChoiceId: null,
+            draftSavedAt: null,
+            draftCumulativeMs: 12_000,
+          },
+        ],
+      }),
+    ]);
+    const useCase = new FinalizeExamAnswersUseCase(
+      questions,
+      attempts,
+      sessions,
+      passthroughTransaction(questions, attempts, sessions),
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+      }),
+    ).resolves.toMatchObject({
+      totals: { answered: 0, correct: 0 },
+    });
+    await expect(
+      attempts.findBySessionId('session-1', 'user-1'),
+    ).resolves.toMatchObject([
+      {
+        questionId: 'q1',
+        outcome: { kind: 'omitted' },
+        isCorrect: false,
+        timeSpentSeconds: 12,
+      },
+    ]);
   });
 
   it('finalizes a saved time-only draft as an omitted attempt with the saved duration', async () => {
@@ -708,10 +828,11 @@ describe('FinalizeExamAnswersUseCase', () => {
       });
     }
 
-    function createFlushUseCase(now: () => Date) {
-      const questions = new FakeQuestionRepository([
-        createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
-      ]);
+    function createFlushUseCase(
+      now: () => Date,
+      question = createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+    ) {
+      const questions = new FakeQuestionRepository([question]);
       const attempts = new FakeAttemptRepository();
       const sessions = new FakePracticeSessionRepository([
         createFlushSession(),
@@ -755,6 +876,38 @@ describe('FinalizeExamAnswersUseCase', () => {
           outcome: { kind: 'answered', selectedChoiceId: 'q1-correct' },
           isCorrect: true,
           timeSpentSeconds: 30,
+        },
+      ]);
+    });
+
+    it('grades a final flush selection for a session-owned question after it leaves the published set', async () => {
+      const { attempts, useCase } = createFlushUseCase(
+        () => new Date(DEADLINE_MS),
+        createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong', {
+          status: 'archived',
+        }),
+      );
+
+      await expect(
+        useCase.execute({
+          userId: 'user-1',
+          sessionId: 'session-1',
+          finalDraftAnswer: {
+            questionId: 'q1',
+            selectedChoiceId: 'q1-correct',
+            cumulativeMs: 30_000,
+          },
+        }),
+      ).resolves.toMatchObject({
+        totals: { answered: 1, correct: 1 },
+      });
+      await expect(
+        attempts.findBySessionId('session-1', 'user-1'),
+      ).resolves.toMatchObject([
+        {
+          questionId: 'q1',
+          outcome: { kind: 'answered', selectedChoiceId: 'q1-correct' },
+          isCorrect: true,
         },
       ]);
     });

--- a/src/application/use-cases/finalize-exam-answers.test.ts
+++ b/src/application/use-cases/finalize-exam-answers.test.ts
@@ -366,6 +366,7 @@ describe('FinalizeExamAnswersUseCase', () => {
     ).resolves.toMatchObject({
       totals: { answered: 0, correct: 0 },
     });
+    expect(questions.findByIdsForSessionCalls).toEqual([]);
     await expect(
       attempts.findBySessionId('session-1', 'user-1'),
     ).resolves.toMatchObject([

--- a/src/application/use-cases/finalize-exam-answers.ts
+++ b/src/application/use-cases/finalize-exam-answers.ts
@@ -4,7 +4,7 @@ import type {
   PracticeSessionRepository,
   QuestionRepository,
 } from '@/src/application/ports/repositories';
-import { fetchQuestionsById } from '@/src/application/shared/fetch-questions-by-id';
+import { fetchSessionOwnedQuestionsById } from '@/src/application/shared/fetch-session-owned-questions-by-id';
 import type { PracticeSession } from '@/src/domain/entities';
 import {
   computeExamDeadline,
@@ -173,7 +173,7 @@ export class FinalizeExamAnswersUseCase {
       const draftedStates = activeSession.questionStates.filter(
         (state) => state.draftSelectedChoiceId !== null,
       );
-      const questionsById = await fetchQuestionsById(
+      const questionsById = await fetchSessionOwnedQuestionsById(
         tx.questions,
         draftedStates.map((state) => state.questionId),
       );
@@ -293,7 +293,7 @@ export class FinalizeExamAnswersUseCase {
     }
 
     if (finalDraftAnswer.selectedChoiceId !== null) {
-      const question = await tx.questions.findPublishedById(
+      const question = await tx.questions.findByIdForSession(
         finalDraftAnswer.questionId,
       );
       if (!question) {

--- a/src/application/use-cases/save-exam-draft-answer.test.ts
+++ b/src/application/use-cases/save-exam-draft-answer.test.ts
@@ -153,6 +153,77 @@ describe('SaveExamDraftAnswerUseCase', () => {
     expect(persisted?.questionStates[0]?.draftCumulativeMs).toBe(15_000);
   });
 
+  it('saves a draft for a session-owned question after it leaves the published set', async () => {
+    const sessions = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: 'session-1',
+        userId: 'user-1',
+        mode: 'exam',
+        questionIds: ['q1'],
+      }),
+    ]);
+    const questions = new FakeQuestionRepository([
+      createQuestion({
+        id: 'q1',
+        status: 'archived',
+        choices: [
+          createChoice({ id: 'choice-1', questionId: 'q1', label: 'A' }),
+          createChoice({ id: 'choice-2', questionId: 'q1', label: 'B' }),
+        ],
+      }),
+    ]);
+    const useCase = new SaveExamDraftAnswerUseCase(questions, sessions);
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+        questionId: 'q1',
+        selectedChoiceId: 'choice-1',
+        cumulativeMs: 15_000,
+      }),
+    ).resolves.toMatchObject({
+      questionId: 'q1',
+      draftSelectedChoiceId: 'choice-1',
+      draftCumulativeMs: 15_000,
+    });
+  });
+
+  it('rejects unpublished question draft saves when the question is not part of the session', async () => {
+    const sessions = new FakePracticeSessionRepository([
+      createPracticeSession({
+        id: 'session-1',
+        userId: 'user-1',
+        mode: 'exam',
+        questionIds: ['q-in-session'],
+      }),
+    ]);
+    const questions = new FakeQuestionRepository([
+      createQuestion({
+        id: 'q-not-in-session',
+        status: 'archived',
+        choices: [
+          createChoice({
+            id: 'external-choice',
+            questionId: 'q-not-in-session',
+            label: 'A',
+          }),
+        ],
+      }),
+    ]);
+    const useCase = new SaveExamDraftAnswerUseCase(questions, sessions);
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+        questionId: 'q-not-in-session',
+        selectedChoiceId: 'external-choice',
+        cumulativeMs: 15_000,
+      }),
+    ).rejects.toEqual(new ApplicationError('NOT_FOUND', 'Question not found'));
+  });
+
   it('clamps oversized cumulativeMs for time-only drafts', async () => {
     const sessions = new FakePracticeSessionRepository([
       createPracticeSession({
@@ -188,7 +259,7 @@ describe('SaveExamDraftAnswerUseCase', () => {
     );
   });
 
-  it('still rejects time-only drafts for unpublished or missing questions', async () => {
+  it('still rejects time-only drafts for missing session-owned questions', async () => {
     const sessions = new FakePracticeSessionRepository([
       createPracticeSession({
         id: 'session-1',

--- a/src/application/use-cases/save-exam-draft-answer.ts
+++ b/src/application/use-cases/save-exam-draft-answer.ts
@@ -56,7 +56,14 @@ export class SaveExamDraftAnswerUseCase {
       throw new ApplicationError('CONFLICT', 'Exam time has expired');
     }
 
-    const question = await this.questions.findPublishedById(input.questionId);
+    const questionBelongsToSession = session.questionStates.some(
+      (state) => state.questionId === input.questionId,
+    );
+    if (!questionBelongsToSession) {
+      throw new ApplicationError('NOT_FOUND', 'Question not found');
+    }
+
+    const question = await this.questions.findByIdForSession(input.questionId);
     if (!question) {
       throw new ApplicationError('NOT_FOUND', 'Question not found');
     }

--- a/tests/integration/question-repository.integration.test.ts
+++ b/tests/integration/question-repository.integration.test.ts
@@ -72,6 +72,43 @@ describe('DrizzleQuestionRepository', () => {
     expect(result.map((q) => q.id)).toEqual([publishedB.id, publishedA.id]);
   });
 
+  it('session-owned lookups return non-published questions while public lookups exclude them', async () => {
+    const published = await createQuestion(db, cleanup, {
+      slug: `it-session-pub-${randomUUID()}`,
+      status: 'published',
+      difficulty: 'easy',
+    });
+    const archived = await createQuestion(db, cleanup, {
+      slug: `it-session-archived-${randomUUID()}`,
+      status: 'archived',
+      difficulty: 'medium',
+    });
+    const draft = await createQuestion(db, cleanup, {
+      slug: `it-session-draft-${randomUUID()}`,
+      status: 'draft',
+      difficulty: 'hard',
+    });
+
+    const repo = new DrizzleQuestionRepository(db);
+
+    await expect(repo.findPublishedById(archived.id)).resolves.toBeNull();
+    await expect(
+      repo.findPublishedByIds([archived.id, published.id, draft.id]),
+    ).resolves.toMatchObject([{ id: published.id, status: 'published' }]);
+
+    await expect(repo.findByIdForSession(archived.id)).resolves.toMatchObject({
+      id: archived.id,
+      status: 'archived',
+    });
+    await expect(
+      repo.findByIdsForSession([draft.id, published.id, archived.id]),
+    ).resolves.toMatchObject([
+      { id: draft.id, status: 'draft' },
+      { id: published.id, status: 'published' },
+      { id: archived.id, status: 'archived' },
+    ]);
+  });
+
   it('listPublishedCandidateIds filters deterministically (difficulty + tags) and orders by createdAt desc, id asc', async () => {
     const tagSlug = `it-tag-${randomUUID()}`;
     const tag = await createTag(db, cleanup, { slug: tagSlug, kind: 'topic' });


### PR DESCRIPTION
## Problem

BUG-257 (P4, latent hardening). Active-exam **write** paths refetch drafted questions through the published-only repository methods (`findPublishedById` / `findPublishedByIds`). If a question is unpublished/archived mid-session by an **out-of-band** content op (migration, re-seed, manual DB edit — no in-app flow does this), the in-progress exam can no longer save or finalize that question and strands with `NOT_FOUND`. Read models already tolerate unavailable rows (`isAvailable:false`); the write path did not. No in-app trigger exists, hence **P4**.

Spec: `docs/bugs/bug-257-active-session-finalization-depends-on-current-published-question.md` (audited for citation accuracy + a single committed fix path; refined in this PR).

## Solution

Add session-scoped, publication-agnostic reads to `QuestionRepository`, used **only after session ownership is proven**:

- `findByIdForSession(id)` / `findByIdsForSession(ids)` — fetch by id regardless of `questions.status` (Drizzle drops the status predicate; relations preserved via a shared `questionRelations` config). JSDoc documents the "session-owned only" contract.
- **`save-exam-draft-answer`**: adds an explicit `session.questionStates` membership gate **before** the non-public lookup — prevents drafting arbitrary archived/draft questions.
- **`finalize-exam-answers`**: drafted-state grading via a new `fetchSessionOwnedQuestionsById` helper (siblings the published one, so read paths are untouched); the BUG-254 expiry flush validates via `findByIdForSession` (ownership already proven by the `questionState` lookup).
- **Boundary preserved**: `findPublished*` / `listPublishedCandidateIds` keep `status='published'`; public browsing, standalone question load, and candidate selection are unchanged. `cached-reads` request decorator widened for the port (React `cache()`, request-scoped — no cross-user leak).

## Tests (TDD, RED→GREEN)

- **Membership-gate bypass**: an archived question that exists but is *not* in the session → rejected `NOT_FOUND`.
- Session-owned archived question: draft save accepted; finalize grades correctly (`isCorrect:true`); omitted path records omitted without fetching; BUG-254 flush grades correctly.
- **Drizzle boundary-lock**: introspects the actual `WHERE` columns — `status` present on public methods, **absent** on session methods; order-preservation for the ids variant.
- Fake parity + focused integration coverage.

Gate (run locally): `typecheck` + `lint` (19 pre-existing warnings only) + **2925 unit tests** + **303 browser tests** + **113 integration tests** (2 skipped) + `build` + **36 E2E tests** all green.

## Scope / severity

P4 hardening — no behavior change for tutor mode or fully-published sessions, and no public-discovery surface relaxed. Bug doc stays `Open` (archived only after prod-verification).

https://claude.ai/code/session_01RhHv6rK1YVBaE8WmPNpGXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved exam session finalization, grace-window flushing, and draft-saving eligibility when questions move out of the public set during an active exam.
  * Session-owned questions are now graded/flushed and validated using session-appropriate lookups, preventing “not found” failures in these edge cases.
* **Performance**
  * Added request-scoped caching for session-owned question reads to reduce duplicate repository calls during server rendering.
* **Documentation**
  * Updated BUG-257 guidance to reflect the resolved robustness gap.
* **Tests**
  * Expanded unit, integration, and caching coverage for archived/non-published session-owned scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->