### PR TITLE
Fix finalize and tutor conflict reason recovery

### DIFF
--- a/app/(app)/app/practice/[sessionId]/components/exam-review-view.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/exam-review-view.browser.spec.tsx
@@ -201,7 +201,9 @@ test('opens a review question and finalizes the exam', async () => {
 });
 
 test('guards against double-clicking confirm submit before pending state updates', async () => {
-  const onFinalizeReview = vi.fn(() => new Promise<void>(() => {}));
+  const onFinalizeReview = vi.fn(
+    () => new Promise<boolean | undefined>(() => {}),
+  );
 
   const screen = await render(
     <ExamReviewView
@@ -228,7 +230,7 @@ test('guards against double-clicking confirm submit before pending state updates
 });
 
 test('allows submitting again after finalize resolves even when pending state never flips', async () => {
-  const finalizeDeferred = createDeferred<void>();
+  const finalizeDeferred = createDeferred<boolean | undefined>();
   const onFinalizeReview = vi.fn(() => finalizeDeferred.promise);
 
   const screen = await render(
@@ -254,7 +256,7 @@ test('allows submitting again after finalize resolves even when pending state ne
   await screen.getByRole('button', { name: 'Confirm submit' }).click();
   expect(onFinalizeReview).toHaveBeenCalledTimes(1);
 
-  finalizeDeferred.resolve();
+  finalizeDeferred.resolve(undefined);
   await finalizeDeferred.promise;
 
   await expect

--- a/app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx
@@ -133,7 +133,7 @@ export function ExamReviewView({
   review: GetPracticeSessionReviewOutput;
   isPending: boolean;
   onOpenQuestion: (questionId: string) => void;
-  onFinalizeReview: () => Promise<void>;
+  onFinalizeReview: () => Promise<boolean | void>;
 }) {
   const unansweredCount = review.totalCount - review.answeredCount;
   const isFinalizingRef = useRef(false);

--- a/app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx
@@ -133,7 +133,7 @@ export function ExamReviewView({
   review: GetPracticeSessionReviewOutput;
   isPending: boolean;
   onOpenQuestion: (questionId: string) => void;
-  onFinalizeReview: () => Promise<boolean | void>;
+  onFinalizeReview: () => Promise<boolean | undefined>;
 }) {
   const unansweredCount = review.totalCount - review.answeredCount;
   const isFinalizingRef = useRef(false);

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx
@@ -77,7 +77,7 @@ export type PracticeSessionPageViewProps = {
   onNavigatePostExamReviewQuestion?: ((questionId: string) => void) | undefined;
   onReenterPostExamReview?: ((questionId?: string) => void) | undefined;
   onViewSummary?: (() => void) | undefined;
-  onFinalizeReview?: (() => Promise<void>) | undefined;
+  onFinalizeReview?: (() => Promise<boolean | void>) | undefined;
 };
 
 export function PracticeSessionPageView(props: PracticeSessionPageViewProps) {

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx
@@ -77,7 +77,7 @@ export type PracticeSessionPageViewProps = {
   onNavigatePostExamReviewQuestion?: ((questionId: string) => void) | undefined;
   onReenterPostExamReview?: ((questionId?: string) => void) | undefined;
   onViewSummary?: (() => void) | undefined;
-  onFinalizeReview?: (() => Promise<boolean | void>) | undefined;
+  onFinalizeReview?: (() => Promise<boolean | undefined>) | undefined;
 };
 
 export function PracticeSessionPageView(props: PracticeSessionPageViewProps) {

--- a/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.browser.spec.tsx
@@ -6,7 +6,7 @@ import { useExamTimer } from './use-exam-timer';
 function TimerProbe(props: {
   initialDeadlineAt: string | null;
   isExamActive?: boolean;
-  onExpire: () => boolean | undefined;
+  onExpire: () => boolean | undefined | Promise<boolean | undefined>;
 }) {
   const [deadlineAt, setDeadlineAt] = useState(props.initialDeadlineAt);
   const timer = useExamTimer({
@@ -102,6 +102,30 @@ describe('useExamTimer', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
     const onExpire = vi.fn().mockReturnValueOnce(false);
+
+    await render(
+      <TimerProbe
+        initialDeadlineAt="2026-05-22T12:00:01.000Z"
+        onExpire={onExpire}
+      />,
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries an expired deadline when onExpire rejects', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    const onExpire = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Finalize failed'));
 
     await render(
       <TimerProbe

--- a/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.browser.spec.tsx
@@ -6,7 +6,7 @@ import { useExamTimer } from './use-exam-timer';
 function TimerProbe(props: {
   initialDeadlineAt: string | null;
   isExamActive?: boolean;
-  onExpire: () => void;
+  onExpire: () => boolean | undefined;
 }) {
   const [deadlineAt, setDeadlineAt] = useState(props.initialDeadlineAt);
   const timer = useExamTimer({
@@ -96,6 +96,28 @@ describe('useExamTimer', () => {
 
     window.dispatchEvent(new Event('focus'));
     expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries an expired deadline when onExpire reports that recovery failed', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    const onExpire = vi.fn().mockReturnValueOnce(false);
+
+    await render(
+      <TimerProbe
+        initialDeadlineAt="2026-05-22T12:00:01.000Z"
+        onExpire={onExpire}
+      />,
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(2);
   });
 
   it('re-latches when a future deadline is replaced by a past deadline', async () => {

--- a/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.ts
@@ -11,7 +11,7 @@ export type ExamTimerState = {
 export type UseExamTimerInput = {
   deadlineAt: string | null;
   isExamActive: boolean;
-  onExpire: () => void;
+  onExpire: () => boolean | undefined | Promise<boolean | undefined>;
 };
 
 function computeRemainingSeconds(deadlineMs: number, nowMs: number): number {
@@ -61,7 +61,17 @@ export function useExamTimer(input: UseExamTimerInput): ExamTimerState | null {
       }
 
       firedDeadlineMsRef.current = deadlineMs;
-      onExpireRef.current();
+      void Promise.resolve(onExpireRef.current())
+        .then((handled) => {
+          if (handled === false && firedDeadlineMsRef.current === deadlineMs) {
+            firedDeadlineMsRef.current = null;
+          }
+        })
+        .catch(() => {
+          if (firedDeadlineMsRef.current === deadlineMs) {
+            firedDeadlineMsRef.current = null;
+          }
+        });
     }
 
     update();

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-ended-session-conflict.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-ended-session-conflict.browser.spec.tsx
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-react';
+import type { ActionResult } from '@/src/adapters/controllers/action-result';
+import {
+  PracticeSessionConflictMessages,
+  PracticeSessionConflictReasons,
+} from '@/src/application/errors';
+import { createDeferred } from '@/tests/test-helpers/create-deferred';
+import { ok } from '@/tests/test-helpers/ok';
+
+import {
+  createQuestionResponse,
+  createReviewResponse,
+  createReviewRow,
+} from './practice-session-page-model.browser.fixtures';
+import {
+  BROWSER_QUESTION_1_ID,
+  BROWSER_SESSION_ID,
+  errorResult,
+  getNextQuestionMock,
+  getPracticeSessionReviewMock,
+  getPracticeSessionSummaryMock,
+  PracticeSessionPageModelNavigationProbe,
+  PracticeSessionPageModelSummaryProbe,
+  setupPracticeSessionPageModelBrowserSpec,
+  submitAnswerMock,
+} from './use-practice-session-page-model-test-helpers';
+
+setupPracticeSessionPageModelBrowserSpec();
+
+function mockTutorSummary() {
+  return ok({
+    sessionId: BROWSER_SESSION_ID,
+    endedAt: '2026-02-07T00:20:00.000Z',
+    mode: 'tutor' as const,
+    questionCount: 2,
+    totals: {
+      answered: 1,
+      correct: 1,
+      accuracy: 0.5,
+      durationSeconds: 1200,
+    },
+  });
+}
+
+function mockTutorReview() {
+  getPracticeSessionReviewMock.mockResolvedValue(
+    ok(
+      createReviewResponse({
+        mode: 'tutor',
+        totalCount: 2,
+        answeredCount: 1,
+        markedCount: 0,
+        rows: [
+          createReviewRow({ questionId: BROWSER_QUESTION_1_ID, order: 1 }),
+        ],
+      }),
+    ),
+  );
+}
+
+function alreadyEndedConflict() {
+  return errorResult('CONFLICT', PracticeSessionConflictMessages.AlreadyEnded, {
+    reason: PracticeSessionConflictReasons.AlreadyEnded,
+  });
+}
+
+function mockActiveTutorQuestionThenEndedConflict() {
+  getNextQuestionMock
+    .mockResolvedValueOnce(
+      ok(
+        createQuestionResponse({
+          questionId: BROWSER_QUESTION_1_ID,
+          session: {
+            mode: 'tutor',
+            deadlineAt: null,
+            index: 0,
+            total: 2,
+            isMarkedForReview: false,
+          },
+        }),
+      ),
+    )
+    .mockResolvedValue(alreadyEndedConflict());
+}
+
+describe('usePracticeSessionPageModel ended-session conflict recovery', () => {
+  it('shows the summary when loading a tutor question reports an AlreadyEnded conflict', async () => {
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockResolvedValueOnce(mockTutorSummary());
+    getNextQuestionMock.mockResolvedValue(alreadyEndedConflict());
+    mockTutorReview();
+
+    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
+
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    await expect
+      .element(screen.getByTestId('summary-mode'))
+      .toHaveTextContent('tutor');
+    await expect
+      .element(screen.getByTestId('error-message'))
+      .toHaveTextContent('');
+  });
+
+  it('keeps the generic load error when ended-session recovery still reports an active session', async () => {
+    getPracticeSessionSummaryMock.mockResolvedValue(
+      errorResult('CONFLICT', 'Practice session has not ended'),
+    );
+    getNextQuestionMock.mockResolvedValue(alreadyEndedConflict());
+
+    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
+
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('');
+    await expect
+      .element(screen.getByTestId('load-status'))
+      .toHaveTextContent('error');
+    await expect
+      .element(screen.getByTestId('error-message'))
+      .toHaveTextContent(PracticeSessionConflictMessages.AlreadyEnded);
+  });
+
+  it('keeps the generic load error when ended-session recovery summary re-read throws', async () => {
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockRejectedValueOnce(new Error('Summary recovery failed'));
+    getNextQuestionMock.mockResolvedValue(alreadyEndedConflict());
+
+    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
+
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('');
+    await expect
+      .element(screen.getByTestId('load-status'))
+      .toHaveTextContent('error');
+    await expect
+      .element(screen.getByTestId('error-message'))
+      .toHaveTextContent(PracticeSessionConflictMessages.AlreadyEnded);
+  });
+
+  it('shows the summary when tutor answer submit reports an AlreadyEnded conflict', async () => {
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockResolvedValueOnce(mockTutorSummary());
+    mockActiveTutorQuestionThenEndedConflict();
+    submitAnswerMock.mockResolvedValue(alreadyEndedConflict());
+    mockTutorReview();
+
+    const screen = await render(<PracticeSessionPageModelNavigationProbe />);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('question');
+    await screen.getByRole('button', { name: 'select-choice-1' }).click();
+    await screen.getByRole('button', { name: 'submit-answer' }).click();
+
+    await expect.poll(() => submitAnswerMock.mock.calls.length > 0).toBe(true);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    await expect
+      .element(screen.getByTestId('summary-answered-count'))
+      .toHaveTextContent('1');
+  });
+
+  it('deduplicates concurrent ended-session summary recovery requests', async () => {
+    const recoverySummary = createDeferred<ActionResult<unknown>>();
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockImplementation(() => recoverySummary.promise);
+    mockActiveTutorQuestionThenEndedConflict();
+    submitAnswerMock.mockResolvedValue(alreadyEndedConflict());
+    mockTutorReview();
+
+    const screen = await render(<PracticeSessionPageModelNavigationProbe />);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('question');
+    await screen.getByRole('button', { name: 'select-choice-1' }).click();
+    await screen.getByRole('button', { name: 'submit-answer' }).click();
+    await screen.getByRole('button', { name: 'next-question' }).click();
+
+    await expect.poll(() => submitAnswerMock.mock.calls.length).toBe(1);
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(2);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+
+    recoverySummary.resolve(mockTutorSummary());
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    expect(getPracticeSessionSummaryMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-init-load.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-init-load.browser.spec.tsx
@@ -286,6 +286,62 @@ describe('usePracticeSessionPageModel (browser)', () => {
       .toHaveTextContent('');
   });
 
+  it('keeps the generic load error when ended-session recovery still reports an active session', async () => {
+    getPracticeSessionSummaryMock.mockResolvedValue(
+      errorResult('CONFLICT', 'Practice session has not ended'),
+    );
+    getNextQuestionMock.mockResolvedValue(
+      errorResult('CONFLICT', 'Practice session already ended', {
+        reason: PracticeSessionConflictReasons.AlreadyEnded,
+      }),
+    );
+
+    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
+
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('');
+    await expect
+      .element(screen.getByTestId('load-status'))
+      .toHaveTextContent('error');
+    await expect
+      .element(screen.getByTestId('error-message'))
+      .toHaveTextContent('Practice session already ended');
+  });
+
+  it('keeps the generic load error when ended-session recovery summary re-read throws', async () => {
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockRejectedValueOnce(new Error('Summary recovery failed'));
+    getNextQuestionMock.mockResolvedValue(
+      errorResult('CONFLICT', 'Practice session already ended', {
+        reason: PracticeSessionConflictReasons.AlreadyEnded,
+      }),
+    );
+
+    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
+
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('');
+    await expect
+      .element(screen.getByTestId('load-status'))
+      .toHaveTextContent('error');
+    await expect
+      .element(screen.getByTestId('error-message'))
+      .toHaveTextContent('Practice session already ended');
+  });
+
   it('keeps the generic empty state when expired-exam recovery still reports an active session', async () => {
     getPracticeSessionSummaryMock.mockResolvedValue(
       errorResult('CONFLICT', 'Practice session has not ended'),

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-init-load.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-init-load.browser.spec.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { STANDARD_READ_TIMEOUT_MS } from '@/app/(app)/app/shared/timeout-tiers';
 import type { ActionResult } from '@/src/adapters/controllers/action-result';
+import { PracticeSessionConflictReasons } from '@/src/application/errors';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
 
@@ -24,6 +25,7 @@ import {
   PracticeSessionPageModelSummaryProbe,
   PracticeSessionPageModelViewProbe,
   setupPracticeSessionPageModelBrowserSpec,
+  submitAnswerMock,
 } from './use-practice-session-page-model-test-helpers';
 
 setupPracticeSessionPageModelBrowserSpec();
@@ -229,6 +231,61 @@ describe('usePracticeSessionPageModel (browser)', () => {
       .toHaveTextContent('');
   });
 
+  it('shows the summary when loading a tutor question reports an AlreadyEnded conflict', async () => {
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockResolvedValueOnce(
+        ok({
+          sessionId: BROWSER_SESSION_ID,
+          endedAt: '2026-02-07T00:20:00.000Z',
+          mode: 'tutor',
+          questionCount: 2,
+          totals: {
+            answered: 1,
+            correct: 1,
+            accuracy: 0.5,
+            durationSeconds: 1200,
+          },
+        }),
+      );
+    getNextQuestionMock.mockResolvedValue(
+      errorResult('CONFLICT', 'Practice session already ended', {
+        reason: PracticeSessionConflictReasons.AlreadyEnded,
+      }),
+    );
+    getPracticeSessionReviewMock.mockResolvedValue(
+      ok(
+        createReviewResponse({
+          mode: 'tutor',
+          totalCount: 2,
+          answeredCount: 1,
+          markedCount: 0,
+          rows: [
+            createReviewRow({ questionId: BROWSER_QUESTION_1_ID, order: 1 }),
+          ],
+        }),
+      ),
+    );
+
+    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
+
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    await expect
+      .element(screen.getByTestId('summary-mode'))
+      .toHaveTextContent('tutor');
+    await expect
+      .element(screen.getByTestId('error-message'))
+      .toHaveTextContent('');
+  });
+
   it('keeps the generic empty state when expired-exam recovery still reports an active session', async () => {
     getPracticeSessionSummaryMock.mockResolvedValue(
       errorResult('CONFLICT', 'Practice session has not ended'),
@@ -371,6 +428,78 @@ describe('usePracticeSessionPageModel (browser)', () => {
       .toHaveTextContent('');
     await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(2);
     expect(getPracticeSessionSummaryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the summary when tutor answer submit reports an AlreadyEnded conflict', async () => {
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockResolvedValueOnce(
+        ok({
+          sessionId: BROWSER_SESSION_ID,
+          endedAt: '2026-02-07T00:20:00.000Z',
+          mode: 'tutor',
+          questionCount: 2,
+          totals: {
+            answered: 1,
+            correct: 1,
+            accuracy: 0.5,
+            durationSeconds: 1200,
+          },
+        }),
+      );
+    getNextQuestionMock.mockResolvedValue(
+      ok(
+        createQuestionResponse({
+          questionId: BROWSER_QUESTION_1_ID,
+          session: {
+            mode: 'tutor',
+            deadlineAt: null,
+            index: 0,
+            total: 2,
+            isMarkedForReview: false,
+          },
+        }),
+      ),
+    );
+    submitAnswerMock.mockResolvedValue(
+      errorResult('CONFLICT', 'Practice session already ended', {
+        reason: PracticeSessionConflictReasons.AlreadyEnded,
+      }),
+    );
+    getPracticeSessionReviewMock.mockResolvedValue(
+      ok(
+        createReviewResponse({
+          mode: 'tutor',
+          totalCount: 2,
+          answeredCount: 1,
+          markedCount: 0,
+          rows: [
+            createReviewRow({ questionId: BROWSER_QUESTION_1_ID, order: 1 }),
+          ],
+        }),
+      ),
+    );
+
+    const screen = await render(<PracticeSessionPageModelNavigationProbe />);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('question');
+    await screen.getByRole('button', { name: 'select-choice-1' }).click();
+    await screen.getByRole('button', { name: 'submit-answer' }).click();
+
+    await expect.poll(() => submitAnswerMock.mock.calls.length > 0).toBe(true);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    await expect
+      .element(screen.getByTestId('summary-answered-count'))
+      .toHaveTextContent('1');
   });
 
   it('recovers a summary when ending an active tutor session returns CONFLICT', async () => {

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-init-load.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-init-load.browser.spec.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { STANDARD_READ_TIMEOUT_MS } from '@/app/(app)/app/shared/timeout-tiers';
 import type { ActionResult } from '@/src/adapters/controllers/action-result';
-import { PracticeSessionConflictReasons } from '@/src/application/errors';
+import { PracticeSessionConflictMessages } from '@/src/application/errors';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
 
@@ -25,7 +25,6 @@ import {
   PracticeSessionPageModelSummaryProbe,
   PracticeSessionPageModelViewProbe,
   setupPracticeSessionPageModelBrowserSpec,
-  submitAnswerMock,
 } from './use-practice-session-page-model-test-helpers';
 
 setupPracticeSessionPageModelBrowserSpec();
@@ -231,117 +230,6 @@ describe('usePracticeSessionPageModel (browser)', () => {
       .toHaveTextContent('');
   });
 
-  it('shows the summary when loading a tutor question reports an AlreadyEnded conflict', async () => {
-    getPracticeSessionSummaryMock
-      .mockResolvedValueOnce(
-        errorResult('CONFLICT', 'Practice session has not ended'),
-      )
-      .mockResolvedValueOnce(
-        ok({
-          sessionId: BROWSER_SESSION_ID,
-          endedAt: '2026-02-07T00:20:00.000Z',
-          mode: 'tutor',
-          questionCount: 2,
-          totals: {
-            answered: 1,
-            correct: 1,
-            accuracy: 0.5,
-            durationSeconds: 1200,
-          },
-        }),
-      );
-    getNextQuestionMock.mockResolvedValue(
-      errorResult('CONFLICT', 'Practice session already ended', {
-        reason: PracticeSessionConflictReasons.AlreadyEnded,
-      }),
-    );
-    getPracticeSessionReviewMock.mockResolvedValue(
-      ok(
-        createReviewResponse({
-          mode: 'tutor',
-          totalCount: 2,
-          answeredCount: 1,
-          markedCount: 0,
-          rows: [
-            createReviewRow({ questionId: BROWSER_QUESTION_1_ID, order: 1 }),
-          ],
-        }),
-      ),
-    );
-
-    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
-
-    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
-    await expect
-      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
-      .toBe(2);
-    await expect
-      .element(screen.getByTestId('active-view'))
-      .toHaveTextContent('summary');
-    await expect
-      .element(screen.getByTestId('summary-mode'))
-      .toHaveTextContent('tutor');
-    await expect
-      .element(screen.getByTestId('error-message'))
-      .toHaveTextContent('');
-  });
-
-  it('keeps the generic load error when ended-session recovery still reports an active session', async () => {
-    getPracticeSessionSummaryMock.mockResolvedValue(
-      errorResult('CONFLICT', 'Practice session has not ended'),
-    );
-    getNextQuestionMock.mockResolvedValue(
-      errorResult('CONFLICT', 'Practice session already ended', {
-        reason: PracticeSessionConflictReasons.AlreadyEnded,
-      }),
-    );
-
-    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
-
-    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
-    await expect
-      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
-      .toBe(2);
-    await expect
-      .element(screen.getByTestId('active-view'))
-      .toHaveTextContent('');
-    await expect
-      .element(screen.getByTestId('load-status'))
-      .toHaveTextContent('error');
-    await expect
-      .element(screen.getByTestId('error-message'))
-      .toHaveTextContent('Practice session already ended');
-  });
-
-  it('keeps the generic load error when ended-session recovery summary re-read throws', async () => {
-    getPracticeSessionSummaryMock
-      .mockResolvedValueOnce(
-        errorResult('CONFLICT', 'Practice session has not ended'),
-      )
-      .mockRejectedValueOnce(new Error('Summary recovery failed'));
-    getNextQuestionMock.mockResolvedValue(
-      errorResult('CONFLICT', 'Practice session already ended', {
-        reason: PracticeSessionConflictReasons.AlreadyEnded,
-      }),
-    );
-
-    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
-
-    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
-    await expect
-      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
-      .toBe(2);
-    await expect
-      .element(screen.getByTestId('active-view'))
-      .toHaveTextContent('');
-    await expect
-      .element(screen.getByTestId('load-status'))
-      .toHaveTextContent('error');
-    await expect
-      .element(screen.getByTestId('error-message'))
-      .toHaveTextContent('Practice session already ended');
-  });
-
   it('keeps the generic empty state when expired-exam recovery still reports an active session', async () => {
     getPracticeSessionSummaryMock.mockResolvedValue(
       errorResult('CONFLICT', 'Practice session has not ended'),
@@ -486,78 +374,6 @@ describe('usePracticeSessionPageModel (browser)', () => {
     expect(getPracticeSessionSummaryMock).toHaveBeenCalledTimes(1);
   });
 
-  it('shows the summary when tutor answer submit reports an AlreadyEnded conflict', async () => {
-    getPracticeSessionSummaryMock
-      .mockResolvedValueOnce(
-        errorResult('CONFLICT', 'Practice session has not ended'),
-      )
-      .mockResolvedValueOnce(
-        ok({
-          sessionId: BROWSER_SESSION_ID,
-          endedAt: '2026-02-07T00:20:00.000Z',
-          mode: 'tutor',
-          questionCount: 2,
-          totals: {
-            answered: 1,
-            correct: 1,
-            accuracy: 0.5,
-            durationSeconds: 1200,
-          },
-        }),
-      );
-    getNextQuestionMock.mockResolvedValue(
-      ok(
-        createQuestionResponse({
-          questionId: BROWSER_QUESTION_1_ID,
-          session: {
-            mode: 'tutor',
-            deadlineAt: null,
-            index: 0,
-            total: 2,
-            isMarkedForReview: false,
-          },
-        }),
-      ),
-    );
-    submitAnswerMock.mockResolvedValue(
-      errorResult('CONFLICT', 'Practice session already ended', {
-        reason: PracticeSessionConflictReasons.AlreadyEnded,
-      }),
-    );
-    getPracticeSessionReviewMock.mockResolvedValue(
-      ok(
-        createReviewResponse({
-          mode: 'tutor',
-          totalCount: 2,
-          answeredCount: 1,
-          markedCount: 0,
-          rows: [
-            createReviewRow({ questionId: BROWSER_QUESTION_1_ID, order: 1 }),
-          ],
-        }),
-      ),
-    );
-
-    const screen = await render(<PracticeSessionPageModelNavigationProbe />);
-
-    await expect
-      .element(screen.getByTestId('active-view'))
-      .toHaveTextContent('question');
-    await screen.getByRole('button', { name: 'select-choice-1' }).click();
-    await screen.getByRole('button', { name: 'submit-answer' }).click();
-
-    await expect.poll(() => submitAnswerMock.mock.calls.length > 0).toBe(true);
-    await expect
-      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
-      .toBe(2);
-    await expect
-      .element(screen.getByTestId('active-view'))
-      .toHaveTextContent('summary');
-    await expect
-      .element(screen.getByTestId('summary-answered-count'))
-      .toHaveTextContent('1');
-  });
-
   it('recovers a summary when ending an active tutor session returns CONFLICT', async () => {
     getPracticeSessionSummaryMock
       .mockResolvedValueOnce(
@@ -607,7 +423,7 @@ describe('usePracticeSessionPageModel (browser)', () => {
       ),
     );
     endPracticeSessionMock.mockResolvedValue(
-      errorResult('CONFLICT', 'Practice session already ended'),
+      errorResult('CONFLICT', PracticeSessionConflictMessages.AlreadyEnded),
     );
 
     const screen = await render(<PracticeSessionPageModelSummaryProbe />);

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-timer.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-timer.browser.spec.tsx
@@ -162,6 +162,90 @@ describe('usePracticeSessionPageModel timer expiry', () => {
     expect(finalizeExamAnswersMock).toHaveBeenCalledTimes(1);
   });
 
+  it('omits a provably stale final draft flush when a backgrounded exam tab resumes after grace', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    mockActiveTimedExam('2026-05-22T12:00:01.000Z');
+    mockFinalizeSummary();
+    saveExamDraftAnswerMock.mockResolvedValue(
+      errorResult('CONFLICT', 'Exam time has expired', {
+        reason: 'exam_time_expired',
+      }),
+    );
+
+    const screen = await render(<PracticeSessionPageModelReviewProbe />);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('question');
+    await screen.getByRole('button', { name: 'select-choice-1' }).click();
+
+    vi.setSystemTime(new Date('2026-05-22T12:00:20.000Z'));
+    window.dispatchEvent(new Event('focus'));
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    await expect
+      .element(screen.getByTestId('summary-answered-count'))
+      .toHaveTextContent('0');
+    expect(finalizeExamAnswersMock).toHaveBeenCalledTimes(1);
+    expect(finalizeExamAnswersMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        finalDraftAnswer: expect.anything(),
+      }),
+    );
+  });
+
+  it('retries timer expiry finalization after a failed attempt with a null-selection draft', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    mockActiveTimedExam('2026-05-22T12:00:01.000Z');
+    finalizeExamAnswersMock
+      .mockResolvedValueOnce(errorResult('INTERNAL_ERROR', 'Finalize failed'))
+      .mockResolvedValueOnce(
+        ok({
+          sessionId: BROWSER_SESSION_ID,
+          endedAt: '2026-05-22T12:01:12.000Z',
+          mode: 'exam',
+          questionCount: 1,
+          totals: {
+            answered: 0,
+            correct: 0,
+            accuracy: 0,
+            durationSeconds: 72,
+          },
+        }),
+      );
+
+    const screen = await render(<PracticeSessionPageModelReviewProbe />);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('question');
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect
+      .element(screen.getByTestId('load-status'))
+      .toHaveTextContent('error');
+    expect(finalizeExamAnswersMock).toHaveBeenCalledTimes(1);
+    expect(finalizeExamAnswersMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        finalDraftAnswer: expect.objectContaining({
+          questionId: BROWSER_QUESTION_1_ID,
+          selectedChoiceId: null,
+        }),
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    expect(finalizeExamAnswersMock).toHaveBeenCalledTimes(2);
+  });
+
   it('manual Review & Submit after expiry proceeds to finalization after a rejected draft save', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
@@ -22,7 +22,10 @@ import {
   getActionResultErrorMessage,
   getThrownErrorMessage,
 } from '@/app/(app)/app/shared/error-message-helpers';
-import { STANDARD_READ_TIMEOUT_MS } from '@/app/(app)/app/shared/timeout-tiers';
+import {
+  STANDARD_MUTATION_TIMEOUT_MS,
+  STANDARD_READ_TIMEOUT_MS,
+} from '@/app/(app)/app/shared/timeout-tiers';
 import { reportClientError } from '@/lib/report-client-error';
 import { useIsMounted } from '@/lib/use-is-mounted';
 import { withTimeout } from '@/lib/with-timeout';
@@ -40,9 +43,12 @@ import {
   getNextQuestion,
   submitAnswer,
 } from '@/src/adapters/controllers/question-controller';
-import { FINALIZE_FLUSH_DEADLINE_GRACE_MS } from '@/src/application/use-cases/finalize-exam-answers';
 
 const BOOTSTRAP_SUMMARY_TIMEOUT_MS = STANDARD_READ_TIMEOUT_MS;
+// Client-side optimization only: avoid sending a draft flush that is already
+// older than one mutation round-trip. The server remains authoritative for the
+// exact finalize grace-window invariant.
+const STALE_FINAL_DRAFT_FLUSH_AFTER_DEADLINE_MS = STANDARD_MUTATION_TIMEOUT_MS;
 
 type PracticeSessionPageModelOutput = Omit<
   PracticeSessionPageViewProps,
@@ -63,7 +69,7 @@ function isFinalDraftFlushProvablyStale(input: {
   const deadlineMs = Date.parse(input.deadlineAt);
   if (!Number.isFinite(deadlineMs)) return false;
 
-  return input.nowMs > deadlineMs + FINALIZE_FLUSH_DEADLINE_GRACE_MS;
+  return input.nowMs > deadlineMs + STALE_FINAL_DRAFT_FLUSH_AFTER_DEADLINE_MS;
 }
 
 export function usePracticeSessionPageModel(

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
@@ -37,6 +37,7 @@ import {
   getNextQuestion,
   submitAnswer,
 } from '@/src/adapters/controllers/question-controller';
+import { FINALIZE_FLUSH_DEADLINE_GRACE_MS } from '@/src/application/use-cases/finalize-exam-answers';
 
 const BOOTSTRAP_SUMMARY_TIMEOUT_MS = STANDARD_READ_TIMEOUT_MS;
 
@@ -50,6 +51,17 @@ type PracticeSessionPageModelOutput = Omit<
   canSubmit: boolean;
   onSubmit: () => void;
 };
+
+function isFinalDraftFlushProvablyStale(input: {
+  deadlineAt: string | null | undefined;
+  nowMs: number;
+}): boolean {
+  if (typeof input.deadlineAt !== 'string') return false;
+  const deadlineMs = Date.parse(input.deadlineAt);
+  if (!Number.isFinite(deadlineMs)) return false;
+
+  return input.nowMs > deadlineMs + FINALIZE_FLUSH_DEADLINE_GRACE_MS;
+}
 
 export function usePracticeSessionPageModel(
   sessionId: string,
@@ -184,16 +196,24 @@ export function usePracticeSessionPageModel(
     isMounted,
   });
 
-  const finalizeExpiredExam = useCallback(() => {
-    if (expiryFinalizeInFlightRef.current) return;
+  const finalizeExpiredExam = useCallback((): Promise<boolean> => {
+    if (expiryFinalizeInFlightRef.current) return Promise.resolve(true);
     expiryFinalizeInFlightRef.current = true;
 
-    void (async () => {
+    return (async () => {
       // BUG-254: capture the on-screen draft BEFORE the save attempt. At the
       // deadline the ordinary draft save is rejected as expired; rather than
       // leaving that doomed save's only effect as an error state, we forward the
       // captured selection to finalization so the server grades it.
-      const finalDraftAnswer = questionFlow.getCurrentExamDraft() ?? undefined;
+      const capturedFinalDraftAnswer = questionFlow.getCurrentExamDraft();
+      const finalDraftAnswer =
+        capturedFinalDraftAnswer &&
+        !isFinalDraftFlushProvablyStale({
+          deadlineAt: questionFlow.sessionInfo?.deadlineAt,
+          nowMs: Date.now(),
+        })
+          ? capturedFinalDraftAnswer
+          : undefined;
       try {
         await questionFlow.saveCurrentExamDraft();
       } catch (error) {
@@ -205,13 +225,30 @@ export function usePracticeSessionPageModel(
         }
       }
 
-      if (!isMounted()) return;
-      await reviewStage.finalizeExamSession(finalDraftAnswer);
+      if (!isMounted()) return false;
+      try {
+        const finalized =
+          await reviewStage.finalizeExamSession(finalDraftAnswer);
+        if (!finalized && isMounted()) {
+          expiryFinalizeInFlightRef.current = false;
+        }
+        return finalized;
+      } catch (error) {
+        if (isMounted()) {
+          expiryFinalizeInFlightRef.current = false;
+          reportClientError(error, {
+            component: 'UsePracticeSessionPageModel',
+            action: 'finalizeExpiredExam',
+          });
+        }
+        return false;
+      }
     })();
   }, [
     isMounted,
     questionFlow.getCurrentExamDraft,
     questionFlow.saveCurrentExamDraft,
+    questionFlow.sessionInfo?.deadlineAt,
     reviewStage.finalizeExamSession,
   ]);
 

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
@@ -22,10 +22,7 @@ import {
   getActionResultErrorMessage,
   getThrownErrorMessage,
 } from '@/app/(app)/app/shared/error-message-helpers';
-import {
-  STANDARD_MUTATION_TIMEOUT_MS,
-  STANDARD_READ_TIMEOUT_MS,
-} from '@/app/(app)/app/shared/timeout-tiers';
+import { STANDARD_READ_TIMEOUT_MS } from '@/app/(app)/app/shared/timeout-tiers';
 import { reportClientError } from '@/lib/report-client-error';
 import { useIsMounted } from '@/lib/use-is-mounted';
 import { withTimeout } from '@/lib/with-timeout';
@@ -43,12 +40,13 @@ import {
   getNextQuestion,
   submitAnswer,
 } from '@/src/adapters/controllers/question-controller';
+import { EXAM_FINAL_DRAFT_FLUSH_GRACE_MS } from '@/src/domain/services';
 
 const BOOTSTRAP_SUMMARY_TIMEOUT_MS = STANDARD_READ_TIMEOUT_MS;
 // Client-side optimization only: avoid sending a draft flush that is already
-// older than one mutation round-trip. The server remains authoritative for the
-// exact finalize grace-window invariant.
-const STALE_FINAL_DRAFT_FLUSH_AFTER_DEADLINE_MS = STANDARD_MUTATION_TIMEOUT_MS;
+// outside the shared server grace window. The server remains authoritative.
+const STALE_FINAL_DRAFT_FLUSH_AFTER_DEADLINE_MS =
+  EXAM_FINAL_DRAFT_FLUSH_GRACE_MS;
 
 type PracticeSessionPageModelOutput = Omit<
   PracticeSessionPageViewProps,
@@ -83,6 +81,9 @@ export function usePracticeSessionPageModel(
   >(null);
   const recoverEndedSessionConflictRef =
     useRef<EndedSessionConflictRecovery | null>(null);
+  const recoverEndedSessionSummaryPromiseRef = useRef<Promise<boolean> | null>(
+    null,
+  );
   const [shouldRetryBootstrap, setShouldRetryBootstrap] = useState(false);
   const onExamServerExpiry = useCallback(
     async (finalDraftAnswer: ExamDraftAnswer | null): Promise<void> => {
@@ -332,32 +333,53 @@ export function usePracticeSessionPageModel(
     [applyBootstrapSummary, isMounted, sessionId],
   );
 
-  const recoverEndedSessionSummary = useCallback(async (): Promise<boolean> => {
-    if (reviewStage.summary) return true;
-
-    let result: Awaited<ReturnType<typeof getPracticeSessionSummary>>;
-    try {
-      result = await withTimeout(
-        getPracticeSessionSummary({ sessionId }),
-        BOOTSTRAP_SUMMARY_TIMEOUT_MS,
-      );
-    } catch (error) {
-      if (isMounted()) {
-        reportClientError(error, {
-          component: 'UsePracticeSessionPageModel',
-          action: 'recoverEndedSessionSummary',
-        });
-      }
-      return false;
+  const recoverEndedSessionSummary = useCallback((): Promise<boolean> => {
+    if (reviewStage.summary || reviewStage.postExamSummary) {
+      return Promise.resolve(true);
+    }
+    if (recoverEndedSessionSummaryPromiseRef.current) {
+      return recoverEndedSessionSummaryPromiseRef.current;
     }
 
-    if (!isMounted()) return false;
-    if (!result.ok) return false;
+    const recovery = (async (): Promise<boolean> => {
+      let result: Awaited<ReturnType<typeof getPracticeSessionSummary>>;
+      try {
+        result = await withTimeout(
+          getPracticeSessionSummary({ sessionId }),
+          BOOTSTRAP_SUMMARY_TIMEOUT_MS,
+        );
+      } catch (error) {
+        if (isMounted()) {
+          reportClientError(error, {
+            component: 'UsePracticeSessionPageModel',
+            action: 'recoverEndedSessionSummary',
+          });
+        }
+        return false;
+      }
 
-    setShouldRetryBootstrap(false);
-    applyBootstrapSummary(result.data);
-    return true;
-  }, [applyBootstrapSummary, isMounted, reviewStage.summary, sessionId]);
+      if (!isMounted()) return false;
+      if (!result.ok) return false;
+
+      setShouldRetryBootstrap(false);
+      applyBootstrapSummary(result.data);
+      return true;
+    })();
+
+    recoverEndedSessionSummaryPromiseRef.current = recovery;
+    void recovery.finally(() => {
+      if (recoverEndedSessionSummaryPromiseRef.current === recovery) {
+        recoverEndedSessionSummaryPromiseRef.current = null;
+      }
+    });
+    return recovery;
+  }, [
+    applyBootstrapSummary,
+    isMounted,
+    reviewStage.postExamSummary,
+    reviewStage.summary,
+    sessionId,
+  ]);
 
   useEffect(() => {
     recoverEndedSessionConflictRef.current = recoverEndedSessionSummary;

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
@@ -14,7 +14,10 @@ import { usePracticeSessionReviewStage } from '@/app/(app)/app/practice/[session
 import { ExamTimer } from '@/app/(app)/app/practice/components/exam-timer';
 import { usePracticeQuestionBookmarks } from '@/app/(app)/app/practice/hooks/use-practice-question-bookmarks';
 import { usePracticeQuestionFeedback } from '@/app/(app)/app/practice/hooks/use-practice-question-feedback';
-import type { ExamDraftAnswer } from '@/app/(app)/app/practice/shared/question-flow-actions';
+import type {
+  EndedSessionConflictRecovery,
+  ExamDraftAnswer,
+} from '@/app/(app)/app/practice/shared/question-flow-actions';
 import {
   getActionResultErrorMessage,
   getThrownErrorMessage,
@@ -72,6 +75,8 @@ export function usePracticeSessionPageModel(
   const onExamServerExpiryRef = useRef<
     ((finalDraftAnswer: ExamDraftAnswer | null) => Promise<void>) | null
   >(null);
+  const recoverEndedSessionConflictRef =
+    useRef<EndedSessionConflictRecovery | null>(null);
   const [shouldRetryBootstrap, setShouldRetryBootstrap] = useState(false);
   const onExamServerExpiry = useCallback(
     async (finalDraftAnswer: ExamDraftAnswer | null): Promise<void> => {
@@ -79,6 +84,10 @@ export function usePracticeSessionPageModel(
     },
     [],
   );
+  const recoverEndedSessionConflict =
+    useCallback(async (): Promise<boolean> => {
+      return (await recoverEndedSessionConflictRef.current?.()) ?? false;
+    }, []);
 
   const questionFlow = usePracticeSessionQuestionFlow({
     sessionId,
@@ -88,6 +97,7 @@ export function usePracticeSessionPageModel(
     submitAnswerFn: submitAnswer,
     saveExamDraftAnswerFn: saveExamDraftAnswer,
     onExamServerExpiry,
+    recoverEndedSessionConflict,
   });
 
   const reviewStage = usePracticeSessionReviewStage({
@@ -315,6 +325,44 @@ export function usePracticeSessionPageModel(
     },
     [applyBootstrapSummary, isMounted, sessionId],
   );
+
+  const recoverEndedSessionSummary = useCallback(async (): Promise<boolean> => {
+    if (reviewStage.summary) return true;
+
+    let result: Awaited<ReturnType<typeof getPracticeSessionSummary>>;
+    try {
+      result = await withTimeout(
+        getPracticeSessionSummary({ sessionId }),
+        BOOTSTRAP_SUMMARY_TIMEOUT_MS,
+      );
+    } catch (error) {
+      if (isMounted()) {
+        reportClientError(error, {
+          component: 'UsePracticeSessionPageModel',
+          action: 'recoverEndedSessionSummary',
+        });
+      }
+      return false;
+    }
+
+    if (!isMounted()) return false;
+    if (!result.ok) return false;
+
+    setShouldRetryBootstrap(false);
+    applyBootstrapSummary(result.data);
+    return true;
+  }, [applyBootstrapSummary, isMounted, reviewStage.summary, sessionId]);
+
+  useEffect(() => {
+    recoverEndedSessionConflictRef.current = recoverEndedSessionSummary;
+    return () => {
+      if (
+        recoverEndedSessionConflictRef.current === recoverEndedSessionSummary
+      ) {
+        recoverEndedSessionConflictRef.current = null;
+      }
+    };
+  }, [recoverEndedSessionSummary]);
 
   const bootstrapSessionSummary = useCallback(() => {
     const requestId = bootstrapRequestIdRef.current + 1;

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.ts
@@ -9,6 +9,7 @@ import {
 } from '@/app/(app)/app/practice/[sessionId]/practice-session-page-logic';
 import type { LoadState } from '@/app/(app)/app/practice/practice-page-logic';
 import {
+  type EndedSessionConflictRecovery,
   type ExamDraftAnswer,
   type ExamDraftSaveResult,
   isExamExpiryDraftSaveConflict,
@@ -37,6 +38,7 @@ export type UsePracticeSessionQuestionFlowInput = {
   onExamServerExpiry?: (
     finalDraftAnswer: ExamDraftAnswer | null,
   ) => Promise<void>;
+  recoverEndedSessionConflict?: EndedSessionConflictRecovery | undefined;
 };
 
 type SubmitOptions = {
@@ -137,6 +139,7 @@ export function usePracticeSessionQuestionFlow(
       setQuestionLoadedAt,
       setQuestion,
       setSessionInfo: applySessionInfo,
+      recoverEndedSessionConflict: input.recoverEndedSessionConflict,
       createRequestSequenceId,
       isLatestRequest,
       isMounted,
@@ -144,6 +147,7 @@ export function usePracticeSessionQuestionFlow(
     [
       input.sessionId,
       input.getNextQuestionFn,
+      input.recoverEndedSessionConflict,
       applySessionInfo,
       createIdempotencyKey,
       createRequestSequenceId,
@@ -418,6 +422,7 @@ export function usePracticeSessionQuestionFlow(
             onSuccess: (result) => {
               captured = result;
             },
+            recoverEndedSessionConflict: input.recoverEndedSessionConflict,
             createRequestSequenceId,
             isLatestRequest,
             isMounted,
@@ -438,6 +443,7 @@ export function usePracticeSessionQuestionFlow(
       createRequestSequenceId,
       input.sessionId,
       input.submitAnswerFn,
+      input.recoverEndedSessionConflict,
       isLatestRequest,
       isMounted,
       question,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.browser.spec.tsx
@@ -249,11 +249,13 @@ describe('usePracticeSessionReviewStageState (browser)', () => {
 
   it('finalizes review state when requested', async () => {
     const input = createInput('exam');
+    vi.mocked(input.finalizeSession).mockResolvedValue(true);
     const harness = await renderHook(() =>
       usePracticeSessionReviewStageState(input),
     );
 
-    harness.result.current.onFinalizeReview();
+    const finalized = await harness.result.current.onFinalizeReview();
+    expect(finalized).toBe(true);
 
     await expect
       .poll(() => vi.mocked(input.finalizeSession).mock.calls.length)

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.ts
@@ -26,7 +26,7 @@ export type UsePracticeSessionReviewStageStateInput = {
   setSessionMode: (mode: 'tutor' | 'exam' | null) => void;
   resetQuestionState: () => void;
   loadSpecificQuestion: (questionId: string) => void;
-  finalizeSession: () => Promise<void>;
+  finalizeSession: () => Promise<boolean>;
   getPracticeSessionReviewFn: (
     input: Pick<GetPracticeSessionReviewUseCaseInput, 'sessionId'>,
   ) => Promise<ActionResult<GetPracticeSessionReviewOutput>>;
@@ -41,7 +41,7 @@ export type UsePracticeSessionReviewStageStateOutput = {
   onEndSession: () => void;
   onRetryReview: () => void;
   onOpenReviewQuestion: (questionId: string) => void;
-  onFinalizeReview: () => Promise<void>;
+  onFinalizeReview: () => Promise<boolean>;
 };
 
 export function usePracticeSessionReviewStageState(
@@ -149,7 +149,7 @@ export function usePracticeSessionReviewStageState(
     [input.loadSpecificQuestion],
   );
 
-  const onFinalizeReview = useCallback((): Promise<void> => {
+  const onFinalizeReview = useCallback((): Promise<boolean> => {
     setReview(null);
     setReviewLoadState({ status: 'idle' });
     setIsInReviewStage(false);

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
@@ -227,7 +227,8 @@ describe('usePracticeSessionReviewStage (browser)', () => {
       usePracticeSessionReviewStage(input),
     );
 
-    await harness.result.current.onFinalizeReview();
+    const finalized = await harness.result.current.onFinalizeReview();
+    expect(finalized).toBeUndefined();
 
     await expect
       .poll(() => harness.result.current.summary?.sessionId ?? null)

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
@@ -228,7 +228,7 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
 
     const finalized = await harness.result.current.onFinalizeReview();
-    expect(finalized).toBeUndefined();
+    expect(finalized).toBe(true);
 
     await expect
       .poll(() => harness.result.current.summary?.sessionId ?? null)

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
@@ -196,6 +196,46 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
   });
 
+  it('awaits tutor finalization from the finalize-review callback', async () => {
+    endPracticeSessionMock.mockResolvedValue(
+      ok({
+        sessionId: fixtureSession1Id,
+        endedAt: '2026-02-07T00:20:00.000Z',
+        mode: 'tutor',
+        questionCount: 10,
+        totals: {
+          answered: 10,
+          correct: 8,
+          accuracy: 0.8,
+          durationSeconds: 1200,
+        },
+      }),
+    );
+    getPracticeSessionReviewMock.mockResolvedValue(
+      ok({
+        sessionId: fixtureSession1Id,
+        mode: 'tutor',
+        totalCount: 10,
+        answeredCount: 10,
+        markedCount: 0,
+        rows: [],
+      }),
+    );
+
+    const input = createInput('tutor');
+    const harness = await renderHook(() =>
+      usePracticeSessionReviewStage(input),
+    );
+
+    await harness.result.current.onFinalizeReview();
+
+    await expect
+      .poll(() => harness.result.current.summary?.sessionId ?? null)
+      .toBe(fixtureSession1Id);
+    expect(endPracticeSessionMock).toHaveBeenCalledTimes(1);
+    expect(finalizeExamAnswersMock).not.toHaveBeenCalled();
+  });
+
   it('sets review load error when exam review loading throws', async () => {
     getPracticeSessionReviewMock.mockRejectedValue(
       new Error('Review load failed'),

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.ts
@@ -243,7 +243,8 @@ export function usePracticeSessionReviewStage(
   ]);
   const onFinalizeReview = useCallback(async (): Promise<void> => {
     if (input.sessionMode !== 'exam') {
-      return reviewStage.onFinalizeReview();
+      await reviewStage.onFinalizeReview();
+      return;
     }
     const finalizedSummary = await finalizeExamSessionForPostReview();
     if (!input.isMounted()) return;

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.ts
@@ -241,16 +241,16 @@ export function usePracticeSessionReviewStage(
     finalizeExamSession,
     reviewStage.onEndSession,
   ]);
-  const onFinalizeReview = useCallback(async (): Promise<void> => {
+  const onFinalizeReview = useCallback(async (): Promise<boolean> => {
     if (input.sessionMode !== 'exam') {
-      await reviewStage.onFinalizeReview();
-      return;
+      return reviewStage.onFinalizeReview();
     }
     const finalizedSummary = await finalizeExamSessionForPostReview();
-    if (!input.isMounted()) return;
-    if (!finalizedSummary) return;
+    if (!input.isMounted()) return false;
+    if (!finalizedSummary) return false;
     reviewStage.setReview(null);
     await examResults.enterPostExamReview(finalizedSummary);
+    return true;
   }, [
     examResults.enterPostExamReview,
     finalizeExamSessionForPostReview,

--- a/app/(app)/app/practice/[sessionId]/practice-session-page-logic.ts
+++ b/app/(app)/app/practice/[sessionId]/practice-session-page-logic.ts
@@ -1,5 +1,6 @@
 import type { LoadState } from '@/app/(app)/app/practice/practice-page-logic';
 import {
+  type EndedSessionConflictRecovery,
   type ExamDraftAnswer,
   type NullQuestionRecovery,
   runLoadQuestionFlow,
@@ -62,6 +63,7 @@ export async function loadNextQuestion(input: {
   setQuestion: (question: NextQuestion | null) => void;
   setSessionInfo: (info: NextQuestion['session']) => void;
   recoverNullQuestion?: NullQuestionRecovery | undefined;
+  recoverEndedSessionConflict?: EndedSessionConflictRecovery | undefined;
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
@@ -90,6 +92,7 @@ export async function loadNextQuestion(input: {
       input.setSessionInfo(question.session);
     },
     recoverNullQuestion: input.recoverNullQuestion,
+    recoverEndedSessionConflict: input.recoverEndedSessionConflict,
     createRequestSequenceId: input.createRequestSequenceId,
     isLatestRequest: input.isLatestRequest,
     isMounted: input.isMounted,
@@ -112,6 +115,7 @@ export function createLoadNextQuestionAction(input: {
   setQuestionLoadedAt: (loadedAtMs: number | null) => void;
   setQuestion: (question: NextQuestion | null) => void;
   setSessionInfo: (info: NextQuestion['session']) => void;
+  recoverEndedSessionConflict?: EndedSessionConflictRecovery | undefined;
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
@@ -137,6 +141,7 @@ export async function submitAnswerForQuestion(input: {
   setLoadState: (state: LoadState) => void;
   setSubmitResult: (result: SubmitAnswerOutput | null) => void;
   onSuccess?: ((result: SubmitAnswerOutput) => void) | undefined;
+  recoverEndedSessionConflict?: EndedSessionConflictRecovery | undefined;
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
@@ -163,6 +168,7 @@ export async function submitAnswerForQuestion(input: {
     setLoadState: input.setLoadState,
     setSubmitResult: input.setSubmitResult,
     onSuccess: input.onSuccess,
+    recoverEndedSessionConflict: input.recoverEndedSessionConflict,
     createRequestSequenceId: input.createRequestSequenceId,
     isLatestRequest: input.isLatestRequest,
     isMounted: input.isMounted,

--- a/app/(app)/app/practice/[sessionId]/practice-session-page-logic.ts
+++ b/app/(app)/app/practice/[sessionId]/practice-session-page-logic.ts
@@ -184,7 +184,7 @@ export async function endSession(input: {
   resetQuestionState: () => void;
   rotateIdempotencyKey?: (() => void) | undefined;
   isMounted?: (() => boolean) | undefined;
-}): Promise<void> {
+}): Promise<boolean> {
   const isMounted = input.isMounted ?? (() => true);
 
   input.setLoadState({ status: 'loading' });
@@ -202,7 +202,7 @@ export async function endSession(input: {
       END_SESSION_TIMEOUT_MS,
     );
   } catch (error) {
-    if (!isMounted()) return;
+    if (!isMounted()) return false;
 
     reportClientError(error, {
       component: 'PracticeSessionPageLogic',
@@ -213,9 +213,9 @@ export async function endSession(input: {
       status: 'error',
       message: getThrownErrorMessage(error),
     });
-    return;
+    return false;
   }
-  if (!isMounted()) return;
+  if (!isMounted()) return false;
   if (!res.ok) {
     let recoveryErrorMessage: string | null = null;
 
@@ -227,17 +227,17 @@ export async function endSession(input: {
           }),
           END_SESSION_TIMEOUT_MS,
         );
-        if (!isMounted()) return;
+        if (!isMounted()) return false;
         if (summaryRes.ok) {
           input.setSummary(summaryRes.data);
           input.resetQuestionState();
           input.setLoadState({ status: 'ready' });
-          return;
+          return true;
         }
 
         recoveryErrorMessage = getActionResultErrorMessage(summaryRes);
       } catch (error) {
-        if (!isMounted()) return;
+        if (!isMounted()) return false;
         reportClientError(error, {
           component: 'PracticeSessionPageLogic',
           action: 'getPracticeSessionSummary',
@@ -251,12 +251,13 @@ export async function endSession(input: {
       status: 'error',
       message: recoveryErrorMessage ?? getActionResultErrorMessage(res),
     });
-    return;
+    return false;
   }
 
   input.setSummary(res.data);
   input.resetQuestionState();
   input.setLoadState({ status: 'ready' });
+  return true;
 }
 
 export function createNavigatorEffect(input: {

--- a/app/(app)/app/practice/shared/question-flow-actions-ended-session-conflict.test.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions-ended-session-conflict.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  runLoadQuestionFlow,
+  runSubmitAnswerFlow,
+} from '@/app/(app)/app/practice/shared/question-flow-actions';
+import type { AsyncLoadStateWithIdle } from '@/app/(app)/app/shared/load-state';
+import { PracticeSessionConflictReasons } from '@/src/application/errors';
+
+const { fixtureChoice1Id, fixtureQuestion1Id, fixtureQuestionOldId } =
+  vi.hoisted(() => ({
+    fixtureChoice1Id: crypto.randomUUID(),
+    fixtureQuestion1Id: crypto.randomUUID(),
+    fixtureQuestionOldId: crypto.randomUUID(),
+  }));
+
+describe('question-flow-actions ended-session conflict recovery', () => {
+  it('runs ended-session recovery instead of committing load error for structured AlreadyEnded conflicts', async () => {
+    let loadState: AsyncLoadStateWithIdle = { status: 'idle' };
+    let question: unknown = { questionId: fixtureQuestionOldId };
+    const recoverEndedSessionConflict = vi.fn(async () => {
+      loadState = { status: 'ready' };
+      return true;
+    });
+
+    await runLoadQuestionFlow({
+      requestInput: {},
+      getQuestionFn: async () => ({
+        ok: false,
+        error: {
+          code: 'CONFLICT',
+          message: 'Practice session already ended',
+          details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
+        },
+      }),
+      createIdempotencyKey: () => 'idemp_new',
+      nowMs: () => 9999,
+      setLoadState: (next) => {
+        loadState = next;
+      },
+      setSelectedChoiceId: () => undefined,
+      setSubmitResult: () => undefined,
+      setSubmitIdempotencyKey: () => undefined,
+      setQuestionLoadedAt: () => undefined,
+      setQuestion: (next) => {
+        question = next;
+      },
+      recoverEndedSessionConflict,
+    });
+
+    expect(recoverEndedSessionConflict).toHaveBeenCalledTimes(1);
+    expect(loadState).toEqual({ status: 'ready' });
+    expect(question).toEqual({ questionId: fixtureQuestionOldId });
+  });
+
+  it('keeps reasonless load CONFLICT as a generic error', async () => {
+    let loadState: AsyncLoadStateWithIdle = { status: 'idle' };
+    const recoverEndedSessionConflict = vi.fn(async () => true);
+
+    await runLoadQuestionFlow({
+      requestInput: {},
+      getQuestionFn: async () => ({
+        ok: false,
+        error: {
+          code: 'CONFLICT',
+          message: 'Practice session already ended',
+        },
+      }),
+      createIdempotencyKey: () => 'idemp_new',
+      nowMs: () => 9999,
+      setLoadState: (next) => {
+        loadState = next;
+      },
+      setSelectedChoiceId: () => undefined,
+      setSubmitResult: () => undefined,
+      setSubmitIdempotencyKey: () => undefined,
+      setQuestionLoadedAt: () => undefined,
+      setQuestion: () => undefined,
+      recoverEndedSessionConflict,
+    });
+
+    expect(recoverEndedSessionConflict).not.toHaveBeenCalled();
+    expect(loadState).toEqual({
+      status: 'error',
+      message: 'Practice session already ended',
+    });
+  });
+
+  it('runs ended-session recovery instead of committing submit error for structured AlreadyEnded conflicts', async () => {
+    let loadState: AsyncLoadStateWithIdle = { status: 'ready' };
+    const recoverEndedSessionConflict = vi.fn(async () => {
+      loadState = { status: 'ready' };
+      return true;
+    });
+
+    await runSubmitAnswerFlow({
+      question: { questionId: fixtureQuestion1Id },
+      selectedChoiceId: fixtureChoice1Id,
+      questionLoadedAtMs: 1000,
+      submitIdempotencyKey: null,
+      submitAnswerFn: async () => ({
+        ok: false,
+        error: {
+          code: 'CONFLICT',
+          message: 'Practice session already ended',
+          details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
+        },
+      }),
+      buildSubmitInput: () => ({}),
+      nowMs: () => 3500,
+      setLoadState: (next) => {
+        loadState = next;
+      },
+      setSubmitResult: () => undefined,
+      recoverEndedSessionConflict,
+    });
+
+    expect(recoverEndedSessionConflict).toHaveBeenCalledTimes(1);
+    expect(loadState).toEqual({ status: 'ready' });
+  });
+
+  it('keeps reasonless submit CONFLICT as a generic error', async () => {
+    let loadState: AsyncLoadStateWithIdle = { status: 'ready' };
+    const recoverEndedSessionConflict = vi.fn(async () => true);
+
+    await runSubmitAnswerFlow({
+      question: { questionId: fixtureQuestion1Id },
+      selectedChoiceId: fixtureChoice1Id,
+      questionLoadedAtMs: 1000,
+      submitIdempotencyKey: null,
+      submitAnswerFn: async () => ({
+        ok: false,
+        error: {
+          code: 'CONFLICT',
+          message: 'Practice session already ended',
+        },
+      }),
+      buildSubmitInput: () => ({}),
+      nowMs: () => 3500,
+      setLoadState: (next) => {
+        loadState = next;
+      },
+      setSubmitResult: () => undefined,
+      recoverEndedSessionConflict,
+    });
+
+    expect(recoverEndedSessionConflict).not.toHaveBeenCalled();
+    expect(loadState).toEqual({
+      status: 'error',
+      message: 'Practice session already ended',
+    });
+  });
+});

--- a/app/(app)/app/practice/shared/question-flow-actions-ended-session-conflict.test.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions-ended-session-conflict.test.ts
@@ -4,14 +4,14 @@ import {
   runSubmitAnswerFlow,
 } from '@/app/(app)/app/practice/shared/question-flow-actions';
 import type { AsyncLoadStateWithIdle } from '@/app/(app)/app/shared/load-state';
-import { PracticeSessionConflictReasons } from '@/src/application/errors';
+import {
+  PracticeSessionConflictMessages,
+  PracticeSessionConflictReasons,
+} from '@/src/application/errors';
 
-const { fixtureChoice1Id, fixtureQuestion1Id, fixtureQuestionOldId } =
-  vi.hoisted(() => ({
-    fixtureChoice1Id: crypto.randomUUID(),
-    fixtureQuestion1Id: crypto.randomUUID(),
-    fixtureQuestionOldId: crypto.randomUUID(),
-  }));
+const fixtureChoice1Id = crypto.randomUUID();
+const fixtureQuestion1Id = crypto.randomUUID();
+const fixtureQuestionOldId = crypto.randomUUID();
 
 describe('question-flow-actions ended-session conflict recovery', () => {
   it('runs ended-session recovery instead of committing load error for structured AlreadyEnded conflicts', async () => {
@@ -28,7 +28,7 @@ describe('question-flow-actions ended-session conflict recovery', () => {
         ok: false,
         error: {
           code: 'CONFLICT',
-          message: 'Practice session already ended',
+          message: PracticeSessionConflictMessages.AlreadyEnded,
           details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
         },
       }),
@@ -62,7 +62,7 @@ describe('question-flow-actions ended-session conflict recovery', () => {
         ok: false,
         error: {
           code: 'CONFLICT',
-          message: 'Practice session already ended',
+          message: PracticeSessionConflictMessages.AlreadyEnded,
         },
       }),
       createIdempotencyKey: () => 'idemp_new',
@@ -81,7 +81,7 @@ describe('question-flow-actions ended-session conflict recovery', () => {
     expect(recoverEndedSessionConflict).not.toHaveBeenCalled();
     expect(loadState).toEqual({
       status: 'error',
-      message: 'Practice session already ended',
+      message: PracticeSessionConflictMessages.AlreadyEnded,
     });
   });
 
@@ -101,7 +101,7 @@ describe('question-flow-actions ended-session conflict recovery', () => {
         ok: false,
         error: {
           code: 'CONFLICT',
-          message: 'Practice session already ended',
+          message: PracticeSessionConflictMessages.AlreadyEnded,
           details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
         },
       }),
@@ -131,7 +131,7 @@ describe('question-flow-actions ended-session conflict recovery', () => {
         ok: false,
         error: {
           code: 'CONFLICT',
-          message: 'Practice session already ended',
+          message: PracticeSessionConflictMessages.AlreadyEnded,
         },
       }),
       buildSubmitInput: () => ({}),
@@ -146,7 +146,7 @@ describe('question-flow-actions ended-session conflict recovery', () => {
     expect(recoverEndedSessionConflict).not.toHaveBeenCalled();
     expect(loadState).toEqual({
       status: 'error',
-      message: 'Practice session already ended',
+      message: PracticeSessionConflictMessages.AlreadyEnded,
     });
   });
 });

--- a/app/(app)/app/practice/shared/question-flow-actions.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions.ts
@@ -62,6 +62,28 @@ function assertRequestSequencingHooks(input: {
   throw new Error('Request sequencing hooks must be provided together');
 }
 
+type EndedSessionConflictRecoveryResult =
+  | 'handled'
+  | 'not-handled'
+  | 'stale-request';
+
+async function tryRecoverEndedSessionConflict(input: {
+  result: ActionResult<unknown>;
+  recoverEndedSessionConflict: EndedSessionConflictRecovery | undefined;
+  canCommit: () => boolean;
+}): Promise<EndedSessionConflictRecoveryResult> {
+  if (
+    !input.recoverEndedSessionConflict ||
+    !isPracticeSessionAlreadyEndedActionConflict(input.result)
+  ) {
+    return 'not-handled';
+  }
+
+  const handled = await input.recoverEndedSessionConflict();
+  if (!input.canCommit()) return 'stale-request';
+  return handled ? 'handled' : 'not-handled';
+}
+
 export function buildTimeSpentSeconds(
   questionLoadedAtMs: number | null,
   nowMs: number,
@@ -131,14 +153,12 @@ export async function runLoadQuestionFlow<TQuestion>(input: {
   if (!canCommit()) return;
 
   if (!res.ok) {
-    if (
-      input.recoverEndedSessionConflict &&
-      isPracticeSessionAlreadyEndedActionConflict(res)
-    ) {
-      const handled = await input.recoverEndedSessionConflict();
-      if (!canCommit()) return;
-      if (handled) return;
-    }
+    const recovery = await tryRecoverEndedSessionConflict({
+      result: res,
+      recoverEndedSessionConflict: input.recoverEndedSessionConflict,
+      canCommit,
+    });
+    if (recovery === 'stale-request' || recovery === 'handled') return;
 
     input.setLoadState({
       status: 'error',
@@ -349,14 +369,12 @@ export async function runSubmitAnswerFlow<
   if (!canCommit()) return;
 
   if (!res.ok) {
-    if (
-      input.recoverEndedSessionConflict &&
-      isPracticeSessionAlreadyEndedActionConflict(res)
-    ) {
-      const handled = await input.recoverEndedSessionConflict();
-      if (!canCommit()) return;
-      if (handled) return;
-    }
+    const recovery = await tryRecoverEndedSessionConflict({
+      result: res,
+      recoverEndedSessionConflict: input.recoverEndedSessionConflict,
+      canCommit,
+    });
+    if (recovery === 'stale-request' || recovery === 'handled') return;
 
     input.setLoadState({
       status: 'error',

--- a/app/(app)/app/practice/shared/question-flow-actions.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions.ts
@@ -31,6 +31,7 @@ export type RequestSequencingHooks = {
 };
 
 export type NullQuestionRecovery = () => Promise<boolean>;
+export type EndedSessionConflictRecovery = () => Promise<boolean>;
 
 export type ExamDraftAnswer = {
   questionId: string;
@@ -86,6 +87,7 @@ export async function runLoadQuestionFlow<TQuestion>(input: {
   setQuestion: (question: TQuestion | null) => void;
   onLoaded?: ((question: TQuestion | null) => void) | undefined;
   recoverNullQuestion?: NullQuestionRecovery | undefined;
+  recoverEndedSessionConflict?: EndedSessionConflictRecovery | undefined;
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
@@ -129,6 +131,15 @@ export async function runLoadQuestionFlow<TQuestion>(input: {
   if (!canCommit()) return;
 
   if (!res.ok) {
+    if (
+      input.recoverEndedSessionConflict &&
+      isPracticeSessionAlreadyEndedActionConflict(res)
+    ) {
+      const handled = await input.recoverEndedSessionConflict();
+      if (!canCommit()) return;
+      if (handled) return;
+    }
+
     input.setLoadState({
       status: 'error',
       message: getActionResultErrorMessage(res),
@@ -177,12 +188,21 @@ export function isExamExpiryDraftSaveConflict(
   );
 }
 
-function getActionResultPracticeSessionConflictReason(
+export function getActionResultPracticeSessionConflictReason(
   result: ActionResult<unknown>,
 ): PracticeSessionConflictReason | undefined {
   if (result.ok) return undefined;
   const reason = result.error.details?.reason;
   return isPracticeSessionConflictReason(reason) ? reason : undefined;
+}
+
+export function isPracticeSessionAlreadyEndedActionConflict(
+  result: ActionResult<unknown>,
+): boolean {
+  return (
+    getActionResultPracticeSessionConflictReason(result) ===
+    PracticeSessionConflictReasons.AlreadyEnded
+  );
 }
 
 export async function maybeSaveDraftBeforeNavigation<
@@ -282,6 +302,7 @@ export async function runSubmitAnswerFlow<
     questionId?: string | null,
   ) => void;
   onSuccess?: ((result: SubmitAnswerOutput) => void) | undefined;
+  recoverEndedSessionConflict?: EndedSessionConflictRecovery | undefined;
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
@@ -328,6 +349,15 @@ export async function runSubmitAnswerFlow<
   if (!canCommit()) return;
 
   if (!res.ok) {
+    if (
+      input.recoverEndedSessionConflict &&
+      isPracticeSessionAlreadyEndedActionConflict(res)
+    ) {
+      const handled = await input.recoverEndedSessionConflict();
+      if (!canCommit()) return;
+      if (handled) return;
+    }
+
     input.setLoadState({
       status: 'error',
       message: getActionResultErrorMessage(res),

--- a/lib/container/use-cases.ts
+++ b/lib/container/use-cases.ts
@@ -128,6 +128,7 @@ export function createUseCaseFactories(input: {
           }),
         ),
       primitives.now,
+      primitives.logger,
     );
 
   return {

--- a/src/adapters/repositories/drizzle-attempt-repository.test.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.test.ts
@@ -5,7 +5,10 @@ import {
   attempts,
   practiceSessions,
 } from '@/db/schema';
-import { ApplicationError } from '@/src/application/errors';
+import {
+  ApplicationError,
+  AttemptConflictMessages,
+} from '@/src/application/errors';
 import { answeredOutcome, omittedOutcome } from '@/src/domain/value-objects';
 import { DrizzleAttemptRepository } from './drizzle-attempt-repository';
 
@@ -480,7 +483,7 @@ describe('DrizzleAttemptRepository', () => {
       await expect(promise).rejects.toEqual(
         new ApplicationError(
           'CONFLICT',
-          'This question has already been answered in this session',
+          AttemptConflictMessages.AlreadyAnsweredInSession,
         ),
       );
     });

--- a/src/adapters/repositories/drizzle-attempt-repository.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.ts
@@ -18,7 +18,10 @@ import {
   questionTags,
   tags,
 } from '@/db/schema';
-import { ApplicationError } from '@/src/application/errors';
+import {
+  ApplicationError,
+  AttemptConflictMessages,
+} from '@/src/application/errors';
 import type {
   AttemptedQuestionSummary,
   AttemptedQuestionsFilters,
@@ -190,7 +193,7 @@ export class DrizzleAttemptRepository implements AttemptRepository {
       ) {
         throw new ApplicationError(
           'CONFLICT',
-          'This question has already been answered in this session',
+          AttemptConflictMessages.AlreadyAnsweredInSession,
         );
       }
       throw new ApplicationError(

--- a/src/application/errors/application-errors.ts
+++ b/src/application/errors/application-errors.ts
@@ -29,6 +29,11 @@ export const PracticeSessionConflictMessages = {
     'Practice session state changed concurrently; please retry.',
 } as const;
 
+export const AttemptConflictMessages = {
+  AlreadyAnsweredInSession:
+    'This question has already been answered in this session',
+} as const;
+
 export type ApplicationErrorDetails = Readonly<{
   reason?: PracticeSessionConflictReason;
 }>;

--- a/src/application/errors/index.ts
+++ b/src/application/errors/index.ts
@@ -3,6 +3,7 @@ export {
   type ApplicationErrorCode,
   ApplicationErrorCodes,
   type ApplicationErrorDetails,
+  AttemptConflictMessages,
   isApplicationError,
   isPracticeSessionConflictReason,
   PracticeSessionConflictMessages,

--- a/src/application/test-helpers/fakes/fake-attempt-repository.ts
+++ b/src/application/test-helpers/fakes/fake-attempt-repository.ts
@@ -1,4 +1,7 @@
-import { ApplicationError } from '@/src/application/errors';
+import {
+  ApplicationError,
+  AttemptConflictMessages,
+} from '@/src/application/errors';
 import type {
   AttemptedQuestionSummary,
   AttemptedQuestionsFilters,
@@ -43,7 +46,7 @@ export class FakeAttemptRepository implements AttemptRepository {
       if (duplicate) {
         throw new ApplicationError(
           'CONFLICT',
-          'This question has already been answered in this session',
+          AttemptConflictMessages.AlreadyAnsweredInSession,
         );
       }
     }

--- a/src/application/use-cases/finalize-exam-answers.test.ts
+++ b/src/application/use-cases/finalize-exam-answers.test.ts
@@ -1261,6 +1261,34 @@ describe('FinalizeExamAnswersUseCase', () => {
       });
     });
 
+    it('drops a late flush without requiring an injected logger', async () => {
+      const { attempts, useCase } = createFlushUseCase(
+        () => new Date(DEADLINE_MS + FINALIZE_FLUSH_DEADLINE_GRACE_MS + 1),
+      );
+
+      await expect(
+        useCase.execute({
+          userId: 'user-1',
+          sessionId: 'session-1',
+          finalDraftAnswer: {
+            questionId: 'q1',
+            selectedChoiceId: 'q1-correct',
+            cumulativeMs: 10_000,
+          },
+        }),
+      ).resolves.toMatchObject({ totals: { answered: 0, correct: 0 } });
+
+      await expect(
+        attempts.findBySessionId('session-1', 'user-1'),
+      ).resolves.toMatchObject([
+        {
+          questionId: 'q1',
+          outcome: { kind: 'omitted' },
+          isCorrect: false,
+        },
+      ]);
+    });
+
     it('rejects a flush for a question that is not in the session', async () => {
       const { attempts, useCase } = createFlushUseCase(
         () => new Date(DEADLINE_MS),

--- a/src/application/use-cases/finalize-exam-answers.test.ts
+++ b/src/application/use-cases/finalize-exam-answers.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ApplicationError } from '@/src/application/errors';
 import {
   FakeAttemptRepository,
+  FakeLogger,
   FakePracticeSessionRepository,
   FakeQuestionRepository,
 } from '@/src/application/test-helpers/fakes';
@@ -832,6 +833,7 @@ describe('FinalizeExamAnswersUseCase', () => {
     function createFlushUseCase(
       now: () => Date,
       question = createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+      logger?: FakeLogger,
     ) {
       const questions = new FakeQuestionRepository([question]);
       const attempts = new FakeAttemptRepository();
@@ -844,6 +846,7 @@ describe('FinalizeExamAnswersUseCase', () => {
         sessions,
         passthroughTransaction(questions, attempts, sessions),
         now,
+        logger,
       );
       return { questions, attempts, sessions, useCase };
     }
@@ -995,9 +998,12 @@ describe('FinalizeExamAnswersUseCase', () => {
       ).resolves.toEqual([]);
     });
 
-    it('rejects a flush arriving after the grace window (arbitrary-late answering)', async () => {
+    it('drops a flush arriving after the grace window and still finalizes', async () => {
+      const logger = new FakeLogger();
       const { attempts, useCase } = createFlushUseCase(
         () => new Date(DEADLINE_MS + FINALIZE_FLUSH_DEADLINE_GRACE_MS + 1),
+        createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+        logger,
       );
 
       await expect(
@@ -1010,16 +1016,26 @@ describe('FinalizeExamAnswersUseCase', () => {
             cumulativeMs: 10_000,
           },
         }),
-      ).rejects.toEqual(
-        new ApplicationError(
-          'CONFLICT',
-          'Final exam answer flush is only allowed at exam expiry',
-        ),
-      );
+      ).resolves.toMatchObject({ totals: { answered: 0, correct: 0 } });
 
       await expect(
         attempts.findBySessionId('session-1', 'user-1'),
-      ).resolves.toEqual([]);
+      ).resolves.toMatchObject([
+        {
+          questionId: 'q1',
+          outcome: { kind: 'omitted' },
+          isCorrect: false,
+          timeSpentSeconds: 0,
+        },
+      ]);
+      expect(logger.warnCalls).toContainEqual({
+        context: {
+          sessionId: 'session-1',
+          userId: 'user-1',
+          questionId: 'q1',
+        },
+        msg: 'Dropped stale final exam draft flush after grace window',
+      });
     });
 
     it('rejects a flush for a question that is not in the session', async () => {

--- a/src/application/use-cases/finalize-exam-answers.test.ts
+++ b/src/application/use-cases/finalize-exam-answers.test.ts
@@ -2,6 +2,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ApplicationError,
+  AttemptConflictMessages,
+  PracticeSessionConflictMessages,
   PracticeSessionConflictReasons,
 } from '@/src/application/errors';
 import {
@@ -726,7 +728,7 @@ describe('FinalizeExamAnswersUseCase', () => {
       }),
     ).rejects.toMatchObject({
       code: 'CONFLICT',
-      message: 'Practice session already ended',
+      message: PracticeSessionConflictMessages.AlreadyEnded,
       details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
     });
   });
@@ -788,7 +790,7 @@ describe('FinalizeExamAnswersUseCase', () => {
       }),
     ).rejects.toMatchObject({
       code: 'CONFLICT',
-      message: 'This question has already been answered in this session',
+      message: AttemptConflictMessages.AlreadyAnsweredInSession,
       details: undefined,
     });
   });
@@ -850,7 +852,7 @@ describe('FinalizeExamAnswersUseCase', () => {
       }),
     ).rejects.toMatchObject({
       code: 'CONFLICT',
-      message: 'This question has already been answered in this session',
+      message: AttemptConflictMessages.AlreadyAnsweredInSession,
       details: undefined,
     });
   });
@@ -1253,7 +1255,6 @@ describe('FinalizeExamAnswersUseCase', () => {
       expect(logger.warnCalls).toContainEqual({
         context: {
           sessionId: 'session-1',
-          userId: 'user-1',
           questionId: 'q1',
         },
         msg: 'Dropped stale final exam draft flush after grace window',

--- a/src/application/use-cases/finalize-exam-answers.test.ts
+++ b/src/application/use-cases/finalize-exam-answers.test.ts
@@ -1,6 +1,9 @@
 // biome-ignore lint/style/noExcessiveLinesPerFile: Keep all FinalizeExamAnswersUseCase behavior (drafted grading, BUG-238 cumulative bounds, BUG-252 nullable drafts, BUG-254 expiry flush) in one file so the use-case contract stays auditable next to its shared fakes/helpers.
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ApplicationError } from '@/src/application/errors';
+import {
+  ApplicationError,
+  PracticeSessionConflictReasons,
+} from '@/src/application/errors';
 import {
   FakeAttemptRepository,
   FakeLogger,
@@ -12,6 +15,7 @@ import {
   MS_PER_SECOND,
 } from '@/src/domain/services';
 import {
+  createAttempt,
   createChoice,
   createPracticeSession,
   createQuestion,
@@ -39,6 +43,32 @@ function passthroughTransaction(
       attempts,
       sessions,
     });
+}
+
+class SequencedFindPracticeSessionRepository extends FakePracticeSessionRepository {
+  private findCallCount = 0;
+
+  constructor(
+    private readonly firstSession: ReturnType<typeof createPracticeSession>,
+    private readonly laterSession: ReturnType<typeof createPracticeSession>,
+  ) {
+    super([]);
+  }
+
+  override async findByIdAndUserId(
+    sessionId: string,
+    userId: string,
+  ): Promise<ReturnType<typeof createPracticeSession> | null> {
+    if (
+      sessionId !== this.firstSession.id ||
+      userId !== this.firstSession.userId
+    ) {
+      return null;
+    }
+
+    this.findCallCount += 1;
+    return this.findCallCount === 1 ? this.firstSession : this.laterSession;
+  }
 }
 
 function createFinalizeQuestion(
@@ -631,6 +661,134 @@ describe('FinalizeExamAnswersUseCase', () => {
     ).rejects.toEqual(
       new ApplicationError('CONFLICT', 'Cannot finalize a completed session'),
     );
+  });
+
+  it('maps a double-finalize already-answered loser to AlreadyEnded after a fresh re-read', async () => {
+    const activeSession = createPracticeSession({
+      id: 'session-1',
+      userId: 'user-1',
+      mode: 'exam',
+      questionIds: ['q1'],
+      questionStates: [
+        {
+          questionId: 'q1',
+          markedForReview: false,
+          latestSelectedChoiceId: null,
+          latestIsCorrect: null,
+          latestAnsweredAt: null,
+          draftSelectedChoiceId: 'q1-correct',
+          draftSavedAt: new Date('2026-03-17T12:00:00.000Z'),
+          draftCumulativeMs: 20_000,
+        },
+      ],
+    });
+    const endedSession = createPracticeSession({
+      ...activeSession,
+      endedAt: new Date('2026-03-17T12:30:00.000Z'),
+    });
+    const questions = new FakeQuestionRepository([
+      createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+    ]);
+    const outerSessions = new SequencedFindPracticeSessionRepository(
+      activeSession,
+      endedSession,
+    );
+    const txSessions = new FakePracticeSessionRepository([activeSession]);
+    const txAttempts = new FakeAttemptRepository([
+      createAttempt({
+        id: 'attempt-1',
+        userId: 'user-1',
+        questionId: 'q1',
+        practiceSessionId: 'session-1',
+        selectedChoiceId: 'q1-correct',
+        isCorrect: true,
+      }),
+    ]);
+    const writeTransaction: FinalizeExamAnswersWriteTransaction = async (fn) =>
+      fn({
+        questions,
+        attempts: txAttempts,
+        sessions: txSessions,
+      });
+    const useCase = new FinalizeExamAnswersUseCase(
+      questions,
+      new FakeAttemptRepository(),
+      outerSessions,
+      writeTransaction,
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Practice session already ended',
+      details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
+    });
+  });
+
+  it('keeps an already-answered finalize conflict unchanged when the fresh re-read is still active', async () => {
+    const activeSession = createPracticeSession({
+      id: 'session-1',
+      userId: 'user-1',
+      mode: 'exam',
+      questionIds: ['q1'],
+      questionStates: [
+        {
+          questionId: 'q1',
+          markedForReview: false,
+          latestSelectedChoiceId: null,
+          latestIsCorrect: null,
+          latestAnsweredAt: null,
+          draftSelectedChoiceId: 'q1-correct',
+          draftSavedAt: new Date('2026-03-17T12:00:00.000Z'),
+          draftCumulativeMs: 20_000,
+        },
+      ],
+    });
+    const questions = new FakeQuestionRepository([
+      createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+    ]);
+    const outerSessions = new SequencedFindPracticeSessionRepository(
+      activeSession,
+      activeSession,
+    );
+    const txSessions = new FakePracticeSessionRepository([activeSession]);
+    const txAttempts = new FakeAttemptRepository([
+      createAttempt({
+        id: 'attempt-1',
+        userId: 'user-1',
+        questionId: 'q1',
+        practiceSessionId: 'session-1',
+        selectedChoiceId: 'q1-correct',
+        isCorrect: true,
+      }),
+    ]);
+    const writeTransaction: FinalizeExamAnswersWriteTransaction = async (fn) =>
+      fn({
+        questions,
+        attempts: txAttempts,
+        sessions: txSessions,
+      });
+    const useCase = new FinalizeExamAnswersUseCase(
+      questions,
+      new FakeAttemptRepository(),
+      outerSessions,
+      writeTransaction,
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'This question has already been answered in this session',
+      details: undefined,
+    });
   });
 
   it('rejects missing sessions', async () => {

--- a/src/application/use-cases/finalize-exam-answers.test.ts
+++ b/src/application/use-cases/finalize-exam-answers.test.ts
@@ -50,7 +50,9 @@ class SequencedFindPracticeSessionRepository extends FakePracticeSessionReposito
 
   constructor(
     private readonly firstSession: ReturnType<typeof createPracticeSession>,
-    private readonly laterSession: ReturnType<typeof createPracticeSession>,
+    private readonly laterSession: ReturnType<
+      typeof createPracticeSession
+    > | null,
   ) {
     super([]);
   }
@@ -754,6 +756,68 @@ describe('FinalizeExamAnswersUseCase', () => {
     const outerSessions = new SequencedFindPracticeSessionRepository(
       activeSession,
       activeSession,
+    );
+    const txSessions = new FakePracticeSessionRepository([activeSession]);
+    const txAttempts = new FakeAttemptRepository([
+      createAttempt({
+        id: 'attempt-1',
+        userId: 'user-1',
+        questionId: 'q1',
+        practiceSessionId: 'session-1',
+        selectedChoiceId: 'q1-correct',
+        isCorrect: true,
+      }),
+    ]);
+    const writeTransaction: FinalizeExamAnswersWriteTransaction = async (fn) =>
+      fn({
+        questions,
+        attempts: txAttempts,
+        sessions: txSessions,
+      });
+    const useCase = new FinalizeExamAnswersUseCase(
+      questions,
+      new FakeAttemptRepository(),
+      outerSessions,
+      writeTransaction,
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'This question has already been answered in this session',
+      details: undefined,
+    });
+  });
+
+  it('keeps an already-answered finalize conflict unchanged when the fresh re-read misses the session', async () => {
+    const activeSession = createPracticeSession({
+      id: 'session-1',
+      userId: 'user-1',
+      mode: 'exam',
+      questionIds: ['q1'],
+      questionStates: [
+        {
+          questionId: 'q1',
+          markedForReview: false,
+          latestSelectedChoiceId: null,
+          latestIsCorrect: null,
+          latestAnsweredAt: null,
+          draftSelectedChoiceId: 'q1-correct',
+          draftSavedAt: new Date('2026-03-17T12:00:00.000Z'),
+          draftCumulativeMs: 20_000,
+        },
+      ],
+    });
+    const questions = new FakeQuestionRepository([
+      createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+    ]);
+    const outerSessions = new SequencedFindPracticeSessionRepository(
+      activeSession,
+      null,
     );
     const txSessions = new FakePracticeSessionRepository([activeSession]);
     const txAttempts = new FakeAttemptRepository([

--- a/src/application/use-cases/finalize-exam-answers.ts
+++ b/src/application/use-cases/finalize-exam-answers.ts
@@ -1,4 +1,8 @@
-import { ApplicationError } from '@/src/application/errors';
+import {
+  ApplicationError,
+  isApplicationError,
+  practiceSessionAlreadyEndedError,
+} from '@/src/application/errors';
 import type { Logger } from '@/src/application/ports/logger';
 import type {
   AttemptWriter,
@@ -63,6 +67,16 @@ export type FinalizeExamAnswersWriteTransaction = <T>(
 const noopFinalizeLogger: Pick<Logger, 'warn'> = {
   warn: () => undefined,
 };
+const ATTEMPT_ALREADY_ANSWERED_CONFLICT_MESSAGE =
+  'This question has already been answered in this session';
+
+function isAttemptAlreadyAnsweredConflict(error: unknown): boolean {
+  return (
+    isApplicationError(error) &&
+    error.code === 'CONFLICT' &&
+    error.message === ATTEMPT_ALREADY_ANSWERED_CONFLICT_MESSAGE
+  );
+}
 
 export function computeFinalExamEndedAt(input: {
   now: Date;
@@ -256,6 +270,9 @@ export class FinalizeExamAnswersUseCase {
         latestAnsweredAt,
       });
       return tx.sessions.end(input.sessionId, input.userId, effectiveEndedAt);
+    }).catch(async (error: unknown) => {
+      await this.throwAlreadyEndedForDoubleFinalizeLoser(input, error);
+      throw error;
     });
 
     const endedAt = endedSession.endedAt;
@@ -267,6 +284,21 @@ export class FinalizeExamAnswersUseCase {
     }
 
     return projectPracticeSessionSummary(endedSession, endedAt);
+  }
+
+  private async throwAlreadyEndedForDoubleFinalizeLoser(
+    input: FinalizeExamAnswersInput,
+    error: unknown,
+  ): Promise<void> {
+    if (!isAttemptAlreadyAnsweredConflict(error)) return;
+
+    const freshSession = await this.sessions.findByIdAndUserId(
+      input.sessionId,
+      input.userId,
+    );
+    if (!freshSession?.endedAt) return;
+
+    throw practiceSessionAlreadyEndedError({ cause: error });
   }
 
   private async applyFinalDraftAnswer(

--- a/src/application/use-cases/finalize-exam-answers.ts
+++ b/src/application/use-cases/finalize-exam-answers.ts
@@ -1,4 +1,5 @@
 import { ApplicationError } from '@/src/application/errors';
+import type { Logger } from '@/src/application/ports/logger';
 import type {
   AttemptWriter,
   PracticeSessionRepository,
@@ -59,6 +60,10 @@ export type FinalizeExamAnswersWriteTransaction = <T>(
   }) => Promise<T>,
 ) => Promise<T>;
 
+const noopFinalizeLogger: Pick<Logger, 'warn'> = {
+  warn: () => undefined,
+};
+
 export function computeFinalExamEndedAt(input: {
   now: Date;
   deadline: Date | null;
@@ -88,6 +93,7 @@ export class FinalizeExamAnswersUseCase {
     private readonly sessions: PracticeSessionRepository,
     private readonly writeTransaction: FinalizeExamAnswersWriteTransaction,
     private readonly now: () => Date = () => new Date(),
+    private readonly logger: Pick<Logger, 'warn'> = noopFinalizeLogger,
   ) {}
 
   async execute(
@@ -284,6 +290,21 @@ export class FinalizeExamAnswersUseCase {
 
     const deadline = computeExamDeadline(session);
     const nowMs = now.getTime();
+    const isAfterGraceWindow =
+      deadline !== null &&
+      nowMs > deadline.getTime() + FINALIZE_FLUSH_DEADLINE_GRACE_MS;
+    if (isAfterGraceWindow) {
+      this.logger.warn(
+        {
+          sessionId: session.id,
+          userId: session.userId,
+          questionId: finalDraftAnswer.questionId,
+        },
+        'Dropped stale final exam draft flush after grace window',
+      );
+      return session;
+    }
+
     const isWithinGraceWindow =
       deadline !== null &&
       nowMs >= deadline.getTime() &&

--- a/src/application/use-cases/finalize-exam-answers.ts
+++ b/src/application/use-cases/finalize-exam-answers.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationError,
+  AttemptConflictMessages,
   isApplicationError,
   practiceSessionAlreadyEndedError,
 } from '@/src/application/errors';
@@ -13,6 +14,7 @@ import { fetchSessionOwnedQuestionsById } from '@/src/application/shared/fetch-s
 import type { PracticeSession } from '@/src/domain/entities';
 import {
   computeExamDeadline,
+  EXAM_FINAL_DRAFT_FLUSH_GRACE_MS,
   gradeAnswer,
   MS_PER_SECOND,
 } from '@/src/domain/services';
@@ -40,7 +42,7 @@ import { SAVE_EXAM_DRAFT_MAX_CUMULATIVE_MS } from './save-exam-draft-answer';
  * (CodeRabbit PR #476 hardening: there is no server "active question" cursor in
  * free-navigation exam mode, so the tight window is the integrity bound).
  */
-export const FINALIZE_FLUSH_DEADLINE_GRACE_MS = 15_000;
+export const FINALIZE_FLUSH_DEADLINE_GRACE_MS = EXAM_FINAL_DRAFT_FLUSH_GRACE_MS;
 
 export type FinalizeExamFinalDraftAnswer = {
   questionId: string;
@@ -67,14 +69,12 @@ export type FinalizeExamAnswersWriteTransaction = <T>(
 const noopFinalizeLogger: Pick<Logger, 'warn'> = {
   warn: () => undefined,
 };
-const ATTEMPT_ALREADY_ANSWERED_CONFLICT_MESSAGE =
-  'This question has already been answered in this session';
 
 function isAttemptAlreadyAnsweredConflict(error: unknown): boolean {
   return (
     isApplicationError(error) &&
     error.code === 'CONFLICT' &&
-    error.message === ATTEMPT_ALREADY_ANSWERED_CONFLICT_MESSAGE
+    error.message === AttemptConflictMessages.AlreadyAnsweredInSession
   );
 }
 
@@ -329,7 +329,6 @@ export class FinalizeExamAnswersUseCase {
       this.logger.warn(
         {
           sessionId: session.id,
-          userId: session.userId,
           questionId: finalDraftAnswer.questionId,
         },
         'Dropped stale final exam draft flush after grace window',

--- a/src/application/use-cases/get-next-question-explicit-question.test.ts
+++ b/src/application/use-cases/get-next-question-explicit-question.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { PracticeSessionConflictReasons } from '@/src/application/errors';
 import {
   ANSWERED_AT,
   createChoice,
@@ -319,6 +320,7 @@ describe('GetNextQuestionUseCase', () => {
     ).rejects.toMatchObject({
       code: 'CONFLICT',
       message: 'Practice session already ended',
+      details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
     });
   });
 });

--- a/src/application/use-cases/get-next-question-navigation.test.ts
+++ b/src/application/use-cases/get-next-question-navigation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { PracticeSessionConflictReasons } from '@/src/application/errors';
 import {
   ANSWERED_AT,
   ApplicationError,
@@ -107,6 +108,7 @@ describe('GetNextQuestionUseCase', () => {
     ).rejects.toMatchObject({
       code: 'CONFLICT',
       message: 'Practice session already ended',
+      details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
     });
   });
 

--- a/src/application/use-cases/get-next-question.ts
+++ b/src/application/use-cases/get-next-question.ts
@@ -12,7 +12,7 @@ import type {
   PracticeMode,
   QuestionDifficulty,
 } from '@/src/domain/value-objects';
-import { ApplicationError } from '../errors';
+import { ApplicationError, practiceSessionAlreadyEndedError } from '../errors';
 import type {
   AttemptMostRecentAnsweredAtReader,
   PracticeSessionRepository,
@@ -173,7 +173,7 @@ export class GetNextQuestionUseCase {
       throw new ApplicationError('NOT_FOUND', 'Practice session not found');
     }
     if (session.endedAt) {
-      throw new ApplicationError('CONFLICT', 'Practice session already ended');
+      throw practiceSessionAlreadyEndedError();
     }
     if (isExamExpired(session, this.now())) {
       if (!this.expiredExamFinalizer) {

--- a/src/application/use-cases/submit-answer-exam.test.ts
+++ b/src/application/use-cases/submit-answer-exam.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { PracticeSessionConflictReasons } from '@/src/application/errors';
+import {
+  PracticeSessionConflictMessages,
+  PracticeSessionConflictReasons,
+} from '@/src/application/errors';
 import {
   ApplicationError,
   createChoice,
@@ -129,7 +132,7 @@ describe('SubmitAnswerUseCase', () => {
       }),
     ).rejects.toMatchObject({
       code: 'CONFLICT',
-      message: 'Practice session already ended',
+      message: PracticeSessionConflictMessages.AlreadyEnded,
       details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
     });
 

--- a/src/application/use-cases/submit-answer-exam.test.ts
+++ b/src/application/use-cases/submit-answer-exam.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { PracticeSessionConflictReasons } from '@/src/application/errors';
 import {
   ApplicationError,
   createChoice,
@@ -126,9 +127,11 @@ describe('SubmitAnswerUseCase', () => {
         choiceId: 'c2',
         sessionId,
       }),
-    ).rejects.toEqual(
-      new ApplicationError('CONFLICT', 'Practice session already ended'),
-    );
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Practice session already ended',
+      details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
+    });
 
     expect(attempts.getAll()).toEqual([]);
   });

--- a/src/application/use-cases/submit-answer-tutor.test.ts
+++ b/src/application/use-cases/submit-answer-tutor.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { PracticeSessionConflictReasons } from '@/src/application/errors';
+import {
+  AttemptConflictMessages,
+  PracticeSessionConflictMessages,
+  PracticeSessionConflictReasons,
+} from '@/src/application/errors';
 import {
   ApplicationError,
   createChoice,
@@ -212,7 +216,7 @@ describe('SubmitAnswerUseCase', () => {
       }),
     ).rejects.toMatchObject({
       code: 'CONFLICT',
-      message: 'Practice session already ended',
+      message: PracticeSessionConflictMessages.AlreadyEnded,
       details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
     });
 
@@ -353,7 +357,7 @@ describe('SubmitAnswerUseCase', () => {
     ).rejects.toEqual(
       new ApplicationError(
         'CONFLICT',
-        'This question has already been answered in this session',
+        AttemptConflictMessages.AlreadyAnsweredInSession,
       ),
     );
 

--- a/src/application/use-cases/submit-answer-tutor.test.ts
+++ b/src/application/use-cases/submit-answer-tutor.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { PracticeSessionConflictReasons } from '@/src/application/errors';
 import {
   ApplicationError,
   createChoice,
@@ -209,9 +210,11 @@ describe('SubmitAnswerUseCase', () => {
         choiceId: 'c2',
         sessionId,
       }),
-    ).rejects.toEqual(
-      new ApplicationError('CONFLICT', 'Practice session already ended'),
-    );
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Practice session already ended',
+      details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
+    });
 
     expect(attempts.getAll()).toEqual([]);
   });

--- a/src/application/use-cases/submit-answer.ts
+++ b/src/application/use-cases/submit-answer.ts
@@ -11,7 +11,7 @@ import {
   shouldShowExplanation as sessionShouldShowExplanation,
 } from '@/src/domain/services';
 import { answeredOutcome } from '@/src/domain/value-objects';
-import { ApplicationError } from '../errors';
+import { ApplicationError, practiceSessionAlreadyEndedError } from '../errors';
 import type {
   AttemptSingleQuestionReader,
   AttemptWriter,
@@ -187,7 +187,7 @@ export class SubmitAnswerUseCase {
     }
 
     if (session && session.endedAt !== null) {
-      throw new ApplicationError('CONFLICT', 'Practice session already ended');
+      throw practiceSessionAlreadyEndedError();
     }
 
     const rawTimeSpentSeconds = input.timeSpentSeconds;

--- a/src/domain/services/index.ts
+++ b/src/domain/services/index.ts
@@ -44,6 +44,7 @@ export {
 } from './subscription-write-guard';
 export {
   DAY_MS,
+  EXAM_FINAL_DRAFT_FLUSH_GRACE_MS,
   EXAM_SECONDS_PER_QUESTION,
   MS_PER_SECOND,
   SECONDS_PER_DAY,

--- a/src/domain/services/time-constants.test.ts
+++ b/src/domain/services/time-constants.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { DAY_MS, MS_PER_SECOND, SECONDS_PER_DAY } from './time-constants';
+import {
+  DAY_MS,
+  EXAM_FINAL_DRAFT_FLUSH_GRACE_MS,
+  MS_PER_SECOND,
+  SECONDS_PER_DAY,
+} from './time-constants';
 
 describe('time-constants', () => {
   it('exports canonical runtime time primitives', () => {
     expect(MS_PER_SECOND).toBe(1000);
+    expect(EXAM_FINAL_DRAFT_FLUSH_GRACE_MS).toBe(15_000);
     expect(SECONDS_PER_DAY).toBe(86_400);
     expect(DAY_MS).toBe(86_400_000);
   });

--- a/src/domain/services/time-constants.ts
+++ b/src/domain/services/time-constants.ts
@@ -1,4 +1,5 @@
 export const MS_PER_SECOND = 1000;
 export const EXAM_SECONDS_PER_QUESTION = 72;
+export const EXAM_FINAL_DRAFT_FLUSH_GRACE_MS = 15 * MS_PER_SECOND;
 export const DAY_MS = 86_400_000;
 export const SECONDS_PER_DAY = DAY_MS / MS_PER_SECOND;


### PR DESCRIPTION
## Summary
- drop provably stale exam-expiry final draft flushes while keeping server-side grace-window grading intact
- add structured AlreadyEnded reasons for ended-session submit/get-next conflicts and recover tutor load/submit conflicts to summary
- map double-finalize already-answered losers to AlreadyEnded only after a fresh post-transaction session re-read
- keep the stale-flush client threshold in the app layer to preserve Clean Architecture boundaries

## Verification
- pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && pnpm test:integration && pnpm build && pnpm test:e2e
- pre-push hook: pnpm typecheck && pnpm test --run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exam timer expiration to support async retry behavior, including re-invoking expiration handling when the first finalize attempt fails.
  * Enhanced “final draft flush” logic by dropping provably stale late flushes (with warnings) so finalization succeeds.
  * Strengthened “session already ended” conflict recovery across load/submission/tutor flows, consistently transitioning back to the summary view.

* **Tests**
  * Added/expanded coverage for timer retry, stale flush dropping, ended-session recovery (including deduping), and structured conflict reason/message assertions.
  * Updated expectations for new boolean return values in review and end-session flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->