### PR TITLE
Promote dev to main: BUG-259..261 filings (docs-only) (#502)

### DIFF
--- a/docs/bugs/bug-259-in-place-rate-limit-errors-cache-idempotency-retries.md
+++ b/docs/bugs/bug-259-in-place-rate-limit-errors-cache-idempotency-retries.md
@@ -1,0 +1,113 @@
+# BUG-259: In-Place Bookmark and Feedback Rate-Limit Errors Are Cached Under Idempotency Keys
+
+**Status:** Open
+**Severity:** P4
+**Date:** 2026-06-23
+**Confirmed:** 2026-06-23
+**Component:** Bookmarks / Question Feedback / Idempotency / Rate Limiting
+
+---
+
+## Summary
+
+The in-place bookmark toggle, question rating, and question report flows keep the same client idempotency key after a failed request. Their controllers run rate-limit checks inside the idempotent operation. When a real `RATE_LIMITED` response happens, `withIdempotency` stores that `ApplicationError` under the key and replays it for repeated requests until the idempotency row expires. A user can wait out the one-minute rate-limit window and still get the cached rate-limit error from the same page.
+
+This does not affect the bookmarks page removal form: that path redirects after failure and gets a fresh rendered hidden key on the next page render.
+
+## Reachability
+
+Reachable by a normal subscribed user who repeatedly toggles a bookmark/rating or submits reports quickly enough to hit the configured limiter, then retries the same in-place control after the limiter window should have reset. The harm is narrow and recoverable by reload, route change, question change, or idempotency expiry, so this is P4 rather than a data-integrity or availability bug.
+
+## Reproduction
+
+1. Open a practice/review question as an entitled user.
+2. Repeatedly invoke one in-place action until the server returns `RATE_LIMITED`:
+   - bookmark toggle: 60 changes per minute,
+   - rating: 60 changes per minute,
+   - report: 10 reports per minute.
+3. Wait longer than the one-minute rate-limit window.
+4. Click the same control again on the same page/question.
+
+Expected: once the limiter window has reset, the action should execute or fail from fresh server state.
+
+Actual: the client reuses the same idempotency key, and the server replays the cached `RATE_LIMITED` error attached to that key.
+
+## Root Cause
+
+The in-place clients retain an idempotency key until success:
+
+- [`bookmark-toggle.ts`](<../../app/(app)/app/shared/bookmark-toggle.ts#L33>) reuses the existing bookmark idempotency key or creates one.
+- [`bookmark-toggle.ts`](<../../app/(app)/app/shared/bookmark-toggle.ts#L36>) persists a generated key before the request.
+- [`bookmark-toggle.ts`](<../../app/(app)/app/shared/bookmark-toggle.ts#L63>) returns on non-ok results before the success-only rotation at [`bookmark-toggle.ts`](<../../app/(app)/app/shared/bookmark-toggle.ts#L87>).
+- [`question-feedback-actions.ts`](<../../app/(app)/app/shared/question-feedback-actions.ts#L40>) does the same for ratings, with error return at [`question-feedback-actions.ts`](<../../app/(app)/app/shared/question-feedback-actions.ts#L74>) before success rotation at [`question-feedback-actions.ts`](<../../app/(app)/app/shared/question-feedback-actions.ts#L91>).
+- [`question-feedback-actions.ts`](<../../app/(app)/app/shared/question-feedback-actions.ts#L113>) does the same for reports, with error return at [`question-feedback-actions.ts`](<../../app/(app)/app/shared/question-feedback-actions.ts#L146>) before success rotation at [`question-feedback-actions.ts`](<../../app/(app)/app/shared/question-feedback-actions.ts#L163>).
+- The current bookmark helper test locks the failure behavior in at [`bookmark-toggle.test.ts`](<../../app/(app)/app/shared/bookmark-toggle.test.ts#L59>).
+
+The affected controllers place rate limiting inside the idempotent closure:
+
+- [`bookmark-controller.ts`](../../src/adapters/controllers/bookmark-controller.ts#L81) performs the bookmark limiter inside `toggle()`, then passes that function to `executeIdempotent` at [`bookmark-controller.ts`](../../src/adapters/controllers/bookmark-controller.ts#L99).
+- [`question-feedback-controller.ts`](../../src/adapters/controllers/question-feedback-controller.ts#L131) performs the rating limiter inside the idempotent operation.
+- [`question-feedback-controller.ts`](../../src/adapters/controllers/question-feedback-controller.ts#L183) performs the report limiter inside the idempotent operation.
+- The configured rate windows are one minute in [`rate-limits.ts`](../../src/adapters/shared/rate-limits.ts#L47), [`rate-limits.ts`](../../src/adapters/shared/rate-limits.ts#L52), and [`rate-limits.ts`](../../src/adapters/shared/rate-limits.ts#L57).
+
+`withIdempotency` deliberately caches completed errors:
+
+- [`with-idempotency.ts`](../../src/adapters/shared/with-idempotency.ts#L11) defaults idempotency TTL to `DAY_MS`.
+- [`with-idempotency.ts`](../../src/adapters/shared/with-idempotency.ts#L77) sets `expiresAt` from that TTL.
+- [`with-idempotency.ts`](../../src/adapters/shared/with-idempotency.ts#L96) stores thrown errors with `storeError`.
+- [`with-idempotency.ts`](../../src/adapters/shared/with-idempotency.ts#L141) rethrows stored errors for repeated keys.
+- [`with-idempotency.test.ts`](../../src/adapters/shared/with-idempotency.test.ts#L270) explicitly verifies a stored `RATE_LIMITED` `ApplicationError` is replayed and the operation executes only once.
+
+## Impact
+
+After a legitimate rate-limit response, an in-page bookmark, rating, or report retry can remain wedged on the same cached error long after the limiter window has reset. The user's saved bookmark/feedback intent is delayed until reload/navigation/key expiry.
+
+## Proposed Fix
+
+Move the bookmark, rating, and report rate-limit checks before `executeIdempotent`, matching the billing controller pattern. A rate-limit denial is not the result of the mutation and should not be cached under the mutation's idempotency key. Successful mutations and use-case failures should keep the existing idempotent replay behavior.
+
+Implementation outline:
+
+1. In `toggleBookmark`, run the bookmark limiter after authentication and before defining/executing the idempotent mutation.
+2. In `rateQuestion` and `submitQuestionReport`, run the corresponding limiter before `executeIdempotent`.
+3. Keep action names, idempotency keys, output schemas, and use-case calls unchanged.
+4. Add controller tests proving that a first call returning `RATE_LIMITED` with an idempotency key does not cache the error: when the fake limiter allows a second call with the same key, the mutation executes.
+
+Rejected alternatives:
+
+- Rotate client idempotency keys after every error: helps honest UI retries, but leaves crafted clients and any missed UI path able to cache `RATE_LIMITED` errors.
+- Teach `withIdempotency` not to cache `RATE_LIMITED` globally: broader semantic change that affects all idempotent actions, including surfaces where cached application errors may be intentional.
+- Shorten idempotency TTL: weakens legitimate replay protection and still leaves the retry stuck for whatever shorter TTL is chosen.
+
+## Failing Test Sketch
+
+```ts
+it('does not cache bookmark RATE_LIMITED errors under the idempotency key', async () => {
+  const deps = createDeps({
+    rateLimitResult: [
+      { success: false, limit: 60, remaining: 0, retryAfterSeconds: 60 },
+      { success: true, limit: 60, remaining: 59, retryAfterSeconds: 0 },
+    ],
+  });
+
+  const input = {
+    questionId,
+    idempotencyKey: '11111111-1111-4111-8111-111111111111',
+  };
+
+  const first = await toggleBookmark(input, deps);
+  const second = await toggleBookmark(input, deps);
+
+  expect(first).toMatchObject({ ok: false, error: { code: 'RATE_LIMITED' } });
+  expect(second).toEqual({ ok: true, data: { bookmarked: true } });
+  expect(deps.toggleBookmarkUseCase.inputs).toHaveLength(1);
+});
+```
+
+Mirror the same shape for `rateQuestion` and `submitQuestionReport`. Today these tests fail because the first rate-limited call is stored as the idempotency result and the second call replays the cached error without invoking the mutation.
+
+## Prior Bug Cross-Refs
+
+- BUG-198 fixed crash-abandoned, incomplete idempotency keys. BUG-259 is different: the key is completed with a stored error.
+- BUG-231 fixed a missing idempotency key on the bookmarks removal form. BUG-259 affects in-place controls that do send a key.
+- BUG-204 and later billing fixes use rate-limit-before-idempotency ordering for checkout/portal actions; this bug is the bookmark/feedback divergence from that safer pattern.

--- a/docs/bugs/bug-260-question-feedback-trusts-client-context-ids.md
+++ b/docs/bugs/bug-260-question-feedback-trusts-client-context-ids.md
@@ -1,0 +1,124 @@
+# BUG-260: Question Feedback Trusts Client-Supplied Attempt and Session Context IDs
+
+**Status:** Open
+**Severity:** P4
+**Date:** 2026-06-23
+**Confirmed:** 2026-06-23
+**Component:** Question Feedback / Analytics Export / Data Integrity
+
+---
+
+## Summary
+
+Question rating and report actions accept optional `attemptId` and `practiceSessionId` from the client, validate only that they are UUID-shaped, and persist them unchanged. The use cases verify that the `questionId` is published, but they never verify that the attempt/session belongs to the current user, matches the feedback question, or contains that question. The export script then emits those context IDs for offline feedback analysis.
+
+The normal UI usually sends server-derived context, so this is not a broad user-facing break. It is still a real low-severity integrity bug because an entitled user can make a crafted server-action call that attaches feedback to unrelated existing context, corrupting the metadata that SPEC-041 says exists for mode/correctness correlation.
+
+## Reachability
+
+Reachable by an authenticated, entitled user through the real `rateQuestion` / `submitQuestionReport` server actions. The honest UI path mostly passes correct server-derived IDs, and cross-user pollution requires knowing an unguessable UUID, so severity stays P4. The concrete harm is persistent misleading feedback metadata in the operator export, not app-visible score corruption or cross-user data disclosure.
+
+## Reproduction
+
+1. As an entitled user, have an existing attempt for question `Q2` or a completed session that does not include question `Q1`.
+2. Submit a crafted `rateQuestion` or `submitQuestionReport` action payload for published question `Q1` with the unrelated `attemptId` or `practiceSessionId`.
+3. The controller accepts the UUID-shaped IDs, the use case validates only `Q1`, and the repository inserts the row.
+4. Run the feedback export.
+
+Expected: feedback context is either verified to match the user/question/session or is rejected/omitted.
+
+Actual: the feedback row persists and exports an unrelated context ID.
+
+## Root Cause
+
+The controller boundary only validates UUID shape:
+
+- [`question-feedback-controller.ts`](../../src/adapters/controllers/question-feedback-controller.ts#L43) accepts `attemptId` and `practiceSessionId` on rating input.
+- [`question-feedback-controller.ts`](../../src/adapters/controllers/question-feedback-controller.ts#L59) accepts the same context fields on report input.
+- [`question-feedback-controller.ts`](../../src/adapters/controllers/question-feedback-controller.ts#L128) authenticates/entitles the rating caller, then [`question-feedback-controller.ts`](../../src/adapters/controllers/question-feedback-controller.ts#L143) forwards the context IDs.
+- [`question-feedback-controller.ts`](../../src/adapters/controllers/question-feedback-controller.ts#L180) authenticates/entitles the report caller, then [`question-feedback-controller.ts`](../../src/adapters/controllers/question-feedback-controller.ts#L195) forwards the context IDs.
+
+The use cases validate the question, but not the context:
+
+- [`rate-question.ts`](../../src/application/use-cases/rate-question.ts#L28) fetches the published question and [`rate-question.ts`](../../src/application/use-cases/rate-question.ts#L33) records the provided `attemptId` / `practiceSessionId`.
+- [`submit-question-report.ts`](../../src/application/use-cases/submit-question-report.ts#L31) fetches the published question and [`submit-question-report.ts`](../../src/application/use-cases/submit-question-report.ts#L36) records the provided context.
+
+The repository and database preserve the supplied IDs:
+
+- [`drizzle-question-feedback-repository.ts`](../../src/adapters/repositories/drizzle-question-feedback-repository.ts#L20) inserts feedback rows.
+- [`drizzle-question-feedback-repository.ts`](../../src/adapters/repositories/drizzle-question-feedback-repository.ts#L25) writes `attemptId` from the event.
+- [`drizzle-question-feedback-repository.ts`](../../src/adapters/repositories/drizzle-question-feedback-repository.ts#L26) writes `practiceSessionId` from the event.
+- [`schema.ts`](../../db/schema.ts#L547) constrains feedback `userId`.
+- [`schema.ts`](../../db/schema.ts#L553) and [`schema.ts`](../../db/schema.ts#L556) define independent FKs to attempts and sessions, but no ownership/question/session-membership constraint.
+
+The exported data makes the stale context operational:
+
+- [`export-question-feedback.ts`](../../scripts/export-question-feedback.ts#L157) reads feedback rows.
+- [`export-question-feedback.ts`](../../scripts/export-question-feedback.ts#L166) selects `attemptId`.
+- [`export-question-feedback.ts`](../../scripts/export-question-feedback.ts#L167) selects `practiceSessionId`.
+- [`export-question-feedback.ts`](../../scripts/export-question-feedback.ts#L217) maps rows to export records, including context at [`export-question-feedback.ts`](../../scripts/export-question-feedback.ts#L225) and [`export-question-feedback.ts`](../../scripts/export-question-feedback.ts#L226).
+- [`export-question-feedback.ts`](../../scripts/export-question-feedback.ts#L246) emits CSV headers including `attempt_id` and `practice_session_id`.
+
+The missing validation matters because the spec says the context exists for correctness/mode correlation:
+
+- [`spec-041-question-feedback.md`](../_archive/specs/spec-041-question-feedback.md#L78) says feedback persists best-effort context so analysis can correlate whether the learner got the question right and in which mode.
+
+## Impact
+
+Feedback analytics can attribute a rating/report to the wrong attempt or practice session. That can mislead content triage about whether a learner got a question right, whether it happened in tutor/exam mode, or which session context produced the report. It does not alter user scores or expose another user's data through an app read path.
+
+## Proposed Fix
+
+Validate feedback context in the application layer before recording feedback. Extend `RateQuestionUseCase` and `SubmitQuestionReportUseCase` with injected `AttemptRepository` and `PracticeSessionRepository` dependencies, and add a shared application helper that normalizes or rejects context:
+
+1. If `attemptId` is present, load it with `findByIdAndUserId(attemptId, userId)` and require `attempt.questionId === input.questionId`.
+2. If `practiceSessionId` is present, load it with `findByIdAndUserId(practiceSessionId, userId)` and require `session.questionIds.includes(input.questionId)`.
+3. If both are present, require the attempt's `practiceSessionId` to match the supplied session when the attempt is session-scoped.
+4. Reject invalid context with `NOT_FOUND` or `VALIDATION_ERROR`; continue allowing null context for standalone or best-effort cases.
+5. Persist only validated context IDs.
+
+Rejected alternatives:
+
+- Trust the existing UI to supply correct context: server actions are callable by authenticated clients and must enforce their own integrity boundary.
+- Drop context IDs from feedback entirely: avoids corruption but loses the intended SPEC-041 analytics feature.
+- Fix only the export script: too late; the persisted row remains misleading and future consumers can still join on bad metadata.
+- Use only database constraints: ownership and session membership are application concepts spanning attempts plus `practice_sessions.params_json`, and are already handled cleanly in use cases elsewhere.
+
+## Failing Test Sketch
+
+```ts
+it('rejects feedback context when the attempt belongs to a different question', async () => {
+  const questions = new FakeQuestionRepository([questionQ1]);
+  const attempts = new FakeAttemptRepository([
+    createAttempt({ id: attemptForQ2Id, userId, questionId: questionQ2Id }),
+  ]);
+  const sessions = new FakePracticeSessionRepository();
+  const feedback = new FakeQuestionFeedbackRepository();
+  const useCase = new RateQuestionUseCase(
+    feedback,
+    questions,
+    attempts,
+    sessions,
+  );
+
+  await expect(
+    useCase.execute({
+      userId,
+      questionId: questionQ1Id,
+      attemptId: attemptForQ2Id,
+      practiceSessionId: null,
+      rating: 'helpful',
+    }),
+  ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+  expect(feedback.recordCalls).toEqual([]);
+});
+```
+
+Add sibling tests for a session that does not contain the question, a valid attempt/session pair, and null context. Today the rejection test fails because the use cases do not load attempts or sessions before recording the feedback row.
+
+## Prior Bug Cross-Refs
+
+- BUG-250 fixed CSV formula injection in the feedback export. BUG-260 is about the integrity of exported context IDs, not formula escaping.
+- BUG-098 covered submit-answer session membership. BUG-260 applies the same ownership/membership principle to optional feedback metadata.
+- BUG-257 added session-owned question reads after session membership is proven. BUG-260 is a separate feedback-context validation gap.

--- a/docs/bugs/bug-261-history-sessions-out-of-range-offset-shows-empty-state.md
+++ b/docs/bugs/bug-261-history-sessions-out-of-range-offset-shows-empty-state.md
@@ -1,0 +1,118 @@
+# BUG-261: Out-of-Range Session History Pages Show a False Empty-State Message
+
+**Status:** Open
+**Severity:** P4
+**Date:** 2026-06-23
+**Confirmed:** 2026-06-23
+**Component:** History / Session Pagination / UI State
+
+---
+
+## Summary
+
+`/app/history?tab=sessions` can receive a valid non-negative `offset` that is beyond the current number of completed sessions. The repository correctly returns `rows: []` with `total > 0`, but `HistorySessionsTab` checks `rows.length === 0` before reading `total`. The UI renders "No completed sessions yet." with only a "Go to Practice" button, even though the user does have completed sessions.
+
+The questions history tab already handles the same pagination shape correctly with a "No more questions on this page" state and a "Back to first page" recovery link.
+
+## Reachability
+
+Reachable by an authenticated entitled user who opens a stale/bookmarked/manually edited sessions-history URL such as `/app/history?tab=sessions&offset=20&limit=20` when their matching completed-session count is below that offset. The route and controller accept offsets up to the configured maximum. The harm is recoverable UI misinformation, not data loss or security exposure, so this is P4.
+
+## Reproduction
+
+1. Have at least one completed practice session and fewer than `offset` matching completed sessions.
+2. Visit `/app/history?tab=sessions&offset=20&limit=20`.
+3. Observe the sessions tab.
+
+Expected: the page should say there are no sessions on that page and offer a recovery link back to the first page.
+
+Actual: the page says "No completed sessions yet." and offers only "Go to Practice."
+
+## Root Cause
+
+The page and controller allow a bounded but out-of-range offset to reach the session history query:
+
+- [`history-search-params.ts`](<../../app/(app)/app/history/history-search-params.ts#L34>) parses any non-negative integer offset and returns it unchanged.
+- [`history/page.tsx`](<../../app/(app)/app/history/page.tsx#L77>) reads search params.
+- [`history/page.tsx`](<../../app/(app)/app/history/page.tsx#L129>) calls `getSessionHistory` with the parsed limit/offset.
+- [`practice-schemas.ts`](../../src/adapters/controllers/practice-schemas.ts#L112) bounds `offset` with `MAX_PAGINATION_OFFSET`, but does not and cannot know the current `total`.
+- [`practice-controller.ts`](../../src/adapters/controllers/practice-controller.ts#L389) forwards the valid offset to the use case.
+
+The use case and repository preserve the pagination shape:
+
+- [`get-session-history.ts`](../../src/application/use-cases/get-session-history.ts#L48) calls `findCompletedByUserId` with the requested offset.
+- [`drizzle-practice-session-repository.ts`](../../src/adapters/repositories/drizzle-practice-session-repository.ts#L125) clamps only invalid/negative offsets.
+- [`drizzle-practice-session-repository.ts`](../../src/adapters/repositories/drizzle-practice-session-repository.ts#L130) counts matching completed sessions.
+- [`drizzle-practice-session-repository.ts`](../../src/adapters/repositories/drizzle-practice-session-repository.ts#L140) applies the safe offset to the row query.
+- [`get-session-history.ts`](../../src/application/use-cases/get-session-history.ts#L100) returns `rows`, `total`, `limit`, and `offset`.
+
+The sessions UI loses the distinction:
+
+- [`history-sessions-tab.tsx`](<../../app/(app)/app/history/components/history-sessions-tab.tsx#L95>) reads `rows`.
+- [`history-sessions-tab.tsx`](<../../app/(app)/app/history/components/history-sessions-tab.tsx#L96>) immediately treats every empty page as the true empty-session state.
+- [`history-sessions-tab.tsx`](<../../app/(app)/app/history/components/history-sessions-tab.tsx#L99>) renders "No completed sessions yet."
+- [`history-sessions-tab.tsx`](<../../app/(app)/app/history/components/history-sessions-tab.tsx#L109>) reads `limit`, `offset`, and `total` only after that early return.
+
+The sibling questions tab demonstrates the intended distinction:
+
+- [`history-questions-tab.tsx`](<../../app/(app)/app/history/components/history-questions-tab.tsx#L417>) branches on empty rows.
+- [`history-questions-tab.tsx`](<../../app/(app)/app/history/components/history-questions-tab.tsx#L440>) renders the out-of-range page state when `totalCount > 0`.
+- [`history-questions-tab.test.tsx`](<../../app/(app)/app/history/components/history-questions-tab.test.tsx#L609>) covers a back-to-first-page link for an empty page with a nonzero total.
+- [`history-sessions-tab.test.tsx`](<../../app/(app)/app/history/components/history-sessions-tab.test.tsx#L678>) covers only the true empty state (`total: 0`).
+
+## Impact
+
+A user with completed sessions can be told they have none, and the visible recovery action sends them to Practice rather than back to their existing history. This is misleading but recoverable by clearing the URL offset or navigating back to History.
+
+## Proposed Fix
+
+Update `HistorySessionsTab` to branch on `total` before rendering the empty state, mirroring `HistoryQuestionsTab`:
+
+1. Read `limit`, `offset`, and `total` immediately after the successful result.
+2. If `rows.length === 0 && total === 0`, keep the current "No completed sessions yet." state.
+3. If `rows.length === 0 && total > 0`, render "No more sessions on this page." with a "Back to first page" link built by `buildHistorySessionsHref({ limit, offset: 0, mode: modeFilter })`.
+4. Preserve `modeFilter` and `limit` in the recovery link.
+
+Rejected alternatives:
+
+- Clamp the offset in the repository or use case: the page still needs an explicit out-of-range UI state, and server-side clamping would make the response less transparent.
+- Redirect from the page to offset 0: adds navigation behavior where a simple render branch is sufficient and consistent with the questions tab.
+- Reuse the true-empty "Go to Practice" state: that is the current bug and gives the wrong recovery path.
+
+## Failing Test Sketch
+
+```tsx
+it('renders an out-of-range empty page state when session total is nonzero', () => {
+  const result: SessionHistoryResult = {
+    ok: true,
+    data: {
+      rows: [],
+      total: 21,
+      limit: 20,
+      offset: 20,
+    },
+  };
+
+  const html = renderToStaticMarkup(
+    <HistorySessionsTab result={result} modeFilter="exam" />,
+  );
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const backToFirstPageLink = Array.from(doc.querySelectorAll('a')).find(
+    (anchor) => anchor.textContent?.trim() === 'Back to first page',
+  );
+
+  expect(html).toContain('No more sessions on this page.');
+  expect(html).not.toContain('No completed sessions yet.');
+  expect(backToFirstPageLink?.getAttribute('href')).toBe(
+    '/app/history?tab=sessions&offset=0&limit=20&mode=exam',
+  );
+});
+```
+
+Today this fails because `HistorySessionsTab` returns the true-empty state before reading `total`.
+
+## Prior Bug Cross-Refs
+
+- BUG-162 fixed an unbounded attempted-questions offset. BUG-261 is not an unbounded-offset performance issue; the session offset is bounded, but the UI mislabels the valid empty page.
+- BUG-253 was withdrawn as an unreachable session-history ordering tiebreaker. BUG-261 is unrelated to ordering and is reachable through the history URL.
+- The questions-tab empty-page branch is the local precedent and should be mirrored for sessions.

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -13,7 +13,59 @@ Bug reports document issues discovered in the codebase along with their root cau
 2. **Regression Prevention** — Ensure we don't reintroduce the same bugs
 3. **Knowledge Base** — Help future developers understand past issues
 
-**Next Bug ID:** BUG-259
+**Next Bug ID:** BUG-262
+
+**Latest manual report (2026-06-23) — Practice corners and adjacent-system follow-up sweep:**
+
+**Methodology:**
+- Read prior art first: `docs/bugs/index.md`, archived BUG-251..258, and the known non-refile registry for active-exam visibility, BUG-137 renewal boundaries, BUG-253, BUG-250, BUG-257 out-of-band publication-state cases, and prior Stripe/billing Audit #21.
+- Split the sweep across practice stats/history/tags/quick-start/resume, bookmarks/feedback/export/notifications, Clerk/entitlement/cron/idempotency/rate limiting, and performance/concurrency/observability.
+- For each candidate, traced a real entry point through controller/schema/use case/repository or UI sink with current file:line anchors, then ran an independent skeptic pass that tried to refute reachability, harm, and prior-art uniqueness.
+- Filed only candidates that survived with concrete user/operator harm. All survivors are P4 because each is narrow, recoverable, or metadata-hardening rather than score/security/data-loss.
+
+**3 new bugs filed (BUG-259..261):**
+
+| Bug | Family | Priority | Summary |
+|-----|--------|----------|---------|
+| [BUG-259](bug-259-in-place-rate-limit-errors-cache-idempotency-retries.md) | Idempotency / rate limiting / bookmarks / feedback | P4 | In-place bookmark/rating/report rate-limit errors are cached under the reused idempotency key, so retry can stay stuck after the limiter window resets |
+| [BUG-260](bug-260-question-feedback-trusts-client-context-ids.md) | Question feedback / analytics metadata | P4 | Rating/report actions persist client-supplied attempt/session context IDs without ownership or question/session validation |
+| [BUG-261](bug-261-history-sessions-out-of-range-offset-shows-empty-state.md) | History / session pagination UI | P4 | Out-of-range session-history pages with `total > 0` render the true-empty "No completed sessions yet" state |
+
+**Coverage ledger:**
+
+| Surface | Result |
+|---------|--------|
+| Dashboard/stats aggregates and streaks | Clean: shared active-exam visibility predicates still apply to counts, recent activity, and answered-at inputs; no divide-by-zero or denominator drift survived tests/source review |
+| Session history projections | Found BUG-261 in the sessions-tab UI sink; repository count/page shape and summary math were otherwise clean |
+| Attempted-question history/filtering | Clean: list and count paths apply the same filters; questions tab already handles out-of-range pages with recovery |
+| Question feedback/rating/export | Found BUG-260 context-integrity gap; BUG-250 CSV formula injection remains fixed, default export redacts user IDs and omits comments unless explicitly requested |
+| Bookmarks in practice/review | Found BUG-259 through the in-place idempotency/rate-limit interaction; user scoping and stale-load guards otherwise held |
+| Tag/taxonomy selection and quick practice | Clean: visible tag-kind filtering, candidate sorting/shuffling, status pools, and empty-result handling matched tests and ordering policy |
+| Tutor mode and session start/resume | Clean: immediate grading, retry semantics, incomplete-session conflict, quick-start idempotency/stale-response guards, and expired-exam summary recovery held |
+| Clerk lifecycle/webhooks | Clean: `verifyWebhook(req)` is live, event claim/locks/tombstones/pending Stripe cancellation drain cover replay/deletion races |
+| Entitlement/access gating | Clean by current product rule: app layout and every app-data server action require `requireEntitledUserId`; no bypass found |
+| Cron/reconciliation | Clean: Vercel cron exists, auth runs before config/rate/work, all-pages job reports early stop; DEBT-422 covers resume/keyset concerns |
+| Stripe replay and billing idempotency | Clean against prior Audit #21 fixes: subscription-write guard prevents stale terminal overwrites; checkout/open-session idempotency and duplicate-sub cancellation remain covered |
+| Performance/concurrency/observability | Clean: bounded sessions plus set-based fetches avoid counted N+1s; CAS updater and monotonic draft guard held; no answer-key/comment/PII logging sink survived grep and trace |
+
+**Refuted candidates deliberately NOT filed (with why):**
+- **Active exam attempts leaking into stats/history:** refuted by `getActiveExamVisibilityCondition()` usage in aggregate/recent/streak/history queries and prior BUG-187/235/236/237 coverage.
+- **Session accuracy denominator drift:** refuted by shared question-count denominator behavior in summary/history and tests for exam, tutor, and zero-answered sessions.
+- **History question filters/count mismatch:** refuted because page filters flow into both attempted-question list and count SQL.
+- **Diagnosis tags in history filters:** refuted by the visible-kind allowlist for `topic` / `substance` / `treatment` and direct page coverage.
+- **Quick-practice and start-session full candidate-pool fetch:** refuted as intentional ordering-policy behavior, not a counted N+1; current content size is finite and persisted session size is capped at 200.
+- **Review/completed-feedback N+1:** refuted by set-based question/session-attempt fetches before bounded per-row mapping.
+- **Session-state lost update or stale draft overwrite:** refuted by CAS `params_json` compare/retry and repository monotonic cumulative draft guard.
+- **Missing await/unhandled rejection in practice async flows:** refuted by transition wrappers, fire-and-forget catch handlers, and action-result error paths.
+- **Question feedback CSV formula injection or default privacy leak:** refuted by BUG-250 escaping and default export redaction/comment omission.
+- **Feedback report comment logging:** refuted; failure logs include error/question/category but not free-text comments, and tests cover omission.
+- **Clerk webhook dummy-secret bypass, deletion replay, and resurrection races:** refuted by live `verifyWebhook(req)`, event claim/processed checks, locks, tombstones, and drain job.
+- **Practice entitlement bypass:** refuted; protected layout and server actions independently enforce entitlement, and the domain check requires an entitled status plus unexpired period.
+- **Cron auth/config leak or missing schedule:** refuted; `vercel.json` schedules the job and auth precedes rate limiting and work.
+- **Stale Stripe webhook/checkout-success replay overwriting active entitlement:** refuted by the shared subscription-write guard and checkout-success fallback to the protected current row.
+- **Concurrent two-tab checkout duplicate subscriptions:** refuted by deterministic Stripe idempotency keys plus open-session reconciliation.
+- **Reconciliation early-stop without automatic resume:** known DEBT-422 observability/resume policy, not a new bug.
+- **Billing idempotency replay consuming rate limit before cache replay:** prior-art accepted ordering for billing; relevant only as the safe contrast for BUG-259.
 
 **Latest manual report (2026-06-23) — Practice/quiz engine correctness, clock, lifecycle, async, observability, performance sweep:**
 
@@ -223,7 +275,13 @@ Bug reports document issues discovered in the codebase along with their root cau
 
 ## Active Bugs
 
-_None — all filed bugs are resolved and archived to [`docs/_archive/bugs/`](../_archive/bugs/)._ Next Bug ID: **BUG-259**.
+| Bug | Severity | Component | Summary |
+|-----|----------|-----------|---------|
+| [BUG-259](bug-259-in-place-rate-limit-errors-cache-idempotency-retries.md) | P4 | Bookmarks / feedback / idempotency | In-place bookmark/rating/report rate-limit errors are cached under a reused idempotency key, wedging same-page retry until reload/navigation/key expiry |
+| [BUG-260](bug-260-question-feedback-trusts-client-context-ids.md) | P4 | Question feedback / analytics export | Feedback actions persist client-supplied attempt/session context IDs without ownership, question-match, or session-membership validation |
+| [BUG-261](bug-261-history-sessions-out-of-range-offset-shows-empty-state.md) | P4 | History / session pagination | Out-of-range session-history pages with `total > 0` show the false "No completed sessions yet" state |
+
+Next Bug ID: **BUG-262**.
 
 ## Audit #21 — Stripe/Billing Deep Sweep (2026-06-11)
 


### PR DESCRIPTION
Promotes the BUG-259..261 P4 bug filings (PR #502, squash `c68eac1c`) from `dev` to `main` to keep the branches in sync.

**Docs-only** — 3 new bug docs + `docs/bugs/index.md` reconcile. No production or test code, so no runtime/build impact (a docs-only `main` merge may not trigger a new Vercel Production deploy, which is expected).

The underlying change was CodeRabbit-APPROVED on PR #502 head `b539b6f2` ("No actionable comments", 0 unresolved threads) with the required `test` check green; this promotion tree is identical to that approved `dev` content.

https://claude.ai/code/session_01RhHv6rK1YVBaE8WmPNpGXQ