### PR TITLE
Promote dev to main: DEBT-424 rate-limit idempotent actions on cache-miss only (#512)

### DIFF
--- a/docs/debt/debt-424-rate-limit-idempotent-actions-on-cache-miss-only.md
+++ b/docs/debt/debt-424-rate-limit-idempotent-actions-on-cache-miss-only.md
@@ -1,6 +1,6 @@
 # DEBT-424: Rate-Limit Idempotent Server Actions on Cache-Miss Only (replay-before-limit)
 
-**Status:** Open
+**Status:** In Review
 **Priority:** P3
 **Date:** 2026-06-24
 **Component:** Idempotency / Rate Limiting / Adapter controllers
@@ -58,7 +58,7 @@ Add an optional `beforeExecute` hook to `executeIdempotent` / `withIdempotency` 
 The cleanup piece is required by the live `withIdempotency` state machine: `repo.claim(...)` creates an incomplete row before `execute()` runs ([`with-idempotency.ts`](../../src/adapters/shared/with-idempotency.ts#L78), [`drizzle-idempotency-key-repository.ts`](../../src/adapters/repositories/drizzle-idempotency-key-repository.ts#L38)). A naive "claim then run hook" would avoid storing `RATE_LIMITED`, but would leave the key pending until zombie recovery. Therefore the implementation must make hook-denied claims explicitly abortable and make pollers tolerate that abort.
 
 1. Add `beforeExecute?: () => Promise<void>` to `executeIdempotent` and `withIdempotency`; keep the no-key fast path running `beforeExecute` then `execute`.
-2. Extend `IdempotencyKeyRepository` (fake + Drizzle implementation) with a narrow `abortClaim(userId, action, key)` operation that removes only an incomplete row for that exact key (`completedAt IS NULL` and no stored error). In `withIdempotency`, after a successful `claim`, run `beforeExecute` before `execute`; if the hook throws, best-effort abort the incomplete claim, log abort failures without masking the original error, and rethrow the original error without calling `storeError`.
+2. Extend `IdempotencyKeyRepository` (fake + Drizzle implementation) so `claim(...)` returns the row's `claimedAt` token on a fresh claim/reclaim and `null` on cache-hit/pending-hit. Add a narrow `abortClaim(userId, action, key, claimedAt)` operation that removes only the still-incomplete row for that exact claim (`claimedAt` matches, `completedAt IS NULL`, and no stored error). Thread the same token through `storeResult(...)` and `storeError(...)`, and require those completion writes to match a still-pending row (`completedAt IS NULL`) so stale executions cannot persist over a newer reclaimed claim and duplicate same-claim writes cannot replace the first cached outcome. In `withIdempotency`, after a successful `claim`, run `beforeExecute` before `execute`; if the hook throws, best-effort abort that exact incomplete claim, log abort failures without masking the original error, and rethrow the original error without calling `storeError`.
 3. Update the polling branch so a waiter that observes a hook-aborted/missing row restarts the claim/read loop instead of returning the current "Idempotency key disappeared during poll" internal error. Keep true store-result / store-error replay behavior unchanged.
 4. Update all **8 in-scope** controllers to pass their `rateLimiter.limit(...)` + `RATE_LIMITED` throw as `beforeExecute` instead of running it ahead of `executeIdempotent`. Leave the 3 no-limiter actions and the webhook routes untouched.
 5. Keep action names, idempotency keys, schemas, output parsing, and use-case calls unchanged.
@@ -72,12 +72,12 @@ The cleanup piece is required by the live `withIdempotency` state machine: `repo
 
 ## Acceptance Criteria
 
-- [ ] `withIdempotency` / `executeIdempotent` accept a `beforeExecute` hook that runs only on a fresh claim/cache miss (and on the no-key fast path), before execute, and whose thrown error is never stored.
-- [ ] A `beforeExecute` denial aborts the incomplete idempotency claim; immediate same-key retry is not wedged behind a pending row, and same-key waiters do not surface `INTERNAL_ERROR` from a disappeared aborted claim.
-- [ ] All 8 in-scope controllers pass their limiter via the hook; none runs the limiter ahead of the cache lookup. The 3 no-limiter actions and webhook routes are unchanged.
-- [ ] Per in-scope action, TDD: (a) a replay with a reused key **while rate-limited** returns the **stored** success/error (CodeRabbit's `[success, RATE_LIMITED]` shape — second call equals the cached first, one use-case invocation); (b) a **fresh** execution is still rate-limited and the `RATE_LIMITED` is **not** cached; (c) success stays idempotent; (d) genuine use-case errors stay cached.
-- [ ] Billing checkout/portal adopt the same hook (no behavior drift versus the other actions).
-- [ ] Full gate green (typecheck, lint, unit, build).
+- [x] `withIdempotency` / `executeIdempotent` accept a `beforeExecute` hook that runs only on a fresh claim/cache miss (and on the no-key fast path), before execute, and whose thrown error is never stored.
+- [x] A `beforeExecute` denial aborts only the exact incomplete idempotency claim it created; immediate same-key retry is not wedged behind a pending row, same-key waiters do not surface `INTERNAL_ERROR` from a disappeared aborted claim, stale hook failures cannot delete a newer reclaimed row, and stale executions cannot store a result/error over a newer reclaimed claim.
+- [x] All 8 in-scope controllers pass their limiter via the hook; none runs the limiter ahead of the cache lookup. The 3 no-limiter actions and webhook routes are unchanged.
+- [x] Per in-scope action, TDD: (a) a replay with a reused key **while rate-limited** returns the **stored** success/error (CodeRabbit's `[success, RATE_LIMITED]` shape — second call equals the cached first, one use-case invocation); (b) a **fresh** execution is still rate-limited and the `RATE_LIMITED` is **not** cached; (c) success stays idempotent; (d) genuine use-case errors stay cached.
+- [x] Billing checkout/portal adopt the same hook (no behavior drift versus the other actions).
+- [x] Full gate green (typecheck, lint, unit, build).
 
 ## References
 

--- a/src/adapters/controllers/billing-controller.test.ts
+++ b/src/adapters/controllers/billing-controller.test.ts
@@ -190,6 +190,77 @@ describe('billing-controller', () => {
       expect(deps._calls.clerkCalls).toHaveLength(1);
     });
 
+    it('does not cache RATE_LIMITED under the checkout idempotency key', async () => {
+      const deps = createDeps({
+        rateLimiter: new FakeRateLimiter([
+          {
+            success: false,
+            limit: 10,
+            remaining: 0,
+            retryAfterSeconds: 60,
+          },
+          {
+            success: true,
+            limit: 10,
+            remaining: 9,
+            retryAfterSeconds: 0,
+          },
+        ]),
+      });
+      const input = {
+        plan: 'monthly',
+        idempotencyKey: '11111111-1111-1111-1111-111111111111',
+      } as const;
+
+      const first = await createCheckoutSession(input, deps);
+      expect(first).toMatchObject({
+        ok: false,
+        error: { code: 'RATE_LIMITED' },
+      });
+
+      const second = await createCheckoutSession(input, deps);
+      expect(second).toEqual({
+        ok: true,
+        data: { url: 'https://stripe/checkout' },
+      });
+      expect(deps.createCheckoutSessionUseCase.inputs).toHaveLength(1);
+    });
+
+    it('replays a cached checkout session while the reused key is rate limited', async () => {
+      const deps = createDeps({
+        rateLimiter: new FakeRateLimiter([
+          {
+            success: true,
+            limit: 10,
+            remaining: 9,
+            retryAfterSeconds: 0,
+          },
+          {
+            success: false,
+            limit: 10,
+            remaining: 0,
+            retryAfterSeconds: 60,
+          },
+        ]),
+      });
+      const input = {
+        plan: 'monthly',
+        idempotencyKey: '11111111-1111-1111-1111-111111111111',
+      } as const;
+
+      const first = await createCheckoutSession(input, deps);
+      const second = await createCheckoutSession(input, deps);
+
+      expect(first).toEqual({
+        ok: true,
+        data: { url: 'https://stripe/checkout' },
+      });
+      expect(second).toEqual(first);
+      expect(deps.createCheckoutSessionUseCase.inputs).toHaveLength(1);
+      expect(deps._calls.clerkCalls).toHaveLength(1);
+      expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
+    });
+
     it('returns the cached checkout session when same-form double submit races with the same idempotencyKey', async () => {
       const deps = createDeps();
 
@@ -228,6 +299,44 @@ describe('billing-controller', () => {
         ok: false,
         error: { code: 'ALREADY_SUBSCRIBED', message: 'Already subscribed' },
       });
+    });
+
+    it('keeps genuine checkout use-case ApplicationErrors cached when idempotencyKey is reused', async () => {
+      const deps = createDeps({
+        rateLimiter: new FakeRateLimiter([
+          {
+            success: true,
+            limit: 10,
+            remaining: 9,
+            retryAfterSeconds: 0,
+          },
+          {
+            success: false,
+            limit: 10,
+            remaining: 0,
+            retryAfterSeconds: 60,
+          },
+        ]),
+        checkoutThrows: new ApplicationError(
+          'ALREADY_SUBSCRIBED',
+          'Already subscribed',
+        ),
+      });
+      const input = {
+        plan: 'monthly',
+        idempotencyKey: '11111111-1111-1111-1111-111111111111',
+      } as const;
+
+      const first = await createCheckoutSession(input, deps);
+      const second = await createCheckoutSession(input, deps);
+
+      expect(first).toEqual({
+        ok: false,
+        error: { code: 'ALREADY_SUBSCRIBED', message: 'Already subscribed' },
+      });
+      expect(second).toEqual(first);
+      expect(deps.createCheckoutSessionUseCase.inputs).toHaveLength(1);
+      expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
     });
   });
 
@@ -339,6 +448,39 @@ describe('billing-controller', () => {
       ]);
     });
 
+    it('replays a cached portal session while the reused key is rate limited', async () => {
+      const deps = createDeps({
+        rateLimiter: new FakeRateLimiter([
+          {
+            success: true,
+            limit: 20,
+            remaining: 19,
+            retryAfterSeconds: 0,
+          },
+          {
+            success: false,
+            limit: 20,
+            remaining: 0,
+            retryAfterSeconds: 60,
+          },
+        ]),
+      });
+      const input = {
+        idempotencyKey: '11111111-1111-1111-1111-111111111111',
+      } as const;
+
+      const first = await createPortalSession(input, deps);
+      const second = await createPortalSession(input, deps);
+
+      expect(first).toEqual({
+        ok: true,
+        data: { url: 'https://stripe/portal' },
+      });
+      expect(second).toEqual(first);
+      expect(deps.createPortalSessionUseCase.inputs).toHaveLength(1);
+      expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
+    });
+
     it('does not cache RATE_LIMITED under the idempotency key', async () => {
       const rateLimiter = new FakeRateLimiter([
         {
@@ -388,6 +530,43 @@ describe('billing-controller', () => {
         ok: false,
         error: { code: 'NOT_FOUND', message: 'Stripe customer not found' },
       });
+    });
+
+    it('keeps genuine portal use-case ApplicationErrors cached when idempotencyKey is reused', async () => {
+      const deps = createDeps({
+        rateLimiter: new FakeRateLimiter([
+          {
+            success: true,
+            limit: 20,
+            remaining: 19,
+            retryAfterSeconds: 0,
+          },
+          {
+            success: false,
+            limit: 20,
+            remaining: 0,
+            retryAfterSeconds: 60,
+          },
+        ]),
+        portalThrows: new ApplicationError(
+          'NOT_FOUND',
+          'Stripe customer not found',
+        ),
+      });
+      const input = {
+        idempotencyKey: '11111111-1111-1111-1111-111111111111',
+      } as const;
+
+      const first = await createPortalSession(input, deps);
+      const second = await createPortalSession(input, deps);
+
+      expect(first).toEqual({
+        ok: false,
+        error: { code: 'NOT_FOUND', message: 'Stripe customer not found' },
+      });
+      expect(second).toEqual(first);
+      expect(deps.createPortalSessionUseCase.inputs).toHaveLength(1);
+      expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
     });
   });
 });

--- a/src/adapters/controllers/billing-controller.ts
+++ b/src/adapters/controllers/billing-controller.ts
@@ -108,17 +108,6 @@ export const createCheckoutSession = createAction({
     const user = await d.authGateway.requireUser();
     const { plan, idempotencyKey } = input;
 
-    const checkoutRateLimit = await d.rateLimiter.limit({
-      key: `billing:createCheckoutSession:${user.id}`,
-      ...CHECKOUT_SESSION_RATE_LIMIT,
-    });
-    if (!checkoutRateLimit.success) {
-      throw new ApplicationError(
-        'RATE_LIMITED',
-        `Too many checkout attempts. Try again in ${checkoutRateLimit.retryAfterSeconds}s.`,
-      );
-    }
-
     async function createNewSession(): Promise<CreateCheckoutSessionOutput> {
       const checkoutSessionInput = {
         userId: user.id,
@@ -136,12 +125,26 @@ export const createCheckoutSession = createAction({
       );
     }
 
+    async function enforceCheckoutRateLimit(): Promise<void> {
+      const checkoutRateLimit = await d.rateLimiter.limit({
+        key: `billing:createCheckoutSession:${user.id}`,
+        ...CHECKOUT_SESSION_RATE_LIMIT,
+      });
+      if (!checkoutRateLimit.success) {
+        throw new ApplicationError(
+          'RATE_LIMITED',
+          `Too many checkout attempts. Try again in ${checkoutRateLimit.retryAfterSeconds}s.`,
+        );
+      }
+    }
+
     return executeIdempotent({
       d,
       userId: user.id,
       action: 'billing:createCheckoutSession',
       idempotencyKey,
       outputSchema: CreateCheckoutSessionOutputSchema,
+      beforeExecute: enforceCheckoutRateLimit,
       execute: createNewSession,
     });
   },
@@ -153,17 +156,6 @@ export const createPortalSession = createAction({
   execute: async (input, d) => {
     const user = await d.authGateway.requireUser();
     const { idempotencyKey } = input;
-
-    const portalRateLimit = await d.rateLimiter.limit({
-      key: `billing:createPortalSession:${user.id}`,
-      ...PORTAL_SESSION_RATE_LIMIT,
-    });
-    if (!portalRateLimit.success) {
-      throw new ApplicationError(
-        'RATE_LIMITED',
-        `Too many billing portal attempts. Try again in ${portalRateLimit.retryAfterSeconds}s.`,
-      );
-    }
 
     async function createNewSession(): Promise<CreatePortalSessionOutput> {
       const portalSessionInput = {
@@ -180,12 +172,26 @@ export const createPortalSession = createAction({
       return CreatePortalSessionOutputSchema.parse(result);
     }
 
+    async function enforcePortalRateLimit(): Promise<void> {
+      const portalRateLimit = await d.rateLimiter.limit({
+        key: `billing:createPortalSession:${user.id}`,
+        ...PORTAL_SESSION_RATE_LIMIT,
+      });
+      if (!portalRateLimit.success) {
+        throw new ApplicationError(
+          'RATE_LIMITED',
+          `Too many billing portal attempts. Try again in ${portalRateLimit.retryAfterSeconds}s.`,
+        );
+      }
+    }
+
     return executeIdempotent({
       d,
       userId: user.id,
       action: 'billing:createPortalSession',
       idempotencyKey,
       outputSchema: CreatePortalSessionOutputSchema,
+      beforeExecute: enforcePortalRateLimit,
       execute: createNewSession,
     });
   },

--- a/src/adapters/controllers/bookmark-controller.test.ts
+++ b/src/adapters/controllers/bookmark-controller.test.ts
@@ -176,6 +176,38 @@ describe('bookmark-controller', () => {
       expect(deps.toggleBookmarkUseCase.inputs).toHaveLength(1);
     });
 
+    it('replays a cached bookmark toggle while the reused key is rate limited', async () => {
+      const deps = createDeps({
+        toggleBookmarkOutput: { bookmarked: true },
+        rateLimitResult: [
+          {
+            success: true,
+            limit: 60,
+            remaining: 59,
+            retryAfterSeconds: 0,
+          },
+          {
+            success: false,
+            limit: 60,
+            remaining: 0,
+            retryAfterSeconds: 60,
+          },
+        ],
+      });
+      const input = {
+        questionId: '11111111-1111-1111-1111-111111111111',
+        idempotencyKey: '22222222-2222-2222-2222-222222222222',
+      } as const;
+
+      const first = await toggleBookmark(input, deps);
+      const second = await toggleBookmark(input, deps);
+
+      expect(first).toEqual({ ok: true, data: { bookmarked: true } });
+      expect(second).toEqual(first);
+      expect(deps.toggleBookmarkUseCase.inputs).toHaveLength(1);
+      expect(deps.rateLimiter.inputs).toHaveLength(1);
+    });
+
     it('does not cache RATE_LIMITED under the idempotency key', async () => {
       const deps = createDeps({
         rateLimitResult: [
@@ -259,6 +291,20 @@ describe('bookmark-controller', () => {
 
     it('keeps genuine use-case ApplicationErrors cached when idempotencyKey is reused', async () => {
       const deps = createDeps({
+        rateLimitResult: [
+          {
+            success: true,
+            limit: 60,
+            remaining: 59,
+            retryAfterSeconds: 0,
+          },
+          {
+            success: false,
+            limit: 60,
+            remaining: 0,
+            retryAfterSeconds: 60,
+          },
+        ],
         toggleBookmarkThrows: new ApplicationError(
           'NOT_FOUND',
           'Question not found',
@@ -278,6 +324,7 @@ describe('bookmark-controller', () => {
       });
       expect(second).toEqual(first);
       expect(deps.toggleBookmarkUseCase.inputs).toHaveLength(1);
+      expect(deps.rateLimiter.inputs).toHaveLength(1);
     });
 
     it('returns ok when deps are loaded from the container', async () => {

--- a/src/adapters/controllers/bookmark-controller.ts
+++ b/src/adapters/controllers/bookmark-controller.ts
@@ -78,22 +78,24 @@ export const toggleBookmark = createAction({
 
     const { questionId, idempotencyKey } = input;
 
-    const rate = await d.rateLimiter.limit({
-      key: `bookmark:toggleBookmark:${userId}`,
-      ...BOOKMARK_MUTATION_RATE_LIMIT,
-    });
-    if (!rate.success) {
-      throw new ApplicationError(
-        'RATE_LIMITED',
-        `Too many bookmark changes. Try again in ${rate.retryAfterSeconds}s.`,
-      );
-    }
-
     async function toggle(): Promise<ToggleBookmarkOutput> {
       return d.toggleBookmarkUseCase.execute({
         userId,
         questionId,
       });
+    }
+
+    async function enforceBookmarkRateLimit(): Promise<void> {
+      const rate = await d.rateLimiter.limit({
+        key: `bookmark:toggleBookmark:${userId}`,
+        ...BOOKMARK_MUTATION_RATE_LIMIT,
+      });
+      if (!rate.success) {
+        throw new ApplicationError(
+          'RATE_LIMITED',
+          `Too many bookmark changes. Try again in ${rate.retryAfterSeconds}s.`,
+        );
+      }
     }
 
     return executeIdempotent({
@@ -102,6 +104,7 @@ export const toggleBookmark = createAction({
       action: 'bookmark:toggleBookmark',
       idempotencyKey,
       outputSchema: ToggleBookmarkOutputSchema,
+      beforeExecute: enforceBookmarkRateLimit,
       execute: toggle,
     });
   },

--- a/src/adapters/controllers/practice-controller-session-lifecycle.test.ts
+++ b/src/adapters/controllers/practice-controller-session-lifecycle.test.ts
@@ -147,8 +147,36 @@ describe('practice-controller', () => {
       expect(deps.startPracticeSessionUseCase.inputs).toHaveLength(1);
     });
 
+    it('replays a cached start while the reused key is rate limited', async () => {
+      const deps = createDeps({
+        rateLimiter: new FakeRateLimiter([
+          { success: true, limit: 20, remaining: 19, retryAfterSeconds: 0 },
+          { success: false, limit: 20, remaining: 0, retryAfterSeconds: 60 },
+        ]),
+      });
+      const input = {
+        mode: 'tutor',
+        count: 10,
+        tagSlugs: [],
+        difficulties: [],
+        idempotencyKey: '33333333-3333-3333-3333-333333333333',
+      } as const;
+
+      const first = await startPracticeSession(input, deps);
+      const second = await startPracticeSession(input, deps);
+
+      expect(first).toMatchObject({ ok: true });
+      expect(second).toEqual(first);
+      expect(deps.startPracticeSessionUseCase.inputs).toHaveLength(1);
+      expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
+    });
+
     it('keeps genuine use-case ApplicationErrors cached when idempotencyKey is reused', async () => {
       const deps = createDeps({
+        rateLimiter: new FakeRateLimiter([
+          { success: true, limit: 20, remaining: 19, retryAfterSeconds: 0 },
+          { success: false, limit: 20, remaining: 0, retryAfterSeconds: 60 },
+        ]),
         startThrows: new ApplicationError('NOT_FOUND', 'Question not found'),
       });
       const input = {
@@ -168,6 +196,7 @@ describe('practice-controller', () => {
       });
       expect(second).toEqual(first);
       expect(deps.startPracticeSessionUseCase.inputs).toHaveLength(1);
+      expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
     });
 
     it('returns sessionId when use case succeeds', async () => {
@@ -535,6 +564,75 @@ describe('practice-controller', () => {
       expect(first).toEqual({ ok: true, data: { discarded: true } });
       expect(second).toEqual(first);
       expect(deps.discardPracticeSessionUseCase.inputs).toHaveLength(1);
+    });
+
+    it('does not cache RATE_LIMITED under the discard idempotency key', async () => {
+      const deps = createDeps({
+        rateLimiter: new FakeRateLimiter([
+          { success: false, limit: 20, remaining: 0, retryAfterSeconds: 60 },
+          { success: true, limit: 20, remaining: 19, retryAfterSeconds: 0 },
+        ]),
+      });
+      const input = {
+        sessionId: '11111111-1111-1111-1111-111111111111',
+        idempotencyKey: '11111111-1111-1111-1111-111111111111',
+      } as const;
+
+      const first = await discardPracticeSession(input, deps);
+      expect(first).toMatchObject({
+        ok: false,
+        error: { code: 'RATE_LIMITED' },
+      });
+
+      const second = await discardPracticeSession(input, deps);
+      expect(second).toEqual({ ok: true, data: { discarded: true } });
+      expect(deps.discardPracticeSessionUseCase.inputs).toHaveLength(1);
+    });
+
+    it('replays a cached discard while the reused key is rate limited', async () => {
+      const deps = createDeps({
+        rateLimiter: new FakeRateLimiter([
+          { success: true, limit: 20, remaining: 19, retryAfterSeconds: 0 },
+          { success: false, limit: 20, remaining: 0, retryAfterSeconds: 60 },
+        ]),
+      });
+      const input = {
+        sessionId: '11111111-1111-1111-1111-111111111111',
+        idempotencyKey: '11111111-1111-1111-1111-111111111111',
+      } as const;
+
+      const first = await discardPracticeSession(input, deps);
+      const second = await discardPracticeSession(input, deps);
+
+      expect(first).toEqual({ ok: true, data: { discarded: true } });
+      expect(second).toEqual(first);
+      expect(deps.discardPracticeSessionUseCase.inputs).toHaveLength(1);
+      expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
+    });
+
+    it('keeps genuine discard use-case ApplicationErrors cached when idempotencyKey is reused', async () => {
+      const deps = createDeps({
+        rateLimiter: new FakeRateLimiter([
+          { success: true, limit: 20, remaining: 19, retryAfterSeconds: 0 },
+          { success: false, limit: 20, remaining: 0, retryAfterSeconds: 60 },
+        ]),
+        discardThrows: new ApplicationError('NOT_FOUND', 'Session not found'),
+      });
+      const input = {
+        sessionId: '11111111-1111-1111-1111-111111111111',
+        idempotencyKey: '11111111-1111-1111-1111-111111111111',
+      } as const;
+
+      const first = await discardPracticeSession(input, deps);
+      const second = await discardPracticeSession(input, deps);
+
+      expect(first).toEqual({
+        ok: false,
+        error: { code: 'NOT_FOUND', message: 'Session not found' },
+      });
+      expect(second).toEqual(first);
+      expect(deps.discardPracticeSessionUseCase.inputs).toHaveLength(1);
+      expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
     });
   });
 

--- a/src/adapters/controllers/practice-controller.ts
+++ b/src/adapters/controllers/practice-controller.ts
@@ -180,17 +180,6 @@ export const startPracticeSession = createAction({
     const { mode, count, tagSlugs, difficulties, statuses, idempotencyKey } =
       input;
 
-    const rate = await d.rateLimiter.limit({
-      key: `practice:startPracticeSession:${userId}`,
-      ...START_PRACTICE_SESSION_RATE_LIMIT,
-    });
-    if (!rate.success) {
-      throw new ApplicationError(
-        'RATE_LIMITED',
-        `Too many session starts. Try again in ${rate.retryAfterSeconds}s.`,
-      );
-    }
-
     async function createNewSession(): Promise<StartPracticeSessionOutput> {
       return d.startPracticeSessionUseCase.execute({
         userId,
@@ -202,12 +191,26 @@ export const startPracticeSession = createAction({
       });
     }
 
+    async function enforceStartRateLimit(): Promise<void> {
+      const rate = await d.rateLimiter.limit({
+        key: `practice:startPracticeSession:${userId}`,
+        ...START_PRACTICE_SESSION_RATE_LIMIT,
+      });
+      if (!rate.success) {
+        throw new ApplicationError(
+          'RATE_LIMITED',
+          `Too many session starts. Try again in ${rate.retryAfterSeconds}s.`,
+        );
+      }
+    }
+
     return executeIdempotent({
       d,
       userId,
       action: 'practice:startPracticeSession',
       idempotencyKey,
       outputSchema: StartPracticeSessionOutputSchema,
+      beforeExecute: enforceStartRateLimit,
       execute: createNewSession,
     });
   },
@@ -283,18 +286,20 @@ export const discardPracticeSession = createAction({
   execute: async (input, d, meta) => {
     const userId = await requireEntitledUserId(d, meta);
 
-    const rate = await d.rateLimiter.limit({
-      key: `practice:discardPracticeSession:${userId}`,
-      ...PRACTICE_SESSION_MUTATION_RATE_LIMIT,
-    });
-    if (!rate.success) {
-      throw new ApplicationError(
-        'RATE_LIMITED',
-        `Too many session mutations. Try again in ${rate.retryAfterSeconds}s.`,
-      );
-    }
-
     const { sessionId, idempotencyKey } = input;
+
+    async function enforceSessionMutationRateLimit(): Promise<void> {
+      const rate = await d.rateLimiter.limit({
+        key: `practice:discardPracticeSession:${userId}`,
+        ...PRACTICE_SESSION_MUTATION_RATE_LIMIT,
+      });
+      if (!rate.success) {
+        throw new ApplicationError(
+          'RATE_LIMITED',
+          `Too many session mutations. Try again in ${rate.retryAfterSeconds}s.`,
+        );
+      }
+    }
 
     return executeIdempotent({
       d,
@@ -302,6 +307,7 @@ export const discardPracticeSession = createAction({
       action: 'practice:discardPracticeSession',
       idempotencyKey,
       outputSchema: DiscardPracticeSessionOutputSchema,
+      beforeExecute: enforceSessionMutationRateLimit,
       execute: () =>
         d.discardPracticeSessionUseCase.execute({
           userId,

--- a/src/adapters/controllers/question-controller-submit-answer-idempotency.test.ts
+++ b/src/adapters/controllers/question-controller-submit-answer-idempotency.test.ts
@@ -114,8 +114,53 @@ describe('question-controller submitAnswer idempotency', () => {
     expect(deps.submitAnswerUseCase.inputs).toHaveLength(1);
   });
 
+  it('replays a cached submission while the reused key is rate limited', async () => {
+    const deps = createDeps({
+      rateLimiter: new FakeRateLimiter([
+        {
+          success: true,
+          limit: 120,
+          remaining: 119,
+          retryAfterSeconds: 0,
+        },
+        {
+          success: false,
+          limit: 120,
+          remaining: 0,
+          retryAfterSeconds: 60,
+        },
+      ]),
+    });
+    const input = { questionId, choiceId, idempotencyKey } as const;
+
+    const first = await submitAnswer(input, deps);
+    const second = await submitAnswer(input, deps);
+
+    expect(first).toMatchObject({
+      ok: true,
+      data: { attemptId: '44444444-4444-4444-4444-444444444444' },
+    });
+    expect(second).toEqual(first);
+    expect(deps.submitAnswerUseCase.inputs).toHaveLength(1);
+    expect(deps.rateLimiter.inputs).toHaveLength(1);
+  });
+
   it('keeps genuine use-case ApplicationErrors cached when idempotencyKey is reused', async () => {
     const deps = createDeps({
+      rateLimiter: new FakeRateLimiter([
+        {
+          success: true,
+          limit: 120,
+          remaining: 119,
+          retryAfterSeconds: 0,
+        },
+        {
+          success: false,
+          limit: 120,
+          remaining: 0,
+          retryAfterSeconds: 60,
+        },
+      ]),
       submitAnswerThrows: new ApplicationError(
         'NOT_FOUND',
         'Question not found',
@@ -132,5 +177,6 @@ describe('question-controller submitAnswer idempotency', () => {
     });
     expect(second).toEqual(first);
     expect(deps.submitAnswerUseCase.inputs).toHaveLength(1);
+    expect(deps.rateLimiter.inputs).toHaveLength(1);
   });
 });

--- a/src/adapters/controllers/question-controller.ts
+++ b/src/adapters/controllers/question-controller.ts
@@ -232,17 +232,6 @@ export const submitAnswer = createAction({
       timeSpentSeconds,
     } = input;
 
-    const rate = await d.rateLimiter.limit({
-      key: `question:submitAnswer:${userId}`,
-      ...SUBMIT_ANSWER_RATE_LIMIT,
-    });
-    if (!rate.success) {
-      throw new ApplicationError(
-        'RATE_LIMITED',
-        `Too many submissions. Try again in ${rate.retryAfterSeconds}s.`,
-      );
-    }
-
     async function submitOnce(): Promise<SubmitAnswerOutput> {
       return d.submitAnswerUseCase.execute({
         userId,
@@ -256,12 +245,26 @@ export const submitAnswer = createAction({
       });
     }
 
+    async function enforceSubmitAnswerRateLimit(): Promise<void> {
+      const rate = await d.rateLimiter.limit({
+        key: `question:submitAnswer:${userId}`,
+        ...SUBMIT_ANSWER_RATE_LIMIT,
+      });
+      if (!rate.success) {
+        throw new ApplicationError(
+          'RATE_LIMITED',
+          `Too many submissions. Try again in ${rate.retryAfterSeconds}s.`,
+        );
+      }
+    }
+
     return executeIdempotent({
       d,
       userId,
       action: 'question:submitAnswer',
       idempotencyKey,
       outputSchema: SubmitAnswerOutputSchema,
+      beforeExecute: enforceSubmitAnswerRateLimit,
       execute: submitOnce,
     });
   },

--- a/src/adapters/controllers/question-feedback-controller.test.ts
+++ b/src/adapters/controllers/question-feedback-controller.test.ts
@@ -194,7 +194,36 @@ describe('question-feedback-controller', () => {
       expect(first).toEqual({ ok: true, data: { rating: null } });
       expect(second).toEqual(first);
       expect(deps.rateQuestionUseCase.inputs).toHaveLength(1);
-      expect(deps.rateLimiter.inputs).toHaveLength(2);
+      expect(deps.rateLimiter.inputs).toHaveLength(1);
+    });
+
+    it('replays a cached rating while the reused key is rate limited', async () => {
+      const deps = createDeps({
+        rateQuestionOutput: { rating: 'helpful' },
+        rateLimitResult: [
+          {
+            success: true,
+            limit: 60,
+            remaining: 59,
+            retryAfterSeconds: 0,
+          },
+          {
+            success: false,
+            limit: 60,
+            remaining: 0,
+            retryAfterSeconds: 60,
+          },
+        ],
+      });
+      const input = { questionId, rating: 'helpful', idempotencyKey } as const;
+
+      const first = await rateQuestion(input, deps);
+      const second = await rateQuestion(input, deps);
+
+      expect(first).toEqual({ ok: true, data: { rating: 'helpful' } });
+      expect(second).toEqual(first);
+      expect(deps.rateQuestionUseCase.inputs).toHaveLength(1);
+      expect(deps.rateLimiter.inputs).toHaveLength(1);
     });
 
     it('does not cache RATE_LIMITED under the idempotency key', async () => {
@@ -277,6 +306,20 @@ describe('question-feedback-controller', () => {
 
     it('keeps genuine rate use-case ApplicationErrors cached when idempotencyKey is reused', async () => {
       const deps = createDeps({
+        rateLimitResult: [
+          {
+            success: true,
+            limit: 60,
+            remaining: 59,
+            retryAfterSeconds: 0,
+          },
+          {
+            success: false,
+            limit: 60,
+            remaining: 0,
+            retryAfterSeconds: 60,
+          },
+        ],
         rateQuestionThrows: new ApplicationError(
           'NOT_FOUND',
           'Question not found',
@@ -293,6 +336,7 @@ describe('question-feedback-controller', () => {
       });
       expect(second).toEqual(first);
       expect(deps.rateQuestionUseCase.inputs).toHaveLength(1);
+      expect(deps.rateLimiter.inputs).toHaveLength(1);
     });
 
     it('returns ok when deps are loaded from the container', async () => {
@@ -431,7 +475,41 @@ describe('question-feedback-controller', () => {
       expect(first).toEqual({ ok: true, data: { feedbackId } });
       expect(second).toEqual(first);
       expect(deps.submitQuestionReportUseCase.inputs).toHaveLength(1);
-      expect(deps.rateLimiter.inputs).toHaveLength(2);
+      expect(deps.rateLimiter.inputs).toHaveLength(1);
+    });
+
+    it('replays a cached report while the reused key is rate limited', async () => {
+      const deps = createDeps({
+        submitQuestionReportOutput: { feedbackId },
+        rateLimitResult: [
+          {
+            success: true,
+            limit: 10,
+            remaining: 9,
+            retryAfterSeconds: 0,
+          },
+          {
+            success: false,
+            limit: 10,
+            remaining: 0,
+            retryAfterSeconds: 60,
+          },
+        ],
+      });
+      const input = {
+        questionId,
+        category: 'other',
+        comment: 'Looks stale.',
+        idempotencyKey,
+      } as const;
+
+      const first = await submitQuestionReport(input, deps);
+      const second = await submitQuestionReport(input, deps);
+
+      expect(first).toEqual({ ok: true, data: { feedbackId } });
+      expect(second).toEqual(first);
+      expect(deps.submitQuestionReportUseCase.inputs).toHaveLength(1);
+      expect(deps.rateLimiter.inputs).toHaveLength(1);
     });
 
     it('does not cache RATE_LIMITED under the idempotency key', async () => {
@@ -500,6 +578,20 @@ describe('question-feedback-controller', () => {
 
     it('keeps genuine report use-case ApplicationErrors cached when idempotencyKey is reused', async () => {
       const deps = createDeps({
+        rateLimitResult: [
+          {
+            success: true,
+            limit: 10,
+            remaining: 9,
+            retryAfterSeconds: 0,
+          },
+          {
+            success: false,
+            limit: 10,
+            remaining: 0,
+            retryAfterSeconds: 60,
+          },
+        ],
         submitQuestionReportThrows: new ApplicationError(
           'NOT_FOUND',
           'Question not found',
@@ -520,6 +612,7 @@ describe('question-feedback-controller', () => {
       });
       expect(second).toEqual(first);
       expect(deps.submitQuestionReportUseCase.inputs).toHaveLength(1);
+      expect(deps.rateLimiter.inputs).toHaveLength(1);
     });
   });
 });

--- a/src/adapters/controllers/question-feedback-controller.ts
+++ b/src/adapters/controllers/question-feedback-controller.ts
@@ -128,17 +128,6 @@ export const rateQuestion = createAction({
     const userId = await requireEntitledUserId(d, meta);
     const { idempotencyKey } = input;
 
-    const rateLimit = await d.rateLimiter.limit({
-      key: `question-feedback:rateQuestion:${userId}`,
-      ...QUESTION_RATING_RATE_LIMIT,
-    });
-    if (!rateLimit.success) {
-      throw new ApplicationError(
-        'RATE_LIMITED',
-        `Too many question ratings. Try again in ${rateLimit.retryAfterSeconds}s.`,
-      );
-    }
-
     async function rate(): Promise<RateQuestionOutput> {
       return d.rateQuestionUseCase.execute({
         userId,
@@ -149,12 +138,26 @@ export const rateQuestion = createAction({
       });
     }
 
+    async function enforceRatingRateLimit(): Promise<void> {
+      const rateLimit = await d.rateLimiter.limit({
+        key: `question-feedback:rateQuestion:${userId}`,
+        ...QUESTION_RATING_RATE_LIMIT,
+      });
+      if (!rateLimit.success) {
+        throw new ApplicationError(
+          'RATE_LIMITED',
+          `Too many question ratings. Try again in ${rateLimit.retryAfterSeconds}s.`,
+        );
+      }
+    }
+
     return executeIdempotent({
       d,
       userId,
       action: 'question-feedback:rateQuestion',
       idempotencyKey,
       outputSchema: RateQuestionOutputSchema,
+      beforeExecute: enforceRatingRateLimit,
       execute: rate,
     });
   },
@@ -180,17 +183,6 @@ export const submitQuestionReport = createAction({
     const userId = await requireEntitledUserId(d, meta);
     const { idempotencyKey } = input;
 
-    const rateLimit = await d.rateLimiter.limit({
-      key: `question-feedback:submitQuestionReport:${userId}`,
-      ...QUESTION_REPORT_RATE_LIMIT,
-    });
-    if (!rateLimit.success) {
-      throw new ApplicationError(
-        'RATE_LIMITED',
-        `Too many question reports. Try again in ${rateLimit.retryAfterSeconds}s.`,
-      );
-    }
-
     async function submit(): Promise<SubmitQuestionReportOutput> {
       return d.submitQuestionReportUseCase.execute({
         userId,
@@ -202,12 +194,26 @@ export const submitQuestionReport = createAction({
       });
     }
 
+    async function enforceReportRateLimit(): Promise<void> {
+      const rateLimit = await d.rateLimiter.limit({
+        key: `question-feedback:submitQuestionReport:${userId}`,
+        ...QUESTION_REPORT_RATE_LIMIT,
+      });
+      if (!rateLimit.success) {
+        throw new ApplicationError(
+          'RATE_LIMITED',
+          `Too many question reports. Try again in ${rateLimit.retryAfterSeconds}s.`,
+        );
+      }
+    }
+
     return executeIdempotent({
       d,
       userId,
       action: 'question-feedback:submitQuestionReport',
       idempotencyKey,
       outputSchema: SubmitQuestionReportOutputSchema,
+      beforeExecute: enforceReportRateLimit,
       execute: submit,
     });
   },

--- a/src/adapters/controllers/shared/execute-idempotent.test.ts
+++ b/src/adapters/controllers/shared/execute-idempotent.test.ts
@@ -57,6 +57,7 @@ function createDeps() {
 describe('executeIdempotent', () => {
   it('calls execute directly and never touches the repo when idempotencyKey is null', async () => {
     const deps = createDeps();
+    const beforeExecute = vi.fn().mockResolvedValue(undefined);
     const execute = vi.fn().mockResolvedValue({ value: 1 });
     const schema = z.object({ value: z.number() });
     const userId = crypto.randomUUID();
@@ -67,12 +68,39 @@ describe('executeIdempotent', () => {
       idempotencyKey: null,
       action: 'practice:test',
       outputSchema: schema,
+      beforeExecute,
       execute,
     });
 
     expect(result).toEqual({ value: 1 });
+    expect(beforeExecute).toHaveBeenCalledTimes(1);
     expect(execute).toHaveBeenCalledTimes(1);
     expect(deps.idempotencyKeyRepository.calls).toEqual([]);
+  });
+
+  it('does not run beforeExecute when a keyed request replays a cached result', async () => {
+    const deps = createDeps();
+    const beforeExecute = vi.fn().mockResolvedValue(undefined);
+    const execute = vi.fn().mockResolvedValue({ value: 100 });
+    const schema = z.object({ value: z.number() });
+    const userId = crypto.randomUUID();
+    const args = {
+      d: deps,
+      userId,
+      idempotencyKey: '22222222-2222-2222-2222-222222222223',
+      action: 'practice:test',
+      outputSchema: schema,
+      beforeExecute,
+      execute,
+    };
+
+    const first = await executeIdempotent(args);
+    const second = await executeIdempotent(args);
+
+    expect(first).toEqual({ value: 100 });
+    expect(second).toEqual({ value: 100 });
+    expect(beforeExecute).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledTimes(1);
   });
 
   it('calls execute directly when idempotencyKey is undefined', async () => {
@@ -179,11 +207,18 @@ describe('executeIdempotent', () => {
       execute,
     };
 
-    await executeIdempotent(args);
+    const claimedAt = await deps.idempotencyKeyRepository.claim({
+      userId: args.userId,
+      action: args.action,
+      key: args.idempotencyKey,
+      expiresAt: new Date('2026-04-28T12:00:00.000Z'),
+    });
+    if (!claimedAt) throw new Error('Expected idempotency claim');
     await deps.idempotencyKeyRepository.storeResult({
       userId: args.userId,
       action: args.action,
       key: args.idempotencyKey,
+      claimedAt,
       resultJson: { value: 'not-a-number' },
     });
 
@@ -191,6 +226,6 @@ describe('executeIdempotent', () => {
       code: 'INTERNAL_ERROR',
       message: 'Cached idempotency result is invalid',
     });
-    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute).not.toHaveBeenCalled();
   });
 });

--- a/src/adapters/controllers/shared/execute-idempotent.ts
+++ b/src/adapters/controllers/shared/execute-idempotent.ts
@@ -23,6 +23,7 @@ export async function executeIdempotent<TOutput>({
   idempotencyKey,
   action,
   outputSchema,
+  beforeExecute,
   execute,
 }: {
   d: IdempotentControllerDeps;
@@ -30,9 +31,13 @@ export async function executeIdempotent<TOutput>({
   idempotencyKey: string | null | undefined;
   action: string;
   outputSchema: ZodType<TOutput, unknown>;
+  beforeExecute?: () => Promise<void>;
   execute: () => Promise<TOutput>;
 }): Promise<TOutput> {
-  if (!idempotencyKey) return execute();
+  if (!idempotencyKey) {
+    await beforeExecute?.();
+    return execute();
+  }
 
   return withIdempotency({
     repo: d.idempotencyKeyRepository,
@@ -42,6 +47,7 @@ export async function executeIdempotent<TOutput>({
     key: idempotencyKey,
     now: d.now,
     parseResult: (value) => outputSchema.parse(value),
+    ...(beforeExecute ? { beforeExecute } : {}),
     execute,
   });
 }

--- a/src/adapters/repositories/drizzle-idempotency-key-repository.test.ts
+++ b/src/adapters/repositories/drizzle-idempotency-key-repository.test.ts
@@ -39,8 +39,9 @@ function collectColumnNamesForTable(
 
 describe('DrizzleIdempotencyKeyRepository', () => {
   describe('claim', () => {
-    it('returns true when insert succeeds', async () => {
-      const insertReturning = vi.fn(async () => [{ key: 'idem-1' }]);
+    it('returns the claimedAt token when insert succeeds', async () => {
+      const now = new Date('2026-02-08T00:00:00.000Z');
+      const insertReturning = vi.fn(async () => [{ claimedAt: now }]);
       const insertOnConflictDoNothing = vi.fn(() => ({
         returning: insertReturning,
       }));
@@ -56,7 +57,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
         update,
       } as unknown as RepoDb;
 
-      const repo = new DrizzleIdempotencyKeyRepository(db);
+      const repo = new DrizzleIdempotencyKeyRepository(db, () => now);
 
       await expect(
         repo.claim({
@@ -65,7 +66,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
           key: 'idem-1',
           expiresAt: new Date('2026-02-08T01:00:00.000Z'),
         }),
-      ).resolves.toBe(true);
+      ).resolves.toEqual(now);
 
       expect(update).not.toHaveBeenCalled();
       expect(insertValues).toHaveBeenCalledWith(
@@ -75,7 +76,8 @@ describe('DrizzleIdempotencyKeyRepository', () => {
       );
     });
 
-    it('returns true when an expired key is reclaimed', async () => {
+    it('returns the claimedAt token when an expired key is reclaimed', async () => {
+      const now = new Date('2026-02-08T00:00:00.000Z');
       const insertReturning = vi.fn(async () => []);
       const insertOnConflictDoNothing = vi.fn(() => ({
         returning: insertReturning,
@@ -85,7 +87,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
       }));
       const insert = vi.fn(() => ({ values: insertValues }));
 
-      const updateReturning = vi.fn(async () => [{ key: 'idem-1' }]);
+      const updateReturning = vi.fn(async () => [{ claimedAt: now }]);
       const updateWhere = vi.fn(() => ({ returning: updateReturning }));
       const updateSet = vi.fn(() => ({ where: updateWhere }));
       const update = vi.fn(() => ({ set: updateSet }));
@@ -95,10 +97,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
         update,
       } as unknown as RepoDb;
 
-      const repo = new DrizzleIdempotencyKeyRepository(
-        db,
-        () => new Date('2026-02-08T00:00:00.000Z'),
-      );
+      const repo = new DrizzleIdempotencyKeyRepository(db, () => now);
 
       await expect(
         repo.claim({
@@ -107,7 +106,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
           key: 'idem-1',
           expiresAt: new Date('2026-02-08T01:00:00.000Z'),
         }),
-      ).resolves.toBe(true);
+      ).resolves.toEqual(now);
       expect(update).toHaveBeenCalledTimes(1);
       expect(updateSet).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -116,7 +115,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
       );
     });
 
-    it('returns true when a zombie key is reclaimed after the threshold', async () => {
+    it('returns the claimedAt token when a zombie key is reclaimed after the threshold', async () => {
       const insertReturning = vi.fn(async () => []);
       const insertOnConflictDoNothing = vi.fn(() => ({
         returning: insertReturning,
@@ -126,7 +125,8 @@ describe('DrizzleIdempotencyKeyRepository', () => {
       }));
       const insert = vi.fn(() => ({ values: insertValues }));
 
-      const updateReturning = vi.fn(async () => [{ key: 'idem-1' }]);
+      const now = new Date('2026-02-08T00:02:00.000Z');
+      const updateReturning = vi.fn(async () => [{ claimedAt: now }]);
       const updateWhere = vi.fn(() => ({ returning: updateReturning }));
       const updateSet = vi.fn(() => ({ where: updateWhere }));
       const update = vi.fn(() => ({ set: updateSet }));
@@ -136,7 +136,6 @@ describe('DrizzleIdempotencyKeyRepository', () => {
         update,
       } as unknown as RepoDb;
 
-      const now = new Date('2026-02-08T00:02:00.000Z');
       const repo = new DrizzleIdempotencyKeyRepository(db, () => now);
 
       await expect(
@@ -147,7 +146,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
           expiresAt: new Date('2026-02-08T01:00:00.000Z'),
           zombieThresholdMs: 60_000,
         }),
-      ).resolves.toBe(true);
+      ).resolves.toEqual(now);
 
       expect(update).toHaveBeenCalledTimes(1);
       expect(updateSet).toHaveBeenCalledWith(
@@ -168,7 +167,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
       expect(idempotencyColumns).toContain('error_code');
     });
 
-    it('returns false when existing key is still active', async () => {
+    it('returns null when existing key is still active', async () => {
       const insertReturning = vi.fn(async () => []);
       const insertOnConflictDoNothing = vi.fn(() => ({
         returning: insertReturning,
@@ -197,7 +196,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
           key: 'idem-1',
           expiresAt: new Date('2026-02-08T01:00:00.000Z'),
         }),
-      ).resolves.toBe(false);
+      ).resolves.toBeNull();
     });
   });
 
@@ -348,6 +347,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
           userId: '11111111-1111-1111-1111-111111111111',
           action: 'question:submitAnswer',
           key: 'idem-1',
+          claimedAt: new Date('2026-02-08T00:00:00.000Z'),
           resultJson: { ok: true },
         }),
       ).resolves.toBeUndefined();
@@ -370,6 +370,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
         userId: '11111111-1111-1111-1111-111111111111',
         action: 'question:submitAnswer',
         key: 'idem-1',
+        claimedAt: now,
         resultJson: null,
       });
 
@@ -400,6 +401,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
           userId: '11111111-1111-1111-1111-111111111111',
           action: 'question:submitAnswer',
           key: 'idem-1',
+          claimedAt: new Date('2026-02-08T00:00:00.000Z'),
           resultJson: { ok: true },
         }),
       ).rejects.toEqual(
@@ -426,6 +428,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
           userId: '11111111-1111-1111-1111-111111111111',
           action: 'question:submitAnswer',
           key: 'idem-1',
+          claimedAt: new Date('2026-02-08T00:00:00.000Z'),
           error: {
             code: 'INTERNAL_ERROR',
             message: 'unexpected failure',
@@ -451,6 +454,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
         userId: '11111111-1111-1111-1111-111111111111',
         action: 'question:submitAnswer',
         key: 'idem-1',
+        claimedAt: now,
         error: {
           code: 'INTERNAL_ERROR',
           message: 'unexpected failure',
@@ -484,6 +488,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
           userId: '11111111-1111-1111-1111-111111111111',
           action: 'question:submitAnswer',
           key: 'idem-1',
+          claimedAt: new Date('2026-02-08T00:00:00.000Z'),
           error: {
             code: 'INTERNAL_ERROR',
             message: 'unexpected failure',

--- a/src/adapters/repositories/drizzle-idempotency-key-repository.ts
+++ b/src/adapters/repositories/drizzle-idempotency-key-repository.ts
@@ -25,7 +25,7 @@ export class DrizzleIdempotencyKeyRepository
     key: string;
     expiresAt: Date;
     zombieThresholdMs?: number;
-  }): Promise<boolean> {
+  }): Promise<Date | null> {
     const now = this.now();
     const zombieThresholdMs =
       typeof input.zombieThresholdMs === 'number' &&
@@ -55,9 +55,9 @@ export class DrizzleIdempotencyKeyRepository
           idempotencyKeys.key,
         ],
       })
-      .returning({ key: idempotencyKeys.key });
+      .returning({ claimedAt: idempotencyKeys.claimedAt });
 
-    if (row) return true;
+    if (row) return row.claimedAt;
 
     const [updated] = await this.db
       .update(idempotencyKeys)
@@ -84,9 +84,9 @@ export class DrizzleIdempotencyKeyRepository
           ),
         ),
       )
-      .returning({ key: idempotencyKeys.key });
+      .returning({ claimedAt: idempotencyKeys.claimedAt });
 
-    return !!updated;
+    return updated?.claimedAt ?? null;
   }
 
   async find(
@@ -134,6 +134,7 @@ export class DrizzleIdempotencyKeyRepository
     userId: string;
     action: string;
     key: string;
+    claimedAt: Date;
     resultJson: unknown;
   }): Promise<void> {
     const [updated] = await this.db
@@ -149,6 +150,8 @@ export class DrizzleIdempotencyKeyRepository
           eq(idempotencyKeys.userId, input.userId),
           eq(idempotencyKeys.action, input.action),
           eq(idempotencyKeys.key, input.key),
+          eq(idempotencyKeys.claimedAt, input.claimedAt),
+          isNull(idempotencyKeys.completedAt),
         ),
       )
       .returning({ key: idempotencyKeys.key });
@@ -162,6 +165,7 @@ export class DrizzleIdempotencyKeyRepository
     userId: string;
     action: string;
     key: string;
+    claimedAt: Date;
     error: { code: ApplicationErrorCode; message: string };
   }): Promise<void> {
     const [updated] = await this.db
@@ -177,6 +181,8 @@ export class DrizzleIdempotencyKeyRepository
           eq(idempotencyKeys.userId, input.userId),
           eq(idempotencyKeys.action, input.action),
           eq(idempotencyKeys.key, input.key),
+          eq(idempotencyKeys.claimedAt, input.claimedAt),
+          isNull(idempotencyKeys.completedAt),
         ),
       )
       .returning({ key: idempotencyKeys.key });
@@ -184,6 +190,26 @@ export class DrizzleIdempotencyKeyRepository
     if (!updated) {
       throw new ApplicationError('NOT_FOUND', 'Idempotency key not found');
     }
+  }
+
+  async abortClaim(
+    userId: string,
+    action: string,
+    key: string,
+    claimedAt: Date,
+  ): Promise<void> {
+    await this.db
+      .delete(idempotencyKeys)
+      .where(
+        and(
+          eq(idempotencyKeys.userId, userId),
+          eq(idempotencyKeys.action, action),
+          eq(idempotencyKeys.key, key),
+          eq(idempotencyKeys.claimedAt, claimedAt),
+          isNull(idempotencyKeys.completedAt),
+          isNull(idempotencyKeys.errorCode),
+        ),
+      );
   }
 
   async pruneExpiredBefore(cutoff: Date, limit: number): Promise<number> {

--- a/src/adapters/shared/with-idempotency-abort-claim.test.ts
+++ b/src/adapters/shared/with-idempotency-abort-claim.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ApplicationError } from '@/src/application/errors';
+import {
+  FakeIdempotencyKeyRepository,
+  FakeLogger,
+} from '@/src/application/test-helpers/fakes';
+import { withIdempotency } from './with-idempotency';
+
+describe('withIdempotency abortClaim race safety', () => {
+  it('stores non-Error failures as INTERNAL_ERROR records for replay', async () => {
+    const appUserId = crypto.randomUUID();
+    const now = () => new Date('2026-02-07T00:00:00.000Z');
+    const repo = new FakeIdempotencyKeyRepository(now);
+    const logger = new FakeLogger();
+    const key = '11111111-1111-1111-1111-111111111118';
+    const execute = vi.fn(async () => {
+      throw 'plain failure';
+    });
+    const input = {
+      repo,
+      userId: appUserId,
+      action: 'billing:createCheckoutSession',
+      key,
+      now,
+      logger,
+      execute,
+    } as const;
+
+    await expect(withIdempotency(input)).rejects.toBe('plain failure');
+    await expect(withIdempotency(input)).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message: 'plain failure',
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs abort failures without masking the original beforeExecute error', async () => {
+    class AbortFailingRepo extends FakeIdempotencyKeyRepository {
+      override async abortClaim(): Promise<void> {
+        throw new Error('abort failed');
+      }
+    }
+
+    const appUserId = crypto.randomUUID();
+    const now = () => new Date('2026-02-07T00:00:00.000Z');
+    const repo = new AbortFailingRepo(now);
+    const logger = new FakeLogger();
+    const key = '11111111-1111-1111-1111-111111111119';
+    const rateLimitError = new ApplicationError(
+      'RATE_LIMITED',
+      'Too many requests',
+    );
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key,
+        now,
+        logger,
+        beforeExecute: async () => {
+          throw rateLimitError;
+        },
+        execute: async () => ({ ok: true }),
+      }),
+    ).rejects.toBe(rateLimitError);
+
+    expect(logger.errorCalls).toHaveLength(1);
+    expect(logger.errorCalls[0]).toMatchObject({
+      msg: 'Failed to abort idempotency claim after beforeExecute failure',
+      context: {
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key,
+        abortError: 'abort failed',
+        originalError: 'Too many requests',
+      },
+    });
+  });
+
+  it('skips beforeExecute for cached error replays', async () => {
+    const appUserId = crypto.randomUUID();
+    const now = () => new Date('2026-02-07T00:00:00.000Z');
+    const repo = new FakeIdempotencyKeyRepository(now);
+    const logger = new FakeLogger();
+    const key = '11111111-1111-1111-1111-111111111115';
+
+    const claimedAt = await repo.claim({
+      userId: appUserId,
+      action: 'billing:createCheckoutSession',
+      key,
+      expiresAt: new Date('2026-02-08T00:00:00.000Z'),
+    });
+    if (!claimedAt) throw new Error('Expected cached error claim');
+    await repo.storeError({
+      userId: appUserId,
+      action: 'billing:createCheckoutSession',
+      key,
+      claimedAt,
+      error: { code: 'NOT_FOUND', message: 'Missing customer' },
+    });
+
+    const beforeExecute = vi.fn(async () => {
+      throw new ApplicationError('RATE_LIMITED', 'Too many requests');
+    });
+    const execute = vi.fn(async () => ({ ok: true }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key,
+        now,
+        logger,
+        beforeExecute,
+        execute,
+      }),
+    ).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'Missing customer',
+    });
+
+    expect(beforeExecute).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('does not abort a newer reclaimed row after a stale beforeExecute failure', async () => {
+    const appUserId = crypto.randomUUID();
+    const clock = { now: new Date('2026-02-07T00:00:00.000Z') };
+    const now = () => clock.now;
+    const repo = new FakeIdempotencyKeyRepository(now);
+    const logger = new FakeLogger();
+    const key = '11111111-1111-1111-1111-111111111116';
+    const rateLimitError = new ApplicationError(
+      'RATE_LIMITED',
+      'Too many requests',
+    );
+    const beforeExecute = vi.fn(async () => {
+      clock.now = new Date('2026-02-07T00:01:01.000Z');
+      await repo.claim({
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key,
+        expiresAt: new Date('2026-02-08T00:01:01.000Z'),
+        zombieThresholdMs: 60_000,
+      });
+      throw rateLimitError;
+    });
+    const execute = vi.fn(async () => ({ ok: true }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key,
+        now,
+        logger,
+        zombieThresholdMs: 60_000,
+        beforeExecute,
+        execute,
+      }),
+    ).rejects.toBe(rateLimitError);
+
+    await expect(
+      repo.find(appUserId, 'billing:createCheckoutSession', key),
+    ).resolves.toEqual({
+      resultJson: null,
+      error: null,
+      completedAt: null,
+      expiresAt: new Date('2026-02-08T00:01:01.000Z'),
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('does not let a stale execution store over a newer reclaimed result', async () => {
+    const appUserId = crypto.randomUUID();
+    const clock = { now: new Date('2026-02-07T00:00:00.000Z') };
+    const now = () => clock.now;
+    const repo = new FakeIdempotencyKeyRepository(now);
+    const logger = new FakeLogger();
+    const key = '11111111-1111-1111-1111-111111111117';
+    let releaseStaleExecution: (() => void) | undefined;
+    const staleExecutionReleased = new Promise<void>((resolve) => {
+      releaseStaleExecution = resolve;
+    });
+    let markStaleExecutionStarted: (() => void) | undefined;
+    const staleExecutionStarted = new Promise<void>((resolve) => {
+      markStaleExecutionStarted = resolve;
+    });
+
+    const execute = vi.fn(async () => {
+      if (execute.mock.calls.length === 1) {
+        markStaleExecutionStarted?.();
+        await staleExecutionReleased;
+        return { source: 'stale' };
+      }
+
+      return { source: 'newer' };
+    });
+    const base = {
+      repo,
+      userId: appUserId,
+      action: 'billing:createCheckoutSession',
+      key,
+      now,
+      logger,
+      zombieThresholdMs: 60_000,
+      execute,
+    } as const;
+
+    const stale = withIdempotency(base);
+    await staleExecutionStarted;
+
+    clock.now = new Date('2026-02-07T00:01:01.000Z');
+    await expect(withIdempotency(base)).resolves.toEqual({ source: 'newer' });
+
+    if (!releaseStaleExecution) {
+      throw new Error('Expected stale execution release hook');
+    }
+    releaseStaleExecution();
+    await expect(stale).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    await expect(withIdempotency(base)).resolves.toEqual({ source: 'newer' });
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/adapters/shared/with-idempotency.test.ts
+++ b/src/adapters/shared/with-idempotency.test.ts
@@ -30,6 +30,66 @@ describe('withIdempotency', () => {
     expect(execute).toHaveBeenCalledTimes(1);
   });
 
+  it('runs beforeExecute only for the fresh claim and skips it for cached result replays', async () => {
+    const now = () => new Date();
+    const repo = new FakeIdempotencyKeyRepository(now);
+    const logger = new FakeLogger();
+    const beforeExecute = vi.fn(async () => undefined);
+    const execute = vi.fn(async () => ({ ok: true }));
+
+    const input = {
+      repo,
+      userId: appUserId,
+      action: 'billing:createCheckoutSession',
+      key: '11111111-1111-1111-1111-111111111113',
+      now,
+      logger,
+      beforeExecute,
+      execute,
+    } as const;
+
+    await expect(withIdempotency(input)).resolves.toEqual({ ok: true });
+    await expect(withIdempotency(input)).resolves.toEqual({ ok: true });
+    expect(beforeExecute).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the fresh claim and does not cache errors thrown by beforeExecute', async () => {
+    const now = () => new Date();
+    const repo = new FakeIdempotencyKeyRepository(now);
+    const logger = new FakeLogger();
+    const key = '11111111-1111-1111-1111-111111111114';
+    const rateLimitError = new ApplicationError(
+      'RATE_LIMITED',
+      'Too many requests',
+    );
+    const beforeExecute = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce(undefined);
+    const execute = vi.fn(async () => ({ ok: true }));
+
+    const input = {
+      repo,
+      userId: appUserId,
+      action: 'billing:createCheckoutSession',
+      key,
+      now,
+      logger,
+      beforeExecute,
+      execute,
+    } as const;
+
+    await expect(withIdempotency(input)).rejects.toBe(rateLimitError);
+    await expect(
+      repo.find(appUserId, 'billing:createCheckoutSession', key),
+    ).resolves.toBeNull();
+
+    await expect(withIdempotency(input)).resolves.toEqual({ ok: true });
+    expect(beforeExecute).toHaveBeenCalledTimes(2);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
   it('parses cached results when parseResult is provided', async () => {
     const now = () => new Date();
     const repo = new FakeIdempotencyKeyRepository(now);
@@ -150,17 +210,19 @@ describe('withIdempotency', () => {
     const logger = new FakeLogger();
     const key = '22222222-2222-2222-2222-222222222223';
 
-    await repo.claim({
+    const claimedAt = await repo.claim({
       userId: appUserId,
       action: 'question:submitAnswer',
       key,
       expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
     });
+    if (!claimedAt) throw new Error('Expected cached null claim');
 
     await repo.storeResult({
       userId: appUserId,
       action: 'question:submitAnswer',
       key,
+      claimedAt,
       resultJson: null,
     });
 
@@ -186,16 +248,18 @@ describe('withIdempotency', () => {
     const logger = new FakeLogger();
     const key = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 
-    await repo.claim({
+    const claimedAt = await repo.claim({
       userId: appUserId,
       action: 'question:submitAnswer',
       key,
       expiresAt: new Date('2026-02-08T00:00:00.000Z'),
     });
+    if (!claimedAt) throw new Error('Expected cached null claim');
     await repo.storeResult({
       userId: appUserId,
       action: 'question:submitAnswer',
       key,
+      claimedAt,
       resultJson: null,
     });
 
@@ -225,16 +289,18 @@ describe('withIdempotency', () => {
     const logger = new FakeLogger();
     const key = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
 
-    await repo.claim({
+    const claimedAt = await repo.claim({
       userId: appUserId,
       action: 'question:submitAnswer',
       key,
       expiresAt: new Date('2026-02-08T00:00:00.000Z'),
     });
+    if (!claimedAt) throw new Error('Expected cached null claim');
     await repo.storeResult({
       userId: appUserId,
       action: 'question:submitAnswer',
       key,
+      claimedAt,
       resultJson: null,
     });
 
@@ -396,45 +462,61 @@ describe('withIdempotency', () => {
     expect(execute).toHaveBeenCalledTimes(1);
   });
 
-  it('throws INTERNAL_ERROR when key disappears during polling', async () => {
-    class DisappearingFindRepo extends FakeIdempotencyKeyRepository {
-      override async find(): Promise<null> {
-        return null;
-      }
-    }
-
+  it('restarts when a concurrent waiter observes a beforeExecute-aborted claim', async () => {
     const now = () => new Date('2026-02-07T00:00:00.000Z');
-    const repo = new DisappearingFindRepo(now);
+    const repo = new FakeIdempotencyKeyRepository(now);
     const logger = new FakeLogger();
     const key = '44444444-4444-4444-4444-444444444445';
+    const rateLimitError = new ApplicationError(
+      'RATE_LIMITED',
+      'Too many requests',
+    );
 
-    await repo.claim({
+    let markHookStarted: (() => void) | undefined;
+    const hookStarted = new Promise<void>((resolve) => {
+      markHookStarted = resolve;
+    });
+
+    let releaseHook: (() => void) | undefined;
+    const release = new Promise<void>((resolve) => {
+      releaseHook = resolve;
+    });
+
+    const beforeExecute = vi.fn(async () => {
+      if (beforeExecute.mock.calls.length === 1) {
+        markHookStarted?.();
+        await release;
+        throw rateLimitError;
+      }
+    });
+    const execute = vi.fn(async () => ({ ok: true }));
+
+    const input = {
+      repo,
       userId: appUserId,
       action: 'billing:createCheckoutSession',
       key,
-      expiresAt: new Date('2026-02-08T00:00:00.000Z'),
-    });
+      now,
+      logger,
+      maxWaitMs: 100,
+      pollIntervalMs: 1,
+      beforeExecute,
+      execute,
+    } as const;
 
-    const execute = vi.fn(async () => ({ ok: true }));
+    const first = withIdempotency(input);
+    await hookStarted;
+    const second = withIdempotency(input);
 
-    await expect(
-      withIdempotency({
-        repo,
-        userId: appUserId,
-        action: 'billing:createCheckoutSession',
-        key,
-        now,
-        logger,
-        maxWaitMs: 100,
-        pollIntervalMs: 1,
-        execute,
-      }),
-    ).rejects.toMatchObject({
-      code: 'INTERNAL_ERROR',
-      message: 'Idempotency key disappeared during poll',
-    });
+    if (!releaseHook) {
+      throw new Error('Expected beforeExecute to initialize release hook');
+    }
+    releaseHook();
 
-    expect(execute).not.toHaveBeenCalled();
+    await expect(first).rejects.toBe(rateLimitError);
+    await expect(second).resolves.toEqual({ ok: true });
+    expect(beforeExecute).toHaveBeenCalledTimes(2);
+    expect(execute).toHaveBeenCalledTimes(1);
   });
 
   it('prunes expired idempotency keys before processing requests', async () => {

--- a/src/adapters/shared/with-idempotency.ts
+++ b/src/adapters/shared/with-idempotency.ts
@@ -50,6 +50,7 @@ export async function withIdempotency<T>(input: {
   pollIntervalMs?: number;
   zombieThresholdMs?: number;
   parseResult?: (value: unknown) => T;
+  beforeExecute?: () => Promise<void>;
   execute: () => Promise<T>;
 }): Promise<T> {
   const ttlMs = input.ttlMs ?? DEFAULT_TTL_MS;
@@ -74,99 +75,136 @@ export async function withIdempotency<T>(input: {
     );
   }
 
-  const expiresAt = new Date(input.now().getTime() + ttlMs);
-  const claimed = await input.repo.claim({
-    userId: input.userId,
-    action: input.action,
-    key: input.key,
-    expiresAt,
-    zombieThresholdMs,
-  });
+  const startMs = input.now().getTime();
 
-  if (claimed) {
-    try {
-      const result = await input.execute();
-      await input.repo.storeResult({
-        userId: input.userId,
-        action: input.action,
-        key: input.key,
-        resultJson: result,
-      });
-      return result;
-    } catch (error) {
+  while (input.now().getTime() - startMs <= maxWaitMs) {
+    const expiresAt = new Date(input.now().getTime() + ttlMs);
+    const claimedAt = await input.repo.claim({
+      userId: input.userId,
+      action: input.action,
+      key: input.key,
+      expiresAt,
+      zombieThresholdMs,
+    });
+
+    if (claimedAt) {
+      if (input.beforeExecute) {
+        try {
+          await input.beforeExecute();
+        } catch (error) {
+          try {
+            await input.repo.abortClaim(
+              input.userId,
+              input.action,
+              input.key,
+              claimedAt,
+            );
+          } catch (abortError) {
+            try {
+              input.logger.error(
+                {
+                  userId: input.userId,
+                  action: input.action,
+                  key: input.key,
+                  abortError:
+                    abortError instanceof Error
+                      ? abortError.message
+                      : String(abortError),
+                  originalError:
+                    error instanceof Error ? error.message : String(error),
+                },
+                'Failed to abort idempotency claim after beforeExecute failure',
+              );
+            } catch {
+              // Preserve the original beforeExecute error even if logging fails.
+            }
+          }
+          throw error;
+        }
+      }
+
       try {
-        await input.repo.storeError({
+        const result = await input.execute();
+        await input.repo.storeResult({
           userId: input.userId,
           action: input.action,
           key: input.key,
-          error: toErrorRecord(error),
+          claimedAt,
+          resultJson: result,
         });
-      } catch (storeError) {
+        return result;
+      } catch (error) {
         try {
-          input.logger.error(
-            {
-              userId: input.userId,
-              action: input.action,
-              key: input.key,
-              storeError:
-                storeError instanceof Error
-                  ? storeError.message
-                  : String(storeError),
-              originalError:
-                error instanceof Error ? error.message : String(error),
-            },
-            'Failed to persist idempotency error record',
+          await input.repo.storeError({
+            userId: input.userId,
+            action: input.action,
+            key: input.key,
+            claimedAt,
+            error: toErrorRecord(error),
+          });
+        } catch (storeError) {
+          try {
+            input.logger.error(
+              {
+                userId: input.userId,
+                action: input.action,
+                key: input.key,
+                storeError:
+                  storeError instanceof Error
+                    ? storeError.message
+                    : String(storeError),
+                originalError:
+                  error instanceof Error ? error.message : String(error),
+              },
+              'Failed to persist idempotency error record',
+            );
+          } catch {
+            // Preserve original execute error even if logger.error throws.
+          }
+        }
+        throw error;
+      }
+    }
+
+    let shouldRestartClaim = false;
+    while (input.now().getTime() - startMs <= maxWaitMs) {
+      const existing = await input.repo.find(
+        input.userId,
+        input.action,
+        input.key,
+      );
+      if (!existing) {
+        shouldRestartClaim = true;
+        break;
+      }
+
+      if (existing.error) {
+        throw new ApplicationError(existing.error.code, existing.error.message);
+      }
+
+      if (existing.completedAt !== null) {
+        if (!input.parseResult) {
+          return existing.resultJson as T;
+        }
+
+        try {
+          return input.parseResult(existing.resultJson);
+        } catch (cause) {
+          throw new ApplicationError(
+            'INTERNAL_ERROR',
+            'Cached idempotency result is invalid',
+            undefined,
+            { cause },
           );
-        } catch {
-          // Preserve original execute error even if logger.error throws.
         }
       }
-      throw error;
-    }
-  }
 
-  const startMs = input.now().getTime();
-  let keyDisappearedDuringPoll = false;
-  while (input.now().getTime() - startMs <= maxWaitMs) {
-    const existing = await input.repo.find(
-      input.userId,
-      input.action,
-      input.key,
-    );
-    if (!existing) {
-      keyDisappearedDuringPoll = true;
+      await delay(pollIntervalMs);
+    }
+
+    if (!shouldRestartClaim) {
       break;
     }
-
-    if (existing.error) {
-      throw new ApplicationError(existing.error.code, existing.error.message);
-    }
-
-    if (existing.completedAt !== null) {
-      if (!input.parseResult) {
-        return existing.resultJson as T;
-      }
-
-      try {
-        return input.parseResult(existing.resultJson);
-      } catch (cause) {
-        throw new ApplicationError(
-          'INTERNAL_ERROR',
-          'Cached idempotency result is invalid',
-          undefined,
-          { cause },
-        );
-      }
-    }
-
-    await delay(pollIntervalMs);
-  }
-
-  if (keyDisappearedDuringPoll) {
-    throw new ApplicationError(
-      'INTERNAL_ERROR',
-      'Idempotency key disappeared during poll',
-    );
   }
 
   throw new ApplicationError(

--- a/src/application/ports/idempotency-key-repository.ts
+++ b/src/application/ports/idempotency-key-repository.ts
@@ -19,8 +19,8 @@ export interface IdempotencyKeyRepository {
    * Attempt to claim an idempotency key for exclusive execution.
    *
    * Returns:
-   * - true when the key was inserted (caller should execute the operation)
-   * - false when the key already exists (caller should read and reuse result)
+   * - the claimedAt token when the key was inserted/reclaimed
+   * - null when the key already exists (caller should read and reuse result)
    */
   claim(input: {
     userId: string;
@@ -28,7 +28,7 @@ export interface IdempotencyKeyRepository {
     key: string;
     expiresAt: Date;
     zombieThresholdMs?: number;
-  }): Promise<boolean>;
+  }): Promise<Date | null>;
 
   /**
    * Read an existing idempotency record.
@@ -43,19 +43,45 @@ export interface IdempotencyKeyRepository {
     key: string,
   ): Promise<IdempotencyKeyRecord | null>;
 
+  /**
+   * Persist the first successful result for the exact still-pending claim.
+   *
+   * Must reject missing, reclaimed, or already completed rows so cached
+   * idempotency outcomes remain immutable after first completion.
+   */
   storeResult(input: {
     userId: string;
     action: string;
     key: string;
+    claimedAt: Date;
     resultJson: unknown;
   }): Promise<void>;
 
+  /**
+   * Persist the first failure record for the exact still-pending claim.
+   *
+   * Must reject missing, reclaimed, or already completed rows so cached
+   * idempotency outcomes remain immutable after first completion.
+   */
   storeError(input: {
     userId: string;
     action: string;
     key: string;
+    claimedAt: Date;
     error: IdempotencyKeyError;
   }): Promise<void>;
+
+  /**
+   * Remove a freshly claimed key that never reached execute/store.
+   *
+   * Must be a no-op for completed rows, stored-error rows, and missing keys.
+   */
+  abortClaim(
+    userId: string,
+    action: string,
+    key: string,
+    claimedAt: Date,
+  ): Promise<void>;
 
   pruneExpiredBefore(cutoff: Date, limit: number): Promise<number>;
 }

--- a/src/application/test-helpers/fakes/fake-idempotency-key-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-idempotency-key-repository.test.ts
@@ -24,8 +24,8 @@ describe('FakeIdempotencyKeyRepository', () => {
       const expiresAt = new Date('2026-03-01T00:10:00.000Z');
       const input = createClaimInput(expiresAt);
 
-      await expect(repo.claim(input)).resolves.toBe(true);
-      await expect(repo.claim(input)).resolves.toBe(false);
+      await expect(repo.claim(input)).resolves.toEqual(clock.now);
+      await expect(repo.claim(input)).resolves.toBeNull();
 
       await expect(
         repo.find(input.userId, input.action, input.key),
@@ -35,6 +35,16 @@ describe('FakeIdempotencyKeyRepository', () => {
         completedAt: null,
         expiresAt,
       });
+    });
+
+    it('returns the claimedAt token for the claim it created', async () => {
+      const clock = { now: new Date('2026-03-01T00:00:00.000Z') };
+      const repo = createRepo(clock);
+      const expiresAt = new Date('2026-03-01T00:10:00.000Z');
+      const input = createClaimInput(expiresAt);
+
+      await expect(repo.claim(input)).resolves.toEqual(clock.now);
+      await expect(repo.claim(input)).resolves.toBeNull();
     });
 
     it('allows claim again after record expiration', async () => {
@@ -50,7 +60,7 @@ describe('FakeIdempotencyKeyRepository', () => {
 
       await expect(
         repo.claim(createClaimInput(new Date('2026-03-01T00:05:00.000Z'))),
-      ).resolves.toBe(true);
+      ).resolves.toEqual(clock.now);
     });
   });
 
@@ -61,13 +71,15 @@ describe('FakeIdempotencyKeyRepository', () => {
       const expiresAt = new Date('2026-03-01T01:00:00.000Z');
       const input = createClaimInput(expiresAt);
 
-      await repo.claim(input);
+      const claimedAt = await repo.claim(input);
+      if (!claimedAt) throw new Error('Expected claim');
 
       clock.now = new Date('2026-03-01T00:00:05.000Z');
       await repo.storeResult({
         userId: input.userId,
         action: input.action,
         key: input.key,
+        claimedAt,
         resultJson: { checkoutUrl: 'https://example.test/checkout' },
       });
 
@@ -81,25 +93,21 @@ describe('FakeIdempotencyKeyRepository', () => {
       });
     });
 
-    it('stores error payload, clears result payload, and sets completion timestamp', async () => {
+    it('stores error payload and sets completion timestamp', async () => {
       const clock = { now: new Date('2026-03-01T00:00:00.000Z') };
       const repo = createRepo(clock);
       const expiresAt = new Date('2026-03-01T01:00:00.000Z');
       const input = createClaimInput(expiresAt);
 
-      await repo.claim(input);
-      await repo.storeResult({
-        userId: input.userId,
-        action: input.action,
-        key: input.key,
-        resultJson: { checkoutUrl: 'https://example.test/checkout' },
-      });
+      const claimedAt = await repo.claim(input);
+      if (!claimedAt) throw new Error('Expected claim');
 
       clock.now = new Date('2026-03-01T00:00:06.000Z');
       await repo.storeError({
         userId: input.userId,
         action: input.action,
         key: input.key,
+        claimedAt,
         error: { code: 'INTERNAL_ERROR', message: 'boom' },
       });
 
@@ -113,6 +121,84 @@ describe('FakeIdempotencyKeyRepository', () => {
       });
     });
 
+    it('rejects duplicate result completion with the same claim token', async () => {
+      const clock = { now: new Date('2026-03-01T00:00:00.000Z') };
+      const repo = createRepo(clock);
+      const expiresAt = new Date('2026-03-01T01:00:00.000Z');
+      const input = createClaimInput(expiresAt);
+
+      const claimedAt = await repo.claim(input);
+      if (!claimedAt) throw new Error('Expected claim');
+
+      clock.now = new Date('2026-03-01T00:00:05.000Z');
+      await repo.storeResult({
+        userId: input.userId,
+        action: input.action,
+        key: input.key,
+        claimedAt,
+        resultJson: { source: 'first' },
+      });
+
+      clock.now = new Date('2026-03-01T00:00:06.000Z');
+      await expect(
+        repo.storeResult({
+          userId: input.userId,
+          action: input.action,
+          key: input.key,
+          claimedAt,
+          resultJson: { source: 'second' },
+        }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+      await expect(
+        repo.find(input.userId, input.action, input.key),
+      ).resolves.toEqual({
+        resultJson: { source: 'first' },
+        error: null,
+        completedAt: new Date('2026-03-01T00:00:05.000Z'),
+        expiresAt,
+      });
+    });
+
+    it('rejects duplicate error completion with the same claim token', async () => {
+      const clock = { now: new Date('2026-03-01T00:00:00.000Z') };
+      const repo = createRepo(clock);
+      const expiresAt = new Date('2026-03-01T01:00:00.000Z');
+      const input = createClaimInput(expiresAt);
+
+      const claimedAt = await repo.claim(input);
+      if (!claimedAt) throw new Error('Expected claim');
+
+      clock.now = new Date('2026-03-01T00:00:05.000Z');
+      await repo.storeError({
+        userId: input.userId,
+        action: input.action,
+        key: input.key,
+        claimedAt,
+        error: { code: 'INTERNAL_ERROR', message: 'first' },
+      });
+
+      clock.now = new Date('2026-03-01T00:00:06.000Z');
+      await expect(
+        repo.storeError({
+          userId: input.userId,
+          action: input.action,
+          key: input.key,
+          claimedAt,
+          error: { code: 'VALIDATION_ERROR', message: 'second' },
+        }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+      await expect(
+        repo.find(input.userId, input.action, input.key),
+      ).resolves.toEqual({
+        resultJson: null,
+        error: { code: 'INTERNAL_ERROR', message: 'first' },
+        completedAt: new Date('2026-03-01T00:00:05.000Z'),
+        expiresAt,
+      });
+    });
+
     it('throws NOT_FOUND when storing result/error for a missing key', async () => {
       const clock = { now: new Date('2026-03-01T00:00:00.000Z') };
       const repo = createRepo(clock);
@@ -122,6 +208,7 @@ describe('FakeIdempotencyKeyRepository', () => {
           userId: 'user_1',
           action: 'createCheckoutSession',
           key: 'missing',
+          claimedAt: new Date('2026-03-01T00:00:00.000Z'),
           resultJson: { ok: true },
         }),
       ).rejects.toMatchObject({
@@ -133,10 +220,223 @@ describe('FakeIdempotencyKeyRepository', () => {
           userId: 'user_1',
           action: 'createCheckoutSession',
           key: 'missing',
+          claimedAt: new Date('2026-03-01T00:00:00.000Z'),
           error: { code: 'INTERNAL_ERROR', message: 'boom' },
         }),
       ).rejects.toMatchObject({
         code: 'NOT_FOUND',
+      });
+    });
+  });
+
+  describe('abortClaim', () => {
+    it('removes only an incomplete pending claim for the exact key', async () => {
+      const clock = { now: new Date('2026-03-01T00:00:00.000Z') };
+      const repo = createRepo(clock);
+      const expiresAt = new Date('2026-03-01T01:00:00.000Z');
+      const input = createClaimInput(expiresAt);
+
+      const claimedAt = await repo.claim(input);
+      if (!claimedAt) throw new Error('Expected pending claim');
+      await repo.claim({
+        ...input,
+        key: 'other_key',
+      });
+
+      await repo.abortClaim(input.userId, input.action, input.key, claimedAt);
+
+      await expect(
+        repo.find(input.userId, input.action, input.key),
+      ).resolves.toBeNull();
+      await expect(
+        repo.find(input.userId, input.action, 'other_key'),
+      ).resolves.toEqual({
+        resultJson: null,
+        error: null,
+        completedAt: null,
+        expiresAt,
+      });
+      await expect(repo.claim(input)).resolves.toEqual(clock.now);
+    });
+
+    it('does not remove a newer reclaimed pending row when aborting a stale claim token', async () => {
+      const clock = { now: new Date('2026-03-01T00:00:00.000Z') };
+      const repo = createRepo(clock);
+      const initialClaimedAt = clock.now;
+      const input = createClaimInput(new Date('2026-03-01T01:00:00.000Z'));
+
+      await repo.claim({ ...input, zombieThresholdMs: 60_000 });
+
+      clock.now = new Date('2026-03-01T00:01:01.000Z');
+      const reclaimedAt = clock.now;
+      await expect(
+        repo.claim({
+          ...input,
+          expiresAt: new Date('2026-03-01T02:00:00.000Z'),
+          zombieThresholdMs: 60_000,
+        }),
+      ).resolves.toEqual(reclaimedAt);
+
+      await repo.abortClaim(
+        input.userId,
+        input.action,
+        input.key,
+        initialClaimedAt,
+      );
+
+      await expect(
+        repo.find(input.userId, input.action, input.key),
+      ).resolves.toEqual({
+        resultJson: null,
+        error: null,
+        completedAt: null,
+        expiresAt: new Date('2026-03-01T02:00:00.000Z'),
+      });
+    });
+
+    it('does not let a stale claim token store a result over a newer reclaimed row', async () => {
+      const clock = { now: new Date('2026-03-01T00:00:00.000Z') };
+      const repo = createRepo(clock);
+      const input = createClaimInput(new Date('2026-03-01T01:00:00.000Z'));
+
+      const initialClaimedAt = await repo.claim({
+        ...input,
+        zombieThresholdMs: 60_000,
+      });
+      if (!initialClaimedAt) throw new Error('Expected initial claim');
+
+      clock.now = new Date('2026-03-01T00:01:01.000Z');
+      const reclaimedAt = await repo.claim({
+        ...input,
+        expiresAt: new Date('2026-03-01T02:00:00.000Z'),
+        zombieThresholdMs: 60_000,
+      });
+      if (!reclaimedAt) throw new Error('Expected reclaimed claim');
+
+      await expect(
+        repo.storeResult({
+          userId: input.userId,
+          action: input.action,
+          key: input.key,
+          claimedAt: initialClaimedAt,
+          resultJson: { ok: 'stale' },
+        }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+      await repo.storeResult({
+        userId: input.userId,
+        action: input.action,
+        key: input.key,
+        claimedAt: reclaimedAt,
+        resultJson: { ok: 'newer' },
+      });
+
+      await expect(
+        repo.find(input.userId, input.action, input.key),
+      ).resolves.toMatchObject({
+        resultJson: { ok: 'newer' },
+        error: null,
+      });
+    });
+
+    it('does not let a stale claim token store an error over a newer reclaimed row', async () => {
+      const clock = { now: new Date('2026-03-01T00:00:00.000Z') };
+      const repo = createRepo(clock);
+      const input = createClaimInput(new Date('2026-03-01T01:00:00.000Z'));
+
+      const initialClaimedAt = await repo.claim({
+        ...input,
+        zombieThresholdMs: 60_000,
+      });
+      if (!initialClaimedAt) throw new Error('Expected initial claim');
+
+      clock.now = new Date('2026-03-01T00:01:01.000Z');
+      const reclaimedAt = await repo.claim({
+        ...input,
+        expiresAt: new Date('2026-03-01T02:00:00.000Z'),
+        zombieThresholdMs: 60_000,
+      });
+      if (!reclaimedAt) throw new Error('Expected reclaimed claim');
+
+      await expect(
+        repo.storeError({
+          userId: input.userId,
+          action: input.action,
+          key: input.key,
+          claimedAt: initialClaimedAt,
+          error: { code: 'INTERNAL_ERROR', message: 'stale' },
+        }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+      await repo.storeResult({
+        userId: input.userId,
+        action: input.action,
+        key: input.key,
+        claimedAt: reclaimedAt,
+        resultJson: { ok: 'newer' },
+      });
+
+      await expect(
+        repo.find(input.userId, input.action, input.key),
+      ).resolves.toMatchObject({
+        resultJson: { ok: 'newer' },
+        error: null,
+      });
+    });
+
+    it('does not remove completed result or error records', async () => {
+      const clock = { now: new Date('2026-03-01T00:00:00.000Z') };
+      const repo = createRepo(clock);
+      const expiresAt = new Date('2026-03-01T01:00:00.000Z');
+      const resultInput = createClaimInput(expiresAt);
+      const errorInput = {
+        ...resultInput,
+        key: 'idem_key_error',
+      };
+
+      const resultClaimedAt = await repo.claim(resultInput);
+      if (!resultClaimedAt) throw new Error('Expected result claim');
+      await repo.storeResult({
+        userId: resultInput.userId,
+        action: resultInput.action,
+        key: resultInput.key,
+        claimedAt: resultClaimedAt,
+        resultJson: { ok: true },
+      });
+      const errorClaimedAt = await repo.claim(errorInput);
+      if (!errorClaimedAt) throw new Error('Expected error claim');
+      await repo.storeError({
+        userId: errorInput.userId,
+        action: errorInput.action,
+        key: errorInput.key,
+        claimedAt: errorClaimedAt,
+        error: { code: 'INTERNAL_ERROR', message: 'boom' },
+      });
+
+      await repo.abortClaim(
+        resultInput.userId,
+        resultInput.action,
+        resultInput.key,
+        resultClaimedAt,
+      );
+      await repo.abortClaim(
+        errorInput.userId,
+        errorInput.action,
+        errorInput.key,
+        errorClaimedAt,
+      );
+
+      await expect(
+        repo.find(resultInput.userId, resultInput.action, resultInput.key),
+      ).resolves.toMatchObject({
+        resultJson: { ok: true },
+        error: null,
+      });
+      await expect(
+        repo.find(errorInput.userId, errorInput.action, errorInput.key),
+      ).resolves.toMatchObject({
+        resultJson: null,
+        error: { code: 'INTERNAL_ERROR', message: 'boom' },
       });
     });
   });

--- a/src/application/test-helpers/fakes/fake-idempotency-key-repository.ts
+++ b/src/application/test-helpers/fakes/fake-idempotency-key-repository.ts
@@ -29,7 +29,7 @@ export class FakeIdempotencyKeyRepository implements IdempotencyKeyRepository {
     key: string;
     expiresAt: Date;
     zombieThresholdMs?: number;
-  }): Promise<boolean> {
+  }): Promise<Date | null> {
     const now = this.now();
     const zombieThresholdMs =
       typeof input.zombieThresholdMs === 'number' &&
@@ -47,7 +47,7 @@ export class FakeIdempotencyKeyRepository implements IdempotencyKeyRepository {
         existing.error === null &&
         existing.claimedAt.getTime() < zombieCutoff.getTime();
       if (!isExpired && !isZombie) {
-        return false;
+        return null;
       }
     }
 
@@ -58,7 +58,7 @@ export class FakeIdempotencyKeyRepository implements IdempotencyKeyRepository {
       completedAt: null,
       expiresAt: input.expiresAt,
     });
-    return true;
+    return now;
   }
 
   async find(
@@ -86,11 +86,16 @@ export class FakeIdempotencyKeyRepository implements IdempotencyKeyRepository {
     userId: string;
     action: string;
     key: string;
+    claimedAt: Date;
     resultJson: unknown;
   }): Promise<void> {
     const id = this.toKey(input.userId, input.action, input.key);
     const existing = this.records.get(id);
-    if (!existing) {
+    if (
+      !existing ||
+      existing.claimedAt.getTime() !== input.claimedAt.getTime() ||
+      existing.completedAt !== null
+    ) {
       throw new ApplicationError('NOT_FOUND', 'Idempotency key not found');
     }
 
@@ -106,11 +111,16 @@ export class FakeIdempotencyKeyRepository implements IdempotencyKeyRepository {
     userId: string;
     action: string;
     key: string;
+    claimedAt: Date;
     error: IdempotencyKeyError;
   }): Promise<void> {
     const id = this.toKey(input.userId, input.action, input.key);
     const existing = this.records.get(id);
-    if (!existing) {
+    if (
+      !existing ||
+      existing.claimedAt.getTime() !== input.claimedAt.getTime() ||
+      existing.completedAt !== null
+    ) {
       throw new ApplicationError('NOT_FOUND', 'Idempotency key not found');
     }
 
@@ -120,6 +130,24 @@ export class FakeIdempotencyKeyRepository implements IdempotencyKeyRepository {
       error: input.error,
       completedAt: this.now(),
     });
+  }
+
+  async abortClaim(
+    userId: string,
+    action: string,
+    key: string,
+    claimedAt: Date,
+  ): Promise<void> {
+    const id = this.toKey(userId, action, key);
+    const existing = this.records.get(id);
+    if (!existing || existing.completedAt !== null || existing.error !== null) {
+      return;
+    }
+    if (existing.claimedAt.getTime() !== claimedAt.getTime()) {
+      return;
+    }
+
+    this.records.delete(id);
   }
 
   async pruneExpiredBefore(cutoff: Date, limit: number): Promise<number> {

--- a/tests/integration/idempotency-key-repository.integration.test.ts
+++ b/tests/integration/idempotency-key-repository.integration.test.ts
@@ -28,14 +28,20 @@ describe('DrizzleIdempotencyKeyRepository', () => {
 
     const expiresAt = new Date('2026-02-02T00:00:00.000Z');
 
-    await expect(
-      repo.claim({ userId: user.id, action: 'it', key: 'k1', expiresAt }),
-    ).resolves.toBe(true);
+    const resultClaimedAt = await repo.claim({
+      userId: user.id,
+      action: 'it',
+      key: 'k1',
+      expiresAt,
+    });
+    expect(resultClaimedAt).toEqual(completedAt);
+    if (!resultClaimedAt) throw new Error('Expected result claim');
 
     await repo.storeResult({
       userId: user.id,
       action: 'it',
       key: 'k1',
+      claimedAt: resultClaimedAt,
       resultJson: { ok: true },
     });
 
@@ -46,14 +52,20 @@ describe('DrizzleIdempotencyKeyRepository', () => {
       expiresAt,
     });
 
-    await expect(
-      repo.claim({ userId: user.id, action: 'it', key: 'k2', expiresAt }),
-    ).resolves.toBe(true);
+    const errorClaimedAt = await repo.claim({
+      userId: user.id,
+      action: 'it',
+      key: 'k2',
+      expiresAt,
+    });
+    expect(errorClaimedAt).toEqual(completedAt);
+    if (!errorClaimedAt) throw new Error('Expected error claim');
 
     await repo.storeError({
       userId: user.id,
       action: 'it',
       key: 'k2',
+      claimedAt: errorClaimedAt,
       error: { code: 'INTERNAL_ERROR', message: 'boom' },
     });
 
@@ -72,14 +84,20 @@ describe('DrizzleIdempotencyKeyRepository', () => {
     const repo = new DrizzleIdempotencyKeyRepository(db, now);
     const expiresAt = new Date('2026-02-02T00:00:00.000Z');
 
-    await expect(
-      repo.claim({ userId: user.id, action: 'it', key: 'k-null', expiresAt }),
-    ).resolves.toBe(true);
+    const claimedAt = await repo.claim({
+      userId: user.id,
+      action: 'it',
+      key: 'k-null',
+      expiresAt,
+    });
+    expect(claimedAt).toEqual(completedAt);
+    if (!claimedAt) throw new Error('Expected null-result claim');
 
     await repo.storeResult({
       userId: user.id,
       action: 'it',
       key: 'k-null',
+      claimedAt,
       resultJson: null,
     });
 
@@ -93,7 +111,8 @@ describe('DrizzleIdempotencyKeyRepository', () => {
 
   it('reclaims expired keys and resets stored state', async () => {
     const user = await createUser(db, cleanup);
-    const now = () => new Date('2026-02-01T00:00:10.000Z');
+    const claimedAt = new Date('2026-02-01T00:00:10.000Z');
+    const now = () => claimedAt;
     const repo = new DrizzleIdempotencyKeyRepository(db, now);
 
     const expiredAt = new Date('2026-02-01T00:00:00.000Z');
@@ -104,12 +123,13 @@ describe('DrizzleIdempotencyKeyRepository', () => {
         key: 'k3',
         expiresAt: expiredAt,
       }),
-    ).resolves.toBe(true);
+    ).resolves.toEqual(claimedAt);
 
     await repo.storeResult({
       userId: user.id,
       action: 'it',
       key: 'k3',
+      claimedAt,
       resultJson: { ok: true },
     });
 
@@ -121,7 +141,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
         key: 'k3',
         expiresAt: refreshedAt,
       }),
-    ).resolves.toBe(true);
+    ).resolves.toEqual(claimedAt);
 
     await expect(repo.find(user.id, 'it', 'k3')).resolves.toMatchObject({
       resultJson: null,
@@ -146,7 +166,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
         expiresAt: firstExpiry,
         zombieThresholdMs: 60_000,
       }),
-    ).resolves.toBe(true);
+    ).resolves.toEqual(currentTime);
 
     currentTime = new Date('2026-02-01T00:00:30.000Z');
     await expect(
@@ -157,7 +177,7 @@ describe('DrizzleIdempotencyKeyRepository', () => {
         expiresAt: new Date('2026-02-02T00:00:30.000Z'),
         zombieThresholdMs: 60_000,
       }),
-    ).resolves.toBe(false);
+    ).resolves.toBeNull();
 
     currentTime = new Date('2026-02-01T00:01:10.000Z');
     const refreshedExpiry = new Date('2026-02-02T00:01:10.000Z');
@@ -169,13 +189,323 @@ describe('DrizzleIdempotencyKeyRepository', () => {
         expiresAt: refreshedExpiry,
         zombieThresholdMs: 60_000,
       }),
-    ).resolves.toBe(true);
+    ).resolves.toEqual(currentTime);
 
     await expect(repo.find(user.id, 'it', 'k-zombie')).resolves.toMatchObject({
       resultJson: null,
       error: null,
       completedAt: null,
       expiresAt: refreshedExpiry,
+    });
+  });
+
+  it('does not abort a pending row reclaimed after the original claim token', async () => {
+    const user = await createUser(db, cleanup);
+    let currentTime = new Date('2026-02-01T00:00:00.000Z');
+    const now = () => currentTime;
+    const repo = new DrizzleIdempotencyKeyRepository(db, now);
+    const key = 'k-stale-abort';
+
+    const firstClaimedAt = currentTime;
+    await expect(
+      repo.claim({
+        userId: user.id,
+        action: 'it',
+        key,
+        expiresAt: new Date('2026-02-02T00:00:00.000Z'),
+        zombieThresholdMs: 60_000,
+      }),
+    ).resolves.toEqual(firstClaimedAt);
+
+    currentTime = new Date('2026-02-01T00:01:01.000Z');
+    const reclaimedAt = currentTime;
+    const reclaimedExpiry = new Date('2026-02-02T00:01:01.000Z');
+    await expect(
+      repo.claim({
+        userId: user.id,
+        action: 'it',
+        key,
+        expiresAt: reclaimedExpiry,
+        zombieThresholdMs: 60_000,
+      }),
+    ).resolves.toEqual(reclaimedAt);
+
+    await repo.abortClaim(user.id, 'it', key, firstClaimedAt);
+
+    await expect(repo.find(user.id, 'it', key)).resolves.toMatchObject({
+      resultJson: null,
+      error: null,
+      completedAt: null,
+      expiresAt: reclaimedExpiry,
+    });
+  });
+
+  it('does not let a stale result writer overwrite a newer reclaimed result', async () => {
+    const user = await createUser(db, cleanup);
+    let currentTime = new Date('2026-02-01T00:00:00.000Z');
+    const now = () => currentTime;
+    const repo = new DrizzleIdempotencyKeyRepository(db, now);
+    const key = 'k-stale-result-store';
+
+    const firstClaimedAt = currentTime;
+    await expect(
+      repo.claim({
+        userId: user.id,
+        action: 'it',
+        key,
+        expiresAt: new Date('2026-02-02T00:00:00.000Z'),
+        zombieThresholdMs: 60_000,
+      }),
+    ).resolves.toEqual(firstClaimedAt);
+
+    currentTime = new Date('2026-02-01T00:01:01.000Z');
+    const reclaimedAt = currentTime;
+    await expect(
+      repo.claim({
+        userId: user.id,
+        action: 'it',
+        key,
+        expiresAt: new Date('2026-02-02T00:01:01.000Z'),
+        zombieThresholdMs: 60_000,
+      }),
+    ).resolves.toEqual(reclaimedAt);
+
+    await repo.storeResult({
+      userId: user.id,
+      action: 'it',
+      key,
+      claimedAt: reclaimedAt,
+      resultJson: { source: 'newer' },
+    });
+
+    await expect(
+      repo.storeResult({
+        userId: user.id,
+        action: 'it',
+        key,
+        claimedAt: firstClaimedAt,
+        resultJson: { source: 'stale' },
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    await expect(repo.find(user.id, 'it', key)).resolves.toMatchObject({
+      resultJson: { source: 'newer' },
+      error: null,
+    });
+  });
+
+  it('does not let a stale error writer overwrite a newer reclaimed result', async () => {
+    const user = await createUser(db, cleanup);
+    let currentTime = new Date('2026-02-01T00:00:00.000Z');
+    const now = () => currentTime;
+    const repo = new DrizzleIdempotencyKeyRepository(db, now);
+    const key = 'k-stale-error-store';
+
+    const firstClaimedAt = currentTime;
+    await expect(
+      repo.claim({
+        userId: user.id,
+        action: 'it',
+        key,
+        expiresAt: new Date('2026-02-02T00:00:00.000Z'),
+        zombieThresholdMs: 60_000,
+      }),
+    ).resolves.toEqual(firstClaimedAt);
+
+    currentTime = new Date('2026-02-01T00:01:01.000Z');
+    const reclaimedAt = currentTime;
+    await expect(
+      repo.claim({
+        userId: user.id,
+        action: 'it',
+        key,
+        expiresAt: new Date('2026-02-02T00:01:01.000Z'),
+        zombieThresholdMs: 60_000,
+      }),
+    ).resolves.toEqual(reclaimedAt);
+
+    await repo.storeResult({
+      userId: user.id,
+      action: 'it',
+      key,
+      claimedAt: reclaimedAt,
+      resultJson: { source: 'newer' },
+    });
+
+    await expect(
+      repo.storeError({
+        userId: user.id,
+        action: 'it',
+        key,
+        claimedAt: firstClaimedAt,
+        error: { code: 'INTERNAL_ERROR', message: 'stale' },
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    await expect(repo.find(user.id, 'it', key)).resolves.toMatchObject({
+      resultJson: { source: 'newer' },
+      error: null,
+    });
+  });
+
+  it('rejects duplicate result completion with the same claim token', async () => {
+    const user = await createUser(db, cleanup);
+    let currentTime = new Date('2026-02-01T00:00:00.000Z');
+    const now = () => currentTime;
+    const repo = new DrizzleIdempotencyKeyRepository(db, now);
+    const expiresAt = new Date('2026-02-02T00:00:00.000Z');
+    const key = 'k-duplicate-result';
+
+    const claimedAt = await repo.claim({
+      userId: user.id,
+      action: 'it',
+      key,
+      expiresAt,
+    });
+    if (!claimedAt) throw new Error('Expected result claim');
+
+    currentTime = new Date('2026-02-01T00:00:05.000Z');
+    await repo.storeResult({
+      userId: user.id,
+      action: 'it',
+      key,
+      claimedAt,
+      resultJson: { source: 'first' },
+    });
+
+    currentTime = new Date('2026-02-01T00:00:06.000Z');
+    await expect(
+      repo.storeResult({
+        userId: user.id,
+        action: 'it',
+        key,
+        claimedAt,
+        resultJson: { source: 'second' },
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    await expect(repo.find(user.id, 'it', key)).resolves.toMatchObject({
+      resultJson: { source: 'first' },
+      error: null,
+      completedAt: new Date('2026-02-01T00:00:05.000Z'),
+    });
+  });
+
+  it('rejects duplicate error completion with the same claim token', async () => {
+    const user = await createUser(db, cleanup);
+    let currentTime = new Date('2026-02-01T00:00:00.000Z');
+    const now = () => currentTime;
+    const repo = new DrizzleIdempotencyKeyRepository(db, now);
+    const expiresAt = new Date('2026-02-02T00:00:00.000Z');
+    const key = 'k-duplicate-error';
+
+    const claimedAt = await repo.claim({
+      userId: user.id,
+      action: 'it',
+      key,
+      expiresAt,
+    });
+    if (!claimedAt) throw new Error('Expected error claim');
+
+    currentTime = new Date('2026-02-01T00:00:05.000Z');
+    await repo.storeError({
+      userId: user.id,
+      action: 'it',
+      key,
+      claimedAt,
+      error: { code: 'INTERNAL_ERROR', message: 'first' },
+    });
+
+    currentTime = new Date('2026-02-01T00:00:06.000Z');
+    await expect(
+      repo.storeError({
+        userId: user.id,
+        action: 'it',
+        key,
+        claimedAt,
+        error: { code: 'VALIDATION_ERROR', message: 'second' },
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    await expect(repo.find(user.id, 'it', key)).resolves.toMatchObject({
+      resultJson: null,
+      error: { code: 'INTERNAL_ERROR', message: 'first' },
+      completedAt: new Date('2026-02-01T00:00:05.000Z'),
+    });
+  });
+
+  it('aborts only pending incomplete claims and preserves completed rows', async () => {
+    const user = await createUser(db, cleanup);
+    const completedAt = new Date('2026-02-01T00:00:05.000Z');
+    const now = () => completedAt;
+    const repo = new DrizzleIdempotencyKeyRepository(db, now);
+    const expiresAt = new Date('2026-02-02T00:00:00.000Z');
+
+    const pendingClaimedAt = await repo.claim({
+      userId: user.id,
+      action: 'it',
+      key: 'k-pending',
+      expiresAt,
+    });
+    if (!pendingClaimedAt) throw new Error('Expected pending claim');
+    const completedClaimedAt = await repo.claim({
+      userId: user.id,
+      action: 'it',
+      key: 'k-completed',
+      expiresAt,
+    });
+    if (!completedClaimedAt) throw new Error('Expected completed claim');
+    await repo.storeResult({
+      userId: user.id,
+      action: 'it',
+      key: 'k-completed',
+      claimedAt: completedClaimedAt,
+      resultJson: { ok: true },
+    });
+
+    await repo.abortClaim(user.id, 'it', 'k-pending', pendingClaimedAt);
+    await repo.abortClaim(user.id, 'it', 'k-completed', completedClaimedAt);
+
+    await expect(repo.find(user.id, 'it', 'k-pending')).resolves.toBeNull();
+    await expect(
+      repo.find(user.id, 'it', 'k-completed'),
+    ).resolves.toMatchObject({
+      resultJson: { ok: true },
+      error: null,
+      completedAt,
+      expiresAt,
+    });
+  });
+
+  it('does not abort stored error rows', async () => {
+    const user = await createUser(db, cleanup);
+    const completedAt = new Date('2026-02-01T00:00:05.000Z');
+    const now = () => completedAt;
+    const repo = new DrizzleIdempotencyKeyRepository(db, now);
+    const expiresAt = new Date('2026-02-02T00:00:00.000Z');
+
+    const errorClaimedAt = await repo.claim({
+      userId: user.id,
+      action: 'it',
+      key: 'k-error',
+      expiresAt,
+    });
+    if (!errorClaimedAt) throw new Error('Expected error claim');
+    await repo.storeError({
+      userId: user.id,
+      action: 'it',
+      key: 'k-error',
+      claimedAt: errorClaimedAt,
+      error: { code: 'INTERNAL_ERROR', message: 'boom' },
+    });
+
+    await repo.abortClaim(user.id, 'it', 'k-error', errorClaimedAt);
+
+    await expect(repo.find(user.id, 'it', 'k-error')).resolves.toMatchObject({
+      resultJson: null,
+      error: { code: 'INTERNAL_ERROR', message: 'boom' },
+      completedAt,
+      expiresAt,
     });
   });
 });


### PR DESCRIPTION
## Promotion

Promotes dev → main with the DEBT-424 resolution (squashed to dev as `40c33e4b`, PR #512).

### What ships
DEBT-424 — idempotent server actions now run their rate-limiter **only on a fresh cache-miss claim** (replay-before-limit), so an idempotent retry returns the cached outcome instead of a spurious `RATE_LIMITED`. Hardening included:
- `claim()` returns the claim's `claimedAt` token; `abortClaim` / `storeResult` / `storeError` are fenced to that exact still-pending claim (outcome immutability — never clobber a completed or reclaimed row).
- `beforeExecute` hook in `withIdempotency` aborts the claim on hook failure without ever caching `RATE_LIMITED`.
- Applied across all 8 in-scope idempotent controller actions (behavior-preserving moves).

### Verification (from ground truth, on head `7ab0de10`)
- CodeRabbit: reviewed range `3e9b0afc…` → `7ab0de10` (exact head), **"No actionable comments"**, `reviewDecision: APPROVED`, 0 unresolved threads, not rate-limit-masked.
- Local full gate re-run (typecheck + lint + unit + build): green.
- Independent adversarial concurrency review: CLEAN (claim-token round-trip, abort scoping, immutability/loser-path, fake↔Drizzle parity, no infinite-loop, non-tautological tests).

Tree is byte-identical to the CR-approved #512 head. Merge as a **merge commit**; do not delete `dev`.

https://claude.ai/code/session_01RhHv6rK1YVBaE8WmPNpGXQ