### PR TITLE
Patch js-yaml DoS (CVE-2026-53550) + drop aged-out undici age exception

### DIFF
--- a/docs/dev/supply-chain-overrides.md
+++ b/docs/dev/supply-chain-overrides.md
@@ -38,9 +38,10 @@ allowBuilds:
 
 Do not weaken these settings casually. Every exception must be small,
 named in the PR body, and removed when it is no longer needed.
-There are no standing `minimumReleaseAgeExclude` entries in the active
-policy; add one only as a dated temporary override through the workflow
-below.
+`minimumReleaseAgeExclude` entries are always dated, temporary overrides for
+in-flight security patches — never standing policy. Add one only through the
+workflow below, and remove it once the pinned version is older than the 7-day
+window (see the worked example below).
 
 ## Urgent CVE patches before the 7-day cooldown
 
@@ -88,6 +89,59 @@ window. Do not use package-wide bootstrap exceptions.
 
 PR #382 removed the dated DEBT-394 bootstrap exceptions after they aged
 out. There are no current package-wide bootstrap exceptions.
+
+### Worked example: js-yaml CVE-2026-53550 (2026-06-29)
+
+Dependabot alert #13 flagged `js-yaml` (medium): CVE-2026-53550 /
+GHSA-h67p-54hq-rp68, a quadratic-complexity denial-of-service in merge-key
+handling via repeated aliases, affecting `< 3.15.0`.
+
+**Reachability (why it was low-risk).** `js-yaml@3.14.2` was transitive-only.
+`pnpm why js-yaml` showed two production paths and no direct imports:
+
+- `gray-matter@4.0.3` → `js-yaml` — used only by seed/build scripts
+  (`scripts/seed/question-parser.ts`, `scripts/draft-question-import.ts`) to
+  parse YAML frontmatter in our own first-party question markdown. Not a
+  runtime request path and not attacker-controlled.
+- `@istanbuljs/load-nyc-config` → `babel-plugin-istanbul` → jest →
+  `react-native` → `@clerk/ui` — test/build tooling the deployed Next.js app
+  never executes.
+
+No code path parses attacker-supplied YAML, so the DoS was not exploitable in
+production. We patched anyway, as defense-in-depth and to clear the alert.
+
+**Fix — two edits in `pnpm-workspace.yaml`.**
+
+1. Pin the patched version with an exact override. `3.15.0` is the
+   `v3-legacy` security backport; it satisfies both consumers' `^3.13.1` and
+   is an upgrade from `3.14.2`, so `no-downgrade` stays satisfied:
+
+   ```yaml
+   overrides:
+     js-yaml: 3.15.0 # GHSA-h67p-54hq-rp68 / CVE-2026-53550 DoS patch
+   ```
+
+2. `3.15.0` was published 2026-06-26 (~3 days old at fix time), so
+   `minimumReleaseAgeStrict` would refuse it. Add the smallest dated
+   exception:
+
+   ```yaml
+   minimumReleaseAgeExclude:
+     - js-yaml@3.15.0 # remove after ~2026-07-03 (7 days post-publish)
+   ```
+
+Then regenerate and verify:
+
+```sh
+pnpm install                       # rewrites the lockfile (Packages: +1 -1)
+pnpm why js-yaml                    # must show js-yaml@3.15.0, no 3.14.2
+pnpm typecheck && pnpm lint && pnpm test --run && pnpm build
+```
+
+**Removal.** Drop the `minimumReleaseAgeExclude: js-yaml@3.15.0` line once the
+version is older than 7 days (~2026-07-03); a clean `pnpm install` will still
+resolve `3.15.0` because the override remains. The override pin itself can stay
+until a newer mature `js-yaml` (or a `4.x` consumer) makes it unnecessary.
 
 ## Adding a new native-build package to allowBuilds
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   '@opentelemetry/core': 2.8.0
   '@opentelemetry/resources': 2.8.0
   '@opentelemetry/sdk-trace-base': 2.8.0
+  js-yaml: 3.15.0
 
 importers:
 
@@ -4157,8 +4158,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   jsc-safe-url@0.2.4:
@@ -6473,7 +6474,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -9570,7 +9571,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -9888,7 +9889,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,6 @@ minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true # v11-only: fail when no version satisfies the 7-day age threshold.
 minimumReleaseAgeIgnoreMissingTime: false # v11-only: fail when registry metadata lacks package publish time.
 minimumReleaseAgeExclude:
-  - undici@7.28.0 # Security: dev-only undici patch (6 GHSAs) published 2026-06-15, 4 days old at fix time. Exact, narrow exception so the security patch lands now instead of waiting out the 7-day gate. Official undici-team release; safe to drop after it ages in (~2026-06-22).
   - js-yaml@3.15.0 # Security: CVE-2026-53550 / GHSA-h67p-54hq-rp68 quadratic-complexity DoS patch (v3-legacy backport) published 2026-06-26, ~3 days old at fix time. Exact, narrow exception so the security patch lands now instead of waiting out the 7-day gate. Safe to drop after it ages in (~2026-07-03).
 blockExoticSubdeps: true
 overrides:
@@ -12,7 +11,7 @@ overrides:
   # Security: 6 advisories (high→low) — SOCKS5 cross-origin routing & TLS-validation
   # bypass, Set-Cookie header injection / SameSite downgrade, shared-cache disclosure,
   # keep-alive response-queue poisoning. All dev-scoped via jsdom/vitest. Patched in
-  # undici 7.28.0; see minimumReleaseAgeExclude above for the age-gate exception.
+  # undici 7.28.0 (aged past the 7-day release gate ~2026-06-22; no age exception needed).
   undici: 7.28.0
   # Security: GHSA-8988-4f7v-96qf — W3CBaggagePropagator.extract() lacked inbound
   # size caps (unbounded allocation). Patched in OTel 2.8.0. Pinned exact to keep the

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ minimumReleaseAgeStrict: true # v11-only: fail when no version satisfies the 7-d
 minimumReleaseAgeIgnoreMissingTime: false # v11-only: fail when registry metadata lacks package publish time.
 minimumReleaseAgeExclude:
   - undici@7.28.0 # Security: dev-only undici patch (6 GHSAs) published 2026-06-15, 4 days old at fix time. Exact, narrow exception so the security patch lands now instead of waiting out the 7-day gate. Official undici-team release; safe to drop after it ages in (~2026-06-22).
+  - js-yaml@3.15.0 # Security: CVE-2026-53550 / GHSA-h67p-54hq-rp68 quadratic-complexity DoS patch (v3-legacy backport) published 2026-06-26, ~3 days old at fix time. Exact, narrow exception so the security patch lands now instead of waiting out the 7-day gate. Safe to drop after it ages in (~2026-07-03).
 blockExoticSubdeps: true
 overrides:
   postcss: 8.5.15
@@ -20,6 +21,14 @@ overrides:
   '@opentelemetry/core': 2.8.0
   '@opentelemetry/resources': 2.8.0
   '@opentelemetry/sdk-trace-base': 2.8.0
+  # Security: GHSA-h67p-54hq-rp68 / CVE-2026-53550 — quadratic-complexity DoS in js-yaml
+  # merge-key handling via repeated aliases (affected < 3.15.0). Patched in the 3.15.0
+  # v3-legacy backport. js-yaml is transitive-only — gray-matter (seed/build scripts over
+  # first-party markdown) and @clerk/ui's react-native test tooling — with no runtime
+  # attacker-controlled YAML path, so this is defense-in-depth. 3.15.0 satisfies both
+  # consumers' ^3.13.1; it's an upgrade (no-downgrade safe). Fresh release; see the
+  # minimumReleaseAgeExclude entry above for the 7-day age-gate exception.
+  js-yaml: 3.15.0
 trustPolicy: no-downgrade
 trustPolicyExclude:
   - semver@6.3.1 # legacy Babel dependency published in 2023; exact exception for no-downgrade provenance gap.


### PR DESCRIPTION
## Problem

Dependabot alert #13 — **js-yaml** medium (CVE-2026-53550 / GHSA-h67p-54hq-rp68): a quadratic-complexity denial-of-service in merge-key handling via repeated aliases, affecting `< 3.15.0`. Our lockfile carried `js-yaml@3.14.2`.

## Reachability — why this was low real-world risk

`js-yaml@3.14.2` was **transitive-only** (no direct imports anywhere). `pnpm why js-yaml` shows two production paths:

- `gray-matter@4.0.3` → `js-yaml` — used **only by seed/build scripts** (`scripts/seed/question-parser.ts`, `scripts/draft-question-import.ts`) parsing YAML frontmatter in our **own first-party** question markdown. Not a runtime request path; not attacker-controlled.
- `@istanbuljs/load-nyc-config` → `babel-plugin-istanbul` → jest → `react-native` → `@clerk/ui` — test/build tooling the deployed Next.js app never executes.

No code path parses attacker-supplied YAML, so the DoS was **not exploitable in production**. Patched anyway as defense-in-depth and to clear the alert.

## Fix (commit 1)

Two edits in `pnpm-workspace.yaml`:

1. **Override** `js-yaml: 3.15.0` — the `v3-legacy` security backport. Satisfies both consumers' `^3.13.1` and is an upgrade from `3.14.2`, so `trustPolicy: no-downgrade` stays satisfied. (Deterministic exact-pin; the dated age-exclude below is what actually unlocks the fresh version under the strict gate.)
2. **Dated age-gate exception** `minimumReleaseAgeExclude: - js-yaml@3.15.0` — `3.15.0` was published 2026-06-26 (~3 days old), so `minimumReleaseAgeStrict` would otherwise refuse it. **Remove after ~2026-07-03.**

Lockfile regenerated (`Packages: +1 -1`); diff is contained to js-yaml's version (argparse/esprima untouched). `pnpm why js-yaml` → `js-yaml@3.15.0`.

## Policy hygiene (commit 2)

Removed the **aged-out** `undici@7.28.0` `minimumReleaseAgeExclude` entry — undici 7.28.0 (published 2026-06-15) is now > 7 days old and passes the strict gate on its own, so the dated exception is no longer needed (per the playbook: excludes are temporary). The `undici: 7.28.0` **security override pin is retained**; only its now-stale comment was updated. **Zero lockfile impact** (undici stays 7.28.0; `pnpm-lock.yaml` unchanged by this commit). After this PR, the only age-gate exception left is the dated `js-yaml@3.15.0`.

## Docs

`docs/dev/supply-chain-overrides.md` gains a **worked-example** disposition for the js-yaml CVE (reachability + exact fix + removal date) and an accurate restatement of the "exclude entries are always dated/temporary" rule.

## Verification

Full local gate green (re-run after each commit):
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (21 warnings, all pre-existing — change touches only YAML + markdown)
- `pnpm test --run` ✅ 359 files / 3029 tests
- `pnpm build` ✅ (incl. `/sign-in`, `/sign-up` prerender)

## Merge path / gate note

Targets `dev` (CodeRabbit auto-skips non-default-base PRs by design). The substantive CR review happens on the `dev → main` promo, which targets the default branch. The **enforced** gate on `main` is the `test` status check (the `main-protection` ruleset does not require CodeRabbit — intentional, so CR's rate-limit can't deadlock merges); CR is a process review we honor before merging.

https://claude.ai/code/session_01RhHv6rK1YVBaE8WmPNpGXQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the supply-chain override playbook with clearer guidance for temporary, dated release-age exceptions and when to remove them.
  * Added a worked example for handling a dependency/security policy conflict, including verification and cleanup steps.

* **Bug Fixes**
  * Adjusted dependency pinning so the security update can be applied immediately.
  * Moved the release-age exception from one dependency to another and updated related notes to reflect the current policy state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->