### PR TITLE
Fix idempotency failure domains for session abandonment

### DIFF
--- a/app/(app)/app/practice/hooks/use-practice-incomplete-session.ts
+++ b/app/(app)/app/practice/hooks/use-practice-incomplete-session.ts
@@ -35,6 +35,9 @@ export function usePracticeIncompleteSession(
   >(null);
   const [incompleteSession, setIncompleteSession] =
     useState<IncompletePracticeSession | null>(null);
+  const [abandonIdempotencyKey, setAbandonIdempotencyKey] = useState(() =>
+    crypto.randomUUID(),
+  );
 
   useEffect(() => {
     return createIncompleteSessionEffect({
@@ -50,6 +53,8 @@ export function usePracticeIncompleteSession(
 
     await abandonIncompleteSession({
       sessionId: incompleteSession.sessionId,
+      idempotencyKey: abandonIdempotencyKey,
+      rotateIdempotencyKey: () => setAbandonIdempotencyKey(crypto.randomUUID()),
       mode: incompleteSession.mode,
       endPracticeSessionFn: endPracticeSession,
       discardPracticeSessionFn: discardPracticeSession,
@@ -58,7 +63,7 @@ export function usePracticeIncompleteSession(
       setIncompleteSession,
       isMounted: input.isMounted,
     });
-  }, [incompleteSession, input.isMounted]);
+  }, [abandonIdempotencyKey, incompleteSession, input.isMounted]);
 
   return {
     incompleteSessionStatus,

--- a/app/(app)/app/practice/hooks/use-practice-session-controls.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-controls.browser.spec.tsx
@@ -25,6 +25,8 @@ const getIncompletePracticeSession = vi.mocked(
   practiceController.getIncompletePracticeSession,
 );
 const reportClientErrorSpy = vi.mocked(reportClientError.reportClientError);
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 installReportClientErrorMocks(reportClientError);
 
@@ -211,6 +213,9 @@ describe('usePracticeSessionControls (browser)', () => {
 
     expect(endPracticeSession).toHaveBeenCalledWith({
       sessionId,
+      idempotencyKey: expect.stringMatching(UUID_PATTERN),
+    });
+    expect(endPracticeSession.mock.calls[0]?.[0]).not.toMatchObject({
       idempotencyKey: sessionId,
     });
     expect(discardPracticeSession).not.toHaveBeenCalled();
@@ -244,6 +249,9 @@ describe('usePracticeSessionControls (browser)', () => {
 
     expect(discardPracticeSession).toHaveBeenCalledWith({
       sessionId,
+      idempotencyKey: expect.stringMatching(UUID_PATTERN),
+    });
+    expect(discardPracticeSession.mock.calls[0]?.[0]).not.toMatchObject({
       idempotencyKey: sessionId,
     });
     expect(endPracticeSession).not.toHaveBeenCalled();

--- a/app/(app)/app/practice/hooks/use-practice-session-controls.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-controls.browser.spec.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import * as reportClientError from '@/lib/report-client-error';
+import { err } from '@/src/adapters/controllers/action-result';
 import * as practiceController from '@/src/adapters/controllers/practice-controller';
 import * as tagController from '@/src/adapters/controllers/tag-controller';
 import { ok } from '@/tests/test-helpers/ok';
@@ -172,7 +173,7 @@ describe('usePracticeSessionControls (browser)', () => {
     });
   });
 
-  it('passes session id as idempotency key when abandoning an incomplete session', async () => {
+  it('passes a generated idempotency key when abandoning an incomplete session', async () => {
     const sessionId = '11111111-1111-1111-1111-111111111111';
 
     getTags.mockResolvedValue(ok({ rows: [] }));
@@ -219,6 +220,71 @@ describe('usePracticeSessionControls (browser)', () => {
       idempotencyKey: sessionId,
     });
     expect(discardPracticeSession).not.toHaveBeenCalled();
+  });
+
+  it('rotates the generated abandon idempotency key after an abandon failure', async () => {
+    const sessionId = '11111111-1111-1111-1111-111111111113';
+
+    getTags.mockResolvedValue(ok({ rows: [] }));
+    getIncompletePracticeSession.mockResolvedValue(
+      ok({
+        sessionId,
+        mode: 'tutor',
+        answeredCount: 2,
+        totalCount: 10,
+        startedAt: '2026-02-08T00:00:00.000Z',
+      }),
+    );
+    endPracticeSession
+      .mockResolvedValueOnce(err('INTERNAL_ERROR', 'Nope'))
+      .mockResolvedValueOnce(
+        ok({
+          sessionId,
+          mode: 'tutor',
+          questionCount: 10,
+          endedAt: '2026-02-08T01:00:00.000Z',
+          totals: {
+            answered: 2,
+            correct: 1,
+            accuracy: 0.5,
+            durationSeconds: 120,
+          },
+        }),
+      );
+    countAvailableQuestions.mockResolvedValue(ok({ count: 0 }));
+
+    const screen = await render(<PracticeSessionControlsHookProbe />);
+
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('idle');
+
+    await screen
+      .getByRole('button', { name: 'abandon-incomplete-session' })
+      .click();
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('error');
+
+    const firstCallInput = endPracticeSession.mock.calls[0]?.[0] as
+      | { idempotencyKey?: unknown }
+      | undefined;
+    const firstKey = firstCallInput?.idempotencyKey;
+    expect(firstKey).toEqual(expect.stringMatching(UUID_PATTERN));
+
+    await screen
+      .getByRole('button', { name: 'abandon-incomplete-session' })
+      .click();
+
+    const secondCallInput = endPracticeSession.mock.calls[1]?.[0] as
+      | { idempotencyKey?: unknown }
+      | undefined;
+    const secondKey = secondCallInput?.idempotencyKey;
+    expect(secondKey).toEqual(expect.stringMatching(UUID_PATTERN));
+    expect(secondKey).not.toBe(firstKey);
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('idle');
   });
 
   it('uses discard instead of end when abandoning an incomplete exam session', async () => {

--- a/app/(app)/app/practice/practice-page-incomplete-session.test.ts
+++ b/app/(app)/app/practice/practice-page-incomplete-session.test.ts
@@ -144,6 +144,7 @@ describe('practice-page-incomplete-session', () => {
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        idempotencyKey: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
         mode: 'tutor',
         endPracticeSessionFn,
         discardPracticeSessionFn,
@@ -155,7 +156,7 @@ describe('practice-page-incomplete-session', () => {
 
       expect(endPracticeSessionFn).toHaveBeenCalledWith({
         sessionId: fixtureSession1Id,
-        idempotencyKey: fixtureSession1Id,
+        idempotencyKey: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       });
       expect(discardPracticeSessionFn).not.toHaveBeenCalled();
       expect(setSession).toHaveBeenCalledWith(null);
@@ -171,6 +172,7 @@ describe('practice-page-incomplete-session', () => {
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        idempotencyKey: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
         mode: 'exam',
         endPracticeSessionFn,
         discardPracticeSessionFn,
@@ -182,7 +184,7 @@ describe('practice-page-incomplete-session', () => {
 
       expect(discardPracticeSessionFn).toHaveBeenCalledWith({
         sessionId: fixtureSession1Id,
-        idempotencyKey: fixtureSession1Id,
+        idempotencyKey: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
       });
       expect(endPracticeSessionFn).not.toHaveBeenCalled();
       expect(setSession).toHaveBeenCalledWith(null);
@@ -201,6 +203,7 @@ describe('practice-page-incomplete-session', () => {
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        idempotencyKey: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
         mode: 'tutor',
         endPracticeSessionFn,
         discardPracticeSessionFn,
@@ -219,6 +222,38 @@ describe('practice-page-incomplete-session', () => {
       });
     });
 
+    it('rotates the abandon idempotency key when the request fails', async () => {
+      const setStatus = vi.fn();
+      const setError = vi.fn();
+      const setSession = vi.fn();
+      const rotateIdempotencyKey = vi.fn();
+      const endPracticeSessionFn = vi.fn(async () =>
+        err('INTERNAL_ERROR', 'Nope'),
+      );
+      const discardPracticeSessionFn = vi.fn(async () => ok({}));
+
+      await abandonIncompleteSession({
+        sessionId: fixtureSession1Id,
+        idempotencyKey: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+        rotateIdempotencyKey,
+        mode: 'tutor',
+        endPracticeSessionFn,
+        discardPracticeSessionFn,
+        setIncompleteSessionStatus: setStatus,
+        setIncompleteSessionError: setError,
+        setIncompleteSession: setSession,
+        isMounted: () => true,
+      });
+
+      expect(endPracticeSessionFn).toHaveBeenCalledWith({
+        sessionId: fixtureSession1Id,
+        idempotencyKey: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      });
+      expect(rotateIdempotencyKey).toHaveBeenCalledTimes(1);
+      expect(setStatus).toHaveBeenLastCalledWith('error');
+      expect(setError).toHaveBeenLastCalledWith('Nope');
+    });
+
     it('does not set error state when unmounted after a thrown request', async () => {
       const setStatus = vi.fn();
       const setError = vi.fn();
@@ -230,6 +265,7 @@ describe('practice-page-incomplete-session', () => {
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        idempotencyKey: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
         mode: 'tutor',
         endPracticeSessionFn,
         discardPracticeSessionFn,
@@ -256,6 +292,7 @@ describe('practice-page-incomplete-session', () => {
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        idempotencyKey: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
         mode: 'tutor',
         endPracticeSessionFn,
         discardPracticeSessionFn,

--- a/app/(app)/app/practice/practice-page-incomplete-session.test.ts
+++ b/app/(app)/app/practice/practice-page-incomplete-session.test.ts
@@ -195,6 +195,7 @@ describe('practice-page-incomplete-session', () => {
       const setStatus = vi.fn();
       const setError = vi.fn();
       const setSession = vi.fn();
+      const rotateIdempotencyKey = vi.fn();
       const error = new Error('boom');
       const endPracticeSessionFn = vi.fn(async () => {
         throw error;
@@ -204,6 +205,7 @@ describe('practice-page-incomplete-session', () => {
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
         idempotencyKey: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        rotateIdempotencyKey,
         mode: 'tutor',
         endPracticeSessionFn,
         discardPracticeSessionFn,
@@ -215,6 +217,7 @@ describe('practice-page-incomplete-session', () => {
 
       expect(setStatus).toHaveBeenLastCalledWith('error');
       expect(setError).toHaveBeenLastCalledWith('boom');
+      expect(rotateIdempotencyKey).toHaveBeenCalledTimes(1);
       expect(setSession).not.toHaveBeenCalled();
       expect(reportClientErrorMock).toHaveBeenCalledWith(error, {
         component: 'PracticePageIncompleteSession',

--- a/app/(app)/app/practice/practice-page-incomplete-session.ts
+++ b/app/(app)/app/practice/practice-page-incomplete-session.ts
@@ -63,6 +63,8 @@ export function createIncompleteSessionEffect<T>(input: {
 
 export async function abandonIncompleteSession<T>(input: {
   sessionId: string;
+  idempotencyKey: string;
+  rotateIdempotencyKey?: () => void;
   mode: 'tutor' | 'exam';
   endPracticeSessionFn: (input: unknown) => Promise<ActionResult<unknown>>;
   discardPracticeSessionFn: (input: unknown) => Promise<ActionResult<unknown>>;
@@ -86,7 +88,7 @@ export async function abandonIncompleteSession<T>(input: {
     res = await withTimeout(
       abandonSessionFn({
         sessionId: input.sessionId,
-        idempotencyKey: input.sessionId,
+        idempotencyKey: input.idempotencyKey,
       }),
       ABANDON_SESSION_TIMEOUT_MS,
     );
@@ -96,6 +98,7 @@ export async function abandonIncompleteSession<T>(input: {
       component: 'PracticePageIncompleteSession',
       action: 'abandonIncompleteSession',
     });
+    input.rotateIdempotencyKey?.();
     input.setIncompleteSessionStatus('error');
     input.setIncompleteSessionError(getThrownErrorMessage(error));
     return;
@@ -103,6 +106,7 @@ export async function abandonIncompleteSession<T>(input: {
   if (!input.isMounted()) return;
 
   if (!res.ok) {
+    input.rotateIdempotencyKey?.();
     input.setIncompleteSessionStatus('error');
     input.setIncompleteSessionError(getActionResultErrorMessage(res));
     return;

--- a/src/adapters/controllers/practice-controller-session-lifecycle-idempotency-policy.test.ts
+++ b/src/adapters/controllers/practice-controller-session-lifecycle-idempotency-policy.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ApplicationError,
+  PracticeSessionConflictReasons,
+  practiceSessionAlreadyEndedError,
+} from '@/src/application/errors';
+import { FakeRateLimiter } from '@/src/application/test-helpers/fakes';
+import type {
+  DiscardPracticeSessionInput,
+  DiscardPracticeSessionOutput,
+  EndPracticeSessionInput,
+  EndPracticeSessionOutput,
+} from '@/src/application/use-cases';
+import {
+  discardPracticeSession,
+  endPracticeSession,
+} from './practice-controller';
+import { createDeps } from './practice-controller-test-helpers';
+
+function createOneTimeFailureUseCase<I, O>(input: {
+  output: O;
+  error: unknown;
+}) {
+  const inputs: I[] = [];
+
+  return {
+    inputs,
+    async execute(nextInput: I): Promise<O> {
+      inputs.push(nextInput);
+      if (inputs.length === 1) throw input.error;
+      return input.output;
+    },
+  };
+}
+
+describe('practice-controller lifecycle idempotency policy', () => {
+  it('does not cache transient end-session failures under the idempotency key', async () => {
+    const endOutput = {
+      sessionId: '22222222-2222-2222-2222-222222222222',
+      endedAt: '2026-02-01T00:00:00.000Z',
+      mode: 'tutor',
+      questionCount: 1,
+      totals: { answered: 0, correct: 0, accuracy: 0, durationSeconds: 0 },
+    } as const satisfies EndPracticeSessionOutput;
+    const endUseCase = createOneTimeFailureUseCase<
+      EndPracticeSessionInput,
+      EndPracticeSessionOutput
+    >({
+      output: endOutput,
+      error: new ApplicationError('INTERNAL_ERROR', 'connection reset'),
+    });
+    const deps = {
+      ...createDeps(),
+      endPracticeSessionUseCase: endUseCase,
+    };
+    const input = {
+      sessionId: '11111111-1111-1111-1111-111111111111',
+      idempotencyKey: '11111111-1111-1111-1111-111111111111',
+    } as const;
+
+    const first = await endPracticeSession(input, deps);
+    expect(first).toMatchObject({
+      ok: false,
+      error: { code: 'INTERNAL_ERROR', message: 'connection reset' },
+    });
+
+    const second = await endPracticeSession(input, deps);
+    expect(second).toEqual({ ok: true, data: endOutput });
+    expect(endUseCase.inputs).toHaveLength(2);
+  });
+
+  it('caches terminal end-session conflicts with structured reasons', async () => {
+    const terminalError = practiceSessionAlreadyEndedError();
+    const endUseCase = {
+      inputs: [] as EndPracticeSessionInput[],
+      async execute(input: EndPracticeSessionInput) {
+        this.inputs.push(input);
+        throw terminalError;
+      },
+    };
+    const deps = {
+      ...createDeps(),
+      endPracticeSessionUseCase: endUseCase,
+    };
+    const input = {
+      sessionId: '11111111-1111-1111-1111-111111111111',
+      idempotencyKey: '11111111-1111-1111-1111-111111111111',
+    } as const;
+
+    const first = await endPracticeSession(input, deps);
+    const second = await endPracticeSession(input, deps);
+
+    expect(first).toEqual({
+      ok: false,
+      error: {
+        code: 'CONFLICT',
+        message: 'Practice session already ended',
+        details: {
+          reason: PracticeSessionConflictReasons.AlreadyEnded,
+        },
+      },
+    });
+    expect(second).toEqual(first);
+    expect(endUseCase.inputs).toHaveLength(1);
+  });
+
+  it('does not cache non-terminal discard use-case ApplicationErrors when idempotencyKey is reused', async () => {
+    const discardUseCase = createOneTimeFailureUseCase<
+      DiscardPracticeSessionInput,
+      DiscardPracticeSessionOutput
+    >({
+      output: { discarded: true },
+      error: new ApplicationError('NOT_FOUND', 'Session not found'),
+    });
+    const deps = {
+      ...createDeps({
+        rateLimiter: new FakeRateLimiter([
+          { success: true, limit: 20, remaining: 19, retryAfterSeconds: 0 },
+          { success: true, limit: 20, remaining: 18, retryAfterSeconds: 0 },
+        ]),
+      }),
+      discardPracticeSessionUseCase: discardUseCase,
+    };
+    const input = {
+      sessionId: '11111111-1111-1111-1111-111111111111',
+      idempotencyKey: '11111111-1111-1111-1111-111111111111',
+    } as const;
+
+    const first = await discardPracticeSession(input, deps);
+    const second = await discardPracticeSession(input, deps);
+
+    expect(first).toEqual({
+      ok: false,
+      error: { code: 'NOT_FOUND', message: 'Session not found' },
+    });
+    expect(second).toEqual({ ok: true, data: { discarded: true } });
+    expect(discardUseCase.inputs).toHaveLength(2);
+    expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(2);
+  });
+
+  it('does not cache internal discard failures when idempotencyKey is reused', async () => {
+    const discardUseCase = createOneTimeFailureUseCase<
+      DiscardPracticeSessionInput,
+      DiscardPracticeSessionOutput
+    >({
+      output: { discarded: true },
+      error: new ApplicationError('INTERNAL_ERROR', 'deadlock victim'),
+    });
+    const deps = {
+      ...createDeps({
+        rateLimiter: new FakeRateLimiter([
+          { success: true, limit: 20, remaining: 19, retryAfterSeconds: 0 },
+          { success: true, limit: 20, remaining: 18, retryAfterSeconds: 0 },
+        ]),
+      }),
+      discardPracticeSessionUseCase: discardUseCase,
+    };
+    const input = {
+      sessionId: '11111111-1111-1111-1111-111111111111',
+      idempotencyKey: '11111111-1111-1111-1111-111111111111',
+    } as const;
+
+    const first = await discardPracticeSession(input, deps);
+    const second = await discardPracticeSession(input, deps);
+
+    expect(first).toEqual({
+      ok: false,
+      error: { code: 'INTERNAL_ERROR', message: 'deadlock victim' },
+    });
+    expect(second).toEqual({ ok: true, data: { discarded: true } });
+    expect(discardUseCase.inputs).toHaveLength(2);
+    expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(2);
+  });
+
+  it('caches terminal discard conflicts with structured reasons', async () => {
+    const terminalError = practiceSessionAlreadyEndedError();
+    const discardUseCase = {
+      inputs: [] as DiscardPracticeSessionInput[],
+      async execute(input: DiscardPracticeSessionInput) {
+        this.inputs.push(input);
+        throw terminalError;
+      },
+    };
+    const deps = {
+      ...createDeps({
+        rateLimiter: new FakeRateLimiter([
+          { success: true, limit: 20, remaining: 19, retryAfterSeconds: 0 },
+          { success: false, limit: 20, remaining: 0, retryAfterSeconds: 60 },
+        ]),
+      }),
+      discardPracticeSessionUseCase: discardUseCase,
+    };
+    const input = {
+      sessionId: '11111111-1111-1111-1111-111111111111',
+      idempotencyKey: '11111111-1111-1111-1111-111111111111',
+    } as const;
+
+    const first = await discardPracticeSession(input, deps);
+    const second = await discardPracticeSession(input, deps);
+
+    expect(first).toEqual({
+      ok: false,
+      error: {
+        code: 'CONFLICT',
+        message: 'Practice session already ended',
+        details: {
+          reason: PracticeSessionConflictReasons.AlreadyEnded,
+        },
+      },
+    });
+    expect(second).toEqual(first);
+    expect(discardUseCase.inputs).toHaveLength(1);
+    expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
+  });
+});

--- a/src/adapters/controllers/practice-controller-session-lifecycle.test.ts
+++ b/src/adapters/controllers/practice-controller-session-lifecycle.test.ts
@@ -609,31 +609,6 @@ describe('practice-controller', () => {
       expect(deps.discardPracticeSessionUseCase.inputs).toHaveLength(1);
       expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
     });
-
-    it('keeps genuine discard use-case ApplicationErrors cached when idempotencyKey is reused', async () => {
-      const deps = createDeps({
-        rateLimiter: new FakeRateLimiter([
-          { success: true, limit: 20, remaining: 19, retryAfterSeconds: 0 },
-          { success: false, limit: 20, remaining: 0, retryAfterSeconds: 60 },
-        ]),
-        discardThrows: new ApplicationError('NOT_FOUND', 'Session not found'),
-      });
-      const input = {
-        sessionId: '11111111-1111-1111-1111-111111111111',
-        idempotencyKey: '11111111-1111-1111-1111-111111111111',
-      } as const;
-
-      const first = await discardPracticeSession(input, deps);
-      const second = await discardPracticeSession(input, deps);
-
-      expect(first).toEqual({
-        ok: false,
-        error: { code: 'NOT_FOUND', message: 'Session not found' },
-      });
-      expect(second).toEqual(first);
-      expect(deps.discardPracticeSessionUseCase.inputs).toHaveLength(1);
-      expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
-    });
   });
 
   describe('finalizeExamAnswers', () => {

--- a/src/adapters/controllers/practice-controller.ts
+++ b/src/adapters/controllers/practice-controller.ts
@@ -67,7 +67,10 @@ import {
 import type { CheckEntitlementUseCase } from './require-entitled-user-id';
 import { requireEntitledUserId } from './require-entitled-user-id';
 import { executeIdempotent } from './shared/execute-idempotent';
-import { shouldCachePracticeSessionStateWriteError } from './shared/practice-session-idempotency-policy';
+import {
+  shouldCachePracticeSessionLifecycleError,
+  shouldCachePracticeSessionStateWriteError,
+} from './shared/practice-session-idempotency-policy';
 
 export type {
   CountAvailableQuestionsOutput,
@@ -272,6 +275,7 @@ export const endPracticeSession = createAction({
       action: 'practice:endPracticeSession',
       idempotencyKey,
       outputSchema: EndPracticeSessionOutputSchema,
+      shouldCacheError: shouldCachePracticeSessionLifecycleError,
       execute: () =>
         d.endPracticeSessionUseCase.execute({
           userId,
@@ -309,6 +313,7 @@ export const discardPracticeSession = createAction({
       idempotencyKey,
       outputSchema: DiscardPracticeSessionOutputSchema,
       beforeExecute: enforceSessionMutationRateLimit,
+      shouldCacheError: shouldCachePracticeSessionLifecycleError,
       execute: () =>
         d.discardPracticeSessionUseCase.execute({
           userId,

--- a/src/adapters/controllers/shared/practice-session-idempotency-policy.test.ts
+++ b/src/adapters/controllers/shared/practice-session-idempotency-policy.test.ts
@@ -5,7 +5,10 @@ import {
   practiceSessionAlreadyEndedError,
   practiceSessionStateChangedConcurrentlyError,
 } from '@/src/application/errors';
-import { shouldCachePracticeSessionStateWriteError } from './practice-session-idempotency-policy';
+import {
+  shouldCachePracticeSessionLifecycleError,
+  shouldCachePracticeSessionStateWriteError,
+} from './practice-session-idempotency-policy';
 
 describe('shouldCachePracticeSessionStateWriteError', () => {
   it('does not cache transient practice-session state conflicts', () => {
@@ -42,5 +45,50 @@ describe('shouldCachePracticeSessionStateWriteError', () => {
         }),
       ),
     ).toBe(true);
+  });
+});
+
+describe('shouldCachePracticeSessionLifecycleError', () => {
+  it('caches only monotone terminal practice-session conflicts', () => {
+    expect(
+      shouldCachePracticeSessionLifecycleError(
+        practiceSessionAlreadyEndedError(),
+      ),
+    ).toBe(true);
+    expect(
+      shouldCachePracticeSessionLifecycleError(
+        new ApplicationError('CONFLICT', 'Exam time expired', undefined, {
+          details: {
+            reason: PracticeSessionConflictReasons.ExamTimeExpired,
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not cache transient, unmapped, or non-terminal lifecycle failures', () => {
+    expect(
+      shouldCachePracticeSessionLifecycleError(
+        practiceSessionStateChangedConcurrentlyError(),
+      ),
+    ).toBe(false);
+    expect(
+      shouldCachePracticeSessionLifecycleError(
+        new ApplicationError('CONFLICT', 'Plain conflict'),
+      ),
+    ).toBe(false);
+    expect(
+      shouldCachePracticeSessionLifecycleError(
+        new ApplicationError('INTERNAL_ERROR', 'deadlock victim'),
+      ),
+    ).toBe(false);
+    expect(
+      shouldCachePracticeSessionLifecycleError(
+        new ApplicationError('NOT_FOUND', 'Practice session not found'),
+      ),
+    ).toBe(false);
+    expect(shouldCachePracticeSessionLifecycleError(new Error('40P01'))).toBe(
+      false,
+    );
   });
 });

--- a/src/adapters/controllers/shared/practice-session-idempotency-policy.ts
+++ b/src/adapters/controllers/shared/practice-session-idempotency-policy.ts
@@ -1,5 +1,6 @@
 import {
   isApplicationError,
+  isPracticeSessionConflictReason,
   PracticeSessionConflictReasons,
 } from '@/src/application/errors';
 
@@ -10,5 +11,19 @@ export function shouldCachePracticeSessionStateWriteError(
     isApplicationError(error) &&
     error.details?.reason ===
       PracticeSessionConflictReasons.StateChangedConcurrently
+  );
+}
+
+export function shouldCachePracticeSessionLifecycleError(
+  error: unknown,
+): boolean {
+  if (!isApplicationError(error) || error.code !== 'CONFLICT') return false;
+
+  const reason = error.details?.reason;
+  if (!isPracticeSessionConflictReason(reason)) return false;
+
+  return (
+    reason === PracticeSessionConflictReasons.AlreadyEnded ||
+    reason === PracticeSessionConflictReasons.ExamTimeExpired
   );
 }

--- a/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   PRACTICE_SESSIONS_USER_INCOMPLETE_UQ,
+  practiceSessionQuestionStates,
   practiceSessions,
 } from '@/db/schema';
 import { ApplicationError } from '@/src/application/errors';
@@ -314,12 +315,20 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
     expect(tx.insert).toHaveBeenCalledTimes(1);
   });
 
-  it('discards an incomplete practice session by deleting the session row', async () => {
+  it('discards an incomplete practice session child-first in one transaction', async () => {
     const deleteWhere = vi.fn(async () => undefined);
     const deleteFrom = vi.fn(() => ({ where: deleteWhere }));
+    const tx = {
+      delete: deleteFrom,
+    };
 
     const db = {
-      delete: deleteFrom,
+      transaction: vi.fn(async (fn: (client: typeof tx) => Promise<unknown>) =>
+        fn(tx),
+      ),
+      delete: () => {
+        throw new Error('unexpected delete outside transaction');
+      },
       insert: () => {
         throw new Error('unexpected insert');
       },
@@ -342,8 +351,13 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
 
     await expect(repo.discard(sessionId, userId)).resolves.toBeUndefined();
 
-    expect(deleteFrom).toHaveBeenCalledWith(practiceSessions);
-    expect(deleteWhere).toHaveBeenCalledTimes(1);
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(deleteFrom).toHaveBeenNthCalledWith(
+      1,
+      practiceSessionQuestionStates,
+    );
+    expect(deleteFrom).toHaveBeenNthCalledWith(2, practiceSessions);
+    expect(deleteWhere).toHaveBeenCalledTimes(2);
   });
 
   it('ends an active practice session', async () => {

--- a/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
@@ -1,3 +1,5 @@
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   PRACTICE_SESSIONS_USER_INCOMPLETE_UQ,
@@ -352,12 +354,27 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
     await expect(repo.discard(sessionId, userId)).resolves.toBeUndefined();
 
     expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(db.transaction).toHaveBeenCalledWith(expect.any(Function), {
+      isolationLevel: 'repeatable read',
+    });
     expect(deleteFrom).toHaveBeenNthCalledWith(
       1,
       practiceSessionQuestionStates,
     );
     expect(deleteFrom).toHaveBeenNthCalledWith(2, practiceSessions);
     expect(deleteWhere).toHaveBeenCalledTimes(2);
+
+    const childDeleteWhere = deleteWhere.mock.calls[0]?.[0];
+    expect(childDeleteWhere).toBeDefined();
+    const childDeleteSql = new PgDialect().sqlToQuery(
+      childDeleteWhere as SQL,
+    ).sql;
+    expect(childDeleteSql).toContain(
+      '"practice_session_question_states"."practice_session_id"',
+    );
+    expect(childDeleteSql).toContain('exists');
+    expect(childDeleteSql).toContain('"practice_sessions"."user_id"');
+    expect(childDeleteSql).toContain('"practice_sessions"."ended_at" is null');
   });
 
   it('ends an active practice session', async () => {

--- a/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
@@ -318,7 +318,7 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
   });
 
   it('discards an incomplete practice session child-first in one transaction', async () => {
-    const deleteWhere = vi.fn(async () => undefined);
+    const deleteWhere = vi.fn(async (_where: unknown) => undefined);
     const deleteFrom = vi.fn(() => ({ where: deleteWhere }));
     const tx = {
       delete: deleteFrom,
@@ -367,7 +367,7 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
     const childDeleteWhere = deleteWhere.mock.calls[0]?.[0];
     expect(childDeleteWhere).toBeDefined();
     const childDeleteSql = new PgDialect().sqlToQuery(
-      childDeleteWhere as SQL,
+      childDeleteWhere as unknown as SQL,
     ).sql;
     expect(childDeleteSql).toContain(
       '"practice_session_question_states"."practice_session_id"',

--- a/src/adapters/repositories/drizzle-practice-session-repository.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository.ts
@@ -449,15 +449,30 @@ export class DrizzlePracticeSessionRepository
   }
 
   async discard(id: string, userId: string): Promise<void> {
-    await this.db
-      .delete(practiceSessions)
-      .where(
+    await this.db.transaction(async (tx) => {
+      await tx.delete(practiceSessionQuestionStates).where(
         and(
-          eq(practiceSessions.id, id),
-          eq(practiceSessions.userId, userId),
-          isNull(practiceSessions.endedAt),
+          eq(practiceSessionQuestionStates.practiceSessionId, id),
+          sql`exists (
+              select 1
+              from ${practiceSessions}
+              where ${practiceSessions.id} = ${practiceSessionQuestionStates.practiceSessionId}
+                and ${practiceSessions.userId} = ${userId}
+                and ${practiceSessions.endedAt} is null
+            )`,
         ),
       );
+
+      await tx
+        .delete(practiceSessions)
+        .where(
+          and(
+            eq(practiceSessions.id, id),
+            eq(practiceSessions.userId, userId),
+            isNull(practiceSessions.endedAt),
+          ),
+        );
+    });
   }
 
   async end(id: string, userId: string, explicitEndedAt?: Date) {

--- a/src/adapters/repositories/drizzle-practice-session-repository.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository.ts
@@ -449,30 +449,33 @@ export class DrizzlePracticeSessionRepository
   }
 
   async discard(id: string, userId: string): Promise<void> {
-    await this.db.transaction(async (tx) => {
-      await tx.delete(practiceSessionQuestionStates).where(
-        and(
-          eq(practiceSessionQuestionStates.practiceSessionId, id),
-          sql`exists (
+    await this.db.transaction(
+      async (tx) => {
+        await tx.delete(practiceSessionQuestionStates).where(
+          and(
+            eq(practiceSessionQuestionStates.practiceSessionId, id),
+            sql`exists (
               select 1
               from ${practiceSessions}
               where ${practiceSessions.id} = ${practiceSessionQuestionStates.practiceSessionId}
                 and ${practiceSessions.userId} = ${userId}
                 and ${practiceSessions.endedAt} is null
             )`,
-        ),
-      );
-
-      await tx
-        .delete(practiceSessions)
-        .where(
-          and(
-            eq(practiceSessions.id, id),
-            eq(practiceSessions.userId, userId),
-            isNull(practiceSessions.endedAt),
           ),
         );
-    });
+
+        await tx
+          .delete(practiceSessions)
+          .where(
+            and(
+              eq(practiceSessions.id, id),
+              eq(practiceSessions.userId, userId),
+              isNull(practiceSessions.endedAt),
+            ),
+          );
+      },
+      { isolationLevel: 'repeatable read' },
+    );
   }
 
   async end(id: string, userId: string, explicitEndedAt?: Date) {

--- a/src/adapters/shared/with-idempotency-outcome-write.test.ts
+++ b/src/adapters/shared/with-idempotency-outcome-write.test.ts
@@ -92,4 +92,36 @@ describe('withIdempotency outcome writes', () => {
     });
     expect(execute).toHaveBeenCalledTimes(1);
   });
+
+  it('returns the committed result when both storeResult and outcome logging fail', async () => {
+    class StoreResultFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        throw new Error('store result failed');
+      }
+    }
+
+    class ThrowingErrorLogger extends FakeLogger {
+      override error(): void {
+        throw new Error('logger failed');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new StoreResultFailingRepo(now);
+    const logger = new ThrowingErrorLogger();
+    const execute = vi.fn(async () => ({ ok: true }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key: '14141414-1414-1414-1414-141414141414',
+        now,
+        logger,
+        execute,
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/adapters/shared/with-idempotency-outcome-write.test.ts
+++ b/src/adapters/shared/with-idempotency-outcome-write.test.ts
@@ -124,4 +124,65 @@ describe('withIdempotency outcome writes', () => {
     ).resolves.toEqual({ ok: true });
     expect(execute).toHaveBeenCalledTimes(1);
   });
+
+  it('preserves the stale-claim error when storeResult detects a fenced claim', async () => {
+    const staleClaimError = new ApplicationError(
+      'NOT_FOUND',
+      'Idempotency claim is no longer current',
+    );
+    class StaleClaimRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        throw staleClaimError;
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new StaleClaimRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ ok: true }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key: '15151515-1515-1515-1515-151515151515',
+        now,
+        logger,
+        execute,
+      }),
+    ).rejects.toBe(staleClaimError);
+    expect(logger.errorCalls).toHaveLength(0);
+  });
+
+  it('logs non-error storeResult failures and returns the committed result', async () => {
+    class StoreResultFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        return Promise.reject('store result failed literal');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new StoreResultFailingRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ ok: true }));
+    const key = '16161616-1616-1616-1616-161616161616';
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key,
+        now,
+        logger,
+        execute,
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(logger.errorCalls[0]).toMatchObject({
+      context: {
+        storeResultError: 'store result failed literal',
+      },
+    });
+  });
 });

--- a/src/adapters/shared/with-idempotency-outcome-write.test.ts
+++ b/src/adapters/shared/with-idempotency-outcome-write.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ApplicationError } from '@/src/application/errors';
+import {
+  FakeIdempotencyKeyRepository,
+  FakeLogger,
+} from '@/src/application/test-helpers/fakes';
+import { withIdempotency } from './with-idempotency';
+
+const appUserId = crypto.randomUUID();
+
+describe('withIdempotency outcome writes', () => {
+  it('returns the committed result and does not cache an error when storeResult fails after execute succeeds', async () => {
+    class StoreResultFailingRepo extends FakeIdempotencyKeyRepository {
+      storeErrorCalls = 0;
+
+      override async storeResult(): Promise<void> {
+        throw new Error('store result failed');
+      }
+
+      override async storeError(
+        input: Parameters<FakeIdempotencyKeyRepository['storeError']>[0],
+      ): Promise<void> {
+        this.storeErrorCalls += 1;
+        await super.storeError(input);
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new StoreResultFailingRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ ok: true }));
+    const key = '12121212-1212-1212-1212-121212121212';
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key,
+        now,
+        logger,
+        execute,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    await expect(
+      repo.find(appUserId, 'billing:createCheckoutSession', key),
+    ).resolves.toMatchObject({
+      error: null,
+      completedAt: null,
+    });
+    expect(repo.storeErrorCalls).toBe(0);
+    expect(logger.errorCalls).toHaveLength(1);
+    expect(logger.errorCalls[0]).toMatchObject({
+      msg: 'Idempotency outcome write failed after committed success',
+      context: {
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key,
+        storeResultError: 'store result failed',
+      },
+    });
+  });
+
+  it('continues to cache cacheable execute failures after separating outcome-write failures', async () => {
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new FakeIdempotencyKeyRepository(now);
+    const logger = new FakeLogger();
+    const key = '13131313-1313-1313-1313-131313131313';
+    const executeError = new ApplicationError(
+      'INTERNAL_ERROR',
+      'execute failed',
+    );
+    const execute = vi.fn(async () => {
+      throw executeError;
+    });
+
+    const input = {
+      repo,
+      userId: appUserId,
+      action: 'billing:createCheckoutSession',
+      key,
+      now,
+      logger,
+      execute,
+    } as const;
+
+    await expect(withIdempotency(input)).rejects.toBe(executeError);
+    await expect(withIdempotency(input)).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message: 'execute failed',
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/adapters/shared/with-idempotency.ts
+++ b/src/adapters/shared/with-idempotency.ts
@@ -162,16 +162,9 @@ export async function withIdempotency<T>(input: {
         }
       }
 
+      let result: T;
       try {
-        const result = await input.execute();
-        await input.repo.storeResult({
-          userId: input.userId,
-          action: input.action,
-          key: input.key,
-          claimedAt,
-          resultJson: result,
-        });
-        return result;
+        result = await input.execute();
       } catch (error) {
         if (!shouldCacheExecutionError(input.shouldCacheError, error)) {
           await abortClaimPreservingOriginalError(
@@ -213,6 +206,42 @@ export async function withIdempotency<T>(input: {
         }
         throw error;
       }
+
+      try {
+        await input.repo.storeResult({
+          userId: input.userId,
+          action: input.action,
+          key: input.key,
+          claimedAt,
+          resultJson: result,
+        });
+      } catch (storeResultError) {
+        if (
+          isApplicationError(storeResultError) &&
+          storeResultError.code === 'NOT_FOUND'
+        ) {
+          throw storeResultError;
+        }
+
+        try {
+          input.logger.error(
+            {
+              userId: input.userId,
+              action: input.action,
+              key: input.key,
+              storeResultError:
+                storeResultError instanceof Error
+                  ? storeResultError.message
+                  : String(storeResultError),
+            },
+            'Idempotency outcome write failed after committed success',
+          );
+        } catch {
+          // Preserve the committed business result even if logging fails.
+        }
+      }
+
+      return result;
     }
 
     let shouldRestartClaim = false;


### PR DESCRIPTION
## Summary
- split idempotency execute failures from post-success outcome-write failures so a failed `storeResult` no longer caches a false error after committed work
- add lifecycle-specific end/discard idempotency error caching: only terminal structured conflicts are cached; transient/internal/unmapped failures abort and re-execute
- make discard delete normalized question-state rows before the parent session row in one transaction
- rotate the incomplete-session abandon idempotency key after failures instead of reusing the raw session id

## Verification
- red-first focused test run failed on the new BUG-279/BUG-278 specs before implementation
- `pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build && pnpm test:e2e`
- final E2E: 36 passed

## Notes
- no migrations
- BUG-277/280/282 are intentionally out of scope for PR-B


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved reliability for abandoning incomplete practice sessions with safer retry handling.

* **Bug Fixes**
  * Repeated abandon/discard actions now behave consistently and won’t reuse stale request identifiers.
  * Incomplete practice sessions are now fully cleaned up, including related session data, so leftovers are less likely after discard.
  * Retry behavior is more resilient when a previous attempt fails, helping preserve successful results and reduce confusing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->