### PR TITLE
Promote: bump stripe to 22.3.0 + pin API version 2026-06-24.dahlia to main

### DIFF
--- a/lib/stripe-api-version.ts
+++ b/lib/stripe-api-version.ts
@@ -1,1 +1,1 @@
-export const STRIPE_API_VERSION = '2026-05-27.dahlia';
+export const STRIPE_API_VERSION = '2026-06-24.dahlia';

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "server-only": "^0.0.1",
-    "stripe": "^22.2.0",
+    "stripe": "^22.3.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "4.3.1",
     "tw-animate-css": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
       stripe:
-        specifier: ^22.2.0
-        version: 22.2.2(@types/node@24.13.2)
+        specifier: ^22.3.0
+        version: 22.3.0(@types/node@24.13.2)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.6.0
@@ -3657,8 +3657,8 @@ packages:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
 
-  enhanced-resolve@5.24.0:
-    resolution: {integrity: sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==}
+  enhanced-resolve@5.24.1:
+    resolution: {integrity: sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==}
     engines: {node: '>=10.13.0'}
 
   entities@8.0.0:
@@ -5123,8 +5123,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -5246,8 +5246,8 @@ packages:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
-  stripe@22.2.2:
-    resolution: {integrity: sha512-lRXLiarjW/I2QVa6QuFfz1Ma7Dc2yBQ7vlYH6NEmp5htMJNQGfiWExmOv0McfqY5wMCGV8DLuCvsyVRIPJlUUQ==}
+  stripe@22.3.0:
+    resolution: {integrity: sha512-ypO6xjVrMWs9SmIMeHr8naCx3dAQ0clxMdUTxn7Ejd7hmY9meBGfE+N4pVHkf9sUNebAHp6uJo6mV3GxDIc2cA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -9345,7 +9345,7 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
-  enhanced-resolve@5.24.0:
+  enhanced-resolve@5.24.1:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -10941,7 +10941,7 @@ snapshots:
 
   react-devtools-core@6.1.5(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
-      shell-quote: 1.8.4
+      shell-quote: 1.9.0
       ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -11312,7 +11312,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.9.0: {}
 
   siginfo@2.0.0: {}
 
@@ -11422,7 +11422,7 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
-  stripe@22.2.2(@types/node@24.13.2):
+  stripe@22.3.0(@types/node@24.13.2):
     optionalDependencies:
       '@types/node': 24.13.2
 
@@ -11724,7 +11724,7 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.17.0)
       browserslist: 4.28.4
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.0
+      enhanced-resolve: 5.24.1
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0


### PR DESCRIPTION
## Summary
- Promotes the dev-merged Stripe SDK bump (#551) to main: `stripe` `^22.2.0` → `^22.3.0`
- Includes the required follow-up fix: pinned `STRIPE_API_VERSION` bumped from `2026-05-27.dahlia` to `2026-06-24.dahlia` in `lib/stripe-api-version.ts`, since stripe-node 22.3.0 only types `apiVersion` against its latest pinned literal
- Changelog review confirmed the API version bump is additive only (new `wechat_pay`/`satispay` payment method enum values, new optional invoice/subscription fields) — no webhook event shape or signature changes
- Full local quality gate run before push: typecheck, lint, unit (3032), browser (315), integration (120) tests, and production build all green

## Test plan
- [x] CI `test` job green on dev merge
- [x] CodeRabbit review: APPROVED, no findings
- [x] Vercel preview build green
- [x] Full local quality gate (typecheck/lint/test/test:browser/test:integration/build) run before pushing the fix commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Stripe integration to a newer supported version.
  * Brought the Stripe-related package dependency up to date for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->