### PR TITLE
Promote dev to main: BUG-261 fix (#504)

### DIFF
--- a/app/(app)/app/history/components/history-sessions-tab.test.tsx
+++ b/app/(app)/app/history/components/history-sessions-tab.test.tsx
@@ -2,12 +2,14 @@
 import type { ComponentType } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildHistorySessionsHref } from '@/app/(app)/app/history/history-search-params';
 import type { AsyncLoadStateWithIdle } from '@/app/(app)/app/shared/load-state';
 import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import type {
   GetPracticeSessionReviewOutput,
   GetSessionHistoryOutput,
 } from '@/src/adapters/controllers/practice-controller';
+import { findAnchorByHref, parseHtml } from '@/tests/shared/dom-helpers';
 
 const {
   fixtureQuestion1Id,
@@ -690,6 +692,32 @@ describe('HistorySessionsTab', () => {
 
     expect(html).toContain('No completed sessions yet.');
     expect(html).toContain('href="/app/practice"');
+  });
+
+  it('renders an out-of-range empty page state with a back-to-first-page link when total is nonzero', () => {
+    const result: SessionHistoryResult = {
+      ok: true,
+      data: {
+        rows: [],
+        total: 21,
+        limit: 20,
+        offset: 20,
+      },
+    };
+
+    const html = renderToStaticMarkup(
+      <HistorySessionsTab result={result} modeFilter="exam" />,
+    );
+    const doc = parseHtml(html);
+    const backToFirstPageLink = findAnchorByHref(
+      doc,
+      buildHistorySessionsHref({ limit: 20, offset: 0, mode: 'exam' }),
+    );
+
+    expect(html).toContain('No more sessions on this page.');
+    expect(html).not.toContain('No completed sessions yet.');
+    expect(backToFirstPageLink).not.toBeNull();
+    expect(backToFirstPageLink?.textContent?.trim()).toBe('Back to first page');
   });
 
   it('renders an error card when result is not ok', () => {

--- a/app/(app)/app/history/components/history-sessions-tab.tsx
+++ b/app/(app)/app/history/components/history-sessions-tab.tsx
@@ -92,21 +92,41 @@ export function HistorySessionsTab({
     return <ErrorCard className="p-4">{result.error.message}</ErrorCard>;
   }
 
-  const rows = result.data.rows;
+  const { rows, limit, offset, total } = result.data;
+
   if (rows.length === 0) {
+    if (total === 0) {
+      return (
+        <div className="text-sm text-muted-foreground">
+          <div>No completed sessions yet.</div>
+          <div className="mt-3">
+            <Button asChild variant="outline" className="rounded-full">
+              <Link href={ROUTES.APP_PRACTICE}>Go to Practice</Link>
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div className="text-sm text-muted-foreground">
-        <div>No completed sessions yet.</div>
+        <div>No more sessions on this page.</div>
         <div className="mt-3">
-          <Button asChild variant="outline" className="rounded-full">
-            <Link href={ROUTES.APP_PRACTICE}>Go to Practice</Link>
+          <Button asChild variant="link" className={headerActionLinkClasses}>
+            <Link
+              href={buildHistorySessionsHref({
+                limit,
+                offset: 0,
+                mode: modeFilter,
+              })}
+            >
+              Back to first page
+            </Link>
           </Button>
         </div>
       </div>
     );
   }
-
-  const { limit, offset, total } = result.data;
   const prevOffset = Math.max(0, offset - limit);
   const nextOffset = offset + limit;
   const hasNextPage = offset + rows.length < total;


### PR DESCRIPTION
Promotes the BUG-261 fix (PR #504, squash `b3bbf76f`) from `dev` to `main` to keep the branches in sync.

**Code change** (UI component + test): `HistorySessionsTab` now renders an out-of-range "No more sessions on this page." + "Back to first page" recovery state when `total > 0` on an empty page, instead of the false true-empty state. This is a real code change, so the `main` merge will trigger a production Vercel deploy.

The underlying change was CodeRabbit **APPROVED** on the exact PR #504 head `ad2db641` (0 unresolved threads; both quick-win test findings addressed) with the required `test` + `codecov/patch` checks green. This promotion tree is identical to that approved `dev` content.

https://claude.ai/code/session_01RhHv6rK1YVBaE8WmPNpGXQ