### PR TITLE
Pluralize question-count copy (1 question, not 1 questions)

### DIFF
--- a/app/(app)/app/practice/[sessionId]/practice-session-toast.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/practice-session-toast.browser.spec.tsx
@@ -37,6 +37,27 @@ test('shows an info toast when fewer questions are available than requested', as
     .toBeVisible();
 });
 
+test('uses the singular noun in the toast when exactly one question matched', async () => {
+  const screen = await render(
+    <NotificationProvider>
+      <PracticeSessionToast
+        code="session_started"
+        requestedCount="20"
+        actualCount="1"
+      />
+      <div>page</div>
+    </NotificationProvider>,
+  );
+
+  await expect
+    .element(
+      screen.getByText(
+        'Only 1 of 20 questions matched your filters. Starting session with 1 question.',
+      ),
+    )
+    .toBeVisible();
+});
+
 test('does not show a toast when requestedCount equals actualCount', async () => {
   await render(
     <NotificationProvider>

--- a/app/(app)/app/practice/[sessionId]/practice-session-toast.tsx
+++ b/app/(app)/app/practice/[sessionId]/practice-session-toast.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useNotification } from '@/components/ui/notification-provider';
+import { pluralize } from '@/lib/pluralize';
 
 type PracticeSessionToastCode = 'session_started';
 
@@ -52,7 +53,7 @@ export function PracticeSessionToast({
     lastHandledToastRef.current = handledKey;
 
     notify({
-      message: `Only ${actual} of ${requested} questions matched your filters. Starting session with ${actual} questions.`,
+      message: `Only ${actual} of ${pluralize(requested, 'question')} matched your filters. Starting session with ${pluralize(actual, 'question')}.`,
       tone: 'info',
     });
 

--- a/app/(app)/app/practice/components/practice-session-starter.test.tsx
+++ b/app/(app)/app/practice/components/practice-session-starter.test.tsx
@@ -2,6 +2,7 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { compactControlShellClasses } from '@/components/ui/control-shell-styles';
+import { parseHtml } from '@/tests/shared/dom-helpers';
 
 const {
   fixtureTag1Id,
@@ -95,7 +96,7 @@ describe('PracticeSessionStarter', () => {
     expect(html).toContain('data-slot="card"');
     expect(html).toContain('data-slot="input"');
 
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHtml(html);
     const title = doc.querySelector('h2');
     const input = findQuestionsInput(doc);
     const inputTokens = getClassTokens(input?.getAttribute('class') ?? '');
@@ -139,7 +140,7 @@ describe('PracticeSessionStarter', () => {
       />,
     );
 
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHtml(html);
     const label = findQuestionsLabel(doc);
     const input = findQuestionsInput(doc);
 
@@ -187,7 +188,7 @@ describe('PracticeSessionStarter', () => {
       </>,
     );
 
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHtml(html);
     const modeLabels = findVisibleLabelsWithId(doc, 'Mode');
     const statusLabels = findVisibleLabelsWithId(doc, 'Status');
     const difficultyLabels = findVisibleLabelsWithId(doc, 'Difficulty');
@@ -237,7 +238,7 @@ describe('PracticeSessionStarter', () => {
         onStartSession={() => undefined}
       />,
     );
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHtml(html);
     const sessionCountInput = findQuestionsInput(doc);
     const starterRow = sessionCountInput?.closest('div[class~="sm:flex-row"]');
     const starterRowTokens = getClassTokens(
@@ -270,7 +271,7 @@ describe('PracticeSessionStarter', () => {
         onStartSession={() => undefined}
       />,
     );
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHtml(html);
     const label = findQuestionsLabel(doc);
     const input = findQuestionsInput(doc);
     const questionsWrapper = label?.parentElement;
@@ -315,7 +316,7 @@ describe('PracticeSessionStarter', () => {
         onStartSession={() => undefined}
       />,
     );
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHtml(html);
     const statusFieldset = findFieldsetByVisibleLabel(doc, 'Status');
     const difficultyFieldset = findFieldsetByVisibleLabel(doc, 'Difficulty');
     const statusWrapper = statusFieldset?.closest('div[class~="space-y-2"]');
@@ -367,7 +368,7 @@ describe('PracticeSessionStarter', () => {
       />,
     );
 
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHtml(html);
     expect(findFieldsetByVisibleLabel(doc, 'Mode')).not.toBeNull();
     expect(findFieldsetByVisibleLabel(doc, 'Status')).not.toBeNull();
     expect(findFieldsetByVisibleLabel(doc, 'Difficulty')).not.toBeNull();
@@ -418,7 +419,7 @@ describe('PracticeSessionStarter', () => {
       />,
     );
 
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHtml(html);
     const details = Array.from(doc.querySelectorAll('details'));
     expect(details.length).toBeGreaterThan(0);
     for (const element of details) {
@@ -613,7 +614,7 @@ describe('PracticeSessionStarter', () => {
     expect(html).not.toContain('Leave empty to include all questions');
     expect(html).not.toContain('Leave empty to include all difficulties');
 
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHtml(html);
     const statusControl = findFieldsetByVisibleLabel(doc, 'Status');
     expect(statusControl).toBeTruthy();
     const activeStatus = statusControl?.querySelector(
@@ -676,7 +677,7 @@ describe('PracticeSessionStarter', () => {
     );
 
     expect(html).not.toContain('Exam Section');
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHtml(html);
     const summaryLabels = Array.from(doc.querySelectorAll('summary')).map(
       (el) => el.textContent ?? '',
     );
@@ -724,7 +725,7 @@ describe('PracticeSessionStarter', () => {
 
   it('pluralizes the available-count message as singular when exactly one question matches', () => {
     const html = renderWithAvailableCount(1, 1);
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHtml(html);
     const message = doc.querySelector('output')?.textContent ?? '';
 
     expect(message).toBe('1 question available.');
@@ -733,7 +734,7 @@ describe('PracticeSessionStarter', () => {
 
   it('keeps the available-count message plural for more than one question', () => {
     const html = renderWithAvailableCount(3, 3);
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHtml(html);
     const message = doc.querySelector('output')?.textContent ?? '';
 
     expect(message).toBe('3 questions available.');
@@ -741,7 +742,7 @@ describe('PracticeSessionStarter', () => {
 
   it('pluralizes the capped-count message as singular when only one question is available', () => {
     const html = renderWithAvailableCount(1, 20);
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHtml(html);
     const message = doc.querySelector('output')?.textContent ?? '';
 
     expect(message).toBe('Only 1 question available. Starting session with 1.');

--- a/app/(app)/app/practice/components/practice-session-starter.test.tsx
+++ b/app/(app)/app/practice/components/practice-session-starter.test.tsx
@@ -696,4 +696,55 @@ describe('PracticeSessionStarter', () => {
     expect(substanceIndex).toBeGreaterThan(topicIndex);
     expect(treatmentIndex).toBeGreaterThan(substanceIndex);
   });
+
+  function renderWithAvailableCount(
+    availableCount: number,
+    sessionCount: number,
+  ) {
+    return renderToStaticMarkup(
+      <PracticeSessionStarter
+        sessionMode="tutor"
+        sessionCount={sessionCount}
+        filters={{ tagSlugs: [], difficulty: null, status: 'unanswered' }}
+        availableCountStatus="idle"
+        availableCount={availableCount}
+        tagLoadStatus="idle"
+        availableTags={[]}
+        sessionStartStatus="idle"
+        sessionStartError={null}
+        onDifficultyChange={() => undefined}
+        onStatusChange={() => undefined}
+        onToggleTag={() => undefined}
+        onSessionModeChange={() => undefined}
+        onSessionCountChange={() => undefined}
+        onStartSession={() => undefined}
+      />,
+    );
+  }
+
+  it('pluralizes the available-count message as singular when exactly one question matches', () => {
+    const html = renderWithAvailableCount(1, 1);
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const message = doc.querySelector('output')?.textContent ?? '';
+
+    expect(message).toBe('1 question available.');
+    expect(message).not.toContain('1 questions');
+  });
+
+  it('keeps the available-count message plural for more than one question', () => {
+    const html = renderWithAvailableCount(3, 3);
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const message = doc.querySelector('output')?.textContent ?? '';
+
+    expect(message).toBe('3 questions available.');
+  });
+
+  it('pluralizes the capped-count message as singular when only one question is available', () => {
+    const html = renderWithAvailableCount(1, 20);
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const message = doc.querySelector('output')?.textContent ?? '';
+
+    expect(message).toBe('Only 1 question available. Starting session with 1.');
+    expect(message).not.toContain('1 questions');
+  });
 });

--- a/app/(app)/app/practice/components/practice-session-starter.tsx
+++ b/app/(app)/app/practice/components/practice-session-starter.tsx
@@ -8,6 +8,7 @@ import { compactControlShellClasses } from '@/components/ui/control-shell-styles
 import { FilterChip } from '@/components/ui/filter-chip';
 import { Input } from '@/components/ui/input';
 import { SegmentedControl } from '@/components/ui/segmented-control';
+import { pluralize } from '@/lib/pluralize';
 import type { TagRow } from '@/src/adapters/controllers/tag-controller';
 import {
   AllDifficulties,
@@ -81,10 +82,10 @@ export function PracticeSessionStarter(props: PracticeSessionStarterProps) {
     }
 
     if (props.sessionCount > props.availableCount) {
-      return `Only ${props.availableCount} questions available. Starting session with ${props.availableCount}.`;
+      return `Only ${pluralize(props.availableCount, 'question')} available. Starting session with ${props.availableCount}.`;
     }
 
-    return `${props.availableCount} questions available.`;
+    return `${pluralize(props.availableCount, 'question')} available.`;
   }, [props.availableCount, props.availableCountStatus, props.sessionCount]);
 
   const isStartDisabled =

--- a/lib/pluralize.test.ts
+++ b/lib/pluralize.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { pluralize } from './pluralize';
+
+describe('pluralize', () => {
+  it('uses the plural form for zero', () => {
+    expect(pluralize(0, 'question')).toBe('0 questions');
+  });
+
+  it('uses the singular form for exactly one', () => {
+    expect(pluralize(1, 'question')).toBe('1 question');
+  });
+
+  it('uses the default "+s" plural for counts greater than one', () => {
+    expect(pluralize(2, 'question')).toBe('2 questions');
+    expect(pluralize(20, 'question')).toBe('20 questions');
+  });
+
+  it('uses an explicit custom plural when provided', () => {
+    expect(pluralize(1, 'match', 'matches')).toBe('1 match');
+    expect(pluralize(3, 'match', 'matches')).toBe('3 matches');
+  });
+});

--- a/lib/pluralize.ts
+++ b/lib/pluralize.ts
@@ -1,0 +1,19 @@
+/**
+ * Formats a count with a grammatically-correct noun.
+ *
+ * Returns `"${count} ${singular}"` when `count === 1`, otherwise
+ * `"${count} ${plural}"`. When `plural` is omitted it defaults to
+ * `singular + 's'`.
+ *
+ * @example
+ * pluralize(1, 'question') // "1 question"
+ * pluralize(2, 'question') // "2 questions"
+ * pluralize(1, 'match', 'matches') // "1 match"
+ */
+export function pluralize(
+  count: number,
+  singular: string,
+  plural?: string,
+): string {
+  return `${count} ${count === 1 ? singular : (plural ?? `${singular}s`)}`;
+}


### PR DESCRIPTION
## Problem

When exactly one question matches the user's practice filters, the UI renders the ungrammatical "1 questions" at three interpolation sites. `SESSION_COUNT_MIN = 1` (in \`practice-page-session-start.ts\`) makes a 1-question filter reachable, so this is a real (cosmetic, P4) defect.

## Solution

Add a small shared helper \`lib/pluralize.ts\` — \`pluralize(count, singular, plural?)\` returning \`\${count} \${count === 1 ? singular : plural ?? singular + 's'}\` (mirrors the existing \`lib/format-duration.ts\` style) — and use it at the three sites so the singular case reads "1 question". Surrounding copy is otherwise byte-identical.

### Sites fixed
- \`practice-session-starter.tsx\` available-count message: \`\${availableCount} questions available.\` → \`1 question available.\` when count is 1.
- \`practice-session-starter.tsx\` capped-count message (\`sessionCount > availableCount\`): \`Only \${availableCount} questions available...\` → \`Only 1 question available...\` when count is 1. (The trailing "Starting session with 1." has no noun and is unchanged.)
- \`practice-session-toast.tsx\` fewer-than-requested toast: \`Starting session with \${actual} questions.\` → \`...with 1 question.\` when \`actual\` is 1. The first \`\${requested} questions\` is routed through \`pluralize\` too for correctness, though \`requested\` is always ≥ 2 on this branch (the toast only fires when \`actual < requested\` and \`actual ≥ 1\`).

## Tests (TDD)
- \`lib/pluralize.test.ts\` — count 0, 1, 2, and a custom plural (was red→green: helper module didn't exist).
- \`practice-session-starter.test.tsx\` — asserts singular "1 question available.", plural "3 questions available.", and capped-singular "Only 1 question available. Starting session with 1." (exact strings the old hardcoded "questions" could not produce).
- \`practice-session-toast.browser.spec.tsx\` — asserts the singular toast noun; the existing "30 of 50 / with 30 questions" plural assertion is unchanged and still passes.

## Gate
\`pnpm typecheck\` ✅ · \`pnpm lint\` ✅ (0 errors; 21 pre-existing oversized-file warnings only) · \`pnpm test --run\` ✅ 3004 passed · \`pnpm build\` ✅ · toast browser spec ✅ 6 passed.

## Notes
- Pure code fix — no \`docs/\` or bug-doc files touched (kept conflict-free with a parallel in-flight branch). BUG-263 deliberately NOT consumed; owner decides bug-vs-debt tracking separately.

https://claude.ai/code/session_01RhHv6rK1YVBaE8WmPNpGXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent singular/plural question-count formatting across practice session notifications and session start prompts.

* **Bug Fixes**
  * Toast and starter messaging now correctly render “question” vs “questions,” including the “exactly 1” and capped availability scenarios.

* **Tests**
  * Expanded automated coverage for pluralization formatting and updated HTML rendering utilities in component tests to validate the displayed output text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->