### PR TITLE
Fix BUG-261: out-of-range session-history page shows false empty state (P4)

### DIFF
--- a/app/(app)/app/history/components/history-sessions-tab.test.tsx
+++ b/app/(app)/app/history/components/history-sessions-tab.test.tsx
@@ -8,6 +8,7 @@ import type {
   GetPracticeSessionReviewOutput,
   GetSessionHistoryOutput,
 } from '@/src/adapters/controllers/practice-controller';
+import { buildHistorySessionsHref } from '../history-search-params';
 
 const {
   fixtureQuestion1Id,
@@ -690,6 +691,32 @@ describe('HistorySessionsTab', () => {
 
     expect(html).toContain('No completed sessions yet.');
     expect(html).toContain('href="/app/practice"');
+  });
+
+  it('renders an out-of-range empty page state with a back-to-first-page link when total is nonzero', () => {
+    const result: SessionHistoryResult = {
+      ok: true,
+      data: {
+        rows: [],
+        total: 21,
+        limit: 20,
+        offset: 20,
+      },
+    };
+
+    const html = renderToStaticMarkup(
+      <HistorySessionsTab result={result} modeFilter="exam" />,
+    );
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const backToFirstPageLink = Array.from(doc.querySelectorAll('a')).find(
+      (anchor) => anchor.textContent?.trim() === 'Back to first page',
+    );
+
+    expect(html).toContain('No more sessions on this page.');
+    expect(html).not.toContain('No completed sessions yet.');
+    expect(backToFirstPageLink?.getAttribute('href')).toBe(
+      buildHistorySessionsHref({ limit: 20, offset: 0, mode: 'exam' }),
+    );
   });
 
   it('renders an error card when result is not ok', () => {

--- a/app/(app)/app/history/components/history-sessions-tab.test.tsx
+++ b/app/(app)/app/history/components/history-sessions-tab.test.tsx
@@ -2,13 +2,14 @@
 import type { ComponentType } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildHistorySessionsHref } from '@/app/(app)/app/history/history-search-params';
 import type { AsyncLoadStateWithIdle } from '@/app/(app)/app/shared/load-state';
 import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import type {
   GetPracticeSessionReviewOutput,
   GetSessionHistoryOutput,
 } from '@/src/adapters/controllers/practice-controller';
-import { buildHistorySessionsHref } from '../history-search-params';
+import { findAnchorByHref, parseHtml } from '@/tests/shared/dom-helpers';
 
 const {
   fixtureQuestion1Id,
@@ -707,16 +708,16 @@ describe('HistorySessionsTab', () => {
     const html = renderToStaticMarkup(
       <HistorySessionsTab result={result} modeFilter="exam" />,
     );
-    const doc = new DOMParser().parseFromString(html, 'text/html');
-    const backToFirstPageLink = Array.from(doc.querySelectorAll('a')).find(
-      (anchor) => anchor.textContent?.trim() === 'Back to first page',
+    const doc = parseHtml(html);
+    const backToFirstPageLink = findAnchorByHref(
+      doc,
+      buildHistorySessionsHref({ limit: 20, offset: 0, mode: 'exam' }),
     );
 
     expect(html).toContain('No more sessions on this page.');
     expect(html).not.toContain('No completed sessions yet.');
-    expect(backToFirstPageLink?.getAttribute('href')).toBe(
-      buildHistorySessionsHref({ limit: 20, offset: 0, mode: 'exam' }),
-    );
+    expect(backToFirstPageLink).not.toBeNull();
+    expect(backToFirstPageLink?.textContent?.trim()).toBe('Back to first page');
   });
 
   it('renders an error card when result is not ok', () => {

--- a/app/(app)/app/history/components/history-sessions-tab.tsx
+++ b/app/(app)/app/history/components/history-sessions-tab.tsx
@@ -92,21 +92,41 @@ export function HistorySessionsTab({
     return <ErrorCard className="p-4">{result.error.message}</ErrorCard>;
   }
 
-  const rows = result.data.rows;
+  const { rows, limit, offset, total } = result.data;
+
   if (rows.length === 0) {
+    if (total === 0) {
+      return (
+        <div className="text-sm text-muted-foreground">
+          <div>No completed sessions yet.</div>
+          <div className="mt-3">
+            <Button asChild variant="outline" className="rounded-full">
+              <Link href={ROUTES.APP_PRACTICE}>Go to Practice</Link>
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div className="text-sm text-muted-foreground">
-        <div>No completed sessions yet.</div>
+        <div>No more sessions on this page.</div>
         <div className="mt-3">
-          <Button asChild variant="outline" className="rounded-full">
-            <Link href={ROUTES.APP_PRACTICE}>Go to Practice</Link>
+          <Button asChild variant="link" className={headerActionLinkClasses}>
+            <Link
+              href={buildHistorySessionsHref({
+                limit,
+                offset: 0,
+                mode: modeFilter,
+              })}
+            >
+              Back to first page
+            </Link>
           </Button>
         </div>
       </div>
     );
   }
-
-  const { limit, offset, total } = result.data;
   const prevOffset = Math.max(0, offset - limit);
   const nextOffset = offset + limit;
   const hasNextPage = offset + rows.length < total;


### PR DESCRIPTION
## Summary

Fixes **BUG-261** (P4). `HistorySessionsTab` returned the true-empty "No completed sessions yet." state on *any* empty page before reading `total`, so a valid but out-of-range session-history offset (e.g. `?tab=sessions&offset=20` with `total > 0`, rows empty) told a user **with** completed sessions they had none and sent them to Practice instead of back to their history.

## Fix
Read `{ rows, limit, offset, total }` before the empty branch and split it, mirroring the sibling `HistoryQuestionsTab`:
- `total === 0` → keep "No completed sessions yet." + Go to Practice
- `total > 0` → render **"No more sessions on this page."** + a **"Back to first page"** link (`buildHistorySessionsHref({ limit, offset: 0, mode: modeFilter })` — preserves the active mode filter + limit, omits `mode` when `all`)

The normal in-range path (`prevOffset`/`nextOffset`/`hasNextPage`/"Showing X–Y of N") is unchanged — it still runs only when rows exist.

## TDD
- 🔴 New out-of-range test (`total: 21, offset: 20`) fails pre-fix (component rendered the true-empty state).
- 🟢 Passes post-fix; existing true-empty test + 16 others unchanged.
- Asserts the new message, the *absence* of the false message, and the exact recovery href via `getAttribute('href')`.

## Scope
UI-only (component + test). Per the established pattern, the bug doc stays `Open`; its Open→Resolved archival is a separate PR after prod-verification.

## Verification
Full local gate green on this commit (run twice — implementer + an independent adversarial reviewer that found nothing to change): typecheck, biome (changed files clean), **unit 2936 passed**, build exit 0. Adversarial review also swept for the same antipattern in other paginated surfaces (bookmarks/dashboard/questions) — none found.

https://claude.ai/code/session_01RhHv6rK1YVBaE8WmPNpGXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session history pagination when the current page is out of range. The component now displays "No more sessions on this page" with a "Back to first page" link when sessions exist but none appear on the current page. This provides clearer guidance for users.

* **Tests**
  * Added test coverage for out-of-range pagination scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->