### PR TITLE
Promote: CodeRabbit fixture-integrity path-instruction to main (#547)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -70,6 +70,14 @@ reviews:
         6. Use factories: createQuestion(), createChoice() from test-helpers/
         7. Do NOT require dynamic import()/beforeAll loading in pure TypeScript *.test.ts suites.
            That React 19 compatibility rule is scoped to **/*.test.tsx component tests.
+        8. FIXTURE IDs (see .claude/rules/fixture-integrity.md): in fakes-only
+           application/domain/use-case tests, readable string IDs such as 'q1',
+           'user-1', or 'attempt-1' are INTENTIONAL and correct — do NOT suggest
+           replacing them with UUIDs or crypto.randomUUID(). UUID-shaped fixtures are
+           required ONLY where an ID crosses a zUuid/Drizzle uuid() boundary, which is
+           covered in adapter/controller tests (those legitimately assert UUID shape and
+           the 'not-a-uuid' rejection path). Flagging readable fake-backed IDs in
+           fakes-only tests is a known recurring false positive in this repo.
 
     # React component tests - React 19 specific
     - path: "**/*.test.tsx"


### PR DESCRIPTION
Promotes the `.coderabbit.yaml` config change from #547 to `main`.

Adds point 8 to the `**/*.test.ts` path-instruction teaching the FIX/LEAVE fixture-ID rule from `.claude/rules/fixture-integrity.md`, so CodeRabbit stops re-flagging readable fake-backed test IDs (`q1`/`user-1`) in fakes-only use-case tests while still flagging genuine `zUuid`/Drizzle `uuid()` boundary cases in adapter/controller tests.

**Provenance (corrected after a ground-truth audit):** the false positive is proven on **BUG-264** (PR #540 CodeRabbit thread on `set-bookmark.test.ts:11-12`, owner-rejected). `set-bookmark.test.ts` did not exist at BUG-260, so the earlier "BUG-260" citation was dropped. The pattern reflects CodeRabbit's default behavior on fakes-only use-case tests generally.

**Effectiveness:** CodeRabbit resolves config from the branch under review with default-branch fallback, so landing this on `main` makes it the fallback/default for all branches and keeps `dev==main`.

Config-only; no runtime/deploy-artifact impact. Promo tree identical to the CI-green `dev` head. CodeRabbit rate-limited → treated CR-exempt for a config-only change on the green required `test` check + owner authorization.