### PR TITLE
Promote dev to main after conflict/idempotency fixes

### DIFF
--- a/app/(app)/app/practice/[sessionId]/components/exam-review-view.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/exam-review-view.browser.spec.tsx
@@ -201,7 +201,9 @@ test('opens a review question and finalizes the exam', async () => {
 });
 
 test('guards against double-clicking confirm submit before pending state updates', async () => {
-  const onFinalizeReview = vi.fn(() => new Promise<void>(() => {}));
+  const onFinalizeReview = vi.fn(
+    () => new Promise<boolean | undefined>(() => {}),
+  );
 
   const screen = await render(
     <ExamReviewView
@@ -228,7 +230,7 @@ test('guards against double-clicking confirm submit before pending state updates
 });
 
 test('allows submitting again after finalize resolves even when pending state never flips', async () => {
-  const finalizeDeferred = createDeferred<void>();
+  const finalizeDeferred = createDeferred<boolean | undefined>();
   const onFinalizeReview = vi.fn(() => finalizeDeferred.promise);
 
   const screen = await render(
@@ -254,7 +256,7 @@ test('allows submitting again after finalize resolves even when pending state ne
   await screen.getByRole('button', { name: 'Confirm submit' }).click();
   expect(onFinalizeReview).toHaveBeenCalledTimes(1);
 
-  finalizeDeferred.resolve();
+  finalizeDeferred.resolve(undefined);
   await finalizeDeferred.promise;
 
   await expect

--- a/app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/exam-review-view.tsx
@@ -133,7 +133,7 @@ export function ExamReviewView({
   review: GetPracticeSessionReviewOutput;
   isPending: boolean;
   onOpenQuestion: (questionId: string) => void;
-  onFinalizeReview: () => Promise<void>;
+  onFinalizeReview: () => Promise<boolean | undefined>;
 }) {
   const unansweredCount = review.totalCount - review.answeredCount;
   const isFinalizingRef = useRef(false);

--- a/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx
+++ b/app/(app)/app/practice/[sessionId]/components/practice-session-page-view.tsx
@@ -77,7 +77,7 @@ export type PracticeSessionPageViewProps = {
   onNavigatePostExamReviewQuestion?: ((questionId: string) => void) | undefined;
   onReenterPostExamReview?: ((questionId?: string) => void) | undefined;
   onViewSummary?: (() => void) | undefined;
-  onFinalizeReview?: (() => Promise<void>) | undefined;
+  onFinalizeReview?: (() => Promise<boolean | undefined>) | undefined;
 };
 
 export function PracticeSessionPageView(props: PracticeSessionPageViewProps) {

--- a/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.browser.spec.tsx
@@ -144,6 +144,27 @@ describe('useExamTimer', () => {
     expect(onExpire).toHaveBeenCalledTimes(2);
   });
 
+  it('retries an expired deadline when onExpire throws synchronously', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    const onExpire = vi.fn(() => {
+      throw new Error('Finalize failed');
+    });
+
+    await render(
+      <TimerProbe
+        initialDeadlineAt="2026-05-22T12:00:01.000Z"
+        onExpire={onExpire}
+      />,
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(2);
+  });
+
   it('re-latches when a future deadline is replaced by a past deadline', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));

--- a/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.browser.spec.tsx
@@ -6,7 +6,7 @@ import { useExamTimer } from './use-exam-timer';
 function TimerProbe(props: {
   initialDeadlineAt: string | null;
   isExamActive?: boolean;
-  onExpire: () => void;
+  onExpire: () => boolean | undefined | Promise<boolean | undefined>;
 }) {
   const [deadlineAt, setDeadlineAt] = useState(props.initialDeadlineAt);
   const timer = useExamTimer({
@@ -96,6 +96,52 @@ describe('useExamTimer', () => {
 
     window.dispatchEvent(new Event('focus'));
     expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries an expired deadline when onExpire reports that recovery failed', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    const onExpire = vi.fn().mockReturnValueOnce(false);
+
+    await render(
+      <TimerProbe
+        initialDeadlineAt="2026-05-22T12:00:01.000Z"
+        onExpire={onExpire}
+      />,
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries an expired deadline when onExpire rejects', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    const onExpire = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Finalize failed'));
+
+    await render(
+      <TimerProbe
+        initialDeadlineAt="2026-05-22T12:00:01.000Z"
+        onExpire={onExpire}
+      />,
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(2);
   });
 
   it('re-latches when a future deadline is replaced by a past deadline', async () => {

--- a/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.ts
@@ -11,7 +11,7 @@ export type ExamTimerState = {
 export type UseExamTimerInput = {
   deadlineAt: string | null;
   isExamActive: boolean;
-  onExpire: () => void;
+  onExpire: () => boolean | undefined | Promise<boolean | undefined>;
 };
 
 function computeRemainingSeconds(deadlineMs: number, nowMs: number): number {
@@ -61,7 +61,17 @@ export function useExamTimer(input: UseExamTimerInput): ExamTimerState | null {
       }
 
       firedDeadlineMsRef.current = deadlineMs;
-      onExpireRef.current();
+      void Promise.resolve(onExpireRef.current())
+        .then((handled) => {
+          if (handled === false && firedDeadlineMsRef.current === deadlineMs) {
+            firedDeadlineMsRef.current = null;
+          }
+        })
+        .catch(() => {
+          if (firedDeadlineMsRef.current === deadlineMs) {
+            firedDeadlineMsRef.current = null;
+          }
+        });
     }
 
     update();

--- a/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.ts
@@ -61,17 +61,20 @@ export function useExamTimer(input: UseExamTimerInput): ExamTimerState | null {
       }
 
       firedDeadlineMsRef.current = deadlineMs;
-      void Promise.resolve(onExpireRef.current())
-        .then((handled) => {
+      void (async () => {
+        try {
+          const handled = await onExpireRef.current();
           if (handled === false && firedDeadlineMsRef.current === deadlineMs) {
             firedDeadlineMsRef.current = null;
           }
-        })
-        .catch(() => {
+        } catch {
+          // onExpire reports its own failures; clear the latch so the next tick
+          // can retry expiry finalization for the same deadline.
           if (firedDeadlineMsRef.current === deadlineMs) {
             firedDeadlineMsRef.current = null;
           }
-        });
+        }
+      })();
     }
 
     update();

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-ended-session-conflict.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-ended-session-conflict.browser.spec.tsx
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-react';
+import type { ActionResult } from '@/src/adapters/controllers/action-result';
+import {
+  PracticeSessionConflictMessages,
+  PracticeSessionConflictReasons,
+} from '@/src/application/errors';
+import { createDeferred } from '@/tests/test-helpers/create-deferred';
+import { ok } from '@/tests/test-helpers/ok';
+
+import {
+  createQuestionResponse,
+  createReviewResponse,
+  createReviewRow,
+} from './practice-session-page-model.browser.fixtures';
+import {
+  BROWSER_QUESTION_1_ID,
+  BROWSER_SESSION_ID,
+  errorResult,
+  getNextQuestionMock,
+  getPracticeSessionReviewMock,
+  getPracticeSessionSummaryMock,
+  PracticeSessionPageModelNavigationProbe,
+  PracticeSessionPageModelSummaryProbe,
+  setupPracticeSessionPageModelBrowserSpec,
+  submitAnswerMock,
+} from './use-practice-session-page-model-test-helpers';
+
+setupPracticeSessionPageModelBrowserSpec();
+
+function mockTutorSummary() {
+  return ok({
+    sessionId: BROWSER_SESSION_ID,
+    endedAt: '2026-02-07T00:20:00.000Z',
+    mode: 'tutor' as const,
+    questionCount: 2,
+    totals: {
+      answered: 1,
+      correct: 1,
+      accuracy: 0.5,
+      durationSeconds: 1200,
+    },
+  });
+}
+
+function mockTutorReview() {
+  getPracticeSessionReviewMock.mockResolvedValue(
+    ok(
+      createReviewResponse({
+        mode: 'tutor',
+        totalCount: 2,
+        answeredCount: 1,
+        markedCount: 0,
+        rows: [
+          createReviewRow({ questionId: BROWSER_QUESTION_1_ID, order: 1 }),
+        ],
+      }),
+    ),
+  );
+}
+
+function alreadyEndedConflict() {
+  return errorResult('CONFLICT', PracticeSessionConflictMessages.AlreadyEnded, {
+    reason: PracticeSessionConflictReasons.AlreadyEnded,
+  });
+}
+
+function mockActiveTutorQuestionThenEndedConflict() {
+  getNextQuestionMock
+    .mockResolvedValueOnce(
+      ok(
+        createQuestionResponse({
+          questionId: BROWSER_QUESTION_1_ID,
+          session: {
+            mode: 'tutor',
+            deadlineAt: null,
+            index: 0,
+            total: 2,
+            isMarkedForReview: false,
+          },
+        }),
+      ),
+    )
+    .mockResolvedValue(alreadyEndedConflict());
+}
+
+describe('usePracticeSessionPageModel ended-session conflict recovery', () => {
+  it('shows the summary when loading a tutor question reports an AlreadyEnded conflict', async () => {
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockResolvedValueOnce(mockTutorSummary());
+    getNextQuestionMock.mockResolvedValue(alreadyEndedConflict());
+    mockTutorReview();
+
+    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
+
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    await expect
+      .element(screen.getByTestId('summary-mode'))
+      .toHaveTextContent('tutor');
+    await expect
+      .element(screen.getByTestId('error-message'))
+      .toHaveTextContent('');
+  });
+
+  it('keeps the generic load error when ended-session recovery still reports an active session', async () => {
+    getPracticeSessionSummaryMock.mockResolvedValue(
+      errorResult('CONFLICT', 'Practice session has not ended'),
+    );
+    getNextQuestionMock.mockResolvedValue(alreadyEndedConflict());
+
+    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
+
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('');
+    await expect
+      .element(screen.getByTestId('load-status'))
+      .toHaveTextContent('error');
+    await expect
+      .element(screen.getByTestId('error-message'))
+      .toHaveTextContent(PracticeSessionConflictMessages.AlreadyEnded);
+  });
+
+  it('keeps the generic load error when ended-session recovery summary re-read throws', async () => {
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockRejectedValueOnce(new Error('Summary recovery failed'));
+    getNextQuestionMock.mockResolvedValue(alreadyEndedConflict());
+
+    const screen = await render(<PracticeSessionPageModelSummaryProbe />);
+
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(1);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('');
+    await expect
+      .element(screen.getByTestId('load-status'))
+      .toHaveTextContent('error');
+    await expect
+      .element(screen.getByTestId('error-message'))
+      .toHaveTextContent(PracticeSessionConflictMessages.AlreadyEnded);
+  });
+
+  it('shows the summary when tutor answer submit reports an AlreadyEnded conflict', async () => {
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockResolvedValueOnce(mockTutorSummary());
+    mockActiveTutorQuestionThenEndedConflict();
+    submitAnswerMock.mockResolvedValue(alreadyEndedConflict());
+    mockTutorReview();
+
+    const screen = await render(<PracticeSessionPageModelNavigationProbe />);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('question');
+    await screen.getByRole('button', { name: 'select-choice-1' }).click();
+    await screen.getByRole('button', { name: 'submit-answer' }).click();
+
+    await expect.poll(() => submitAnswerMock.mock.calls.length > 0).toBe(true);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    await expect
+      .element(screen.getByTestId('summary-answered-count'))
+      .toHaveTextContent('1');
+  });
+
+  it('deduplicates concurrent ended-session summary recovery requests', async () => {
+    const recoverySummary = createDeferred<ActionResult<unknown>>();
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockImplementation(() => recoverySummary.promise);
+    mockActiveTutorQuestionThenEndedConflict();
+    submitAnswerMock.mockResolvedValue(alreadyEndedConflict());
+    mockTutorReview();
+
+    const screen = await render(<PracticeSessionPageModelNavigationProbe />);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('question');
+    await screen.getByRole('button', { name: 'select-choice-1' }).click();
+    await screen.getByRole('button', { name: 'submit-answer' }).click();
+    await screen.getByRole('button', { name: 'next-question' }).click();
+
+    await expect.poll(() => submitAnswerMock.mock.calls.length).toBe(1);
+    await expect.poll(() => getNextQuestionMock.mock.calls.length).toBe(2);
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+
+    recoverySummary.resolve(mockTutorSummary());
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    expect(getPracticeSessionSummaryMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-ended-session-conflict.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-ended-session-conflict.browser.spec.tsx
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { useState } from 'react';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-react';
 import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import {
@@ -14,9 +15,12 @@ import {
   createReviewRow,
 } from './practice-session-page-model.browser.fixtures';
 import {
+  BROWSER_CHOICE_1_ID,
   BROWSER_QUESTION_1_ID,
+  BROWSER_QUESTION_2_ID,
   BROWSER_SESSION_ID,
   errorResult,
+  getCompletedSessionQuestionsWithFeedbackMock,
   getNextQuestionMock,
   getPracticeSessionReviewMock,
   getPracticeSessionSummaryMock,
@@ -28,9 +32,19 @@ import {
 
 setupPracticeSessionPageModelBrowserSpec();
 
-function mockTutorSummary() {
+let usePracticeSessionPageModel: typeof import('./use-practice-session-page-model').usePracticeSessionPageModel;
+
+const BROWSER_SESSION_2_ID = crypto.randomUUID();
+
+beforeAll(async () => {
+  ({ usePracticeSessionPageModel } = await import(
+    './use-practice-session-page-model'
+  ));
+});
+
+function mockTutorSummary(sessionId = BROWSER_SESSION_ID) {
   return ok({
-    sessionId: BROWSER_SESSION_ID,
+    sessionId,
     endedAt: '2026-02-07T00:20:00.000Z',
     mode: 'tutor' as const,
     questionCount: 2,
@@ -43,10 +57,11 @@ function mockTutorSummary() {
   });
 }
 
-function mockTutorReview() {
+function mockTutorReview(sessionId = BROWSER_SESSION_ID) {
   getPracticeSessionReviewMock.mockResolvedValue(
     ok(
       createReviewResponse({
+        sessionId,
         mode: 'tutor',
         totalCount: 2,
         answeredCount: 1,
@@ -56,6 +71,42 @@ function mockTutorReview() {
         ],
       }),
     ),
+  );
+}
+
+function mockCompletedSessionQuestionsWithFeedback(
+  sessionId = BROWSER_SESSION_ID,
+) {
+  getCompletedSessionQuestionsWithFeedbackMock.mockResolvedValue(
+    ok({
+      sessionId,
+      mode: 'tutor',
+      totalCount: 2,
+      answeredCount: 1,
+      markedCount: 0,
+      rows: [
+        {
+          isAvailable: true,
+          questionId: BROWSER_QUESTION_1_ID,
+          slug: 'question-1',
+          stemMd: 'Question 1',
+          difficulty: 'easy',
+          order: 1,
+          isAnswered: true,
+          isCorrect: true,
+          isOmitted: false,
+          markedForReview: false,
+          choices: [
+            { id: BROWSER_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          ],
+          selectedChoiceId: BROWSER_CHOICE_1_ID,
+          correctChoiceId: BROWSER_CHOICE_1_ID,
+          explanationMd: 'Because A is correct.',
+          referenceMd: null,
+          choiceExplanations: [],
+        },
+      ],
+    }),
   );
 }
 
@@ -82,6 +133,45 @@ function mockActiveTutorQuestionThenEndedConflict() {
       ),
     )
     .mockResolvedValue(alreadyEndedConflict());
+}
+
+function getActiveView(output: ReturnType<typeof usePracticeSessionPageModel>) {
+  if (output.summary) return 'summary';
+  if (output.question) return 'question';
+  return '';
+}
+
+function MutableSessionRecoveryProbe() {
+  const [sessionId, setSessionId] = useState(BROWSER_SESSION_ID);
+  const output = usePracticeSessionPageModel(sessionId);
+
+  return (
+    <>
+      <div data-testid="current-session-id">{sessionId}</div>
+      <div data-testid="active-view">{getActiveView(output)}</div>
+      <div data-testid="question-id">{output.question?.questionId ?? ''}</div>
+      <div data-testid="summary-session-id">
+        {output.summary?.sessionId ?? ''}
+      </div>
+      <button
+        type="button"
+        onClick={() => output.onSelectChoice(BROWSER_CHOICE_1_ID)}
+      >
+        select-choice-1
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void output.onSubmit();
+        }}
+      >
+        submit-answer
+      </button>
+      <button type="button" onClick={() => setSessionId(BROWSER_SESSION_2_ID)}>
+        switch-session
+      </button>
+    </>
+  );
 }
 
 describe('usePracticeSessionPageModel ended-session conflict recovery', () => {
@@ -221,5 +311,122 @@ describe('usePracticeSessionPageModel ended-session conflict recovery', () => {
       .element(screen.getByTestId('active-view'))
       .toHaveTextContent('summary');
     expect(getPracticeSessionSummaryMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not let stale ended-session recovery overwrite a newer question load', async () => {
+    const recoverySummary = createDeferred<ActionResult<unknown>>();
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockImplementation(() => recoverySummary.promise);
+    getNextQuestionMock
+      .mockResolvedValueOnce(
+        ok(
+          createQuestionResponse({
+            questionId: BROWSER_QUESTION_1_ID,
+            session: {
+              mode: 'tutor',
+              deadlineAt: null,
+              index: 0,
+              total: 2,
+              isMarkedForReview: false,
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        ok(
+          createQuestionResponse({
+            questionId: BROWSER_QUESTION_2_ID,
+            session: {
+              mode: 'tutor',
+              deadlineAt: null,
+              index: 1,
+              total: 2,
+              isMarkedForReview: false,
+            },
+          }),
+        ),
+      );
+    submitAnswerMock.mockResolvedValue(alreadyEndedConflict());
+    mockTutorReview();
+
+    const screen = await render(<PracticeSessionPageModelNavigationProbe />);
+
+    await expect
+      .element(screen.getByTestId('question-id'))
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
+    await screen.getByRole('button', { name: 'select-choice-1' }).click();
+    await screen.getByRole('button', { name: 'submit-answer' }).click();
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+
+    await screen.getByRole('button', { name: 'next-question' }).click();
+    await expect
+      .element(screen.getByTestId('question-id'))
+      .toHaveTextContent(BROWSER_QUESTION_2_ID);
+
+    recoverySummary.resolve(mockTutorSummary());
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('question');
+    await expect
+      .element(screen.getByTestId('question-id'))
+      .toHaveTextContent(BROWSER_QUESTION_2_ID);
+  });
+
+  it('does not let stale ended-session recovery overwrite a newer session summary', async () => {
+    const recoverySummary = createDeferred<ActionResult<unknown>>();
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockImplementationOnce(() => recoverySummary.promise)
+      .mockResolvedValueOnce(mockTutorSummary(BROWSER_SESSION_2_ID));
+    getNextQuestionMock.mockResolvedValueOnce(
+      ok(
+        createQuestionResponse({
+          questionId: BROWSER_QUESTION_1_ID,
+          session: {
+            mode: 'tutor',
+            deadlineAt: null,
+            index: 0,
+            total: 2,
+            isMarkedForReview: false,
+          },
+        }),
+      ),
+    );
+    submitAnswerMock.mockResolvedValue(alreadyEndedConflict());
+    mockTutorReview(BROWSER_SESSION_2_ID);
+    mockCompletedSessionQuestionsWithFeedback(BROWSER_SESSION_2_ID);
+
+    const screen = await render(<MutableSessionRecoveryProbe />);
+
+    await expect
+      .element(screen.getByTestId('question-id'))
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
+    await screen.getByRole('button', { name: 'select-choice-1' }).click();
+    await screen.getByRole('button', { name: 'submit-answer' }).click();
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+
+    await screen.getByRole('button', { name: 'switch-session' }).click();
+    await expect
+      .element(screen.getByTestId('summary-session-id'))
+      .toHaveTextContent(BROWSER_SESSION_2_ID);
+
+    recoverySummary.resolve(mockTutorSummary(BROWSER_SESSION_ID));
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    await expect
+      .element(screen.getByTestId('summary-session-id'))
+      .toHaveTextContent(BROWSER_SESSION_2_ID);
   });
 });

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-init-load.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-init-load.browser.spec.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { STANDARD_READ_TIMEOUT_MS } from '@/app/(app)/app/shared/timeout-tiers';
 import type { ActionResult } from '@/src/adapters/controllers/action-result';
+import { PracticeSessionConflictMessages } from '@/src/application/errors';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
 
@@ -422,7 +423,7 @@ describe('usePracticeSessionPageModel (browser)', () => {
       ),
     );
     endPracticeSessionMock.mockResolvedValue(
-      errorResult('CONFLICT', 'Practice session already ended'),
+      errorResult('CONFLICT', PracticeSessionConflictMessages.AlreadyEnded),
     );
 
     const screen = await render(<PracticeSessionPageModelSummaryProbe />);

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-timer.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-timer.browser.spec.tsx
@@ -162,6 +162,90 @@ describe('usePracticeSessionPageModel timer expiry', () => {
     expect(finalizeExamAnswersMock).toHaveBeenCalledTimes(1);
   });
 
+  it('omits a provably stale final draft flush when a backgrounded exam tab resumes after grace', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    mockActiveTimedExam('2026-05-22T12:00:01.000Z');
+    mockFinalizeSummary();
+    saveExamDraftAnswerMock.mockResolvedValue(
+      errorResult('CONFLICT', 'Exam time has expired', {
+        reason: 'exam_time_expired',
+      }),
+    );
+
+    const screen = await render(<PracticeSessionPageModelReviewProbe />);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('question');
+    await screen.getByRole('button', { name: 'select-choice-1' }).click();
+
+    vi.setSystemTime(new Date('2026-05-22T12:00:20.000Z'));
+    window.dispatchEvent(new Event('focus'));
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    await expect
+      .element(screen.getByTestId('summary-answered-count'))
+      .toHaveTextContent('0');
+    expect(finalizeExamAnswersMock).toHaveBeenCalledTimes(1);
+    expect(finalizeExamAnswersMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        finalDraftAnswer: expect.anything(),
+      }),
+    );
+  });
+
+  it('retries timer expiry finalization after a failed attempt with a null-selection draft', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    mockActiveTimedExam('2026-05-22T12:00:01.000Z');
+    finalizeExamAnswersMock
+      .mockResolvedValueOnce(errorResult('INTERNAL_ERROR', 'Finalize failed'))
+      .mockResolvedValueOnce(
+        ok({
+          sessionId: BROWSER_SESSION_ID,
+          endedAt: '2026-05-22T12:01:12.000Z',
+          mode: 'exam',
+          questionCount: 1,
+          totals: {
+            answered: 0,
+            correct: 0,
+            accuracy: 0,
+            durationSeconds: 72,
+          },
+        }),
+      );
+
+    const screen = await render(<PracticeSessionPageModelReviewProbe />);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('question');
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect
+      .element(screen.getByTestId('load-status'))
+      .toHaveTextContent('error');
+    expect(finalizeExamAnswersMock).toHaveBeenCalledTimes(1);
+    expect(finalizeExamAnswersMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        finalDraftAnswer: expect.objectContaining({
+          questionId: BROWSER_QUESTION_1_ID,
+          selectedChoiceId: null,
+        }),
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    expect(finalizeExamAnswersMock).toHaveBeenCalledTimes(2);
+  });
+
   it('manual Review & Submit after expiry proceeds to finalization after a rejected draft save', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
@@ -48,6 +48,13 @@ const BOOTSTRAP_SUMMARY_TIMEOUT_MS = STANDARD_READ_TIMEOUT_MS;
 const STALE_FINAL_DRAFT_FLUSH_AFTER_DEADLINE_MS =
   EXAM_FINAL_DRAFT_FLUSH_GRACE_MS;
 
+type EndedSessionSummaryRecovery = {
+  sessionId: string;
+  promise: Promise<Awaited<
+    ReturnType<typeof getPracticeSessionSummary>
+  > | null>;
+};
+
 type PracticeSessionPageModelOutput = Omit<
   PracticeSessionPageViewProps,
   'questionFeedback'
@@ -81,9 +88,10 @@ export function usePracticeSessionPageModel(
   >(null);
   const recoverEndedSessionConflictRef =
     useRef<EndedSessionConflictRecovery | null>(null);
-  const recoverEndedSessionSummaryPromiseRef = useRef<Promise<boolean> | null>(
-    null,
-  );
+  const recoverEndedSessionSummaryPromiseRef =
+    useRef<EndedSessionSummaryRecovery | null>(null);
+  const currentSessionIdRef = useRef(sessionId);
+  currentSessionIdRef.current = sessionId;
   const [shouldRetryBootstrap, setShouldRetryBootstrap] = useState(false);
   const onExamServerExpiry = useCallback(
     async (finalDraftAnswer: ExamDraftAnswer | null): Promise<void> => {
@@ -91,10 +99,18 @@ export function usePracticeSessionPageModel(
     },
     [],
   );
-  const recoverEndedSessionConflict =
-    useCallback(async (): Promise<boolean> => {
-      return (await recoverEndedSessionConflictRef.current?.()) ?? false;
-    }, []);
+  const recoverEndedSessionConflict = useCallback(
+    async (input: { canCommit: () => boolean }): Promise<boolean> => {
+      return (await recoverEndedSessionConflictRef.current?.(input)) ?? false;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (recoverEndedSessionSummaryPromiseRef.current?.sessionId !== sessionId) {
+      recoverEndedSessionSummaryPromiseRef.current = null;
+    }
+  }, [sessionId]);
 
   const questionFlow = usePracticeSessionQuestionFlow({
     sessionId,
@@ -333,53 +349,64 @@ export function usePracticeSessionPageModel(
     [applyBootstrapSummary, isMounted, sessionId],
   );
 
-  const recoverEndedSessionSummary = useCallback((): Promise<boolean> => {
-    if (reviewStage.summary || reviewStage.postExamSummary) {
-      return Promise.resolve(true);
-    }
-    if (recoverEndedSessionSummaryPromiseRef.current) {
-      return recoverEndedSessionSummaryPromiseRef.current;
-    }
-
-    const recovery = (async (): Promise<boolean> => {
-      let result: Awaited<ReturnType<typeof getPracticeSessionSummary>>;
-      try {
-        result = await withTimeout(
-          getPracticeSessionSummary({ sessionId }),
-          BOOTSTRAP_SUMMARY_TIMEOUT_MS,
-        );
-      } catch (error) {
-        if (isMounted()) {
-          reportClientError(error, {
-            component: 'UsePracticeSessionPageModel',
-            action: 'recoverEndedSessionSummary',
-          });
-        }
-        return false;
+  const recoverEndedSessionSummary = useCallback(
+    (input: { canCommit: () => boolean }): Promise<boolean> => {
+      if (reviewStage.summary || reviewStage.postExamSummary) {
+        return Promise.resolve(true);
+      }
+      let recovery = recoverEndedSessionSummaryPromiseRef.current;
+      if (recovery?.sessionId !== sessionId) {
+        recovery = null;
+      }
+      if (!recovery) {
+        const recoverySessionId = sessionId;
+        const promise = (async (): Promise<Awaited<
+          ReturnType<typeof getPracticeSessionSummary>
+        > | null> => {
+          try {
+            return await withTimeout(
+              getPracticeSessionSummary({ sessionId: recoverySessionId }),
+              BOOTSTRAP_SUMMARY_TIMEOUT_MS,
+            );
+          } catch (error) {
+            if (isMounted()) {
+              reportClientError(error, {
+                component: 'UsePracticeSessionPageModel',
+                action: 'recoverEndedSessionSummary',
+              });
+            }
+            return null;
+          }
+        })();
+        recovery = { sessionId: recoverySessionId, promise };
+        recoverEndedSessionSummaryPromiseRef.current = recovery;
+        const activeRecovery = recovery;
+        void promise.finally(() => {
+          if (recoverEndedSessionSummaryPromiseRef.current === activeRecovery) {
+            recoverEndedSessionSummaryPromiseRef.current = null;
+          }
+        });
       }
 
-      if (!isMounted()) return false;
-      if (!result.ok) return false;
+      const recoverySessionId = recovery.sessionId;
+      return recovery.promise.then((result) => {
+        if (currentSessionIdRef.current !== recoverySessionId) return false;
+        if (!isMounted() || !input.canCommit()) return false;
+        if (!result?.ok) return false;
 
-      setShouldRetryBootstrap(false);
-      applyBootstrapSummary(result.data);
-      return true;
-    })();
-
-    recoverEndedSessionSummaryPromiseRef.current = recovery;
-    void recovery.finally(() => {
-      if (recoverEndedSessionSummaryPromiseRef.current === recovery) {
-        recoverEndedSessionSummaryPromiseRef.current = null;
-      }
-    });
-    return recovery;
-  }, [
-    applyBootstrapSummary,
-    isMounted,
-    reviewStage.postExamSummary,
-    reviewStage.summary,
-    sessionId,
-  ]);
+        setShouldRetryBootstrap(false);
+        applyBootstrapSummary(result.data);
+        return true;
+      });
+    },
+    [
+      applyBootstrapSummary,
+      isMounted,
+      reviewStage.postExamSummary,
+      reviewStage.summary,
+      sessionId,
+    ],
+  );
 
   useEffect(() => {
     recoverEndedSessionConflictRef.current = recoverEndedSessionSummary;

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
@@ -14,7 +14,10 @@ import { usePracticeSessionReviewStage } from '@/app/(app)/app/practice/[session
 import { ExamTimer } from '@/app/(app)/app/practice/components/exam-timer';
 import { usePracticeQuestionBookmarks } from '@/app/(app)/app/practice/hooks/use-practice-question-bookmarks';
 import { usePracticeQuestionFeedback } from '@/app/(app)/app/practice/hooks/use-practice-question-feedback';
-import type { ExamDraftAnswer } from '@/app/(app)/app/practice/shared/question-flow-actions';
+import type {
+  EndedSessionConflictRecovery,
+  ExamDraftAnswer,
+} from '@/app/(app)/app/practice/shared/question-flow-actions';
 import {
   getActionResultErrorMessage,
   getThrownErrorMessage,
@@ -37,8 +40,13 @@ import {
   getNextQuestion,
   submitAnswer,
 } from '@/src/adapters/controllers/question-controller';
+import { EXAM_FINAL_DRAFT_FLUSH_GRACE_MS } from '@/src/domain/services';
 
 const BOOTSTRAP_SUMMARY_TIMEOUT_MS = STANDARD_READ_TIMEOUT_MS;
+// Client-side optimization only: avoid sending a draft flush that is already
+// outside the shared server grace window. The server remains authoritative.
+const STALE_FINAL_DRAFT_FLUSH_AFTER_DEADLINE_MS =
+  EXAM_FINAL_DRAFT_FLUSH_GRACE_MS;
 
 type PracticeSessionPageModelOutput = Omit<
   PracticeSessionPageViewProps,
@@ -51,6 +59,17 @@ type PracticeSessionPageModelOutput = Omit<
   onSubmit: () => void;
 };
 
+function isFinalDraftFlushProvablyStale(input: {
+  deadlineAt: string | null | undefined;
+  nowMs: number;
+}): boolean {
+  if (typeof input.deadlineAt !== 'string') return false;
+  const deadlineMs = Date.parse(input.deadlineAt);
+  if (!Number.isFinite(deadlineMs)) return false;
+
+  return input.nowMs > deadlineMs + STALE_FINAL_DRAFT_FLUSH_AFTER_DEADLINE_MS;
+}
+
 export function usePracticeSessionPageModel(
   sessionId: string,
 ): PracticeSessionPageModelOutput {
@@ -60,6 +79,11 @@ export function usePracticeSessionPageModel(
   const onExamServerExpiryRef = useRef<
     ((finalDraftAnswer: ExamDraftAnswer | null) => Promise<void>) | null
   >(null);
+  const recoverEndedSessionConflictRef =
+    useRef<EndedSessionConflictRecovery | null>(null);
+  const recoverEndedSessionSummaryPromiseRef = useRef<Promise<boolean> | null>(
+    null,
+  );
   const [shouldRetryBootstrap, setShouldRetryBootstrap] = useState(false);
   const onExamServerExpiry = useCallback(
     async (finalDraftAnswer: ExamDraftAnswer | null): Promise<void> => {
@@ -67,6 +91,10 @@ export function usePracticeSessionPageModel(
     },
     [],
   );
+  const recoverEndedSessionConflict =
+    useCallback(async (): Promise<boolean> => {
+      return (await recoverEndedSessionConflictRef.current?.()) ?? false;
+    }, []);
 
   const questionFlow = usePracticeSessionQuestionFlow({
     sessionId,
@@ -76,6 +104,7 @@ export function usePracticeSessionPageModel(
     submitAnswerFn: submitAnswer,
     saveExamDraftAnswerFn: saveExamDraftAnswer,
     onExamServerExpiry,
+    recoverEndedSessionConflict,
   });
 
   const reviewStage = usePracticeSessionReviewStage({
@@ -184,16 +213,24 @@ export function usePracticeSessionPageModel(
     isMounted,
   });
 
-  const finalizeExpiredExam = useCallback(() => {
-    if (expiryFinalizeInFlightRef.current) return;
+  const finalizeExpiredExam = useCallback((): Promise<boolean> => {
+    if (expiryFinalizeInFlightRef.current) return Promise.resolve(true);
     expiryFinalizeInFlightRef.current = true;
 
-    void (async () => {
+    return (async () => {
       // BUG-254: capture the on-screen draft BEFORE the save attempt. At the
       // deadline the ordinary draft save is rejected as expired; rather than
       // leaving that doomed save's only effect as an error state, we forward the
       // captured selection to finalization so the server grades it.
-      const finalDraftAnswer = questionFlow.getCurrentExamDraft() ?? undefined;
+      const capturedFinalDraftAnswer = questionFlow.getCurrentExamDraft();
+      const finalDraftAnswer =
+        capturedFinalDraftAnswer &&
+        !isFinalDraftFlushProvablyStale({
+          deadlineAt: questionFlow.sessionInfo?.deadlineAt,
+          nowMs: Date.now(),
+        })
+          ? capturedFinalDraftAnswer
+          : undefined;
       try {
         await questionFlow.saveCurrentExamDraft();
       } catch (error) {
@@ -205,13 +242,30 @@ export function usePracticeSessionPageModel(
         }
       }
 
-      if (!isMounted()) return;
-      await reviewStage.finalizeExamSession(finalDraftAnswer);
+      if (!isMounted()) return false;
+      try {
+        const finalized =
+          await reviewStage.finalizeExamSession(finalDraftAnswer);
+        if (!finalized && isMounted()) {
+          expiryFinalizeInFlightRef.current = false;
+        }
+        return finalized;
+      } catch (error) {
+        if (isMounted()) {
+          expiryFinalizeInFlightRef.current = false;
+          reportClientError(error, {
+            component: 'UsePracticeSessionPageModel',
+            action: 'finalizeExpiredExam',
+          });
+        }
+        return false;
+      }
     })();
   }, [
     isMounted,
     questionFlow.getCurrentExamDraft,
     questionFlow.saveCurrentExamDraft,
+    questionFlow.sessionInfo?.deadlineAt,
     reviewStage.finalizeExamSession,
   ]);
 
@@ -278,6 +332,65 @@ export function usePracticeSessionPageModel(
     },
     [applyBootstrapSummary, isMounted, sessionId],
   );
+
+  const recoverEndedSessionSummary = useCallback((): Promise<boolean> => {
+    if (reviewStage.summary || reviewStage.postExamSummary) {
+      return Promise.resolve(true);
+    }
+    if (recoverEndedSessionSummaryPromiseRef.current) {
+      return recoverEndedSessionSummaryPromiseRef.current;
+    }
+
+    const recovery = (async (): Promise<boolean> => {
+      let result: Awaited<ReturnType<typeof getPracticeSessionSummary>>;
+      try {
+        result = await withTimeout(
+          getPracticeSessionSummary({ sessionId }),
+          BOOTSTRAP_SUMMARY_TIMEOUT_MS,
+        );
+      } catch (error) {
+        if (isMounted()) {
+          reportClientError(error, {
+            component: 'UsePracticeSessionPageModel',
+            action: 'recoverEndedSessionSummary',
+          });
+        }
+        return false;
+      }
+
+      if (!isMounted()) return false;
+      if (!result.ok) return false;
+
+      setShouldRetryBootstrap(false);
+      applyBootstrapSummary(result.data);
+      return true;
+    })();
+
+    recoverEndedSessionSummaryPromiseRef.current = recovery;
+    void recovery.finally(() => {
+      if (recoverEndedSessionSummaryPromiseRef.current === recovery) {
+        recoverEndedSessionSummaryPromiseRef.current = null;
+      }
+    });
+    return recovery;
+  }, [
+    applyBootstrapSummary,
+    isMounted,
+    reviewStage.postExamSummary,
+    reviewStage.summary,
+    sessionId,
+  ]);
+
+  useEffect(() => {
+    recoverEndedSessionConflictRef.current = recoverEndedSessionSummary;
+    return () => {
+      if (
+        recoverEndedSessionConflictRef.current === recoverEndedSessionSummary
+      ) {
+        recoverEndedSessionConflictRef.current = null;
+      }
+    };
+  }, [recoverEndedSessionSummary]);
 
   const bootstrapSessionSummary = useCallback(() => {
     const requestId = bootstrapRequestIdRef.current + 1;

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-question-flow.ts
@@ -9,6 +9,7 @@ import {
 } from '@/app/(app)/app/practice/[sessionId]/practice-session-page-logic';
 import type { LoadState } from '@/app/(app)/app/practice/practice-page-logic';
 import {
+  type EndedSessionConflictRecovery,
   type ExamDraftAnswer,
   type ExamDraftSaveResult,
   isExamExpiryDraftSaveConflict,
@@ -37,6 +38,7 @@ export type UsePracticeSessionQuestionFlowInput = {
   onExamServerExpiry?: (
     finalDraftAnswer: ExamDraftAnswer | null,
   ) => Promise<void>;
+  recoverEndedSessionConflict?: EndedSessionConflictRecovery | undefined;
 };
 
 type SubmitOptions = {
@@ -137,6 +139,7 @@ export function usePracticeSessionQuestionFlow(
       setQuestionLoadedAt,
       setQuestion,
       setSessionInfo: applySessionInfo,
+      recoverEndedSessionConflict: input.recoverEndedSessionConflict,
       createRequestSequenceId,
       isLatestRequest,
       isMounted,
@@ -144,6 +147,7 @@ export function usePracticeSessionQuestionFlow(
     [
       input.sessionId,
       input.getNextQuestionFn,
+      input.recoverEndedSessionConflict,
       applySessionInfo,
       createIdempotencyKey,
       createRequestSequenceId,
@@ -418,6 +422,7 @@ export function usePracticeSessionQuestionFlow(
             onSuccess: (result) => {
               captured = result;
             },
+            recoverEndedSessionConflict: input.recoverEndedSessionConflict,
             createRequestSequenceId,
             isLatestRequest,
             isMounted,
@@ -438,6 +443,7 @@ export function usePracticeSessionQuestionFlow(
       createRequestSequenceId,
       input.sessionId,
       input.submitAnswerFn,
+      input.recoverEndedSessionConflict,
       isLatestRequest,
       isMounted,
       question,

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.browser.spec.tsx
@@ -41,7 +41,7 @@ function createInput(
     setSessionMode: vi.fn(),
     resetQuestionState: vi.fn(),
     loadSpecificQuestion: vi.fn(),
-    finalizeSession: vi.fn().mockResolvedValue(undefined),
+    finalizeSession: vi.fn().mockResolvedValue(true),
     getPracticeSessionReviewFn: getPracticeSessionReviewMock,
   };
 }

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.browser.spec.tsx
@@ -249,11 +249,13 @@ describe('usePracticeSessionReviewStageState (browser)', () => {
 
   it('finalizes review state when requested', async () => {
     const input = createInput('exam');
+    vi.mocked(input.finalizeSession).mockResolvedValue(true);
     const harness = await renderHook(() =>
       usePracticeSessionReviewStageState(input),
     );
 
-    harness.result.current.onFinalizeReview();
+    const finalized = await harness.result.current.onFinalizeReview();
+    expect(finalized).toBe(true);
 
     await expect
       .poll(() => vi.mocked(input.finalizeSession).mock.calls.length)

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.ts
@@ -26,7 +26,7 @@ export type UsePracticeSessionReviewStageStateInput = {
   setSessionMode: (mode: 'tutor' | 'exam' | null) => void;
   resetQuestionState: () => void;
   loadSpecificQuestion: (questionId: string) => void;
-  finalizeSession: () => Promise<void>;
+  finalizeSession: () => Promise<boolean>;
   getPracticeSessionReviewFn: (
     input: Pick<GetPracticeSessionReviewUseCaseInput, 'sessionId'>,
   ) => Promise<ActionResult<GetPracticeSessionReviewOutput>>;
@@ -41,7 +41,7 @@ export type UsePracticeSessionReviewStageStateOutput = {
   onEndSession: () => void;
   onRetryReview: () => void;
   onOpenReviewQuestion: (questionId: string) => void;
-  onFinalizeReview: () => Promise<void>;
+  onFinalizeReview: () => Promise<boolean>;
 };
 
 export function usePracticeSessionReviewStageState(
@@ -149,7 +149,7 @@ export function usePracticeSessionReviewStageState(
     [input.loadSpecificQuestion],
   );
 
-  const onFinalizeReview = useCallback((): Promise<void> => {
+  const onFinalizeReview = useCallback((): Promise<boolean> => {
     setReview(null);
     setReviewLoadState({ status: 'idle' });
     setIsInReviewStage(false);

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.browser.spec.tsx
@@ -196,6 +196,47 @@ describe('usePracticeSessionReviewStage (browser)', () => {
     );
   });
 
+  it('awaits tutor finalization from the finalize-review callback', async () => {
+    endPracticeSessionMock.mockResolvedValue(
+      ok({
+        sessionId: fixtureSession1Id,
+        endedAt: '2026-02-07T00:20:00.000Z',
+        mode: 'tutor',
+        questionCount: 10,
+        totals: {
+          answered: 10,
+          correct: 8,
+          accuracy: 0.8,
+          durationSeconds: 1200,
+        },
+      }),
+    );
+    getPracticeSessionReviewMock.mockResolvedValue(
+      ok({
+        sessionId: fixtureSession1Id,
+        mode: 'tutor',
+        totalCount: 10,
+        answeredCount: 10,
+        markedCount: 0,
+        rows: [],
+      }),
+    );
+
+    const input = createInput('tutor');
+    const harness = await renderHook(() =>
+      usePracticeSessionReviewStage(input),
+    );
+
+    const finalized = await harness.result.current.onFinalizeReview();
+    expect(finalized).toBe(true);
+
+    await expect
+      .poll(() => harness.result.current.summary?.sessionId ?? null)
+      .toBe(fixtureSession1Id);
+    expect(endPracticeSessionMock).toHaveBeenCalledTimes(1);
+    expect(finalizeExamAnswersMock).not.toHaveBeenCalled();
+  });
+
   it('sets review load error when exam review loading throws', async () => {
     getPracticeSessionReviewMock.mockRejectedValue(
       new Error('Review load failed'),

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage.ts
@@ -241,15 +241,16 @@ export function usePracticeSessionReviewStage(
     finalizeExamSession,
     reviewStage.onEndSession,
   ]);
-  const onFinalizeReview = useCallback(async (): Promise<void> => {
+  const onFinalizeReview = useCallback(async (): Promise<boolean> => {
     if (input.sessionMode !== 'exam') {
       return reviewStage.onFinalizeReview();
     }
     const finalizedSummary = await finalizeExamSessionForPostReview();
-    if (!input.isMounted()) return;
-    if (!finalizedSummary) return;
+    if (!input.isMounted()) return false;
+    if (!finalizedSummary) return false;
     reviewStage.setReview(null);
     await examResults.enterPostExamReview(finalizedSummary);
+    return true;
   }, [
     examResults.enterPostExamReview,
     finalizeExamSessionForPostReview,

--- a/app/(app)/app/practice/[sessionId]/practice-session-page-logic.ts
+++ b/app/(app)/app/practice/[sessionId]/practice-session-page-logic.ts
@@ -1,5 +1,6 @@
 import type { LoadState } from '@/app/(app)/app/practice/practice-page-logic';
 import {
+  type EndedSessionConflictRecovery,
   type ExamDraftAnswer,
   type NullQuestionRecovery,
   runLoadQuestionFlow,
@@ -62,6 +63,7 @@ export async function loadNextQuestion(input: {
   setQuestion: (question: NextQuestion | null) => void;
   setSessionInfo: (info: NextQuestion['session']) => void;
   recoverNullQuestion?: NullQuestionRecovery | undefined;
+  recoverEndedSessionConflict?: EndedSessionConflictRecovery | undefined;
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
@@ -90,6 +92,7 @@ export async function loadNextQuestion(input: {
       input.setSessionInfo(question.session);
     },
     recoverNullQuestion: input.recoverNullQuestion,
+    recoverEndedSessionConflict: input.recoverEndedSessionConflict,
     createRequestSequenceId: input.createRequestSequenceId,
     isLatestRequest: input.isLatestRequest,
     isMounted: input.isMounted,
@@ -112,6 +115,7 @@ export function createLoadNextQuestionAction(input: {
   setQuestionLoadedAt: (loadedAtMs: number | null) => void;
   setQuestion: (question: NextQuestion | null) => void;
   setSessionInfo: (info: NextQuestion['session']) => void;
+  recoverEndedSessionConflict?: EndedSessionConflictRecovery | undefined;
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
@@ -137,6 +141,7 @@ export async function submitAnswerForQuestion(input: {
   setLoadState: (state: LoadState) => void;
   setSubmitResult: (result: SubmitAnswerOutput | null) => void;
   onSuccess?: ((result: SubmitAnswerOutput) => void) | undefined;
+  recoverEndedSessionConflict?: EndedSessionConflictRecovery | undefined;
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
@@ -163,6 +168,7 @@ export async function submitAnswerForQuestion(input: {
     setLoadState: input.setLoadState,
     setSubmitResult: input.setSubmitResult,
     onSuccess: input.onSuccess,
+    recoverEndedSessionConflict: input.recoverEndedSessionConflict,
     createRequestSequenceId: input.createRequestSequenceId,
     isLatestRequest: input.isLatestRequest,
     isMounted: input.isMounted,
@@ -184,7 +190,7 @@ export async function endSession(input: {
   resetQuestionState: () => void;
   rotateIdempotencyKey?: (() => void) | undefined;
   isMounted?: (() => boolean) | undefined;
-}): Promise<void> {
+}): Promise<boolean> {
   const isMounted = input.isMounted ?? (() => true);
 
   input.setLoadState({ status: 'loading' });
@@ -202,7 +208,7 @@ export async function endSession(input: {
       END_SESSION_TIMEOUT_MS,
     );
   } catch (error) {
-    if (!isMounted()) return;
+    if (!isMounted()) return false;
 
     reportClientError(error, {
       component: 'PracticeSessionPageLogic',
@@ -213,9 +219,9 @@ export async function endSession(input: {
       status: 'error',
       message: getThrownErrorMessage(error),
     });
-    return;
+    return false;
   }
-  if (!isMounted()) return;
+  if (!isMounted()) return false;
   if (!res.ok) {
     let recoveryErrorMessage: string | null = null;
 
@@ -227,17 +233,17 @@ export async function endSession(input: {
           }),
           END_SESSION_TIMEOUT_MS,
         );
-        if (!isMounted()) return;
+        if (!isMounted()) return false;
         if (summaryRes.ok) {
           input.setSummary(summaryRes.data);
           input.resetQuestionState();
           input.setLoadState({ status: 'ready' });
-          return;
+          return true;
         }
 
         recoveryErrorMessage = getActionResultErrorMessage(summaryRes);
       } catch (error) {
-        if (!isMounted()) return;
+        if (!isMounted()) return false;
         reportClientError(error, {
           component: 'PracticeSessionPageLogic',
           action: 'getPracticeSessionSummary',
@@ -251,12 +257,13 @@ export async function endSession(input: {
       status: 'error',
       message: recoveryErrorMessage ?? getActionResultErrorMessage(res),
     });
-    return;
+    return false;
   }
 
   input.setSummary(res.data);
   input.resetQuestionState();
   input.setLoadState({ status: 'ready' });
+  return true;
 }
 
 export function createNavigatorEffect(input: {

--- a/app/(app)/app/practice/hooks/use-practice-incomplete-session.ts
+++ b/app/(app)/app/practice/hooks/use-practice-incomplete-session.ts
@@ -35,6 +35,9 @@ export function usePracticeIncompleteSession(
   >(null);
   const [incompleteSession, setIncompleteSession] =
     useState<IncompletePracticeSession | null>(null);
+  const [abandonIdempotencyKey, setAbandonIdempotencyKey] = useState(() =>
+    crypto.randomUUID(),
+  );
 
   useEffect(() => {
     return createIncompleteSessionEffect({
@@ -50,6 +53,8 @@ export function usePracticeIncompleteSession(
 
     await abandonIncompleteSession({
       sessionId: incompleteSession.sessionId,
+      idempotencyKey: abandonIdempotencyKey,
+      rotateIdempotencyKey: () => setAbandonIdempotencyKey(crypto.randomUUID()),
       mode: incompleteSession.mode,
       endPracticeSessionFn: endPracticeSession,
       discardPracticeSessionFn: discardPracticeSession,
@@ -58,7 +63,7 @@ export function usePracticeIncompleteSession(
       setIncompleteSession,
       isMounted: input.isMounted,
     });
-  }, [incompleteSession, input.isMounted]);
+  }, [abandonIdempotencyKey, incompleteSession, input.isMounted]);
 
   return {
     incompleteSessionStatus,

--- a/app/(app)/app/practice/hooks/use-practice-session-controls.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-controls.browser.spec.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import * as reportClientError from '@/lib/report-client-error';
+import { err } from '@/src/adapters/controllers/action-result';
 import * as practiceController from '@/src/adapters/controllers/practice-controller';
 import * as tagController from '@/src/adapters/controllers/tag-controller';
 import { ok } from '@/tests/test-helpers/ok';
@@ -25,6 +26,8 @@ const getIncompletePracticeSession = vi.mocked(
   practiceController.getIncompletePracticeSession,
 );
 const reportClientErrorSpy = vi.mocked(reportClientError.reportClientError);
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 installReportClientErrorMocks(reportClientError);
 
@@ -170,7 +173,7 @@ describe('usePracticeSessionControls (browser)', () => {
     });
   });
 
-  it('passes session id as idempotency key when abandoning an incomplete session', async () => {
+  it('passes a generated idempotency key when abandoning an incomplete session', async () => {
     const sessionId = '11111111-1111-1111-1111-111111111111';
 
     getTags.mockResolvedValue(ok({ rows: [] }));
@@ -211,9 +214,77 @@ describe('usePracticeSessionControls (browser)', () => {
 
     expect(endPracticeSession).toHaveBeenCalledWith({
       sessionId,
+      idempotencyKey: expect.stringMatching(UUID_PATTERN),
+    });
+    expect(endPracticeSession.mock.calls[0]?.[0]).not.toMatchObject({
       idempotencyKey: sessionId,
     });
     expect(discardPracticeSession).not.toHaveBeenCalled();
+  });
+
+  it('rotates the generated abandon idempotency key after an abandon failure', async () => {
+    const sessionId = '11111111-1111-1111-1111-111111111113';
+
+    getTags.mockResolvedValue(ok({ rows: [] }));
+    getIncompletePracticeSession.mockResolvedValue(
+      ok({
+        sessionId,
+        mode: 'tutor',
+        answeredCount: 2,
+        totalCount: 10,
+        startedAt: '2026-02-08T00:00:00.000Z',
+      }),
+    );
+    endPracticeSession
+      .mockResolvedValueOnce(err('INTERNAL_ERROR', 'Nope'))
+      .mockResolvedValueOnce(
+        ok({
+          sessionId,
+          mode: 'tutor',
+          questionCount: 10,
+          endedAt: '2026-02-08T01:00:00.000Z',
+          totals: {
+            answered: 2,
+            correct: 1,
+            accuracy: 0.5,
+            durationSeconds: 120,
+          },
+        }),
+      );
+    countAvailableQuestions.mockResolvedValue(ok({ count: 0 }));
+
+    const screen = await render(<PracticeSessionControlsHookProbe />);
+
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('idle');
+
+    await screen
+      .getByRole('button', { name: 'abandon-incomplete-session' })
+      .click();
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('error');
+
+    const firstCallInput = endPracticeSession.mock.calls[0]?.[0] as
+      | { idempotencyKey?: unknown }
+      | undefined;
+    const firstKey = firstCallInput?.idempotencyKey;
+    expect(firstKey).toEqual(expect.stringMatching(UUID_PATTERN));
+
+    await screen
+      .getByRole('button', { name: 'abandon-incomplete-session' })
+      .click();
+
+    const secondCallInput = endPracticeSession.mock.calls[1]?.[0] as
+      | { idempotencyKey?: unknown }
+      | undefined;
+    const secondKey = secondCallInput?.idempotencyKey;
+    expect(secondKey).toEqual(expect.stringMatching(UUID_PATTERN));
+    expect(secondKey).not.toBe(firstKey);
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('idle');
   });
 
   it('uses discard instead of end when abandoning an incomplete exam session', async () => {
@@ -244,6 +315,9 @@ describe('usePracticeSessionControls (browser)', () => {
 
     expect(discardPracticeSession).toHaveBeenCalledWith({
       sessionId,
+      idempotencyKey: expect.stringMatching(UUID_PATTERN),
+    });
+    expect(discardPracticeSession.mock.calls[0]?.[0]).not.toMatchObject({
       idempotencyKey: sessionId,
     });
     expect(endPracticeSession).not.toHaveBeenCalled();

--- a/app/(app)/app/practice/practice-page-incomplete-session.test.ts
+++ b/app/(app)/app/practice/practice-page-incomplete-session.test.ts
@@ -144,6 +144,7 @@ describe('practice-page-incomplete-session', () => {
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        idempotencyKey: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
         mode: 'tutor',
         endPracticeSessionFn,
         discardPracticeSessionFn,
@@ -155,7 +156,7 @@ describe('practice-page-incomplete-session', () => {
 
       expect(endPracticeSessionFn).toHaveBeenCalledWith({
         sessionId: fixtureSession1Id,
-        idempotencyKey: fixtureSession1Id,
+        idempotencyKey: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       });
       expect(discardPracticeSessionFn).not.toHaveBeenCalled();
       expect(setSession).toHaveBeenCalledWith(null);
@@ -171,6 +172,7 @@ describe('practice-page-incomplete-session', () => {
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        idempotencyKey: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
         mode: 'exam',
         endPracticeSessionFn,
         discardPracticeSessionFn,
@@ -182,7 +184,7 @@ describe('practice-page-incomplete-session', () => {
 
       expect(discardPracticeSessionFn).toHaveBeenCalledWith({
         sessionId: fixtureSession1Id,
-        idempotencyKey: fixtureSession1Id,
+        idempotencyKey: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
       });
       expect(endPracticeSessionFn).not.toHaveBeenCalled();
       expect(setSession).toHaveBeenCalledWith(null);
@@ -193,6 +195,7 @@ describe('practice-page-incomplete-session', () => {
       const setStatus = vi.fn();
       const setError = vi.fn();
       const setSession = vi.fn();
+      const rotateIdempotencyKey = vi.fn();
       const error = new Error('boom');
       const endPracticeSessionFn = vi.fn(async () => {
         throw error;
@@ -201,6 +204,8 @@ describe('practice-page-incomplete-session', () => {
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        idempotencyKey: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        rotateIdempotencyKey,
         mode: 'tutor',
         endPracticeSessionFn,
         discardPracticeSessionFn,
@@ -212,11 +217,44 @@ describe('practice-page-incomplete-session', () => {
 
       expect(setStatus).toHaveBeenLastCalledWith('error');
       expect(setError).toHaveBeenLastCalledWith('boom');
+      expect(rotateIdempotencyKey).toHaveBeenCalledTimes(1);
       expect(setSession).not.toHaveBeenCalled();
       expect(reportClientErrorMock).toHaveBeenCalledWith(error, {
         component: 'PracticePageIncompleteSession',
         action: 'abandonIncompleteSession',
       });
+    });
+
+    it('rotates the abandon idempotency key when the request fails', async () => {
+      const setStatus = vi.fn();
+      const setError = vi.fn();
+      const setSession = vi.fn();
+      const rotateIdempotencyKey = vi.fn();
+      const endPracticeSessionFn = vi.fn(async () =>
+        err('INTERNAL_ERROR', 'Nope'),
+      );
+      const discardPracticeSessionFn = vi.fn(async () => ok({}));
+
+      await abandonIncompleteSession({
+        sessionId: fixtureSession1Id,
+        idempotencyKey: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+        rotateIdempotencyKey,
+        mode: 'tutor',
+        endPracticeSessionFn,
+        discardPracticeSessionFn,
+        setIncompleteSessionStatus: setStatus,
+        setIncompleteSessionError: setError,
+        setIncompleteSession: setSession,
+        isMounted: () => true,
+      });
+
+      expect(endPracticeSessionFn).toHaveBeenCalledWith({
+        sessionId: fixtureSession1Id,
+        idempotencyKey: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      });
+      expect(rotateIdempotencyKey).toHaveBeenCalledTimes(1);
+      expect(setStatus).toHaveBeenLastCalledWith('error');
+      expect(setError).toHaveBeenLastCalledWith('Nope');
     });
 
     it('does not set error state when unmounted after a thrown request', async () => {
@@ -230,6 +268,7 @@ describe('practice-page-incomplete-session', () => {
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        idempotencyKey: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
         mode: 'tutor',
         endPracticeSessionFn,
         discardPracticeSessionFn,
@@ -256,6 +295,7 @@ describe('practice-page-incomplete-session', () => {
 
       await abandonIncompleteSession({
         sessionId: fixtureSession1Id,
+        idempotencyKey: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
         mode: 'tutor',
         endPracticeSessionFn,
         discardPracticeSessionFn,

--- a/app/(app)/app/practice/practice-page-incomplete-session.ts
+++ b/app/(app)/app/practice/practice-page-incomplete-session.ts
@@ -63,6 +63,8 @@ export function createIncompleteSessionEffect<T>(input: {
 
 export async function abandonIncompleteSession<T>(input: {
   sessionId: string;
+  idempotencyKey: string;
+  rotateIdempotencyKey?: () => void;
   mode: 'tutor' | 'exam';
   endPracticeSessionFn: (input: unknown) => Promise<ActionResult<unknown>>;
   discardPracticeSessionFn: (input: unknown) => Promise<ActionResult<unknown>>;
@@ -86,7 +88,7 @@ export async function abandonIncompleteSession<T>(input: {
     res = await withTimeout(
       abandonSessionFn({
         sessionId: input.sessionId,
-        idempotencyKey: input.sessionId,
+        idempotencyKey: input.idempotencyKey,
       }),
       ABANDON_SESSION_TIMEOUT_MS,
     );
@@ -96,6 +98,7 @@ export async function abandonIncompleteSession<T>(input: {
       component: 'PracticePageIncompleteSession',
       action: 'abandonIncompleteSession',
     });
+    input.rotateIdempotencyKey?.();
     input.setIncompleteSessionStatus('error');
     input.setIncompleteSessionError(getThrownErrorMessage(error));
     return;
@@ -103,6 +106,7 @@ export async function abandonIncompleteSession<T>(input: {
   if (!input.isMounted()) return;
 
   if (!res.ok) {
+    input.rotateIdempotencyKey?.();
     input.setIncompleteSessionStatus('error');
     input.setIncompleteSessionError(getActionResultErrorMessage(res));
     return;

--- a/app/(app)/app/practice/shared/question-flow-actions-ended-session-conflict.test.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions-ended-session-conflict.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  runLoadQuestionFlow,
+  runSubmitAnswerFlow,
+} from '@/app/(app)/app/practice/shared/question-flow-actions';
+import type { AsyncLoadStateWithIdle } from '@/app/(app)/app/shared/load-state';
+import {
+  PracticeSessionConflictMessages,
+  PracticeSessionConflictReasons,
+} from '@/src/application/errors';
+
+const fixtureChoice1Id = crypto.randomUUID();
+const fixtureQuestion1Id = crypto.randomUUID();
+const fixtureQuestionOldId = crypto.randomUUID();
+
+describe('question-flow-actions ended-session conflict recovery', () => {
+  it('runs ended-session recovery instead of committing load error for structured AlreadyEnded conflicts', async () => {
+    let loadState: AsyncLoadStateWithIdle = { status: 'idle' };
+    let question: unknown = { questionId: fixtureQuestionOldId };
+    const recoverEndedSessionConflict = vi.fn(async () => {
+      loadState = { status: 'ready' };
+      return true;
+    });
+
+    await runLoadQuestionFlow({
+      requestInput: {},
+      getQuestionFn: async () => ({
+        ok: false,
+        error: {
+          code: 'CONFLICT',
+          message: PracticeSessionConflictMessages.AlreadyEnded,
+          details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
+        },
+      }),
+      createIdempotencyKey: () => 'idemp_new',
+      nowMs: () => 9999,
+      setLoadState: (next) => {
+        loadState = next;
+      },
+      setSelectedChoiceId: () => undefined,
+      setSubmitResult: () => undefined,
+      setSubmitIdempotencyKey: () => undefined,
+      setQuestionLoadedAt: () => undefined,
+      setQuestion: (next) => {
+        question = next;
+      },
+      recoverEndedSessionConflict,
+    });
+
+    expect(recoverEndedSessionConflict).toHaveBeenCalledTimes(1);
+    expect(loadState).toEqual({ status: 'ready' });
+    expect(question).toEqual({ questionId: fixtureQuestionOldId });
+  });
+
+  it('keeps reasonless load CONFLICT as a generic error', async () => {
+    let loadState: AsyncLoadStateWithIdle = { status: 'idle' };
+    const recoverEndedSessionConflict = vi.fn(async () => true);
+
+    await runLoadQuestionFlow({
+      requestInput: {},
+      getQuestionFn: async () => ({
+        ok: false,
+        error: {
+          code: 'CONFLICT',
+          message: PracticeSessionConflictMessages.AlreadyEnded,
+        },
+      }),
+      createIdempotencyKey: () => 'idemp_new',
+      nowMs: () => 9999,
+      setLoadState: (next) => {
+        loadState = next;
+      },
+      setSelectedChoiceId: () => undefined,
+      setSubmitResult: () => undefined,
+      setSubmitIdempotencyKey: () => undefined,
+      setQuestionLoadedAt: () => undefined,
+      setQuestion: () => undefined,
+      recoverEndedSessionConflict,
+    });
+
+    expect(recoverEndedSessionConflict).not.toHaveBeenCalled();
+    expect(loadState).toEqual({
+      status: 'error',
+      message: PracticeSessionConflictMessages.AlreadyEnded,
+    });
+  });
+
+  it('runs ended-session recovery instead of committing submit error for structured AlreadyEnded conflicts', async () => {
+    let loadState: AsyncLoadStateWithIdle = { status: 'ready' };
+    const recoverEndedSessionConflict = vi.fn(async () => {
+      loadState = { status: 'ready' };
+      return true;
+    });
+
+    await runSubmitAnswerFlow({
+      question: { questionId: fixtureQuestion1Id },
+      selectedChoiceId: fixtureChoice1Id,
+      questionLoadedAtMs: 1000,
+      submitIdempotencyKey: null,
+      submitAnswerFn: async () => ({
+        ok: false,
+        error: {
+          code: 'CONFLICT',
+          message: PracticeSessionConflictMessages.AlreadyEnded,
+          details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
+        },
+      }),
+      buildSubmitInput: () => ({}),
+      nowMs: () => 3500,
+      setLoadState: (next) => {
+        loadState = next;
+      },
+      setSubmitResult: () => undefined,
+      recoverEndedSessionConflict,
+    });
+
+    expect(recoverEndedSessionConflict).toHaveBeenCalledTimes(1);
+    expect(loadState).toEqual({ status: 'ready' });
+  });
+
+  it('keeps reasonless submit CONFLICT as a generic error', async () => {
+    let loadState: AsyncLoadStateWithIdle = { status: 'ready' };
+    const recoverEndedSessionConflict = vi.fn(async () => true);
+
+    await runSubmitAnswerFlow({
+      question: { questionId: fixtureQuestion1Id },
+      selectedChoiceId: fixtureChoice1Id,
+      questionLoadedAtMs: 1000,
+      submitIdempotencyKey: null,
+      submitAnswerFn: async () => ({
+        ok: false,
+        error: {
+          code: 'CONFLICT',
+          message: PracticeSessionConflictMessages.AlreadyEnded,
+        },
+      }),
+      buildSubmitInput: () => ({}),
+      nowMs: () => 3500,
+      setLoadState: (next) => {
+        loadState = next;
+      },
+      setSubmitResult: () => undefined,
+      recoverEndedSessionConflict,
+    });
+
+    expect(recoverEndedSessionConflict).not.toHaveBeenCalled();
+    expect(loadState).toEqual({
+      status: 'error',
+      message: PracticeSessionConflictMessages.AlreadyEnded,
+    });
+  });
+});

--- a/app/(app)/app/practice/shared/question-flow-actions.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions.ts
@@ -31,6 +31,7 @@ export type RequestSequencingHooks = {
 };
 
 export type NullQuestionRecovery = () => Promise<boolean>;
+export type EndedSessionConflictRecovery = () => Promise<boolean>;
 
 export type ExamDraftAnswer = {
   questionId: string;
@@ -61,6 +62,28 @@ function assertRequestSequencingHooks(input: {
   throw new Error('Request sequencing hooks must be provided together');
 }
 
+type EndedSessionConflictRecoveryResult =
+  | 'handled'
+  | 'not-handled'
+  | 'stale-request';
+
+async function tryRecoverEndedSessionConflict(input: {
+  result: ActionResult<unknown>;
+  recoverEndedSessionConflict: EndedSessionConflictRecovery | undefined;
+  canCommit: () => boolean;
+}): Promise<EndedSessionConflictRecoveryResult> {
+  if (
+    !input.recoverEndedSessionConflict ||
+    !isPracticeSessionAlreadyEndedActionConflict(input.result)
+  ) {
+    return 'not-handled';
+  }
+
+  const handled = await input.recoverEndedSessionConflict();
+  if (!input.canCommit()) return 'stale-request';
+  return handled ? 'handled' : 'not-handled';
+}
+
 export function buildTimeSpentSeconds(
   questionLoadedAtMs: number | null,
   nowMs: number,
@@ -86,6 +109,7 @@ export async function runLoadQuestionFlow<TQuestion>(input: {
   setQuestion: (question: TQuestion | null) => void;
   onLoaded?: ((question: TQuestion | null) => void) | undefined;
   recoverNullQuestion?: NullQuestionRecovery | undefined;
+  recoverEndedSessionConflict?: EndedSessionConflictRecovery | undefined;
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
@@ -129,6 +153,13 @@ export async function runLoadQuestionFlow<TQuestion>(input: {
   if (!canCommit()) return;
 
   if (!res.ok) {
+    const recovery = await tryRecoverEndedSessionConflict({
+      result: res,
+      recoverEndedSessionConflict: input.recoverEndedSessionConflict,
+      canCommit,
+    });
+    if (recovery === 'stale-request' || recovery === 'handled') return;
+
     input.setLoadState({
       status: 'error',
       message: getActionResultErrorMessage(res),
@@ -177,12 +208,21 @@ export function isExamExpiryDraftSaveConflict(
   );
 }
 
-function getActionResultPracticeSessionConflictReason(
+export function getActionResultPracticeSessionConflictReason(
   result: ActionResult<unknown>,
 ): PracticeSessionConflictReason | undefined {
   if (result.ok) return undefined;
   const reason = result.error.details?.reason;
   return isPracticeSessionConflictReason(reason) ? reason : undefined;
+}
+
+export function isPracticeSessionAlreadyEndedActionConflict(
+  result: ActionResult<unknown>,
+): boolean {
+  return (
+    getActionResultPracticeSessionConflictReason(result) ===
+    PracticeSessionConflictReasons.AlreadyEnded
+  );
 }
 
 export async function maybeSaveDraftBeforeNavigation<
@@ -282,6 +322,7 @@ export async function runSubmitAnswerFlow<
     questionId?: string | null,
   ) => void;
   onSuccess?: ((result: SubmitAnswerOutput) => void) | undefined;
+  recoverEndedSessionConflict?: EndedSessionConflictRecovery | undefined;
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
@@ -328,6 +369,13 @@ export async function runSubmitAnswerFlow<
   if (!canCommit()) return;
 
   if (!res.ok) {
+    const recovery = await tryRecoverEndedSessionConflict({
+      result: res,
+      recoverEndedSessionConflict: input.recoverEndedSessionConflict,
+      canCommit,
+    });
+    if (recovery === 'stale-request' || recovery === 'handled') return;
+
     input.setLoadState({
       status: 'error',
       message: getActionResultErrorMessage(res),

--- a/app/(app)/app/practice/shared/question-flow-actions.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions.ts
@@ -31,7 +31,9 @@ export type RequestSequencingHooks = {
 };
 
 export type NullQuestionRecovery = () => Promise<boolean>;
-export type EndedSessionConflictRecovery = () => Promise<boolean>;
+export type EndedSessionConflictRecovery = (input: {
+  canCommit: () => boolean;
+}) => Promise<boolean>;
 
 export type ExamDraftAnswer = {
   questionId: string;
@@ -79,7 +81,9 @@ async function tryRecoverEndedSessionConflict(input: {
     return 'not-handled';
   }
 
-  const handled = await input.recoverEndedSessionConflict();
+  const handled = await input.recoverEndedSessionConflict({
+    canCommit: input.canCommit,
+  });
   if (!input.canCommit()) return 'stale-request';
   return handled ? 'handled' : 'not-handled';
 }

--- a/lib/container/use-cases.ts
+++ b/lib/container/use-cases.ts
@@ -128,6 +128,7 @@ export function createUseCaseFactories(input: {
           }),
         ),
       primitives.now,
+      primitives.logger,
     );
 
   return {

--- a/src/adapters/controllers/practice-controller-session-lifecycle-idempotency-policy.test.ts
+++ b/src/adapters/controllers/practice-controller-session-lifecycle-idempotency-policy.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ApplicationError,
+  PracticeSessionConflictReasons,
+  practiceSessionAlreadyEndedError,
+} from '@/src/application/errors';
+import { FakeRateLimiter } from '@/src/application/test-helpers/fakes';
+import type {
+  DiscardPracticeSessionInput,
+  DiscardPracticeSessionOutput,
+  EndPracticeSessionInput,
+  EndPracticeSessionOutput,
+} from '@/src/application/use-cases';
+import {
+  discardPracticeSession,
+  endPracticeSession,
+} from './practice-controller';
+import { createDeps } from './practice-controller-test-helpers';
+
+function createOneTimeFailureUseCase<I, O>(input: {
+  output: O;
+  error: unknown;
+}) {
+  const inputs: I[] = [];
+
+  return {
+    inputs,
+    async execute(nextInput: I): Promise<O> {
+      inputs.push(nextInput);
+      if (inputs.length === 1) throw input.error;
+      return input.output;
+    },
+  };
+}
+
+describe('practice-controller lifecycle idempotency policy', () => {
+  it('does not cache transient end-session failures under the idempotency key', async () => {
+    const endOutput = {
+      sessionId: '22222222-2222-2222-2222-222222222222',
+      endedAt: '2026-02-01T00:00:00.000Z',
+      mode: 'tutor',
+      questionCount: 1,
+      totals: { answered: 0, correct: 0, accuracy: 0, durationSeconds: 0 },
+    } as const satisfies EndPracticeSessionOutput;
+    const endUseCase = createOneTimeFailureUseCase<
+      EndPracticeSessionInput,
+      EndPracticeSessionOutput
+    >({
+      output: endOutput,
+      error: new ApplicationError('INTERNAL_ERROR', 'connection reset'),
+    });
+    const deps = {
+      ...createDeps(),
+      endPracticeSessionUseCase: endUseCase,
+    };
+    const input = {
+      sessionId: '11111111-1111-1111-1111-111111111111',
+      idempotencyKey: '11111111-1111-1111-1111-111111111111',
+    } as const;
+
+    const first = await endPracticeSession(input, deps);
+    expect(first).toMatchObject({
+      ok: false,
+      error: { code: 'INTERNAL_ERROR', message: 'connection reset' },
+    });
+
+    const second = await endPracticeSession(input, deps);
+    expect(second).toEqual({ ok: true, data: endOutput });
+    expect(endUseCase.inputs).toHaveLength(2);
+  });
+
+  it('caches terminal end-session conflicts with structured reasons', async () => {
+    const terminalError = practiceSessionAlreadyEndedError();
+    const endUseCase = {
+      inputs: [] as EndPracticeSessionInput[],
+      async execute(input: EndPracticeSessionInput) {
+        this.inputs.push(input);
+        throw terminalError;
+      },
+    };
+    const deps = {
+      ...createDeps(),
+      endPracticeSessionUseCase: endUseCase,
+    };
+    const input = {
+      sessionId: '11111111-1111-1111-1111-111111111111',
+      idempotencyKey: '11111111-1111-1111-1111-111111111111',
+    } as const;
+
+    const first = await endPracticeSession(input, deps);
+    const second = await endPracticeSession(input, deps);
+
+    expect(first).toEqual({
+      ok: false,
+      error: {
+        code: 'CONFLICT',
+        message: 'Practice session already ended',
+        details: {
+          reason: PracticeSessionConflictReasons.AlreadyEnded,
+        },
+      },
+    });
+    expect(second).toEqual(first);
+    expect(endUseCase.inputs).toHaveLength(1);
+  });
+
+  it('does not cache non-terminal discard use-case ApplicationErrors when idempotencyKey is reused', async () => {
+    const discardUseCase = createOneTimeFailureUseCase<
+      DiscardPracticeSessionInput,
+      DiscardPracticeSessionOutput
+    >({
+      output: { discarded: true },
+      error: new ApplicationError('NOT_FOUND', 'Session not found'),
+    });
+    const deps = {
+      ...createDeps({
+        rateLimiter: new FakeRateLimiter([
+          { success: true, limit: 20, remaining: 19, retryAfterSeconds: 0 },
+          { success: true, limit: 20, remaining: 18, retryAfterSeconds: 0 },
+        ]),
+      }),
+      discardPracticeSessionUseCase: discardUseCase,
+    };
+    const input = {
+      sessionId: '11111111-1111-1111-1111-111111111111',
+      idempotencyKey: '11111111-1111-1111-1111-111111111111',
+    } as const;
+
+    const first = await discardPracticeSession(input, deps);
+    const second = await discardPracticeSession(input, deps);
+
+    expect(first).toEqual({
+      ok: false,
+      error: { code: 'NOT_FOUND', message: 'Session not found' },
+    });
+    expect(second).toEqual({ ok: true, data: { discarded: true } });
+    expect(discardUseCase.inputs).toHaveLength(2);
+    expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(2);
+  });
+
+  it('does not cache internal discard failures when idempotencyKey is reused', async () => {
+    const discardUseCase = createOneTimeFailureUseCase<
+      DiscardPracticeSessionInput,
+      DiscardPracticeSessionOutput
+    >({
+      output: { discarded: true },
+      error: new ApplicationError('INTERNAL_ERROR', 'deadlock victim'),
+    });
+    const deps = {
+      ...createDeps({
+        rateLimiter: new FakeRateLimiter([
+          { success: true, limit: 20, remaining: 19, retryAfterSeconds: 0 },
+          { success: true, limit: 20, remaining: 18, retryAfterSeconds: 0 },
+        ]),
+      }),
+      discardPracticeSessionUseCase: discardUseCase,
+    };
+    const input = {
+      sessionId: '11111111-1111-1111-1111-111111111111',
+      idempotencyKey: '11111111-1111-1111-1111-111111111111',
+    } as const;
+
+    const first = await discardPracticeSession(input, deps);
+    const second = await discardPracticeSession(input, deps);
+
+    expect(first).toEqual({
+      ok: false,
+      error: { code: 'INTERNAL_ERROR', message: 'deadlock victim' },
+    });
+    expect(second).toEqual({ ok: true, data: { discarded: true } });
+    expect(discardUseCase.inputs).toHaveLength(2);
+    expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(2);
+  });
+
+  it('caches terminal discard conflicts with structured reasons', async () => {
+    const terminalError = practiceSessionAlreadyEndedError();
+    const discardUseCase = {
+      inputs: [] as DiscardPracticeSessionInput[],
+      async execute(input: DiscardPracticeSessionInput) {
+        this.inputs.push(input);
+        throw terminalError;
+      },
+    };
+    const deps = {
+      ...createDeps({
+        rateLimiter: new FakeRateLimiter([
+          { success: true, limit: 20, remaining: 19, retryAfterSeconds: 0 },
+          { success: false, limit: 20, remaining: 0, retryAfterSeconds: 60 },
+        ]),
+      }),
+      discardPracticeSessionUseCase: discardUseCase,
+    };
+    const input = {
+      sessionId: '11111111-1111-1111-1111-111111111111',
+      idempotencyKey: '11111111-1111-1111-1111-111111111111',
+    } as const;
+
+    const first = await discardPracticeSession(input, deps);
+    const second = await discardPracticeSession(input, deps);
+
+    expect(first).toEqual({
+      ok: false,
+      error: {
+        code: 'CONFLICT',
+        message: 'Practice session already ended',
+        details: {
+          reason: PracticeSessionConflictReasons.AlreadyEnded,
+        },
+      },
+    });
+    expect(second).toEqual(first);
+    expect(discardUseCase.inputs).toHaveLength(1);
+    expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
+  });
+});

--- a/src/adapters/controllers/practice-controller-session-lifecycle.test.ts
+++ b/src/adapters/controllers/practice-controller-session-lifecycle.test.ts
@@ -609,31 +609,6 @@ describe('practice-controller', () => {
       expect(deps.discardPracticeSessionUseCase.inputs).toHaveLength(1);
       expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
     });
-
-    it('keeps genuine discard use-case ApplicationErrors cached when idempotencyKey is reused', async () => {
-      const deps = createDeps({
-        rateLimiter: new FakeRateLimiter([
-          { success: true, limit: 20, remaining: 19, retryAfterSeconds: 0 },
-          { success: false, limit: 20, remaining: 0, retryAfterSeconds: 60 },
-        ]),
-        discardThrows: new ApplicationError('NOT_FOUND', 'Session not found'),
-      });
-      const input = {
-        sessionId: '11111111-1111-1111-1111-111111111111',
-        idempotencyKey: '11111111-1111-1111-1111-111111111111',
-      } as const;
-
-      const first = await discardPracticeSession(input, deps);
-      const second = await discardPracticeSession(input, deps);
-
-      expect(first).toEqual({
-        ok: false,
-        error: { code: 'NOT_FOUND', message: 'Session not found' },
-      });
-      expect(second).toEqual(first);
-      expect(deps.discardPracticeSessionUseCase.inputs).toHaveLength(1);
-      expect((deps.rateLimiter as FakeRateLimiter).inputs).toHaveLength(1);
-    });
   });
 
   describe('finalizeExamAnswers', () => {

--- a/src/adapters/controllers/practice-controller.ts
+++ b/src/adapters/controllers/practice-controller.ts
@@ -215,6 +215,7 @@ export const startPracticeSession = createAction({
       idempotencyKey,
       outputSchema: StartPracticeSessionOutputSchema,
       beforeExecute: enforceStartRateLimit,
+      outcomeStoreFailurePolicy: 'cache-error-and-throw',
       execute: createNewSession,
     });
   },

--- a/src/adapters/controllers/practice-controller.ts
+++ b/src/adapters/controllers/practice-controller.ts
@@ -67,7 +67,10 @@ import {
 import type { CheckEntitlementUseCase } from './require-entitled-user-id';
 import { requireEntitledUserId } from './require-entitled-user-id';
 import { executeIdempotent } from './shared/execute-idempotent';
-import { shouldCachePracticeSessionStateWriteError } from './shared/practice-session-idempotency-policy';
+import {
+  shouldCachePracticeSessionLifecycleError,
+  shouldCachePracticeSessionStateWriteError,
+} from './shared/practice-session-idempotency-policy';
 
 export type {
   CountAvailableQuestionsOutput,
@@ -272,6 +275,7 @@ export const endPracticeSession = createAction({
       action: 'practice:endPracticeSession',
       idempotencyKey,
       outputSchema: EndPracticeSessionOutputSchema,
+      shouldCacheError: shouldCachePracticeSessionLifecycleError,
       execute: () =>
         d.endPracticeSessionUseCase.execute({
           userId,
@@ -309,6 +313,7 @@ export const discardPracticeSession = createAction({
       idempotencyKey,
       outputSchema: DiscardPracticeSessionOutputSchema,
       beforeExecute: enforceSessionMutationRateLimit,
+      shouldCacheError: shouldCachePracticeSessionLifecycleError,
       execute: () =>
         d.discardPracticeSessionUseCase.execute({
           userId,

--- a/src/adapters/controllers/question-feedback-controller.ts
+++ b/src/adapters/controllers/question-feedback-controller.ts
@@ -214,6 +214,7 @@ export const submitQuestionReport = createAction({
       idempotencyKey,
       outputSchema: SubmitQuestionReportOutputSchema,
       beforeExecute: enforceReportRateLimit,
+      outcomeStoreFailurePolicy: 'cache-error-and-throw',
       execute: submit,
     });
   },

--- a/src/adapters/controllers/shared/execute-idempotent.ts
+++ b/src/adapters/controllers/shared/execute-idempotent.ts
@@ -1,5 +1,8 @@
 import type { ZodType } from 'zod';
-import { withIdempotency } from '@/src/adapters/shared/with-idempotency';
+import {
+  type IdempotencyOutcomeStoreFailurePolicy,
+  withIdempotency,
+} from '@/src/adapters/shared/with-idempotency';
 import type { Logger } from '@/src/application/ports/logger';
 import type { IdempotencyKeyRepository } from '@/src/application/ports/repositories';
 
@@ -25,6 +28,7 @@ export async function executeIdempotent<TOutput>({
   outputSchema,
   beforeExecute,
   shouldCacheError,
+  outcomeStoreFailurePolicy,
   execute,
 }: {
   d: IdempotentControllerDeps;
@@ -34,6 +38,7 @@ export async function executeIdempotent<TOutput>({
   outputSchema: ZodType<TOutput, unknown>;
   beforeExecute?: () => Promise<void>;
   shouldCacheError?: (error: unknown) => boolean;
+  outcomeStoreFailurePolicy?: IdempotencyOutcomeStoreFailurePolicy;
   execute: () => Promise<TOutput>;
 }): Promise<TOutput> {
   if (!idempotencyKey) {
@@ -51,6 +56,7 @@ export async function executeIdempotent<TOutput>({
     parseResult: (value) => outputSchema.parse(value),
     ...(beforeExecute ? { beforeExecute } : {}),
     ...(shouldCacheError ? { shouldCacheError } : {}),
+    ...(outcomeStoreFailurePolicy ? { outcomeStoreFailurePolicy } : {}),
     execute,
   });
 }

--- a/src/adapters/controllers/shared/practice-session-idempotency-policy.test.ts
+++ b/src/adapters/controllers/shared/practice-session-idempotency-policy.test.ts
@@ -5,7 +5,10 @@ import {
   practiceSessionAlreadyEndedError,
   practiceSessionStateChangedConcurrentlyError,
 } from '@/src/application/errors';
-import { shouldCachePracticeSessionStateWriteError } from './practice-session-idempotency-policy';
+import {
+  shouldCachePracticeSessionLifecycleError,
+  shouldCachePracticeSessionStateWriteError,
+} from './practice-session-idempotency-policy';
 
 describe('shouldCachePracticeSessionStateWriteError', () => {
   it('does not cache transient practice-session state conflicts', () => {
@@ -42,5 +45,50 @@ describe('shouldCachePracticeSessionStateWriteError', () => {
         }),
       ),
     ).toBe(true);
+  });
+});
+
+describe('shouldCachePracticeSessionLifecycleError', () => {
+  it('caches only monotone terminal practice-session conflicts', () => {
+    expect(
+      shouldCachePracticeSessionLifecycleError(
+        practiceSessionAlreadyEndedError(),
+      ),
+    ).toBe(true);
+    expect(
+      shouldCachePracticeSessionLifecycleError(
+        new ApplicationError('CONFLICT', 'Exam time expired', undefined, {
+          details: {
+            reason: PracticeSessionConflictReasons.ExamTimeExpired,
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not cache transient, unmapped, or non-terminal lifecycle failures', () => {
+    expect(
+      shouldCachePracticeSessionLifecycleError(
+        practiceSessionStateChangedConcurrentlyError(),
+      ),
+    ).toBe(false);
+    expect(
+      shouldCachePracticeSessionLifecycleError(
+        new ApplicationError('CONFLICT', 'Plain conflict'),
+      ),
+    ).toBe(false);
+    expect(
+      shouldCachePracticeSessionLifecycleError(
+        new ApplicationError('INTERNAL_ERROR', 'deadlock victim'),
+      ),
+    ).toBe(false);
+    expect(
+      shouldCachePracticeSessionLifecycleError(
+        new ApplicationError('NOT_FOUND', 'Practice session not found'),
+      ),
+    ).toBe(false);
+    expect(shouldCachePracticeSessionLifecycleError(new Error('40P01'))).toBe(
+      false,
+    );
   });
 });

--- a/src/adapters/controllers/shared/practice-session-idempotency-policy.ts
+++ b/src/adapters/controllers/shared/practice-session-idempotency-policy.ts
@@ -1,5 +1,6 @@
 import {
   isApplicationError,
+  isPracticeSessionConflictReason,
   PracticeSessionConflictReasons,
 } from '@/src/application/errors';
 
@@ -10,5 +11,19 @@ export function shouldCachePracticeSessionStateWriteError(
     isApplicationError(error) &&
     error.details?.reason ===
       PracticeSessionConflictReasons.StateChangedConcurrently
+  );
+}
+
+export function shouldCachePracticeSessionLifecycleError(
+  error: unknown,
+): boolean {
+  if (!isApplicationError(error) || error.code !== 'CONFLICT') return false;
+
+  const reason = error.details?.reason;
+  if (!isPracticeSessionConflictReason(reason)) return false;
+
+  return (
+    reason === PracticeSessionConflictReasons.AlreadyEnded ||
+    reason === PracticeSessionConflictReasons.ExamTimeExpired
   );
 }

--- a/src/adapters/repositories/drizzle-attempt-repository.test.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.test.ts
@@ -5,7 +5,10 @@ import {
   attempts,
   practiceSessions,
 } from '@/db/schema';
-import { ApplicationError } from '@/src/application/errors';
+import {
+  ApplicationError,
+  AttemptConflictMessages,
+} from '@/src/application/errors';
 import { answeredOutcome, omittedOutcome } from '@/src/domain/value-objects';
 import { DrizzleAttemptRepository } from './drizzle-attempt-repository';
 
@@ -480,7 +483,7 @@ describe('DrizzleAttemptRepository', () => {
       await expect(promise).rejects.toEqual(
         new ApplicationError(
           'CONFLICT',
-          'This question has already been answered in this session',
+          AttemptConflictMessages.AlreadyAnsweredInSession,
         ),
       );
     });

--- a/src/adapters/repositories/drizzle-attempt-repository.ts
+++ b/src/adapters/repositories/drizzle-attempt-repository.ts
@@ -18,7 +18,10 @@ import {
   questionTags,
   tags,
 } from '@/db/schema';
-import { ApplicationError } from '@/src/application/errors';
+import {
+  ApplicationError,
+  AttemptConflictMessages,
+} from '@/src/application/errors';
 import type {
   AttemptedQuestionSummary,
   AttemptedQuestionsFilters,
@@ -190,7 +193,7 @@ export class DrizzleAttemptRepository implements AttemptRepository {
       ) {
         throw new ApplicationError(
           'CONFLICT',
-          'This question has already been answered in this session',
+          AttemptConflictMessages.AlreadyAnsweredInSession,
         );
       }
       throw new ApplicationError(

--- a/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
@@ -1,6 +1,9 @@
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   PRACTICE_SESSIONS_USER_INCOMPLETE_UQ,
+  practiceSessionQuestionStates,
   practiceSessions,
 } from '@/db/schema';
 import { ApplicationError } from '@/src/application/errors';
@@ -314,12 +317,20 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
     expect(tx.insert).toHaveBeenCalledTimes(1);
   });
 
-  it('discards an incomplete practice session by deleting the session row', async () => {
-    const deleteWhere = vi.fn(async () => undefined);
+  it('discards an incomplete practice session child-first in one transaction', async () => {
+    const deleteWhere = vi.fn(async (_where: unknown) => undefined);
     const deleteFrom = vi.fn(() => ({ where: deleteWhere }));
+    const tx = {
+      delete: deleteFrom,
+    };
 
     const db = {
-      delete: deleteFrom,
+      transaction: vi.fn(async (fn: (client: typeof tx) => Promise<unknown>) =>
+        fn(tx),
+      ),
+      delete: () => {
+        throw new Error('unexpected delete outside transaction');
+      },
       insert: () => {
         throw new Error('unexpected insert');
       },
@@ -342,8 +353,28 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
 
     await expect(repo.discard(sessionId, userId)).resolves.toBeUndefined();
 
-    expect(deleteFrom).toHaveBeenCalledWith(practiceSessions);
-    expect(deleteWhere).toHaveBeenCalledTimes(1);
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(db.transaction).toHaveBeenCalledWith(expect.any(Function), {
+      isolationLevel: 'repeatable read',
+    });
+    expect(deleteFrom).toHaveBeenNthCalledWith(
+      1,
+      practiceSessionQuestionStates,
+    );
+    expect(deleteFrom).toHaveBeenNthCalledWith(2, practiceSessions);
+    expect(deleteWhere).toHaveBeenCalledTimes(2);
+
+    const childDeleteWhere = deleteWhere.mock.calls[0]?.[0];
+    expect(childDeleteWhere).toBeDefined();
+    const childDeleteSql = new PgDialect().sqlToQuery(
+      childDeleteWhere as unknown as SQL,
+    ).sql;
+    expect(childDeleteSql).toContain(
+      '"practice_session_question_states"."practice_session_id"',
+    );
+    expect(childDeleteSql).toContain('exists');
+    expect(childDeleteSql).toContain('"practice_sessions"."user_id"');
+    expect(childDeleteSql).toContain('"practice_sessions"."ended_at" is null');
   });
 
   it('ends an active practice session', async () => {

--- a/src/adapters/repositories/drizzle-practice-session-repository.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository.ts
@@ -449,15 +449,33 @@ export class DrizzlePracticeSessionRepository
   }
 
   async discard(id: string, userId: string): Promise<void> {
-    await this.db
-      .delete(practiceSessions)
-      .where(
-        and(
-          eq(practiceSessions.id, id),
-          eq(practiceSessions.userId, userId),
-          isNull(practiceSessions.endedAt),
-        ),
-      );
+    await this.db.transaction(
+      async (tx) => {
+        await tx.delete(practiceSessionQuestionStates).where(
+          and(
+            eq(practiceSessionQuestionStates.practiceSessionId, id),
+            sql`exists (
+              select 1
+              from ${practiceSessions}
+              where ${practiceSessions.id} = ${practiceSessionQuestionStates.practiceSessionId}
+                and ${practiceSessions.userId} = ${userId}
+                and ${practiceSessions.endedAt} is null
+            )`,
+          ),
+        );
+
+        await tx
+          .delete(practiceSessions)
+          .where(
+            and(
+              eq(practiceSessions.id, id),
+              eq(practiceSessions.userId, userId),
+              isNull(practiceSessions.endedAt),
+            ),
+          );
+      },
+      { isolationLevel: 'repeatable read' },
+    );
   }
 
   async end(id: string, userId: string, explicitEndedAt?: Date) {

--- a/src/adapters/shared/with-idempotency-outcome-write.test.ts
+++ b/src/adapters/shared/with-idempotency-outcome-write.test.ts
@@ -185,4 +185,210 @@ describe('withIdempotency outcome writes', () => {
       },
     });
   });
+
+  it('caches an indeterminate error instead of replaying non-replayable actions after storeResult fails', async () => {
+    class StoreResultFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        throw new Error('store result failed');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new StoreResultFailingRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ feedbackId: crypto.randomUUID() }));
+    const key = '17171717-1717-1717-1717-171717171717';
+    const input = {
+      repo,
+      userId: appUserId,
+      action: 'question-feedback:submitQuestionReport',
+      key,
+      now,
+      logger,
+      outcomeStoreFailurePolicy: 'cache-error-and-throw' as const,
+      execute,
+    };
+
+    await expect(withIdempotency(input)).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message:
+        'Idempotency outcome could not be recorded after committed success',
+    });
+    await expect(withIdempotency(input)).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message:
+        'Idempotency outcome could not be recorded after committed success',
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs when it caches an indeterminate error after storeResult fails', async () => {
+    class StoreResultFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        throw new Error('store result failed');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new StoreResultFailingRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ feedbackId: crypto.randomUUID() }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'question-feedback:submitQuestionReport',
+        key: '21212121-2121-2121-2121-212121212121',
+        now,
+        logger,
+        outcomeStoreFailurePolicy: 'cache-error-and-throw',
+        execute,
+      }),
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message:
+        'Idempotency outcome could not be recorded after committed success',
+    });
+
+    expect(logger.errorCalls).toEqual([
+      {
+        msg: 'Idempotency outcome write failed after committed success; cached indeterminate error',
+        context: {
+          action: 'question-feedback:submitQuestionReport',
+          key: '21212121-2121-2121-2121-212121212121',
+          storeResultError: 'store result failed',
+          userId: appUserId,
+        },
+      },
+    ]);
+  });
+
+  it('throws the indeterminate error and logs when caching it also fails', async () => {
+    class OutcomeWriteFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        throw new Error('store result failed');
+      }
+
+      override async storeError(): Promise<void> {
+        throw new Error('store error failed');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new OutcomeWriteFailingRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ feedbackId: crypto.randomUUID() }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'question-feedback:submitQuestionReport',
+        key: '18181818-1818-1818-1818-181818181818',
+        now,
+        logger,
+        outcomeStoreFailurePolicy: 'cache-error-and-throw',
+        execute,
+      }),
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message:
+        'Idempotency outcome could not be recorded after committed success',
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(logger.errorCalls).toHaveLength(1);
+    expect(logger.errorCalls[0]).toMatchObject({
+      msg: 'Failed to persist indeterminate idempotency outcome',
+      context: {
+        action: 'question-feedback:submitQuestionReport',
+        key: '18181818-1818-1818-1818-181818181818',
+        storeError: 'store error failed',
+        storeResultError: 'store result failed',
+        userId: appUserId,
+      },
+    });
+  });
+
+  it('logs non-error indeterminate outcome cache failures', async () => {
+    class OutcomeWriteFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        return Promise.reject('store result failed literal');
+      }
+
+      override async storeError(): Promise<void> {
+        return Promise.reject('store error failed literal');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new OutcomeWriteFailingRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ feedbackId: crypto.randomUUID() }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'question-feedback:submitQuestionReport',
+        key: '19191919-1919-1919-1919-191919191919',
+        now,
+        logger,
+        outcomeStoreFailurePolicy: 'cache-error-and-throw',
+        execute,
+      }),
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message:
+        'Idempotency outcome could not be recorded after committed success',
+    });
+
+    expect(logger.errorCalls[0]).toMatchObject({
+      context: {
+        storeError: 'store error failed literal',
+        storeResultError: 'store result failed literal',
+      },
+    });
+  });
+
+  it('preserves the indeterminate error when indeterminate outcome logging fails', async () => {
+    class OutcomeWriteFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        throw new Error('store result failed');
+      }
+
+      override async storeError(): Promise<void> {
+        throw new Error('store error failed');
+      }
+    }
+
+    class ThrowingErrorLogger extends FakeLogger {
+      override error(): void {
+        throw new Error('logger failed');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new OutcomeWriteFailingRepo(now);
+    const logger = new ThrowingErrorLogger();
+    const execute = vi.fn(async () => ({ feedbackId: crypto.randomUUID() }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'question-feedback:submitQuestionReport',
+        key: '20202020-2020-2020-2020-202020202020',
+        now,
+        logger,
+        outcomeStoreFailurePolicy: 'cache-error-and-throw',
+        execute,
+      }),
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message:
+        'Idempotency outcome could not be recorded after committed success',
+    });
+  });
 });

--- a/src/adapters/shared/with-idempotency-outcome-write.test.ts
+++ b/src/adapters/shared/with-idempotency-outcome-write.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ApplicationError } from '@/src/application/errors';
+import {
+  FakeIdempotencyKeyRepository,
+  FakeLogger,
+} from '@/src/application/test-helpers/fakes';
+import { withIdempotency } from './with-idempotency';
+
+const appUserId = crypto.randomUUID();
+
+describe('withIdempotency outcome writes', () => {
+  it('returns the committed result and does not cache an error when storeResult fails after execute succeeds', async () => {
+    class StoreResultFailingRepo extends FakeIdempotencyKeyRepository {
+      storeErrorCalls = 0;
+
+      override async storeResult(): Promise<void> {
+        throw new Error('store result failed');
+      }
+
+      override async storeError(
+        input: Parameters<FakeIdempotencyKeyRepository['storeError']>[0],
+      ): Promise<void> {
+        this.storeErrorCalls += 1;
+        await super.storeError(input);
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new StoreResultFailingRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ ok: true }));
+    const key = '12121212-1212-1212-1212-121212121212';
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key,
+        now,
+        logger,
+        execute,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    await expect(
+      repo.find(appUserId, 'billing:createCheckoutSession', key),
+    ).resolves.toMatchObject({
+      error: null,
+      completedAt: null,
+    });
+    expect(repo.storeErrorCalls).toBe(0);
+    expect(logger.errorCalls).toHaveLength(1);
+    expect(logger.errorCalls[0]).toMatchObject({
+      msg: 'Idempotency outcome write failed after committed success',
+      context: {
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key,
+        storeResultError: 'store result failed',
+      },
+    });
+  });
+
+  it('continues to cache cacheable execute failures after separating outcome-write failures', async () => {
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new FakeIdempotencyKeyRepository(now);
+    const logger = new FakeLogger();
+    const key = '13131313-1313-1313-1313-131313131313';
+    const executeError = new ApplicationError(
+      'INTERNAL_ERROR',
+      'execute failed',
+    );
+    const execute = vi.fn(async () => {
+      throw executeError;
+    });
+
+    const input = {
+      repo,
+      userId: appUserId,
+      action: 'billing:createCheckoutSession',
+      key,
+      now,
+      logger,
+      execute,
+    } as const;
+
+    await expect(withIdempotency(input)).rejects.toBe(executeError);
+    await expect(withIdempotency(input)).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message: 'execute failed',
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the committed result when both storeResult and outcome logging fail', async () => {
+    class StoreResultFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        throw new Error('store result failed');
+      }
+    }
+
+    class ThrowingErrorLogger extends FakeLogger {
+      override error(): void {
+        throw new Error('logger failed');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new StoreResultFailingRepo(now);
+    const logger = new ThrowingErrorLogger();
+    const execute = vi.fn(async () => ({ ok: true }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key: '14141414-1414-1414-1414-141414141414',
+        now,
+        logger,
+        execute,
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the stale-claim error when storeResult detects a fenced claim', async () => {
+    const staleClaimError = new ApplicationError(
+      'NOT_FOUND',
+      'Idempotency claim is no longer current',
+    );
+    class StaleClaimRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        throw staleClaimError;
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new StaleClaimRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ ok: true }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key: '15151515-1515-1515-1515-151515151515',
+        now,
+        logger,
+        execute,
+      }),
+    ).rejects.toBe(staleClaimError);
+    expect(logger.errorCalls).toHaveLength(0);
+  });
+
+  it('logs non-error storeResult failures and returns the committed result', async () => {
+    class StoreResultFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        return Promise.reject('store result failed literal');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new StoreResultFailingRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ ok: true }));
+    const key = '16161616-1616-1616-1616-161616161616';
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'billing:createCheckoutSession',
+        key,
+        now,
+        logger,
+        execute,
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(logger.errorCalls[0]).toMatchObject({
+      context: {
+        storeResultError: 'store result failed literal',
+      },
+    });
+  });
+});

--- a/src/adapters/shared/with-idempotency.ts
+++ b/src/adapters/shared/with-idempotency.ts
@@ -1,6 +1,6 @@
 import { delay } from '@/src/adapters/shared/delay';
 import { ApplicationError, isApplicationError } from '@/src/application/errors';
-import type { Logger } from '@/src/application/ports/logger';
+import type { Logger, LoggerContext } from '@/src/application/ports/logger';
 import {
   DEFAULT_IDEMPOTENCY_ZOMBIE_THRESHOLD_MS,
   type IdempotencyKeyError,
@@ -13,6 +13,10 @@ const DEFAULT_TTL_MS = DAY_MS;
 const DEFAULT_MAX_WAIT_MS = 2_000;
 const DEFAULT_POLL_INTERVAL_MS = 50;
 const ERROR_MESSAGE_LIMIT = 1000;
+
+export type IdempotencyOutcomeStoreFailurePolicy =
+  | 'return-result'
+  | 'cache-error-and-throw';
 
 function toErrorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -38,6 +42,18 @@ function toErrorRecord(error: unknown): IdempotencyKeyError {
   }
 
   return { code: 'INTERNAL_ERROR', message: toErrorMessage(error) };
+}
+
+function safeLogError(
+  logger: Logger,
+  context: LoggerContext,
+  msg: string,
+): void {
+  try {
+    logger.error(context, msg);
+  } catch {
+    // Preserve the primary outcome even if logging fails.
+  }
 }
 
 function shouldCacheExecutionError(
@@ -74,26 +90,21 @@ async function abortClaimPreservingOriginalError(
       claimedAt,
     );
   } catch (abortError) {
-    try {
-      input.logger.error(
-        {
-          userId: input.userId,
-          action: input.action,
-          key: input.key,
-          abortError:
-            abortError instanceof Error
-              ? abortError.message
-              : String(abortError),
-          originalError:
-            originalError instanceof Error
-              ? originalError.message
-              : String(originalError),
-        },
-        message,
-      );
-    } catch {
-      // Preserve the original error even if logging fails.
-    }
+    safeLogError(
+      input.logger,
+      {
+        userId: input.userId,
+        action: input.action,
+        key: input.key,
+        abortError:
+          abortError instanceof Error ? abortError.message : String(abortError),
+        originalError:
+          originalError instanceof Error
+            ? originalError.message
+            : String(originalError),
+      },
+      message,
+    );
   }
 }
 
@@ -111,6 +122,7 @@ export async function withIdempotency<T>(input: {
   parseResult?: (value: unknown) => T;
   beforeExecute?: () => Promise<void>;
   shouldCacheError?: (error: unknown) => boolean;
+  outcomeStoreFailurePolicy?: IdempotencyOutcomeStoreFailurePolicy;
   execute: () => Promise<T>;
 }): Promise<T> {
   const ttlMs = input.ttlMs ?? DEFAULT_TTL_MS;
@@ -185,24 +197,21 @@ export async function withIdempotency<T>(input: {
             error: toErrorRecord(error),
           });
         } catch (storeError) {
-          try {
-            input.logger.error(
-              {
-                userId: input.userId,
-                action: input.action,
-                key: input.key,
-                storeError:
-                  storeError instanceof Error
-                    ? storeError.message
-                    : String(storeError),
-                originalError:
-                  error instanceof Error ? error.message : String(error),
-              },
-              'Failed to persist idempotency error record',
-            );
-          } catch {
-            // Preserve original execute error even if logger.error throws.
-          }
+          safeLogError(
+            input.logger,
+            {
+              userId: input.userId,
+              action: input.action,
+              key: input.key,
+              storeError:
+                storeError instanceof Error
+                  ? storeError.message
+                  : String(storeError),
+              originalError:
+                error instanceof Error ? error.message : String(error),
+            },
+            'Failed to persist idempotency error record',
+          );
         }
         throw error;
       }
@@ -223,22 +232,58 @@ export async function withIdempotency<T>(input: {
           throw storeResultError;
         }
 
-        try {
-          input.logger.error(
-            {
+        const outcomeError = new ApplicationError(
+          'INTERNAL_ERROR',
+          'Idempotency outcome could not be recorded after committed success',
+          undefined,
+          { cause: storeResultError },
+        );
+
+        if (input.outcomeStoreFailurePolicy === 'cache-error-and-throw') {
+          try {
+            await input.repo.storeError({
               userId: input.userId,
               action: input.action,
               key: input.key,
-              storeResultError:
-                storeResultError instanceof Error
-                  ? storeResultError.message
-                  : String(storeResultError),
-            },
-            'Idempotency outcome write failed after committed success',
-          );
-        } catch {
-          // Preserve the committed business result even if logging fails.
+              claimedAt,
+              error: toErrorRecord(outcomeError),
+            });
+            safeLogError(
+              input.logger,
+              {
+                userId: input.userId,
+                action: input.action,
+                key: input.key,
+                storeResultError: toErrorMessage(storeResultError),
+              },
+              'Idempotency outcome write failed after committed success; cached indeterminate error',
+            );
+          } catch (storeError) {
+            safeLogError(
+              input.logger,
+              {
+                userId: input.userId,
+                action: input.action,
+                key: input.key,
+                storeError: toErrorMessage(storeError),
+                storeResultError: toErrorMessage(storeResultError),
+              },
+              'Failed to persist indeterminate idempotency outcome',
+            );
+          }
+          throw outcomeError;
         }
+
+        safeLogError(
+          input.logger,
+          {
+            userId: input.userId,
+            action: input.action,
+            key: input.key,
+            storeResultError: toErrorMessage(storeResultError),
+          },
+          'Idempotency outcome write failed after committed success',
+        );
       }
 
       return result;

--- a/src/adapters/shared/with-idempotency.ts
+++ b/src/adapters/shared/with-idempotency.ts
@@ -162,16 +162,9 @@ export async function withIdempotency<T>(input: {
         }
       }
 
+      let result: T;
       try {
-        const result = await input.execute();
-        await input.repo.storeResult({
-          userId: input.userId,
-          action: input.action,
-          key: input.key,
-          claimedAt,
-          resultJson: result,
-        });
-        return result;
+        result = await input.execute();
       } catch (error) {
         if (!shouldCacheExecutionError(input.shouldCacheError, error)) {
           await abortClaimPreservingOriginalError(
@@ -213,6 +206,42 @@ export async function withIdempotency<T>(input: {
         }
         throw error;
       }
+
+      try {
+        await input.repo.storeResult({
+          userId: input.userId,
+          action: input.action,
+          key: input.key,
+          claimedAt,
+          resultJson: result,
+        });
+      } catch (storeResultError) {
+        if (
+          isApplicationError(storeResultError) &&
+          storeResultError.code === 'NOT_FOUND'
+        ) {
+          throw storeResultError;
+        }
+
+        try {
+          input.logger.error(
+            {
+              userId: input.userId,
+              action: input.action,
+              key: input.key,
+              storeResultError:
+                storeResultError instanceof Error
+                  ? storeResultError.message
+                  : String(storeResultError),
+            },
+            'Idempotency outcome write failed after committed success',
+          );
+        } catch {
+          // Preserve the committed business result even if logging fails.
+        }
+      }
+
+      return result;
     }
 
     let shouldRestartClaim = false;

--- a/src/application/errors/application-errors.ts
+++ b/src/application/errors/application-errors.ts
@@ -29,6 +29,11 @@ export const PracticeSessionConflictMessages = {
     'Practice session state changed concurrently; please retry.',
 } as const;
 
+export const AttemptConflictMessages = {
+  AlreadyAnsweredInSession:
+    'This question has already been answered in this session',
+} as const;
+
 export type ApplicationErrorDetails = Readonly<{
   reason?: PracticeSessionConflictReason;
 }>;

--- a/src/application/errors/index.ts
+++ b/src/application/errors/index.ts
@@ -3,6 +3,7 @@ export {
   type ApplicationErrorCode,
   ApplicationErrorCodes,
   type ApplicationErrorDetails,
+  AttemptConflictMessages,
   isApplicationError,
   isPracticeSessionConflictReason,
   PracticeSessionConflictMessages,

--- a/src/application/test-helpers/fakes/fake-attempt-repository.ts
+++ b/src/application/test-helpers/fakes/fake-attempt-repository.ts
@@ -1,4 +1,7 @@
-import { ApplicationError } from '@/src/application/errors';
+import {
+  ApplicationError,
+  AttemptConflictMessages,
+} from '@/src/application/errors';
 import type {
   AttemptedQuestionSummary,
   AttemptedQuestionsFilters,
@@ -43,7 +46,7 @@ export class FakeAttemptRepository implements AttemptRepository {
       if (duplicate) {
         throw new ApplicationError(
           'CONFLICT',
-          'This question has already been answered in this session',
+          AttemptConflictMessages.AlreadyAnsweredInSession,
         );
       }
     }

--- a/src/application/use-cases/finalize-exam-answers.test.ts
+++ b/src/application/use-cases/finalize-exam-answers.test.ts
@@ -1,8 +1,14 @@
 // biome-ignore lint/style/noExcessiveLinesPerFile: Keep all FinalizeExamAnswersUseCase behavior (drafted grading, BUG-238 cumulative bounds, BUG-252 nullable drafts, BUG-254 expiry flush) in one file so the use-case contract stays auditable next to its shared fakes/helpers.
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ApplicationError } from '@/src/application/errors';
+import {
+  ApplicationError,
+  AttemptConflictMessages,
+  PracticeSessionConflictMessages,
+  PracticeSessionConflictReasons,
+} from '@/src/application/errors';
 import {
   FakeAttemptRepository,
+  FakeLogger,
   FakePracticeSessionRepository,
   FakeQuestionRepository,
 } from '@/src/application/test-helpers/fakes';
@@ -11,6 +17,7 @@ import {
   MS_PER_SECOND,
 } from '@/src/domain/services';
 import {
+  createAttempt,
   createChoice,
   createPracticeSession,
   createQuestion,
@@ -38,6 +45,34 @@ function passthroughTransaction(
       attempts,
       sessions,
     });
+}
+
+class SequencedFindPracticeSessionRepository extends FakePracticeSessionRepository {
+  private findCallCount = 0;
+
+  constructor(
+    private readonly firstSession: ReturnType<typeof createPracticeSession>,
+    private readonly laterSession: ReturnType<
+      typeof createPracticeSession
+    > | null,
+  ) {
+    super([]);
+  }
+
+  override async findByIdAndUserId(
+    sessionId: string,
+    userId: string,
+  ): Promise<ReturnType<typeof createPracticeSession> | null> {
+    if (
+      sessionId !== this.firstSession.id ||
+      userId !== this.firstSession.userId
+    ) {
+      return null;
+    }
+
+    this.findCallCount += 1;
+    return this.findCallCount === 1 ? this.firstSession : this.laterSession;
+  }
 }
 
 function createFinalizeQuestion(
@@ -632,6 +667,196 @@ describe('FinalizeExamAnswersUseCase', () => {
     );
   });
 
+  it('maps a double-finalize already-answered loser to AlreadyEnded after a fresh re-read', async () => {
+    const activeSession = createPracticeSession({
+      id: 'session-1',
+      userId: 'user-1',
+      mode: 'exam',
+      questionIds: ['q1'],
+      questionStates: [
+        {
+          questionId: 'q1',
+          markedForReview: false,
+          latestSelectedChoiceId: null,
+          latestIsCorrect: null,
+          latestAnsweredAt: null,
+          draftSelectedChoiceId: 'q1-correct',
+          draftSavedAt: new Date('2026-03-17T12:00:00.000Z'),
+          draftCumulativeMs: 20_000,
+        },
+      ],
+    });
+    const endedSession = createPracticeSession({
+      ...activeSession,
+      endedAt: new Date('2026-03-17T12:30:00.000Z'),
+    });
+    const questions = new FakeQuestionRepository([
+      createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+    ]);
+    const outerSessions = new SequencedFindPracticeSessionRepository(
+      activeSession,
+      endedSession,
+    );
+    const txSessions = new FakePracticeSessionRepository([activeSession]);
+    const txAttempts = new FakeAttemptRepository([
+      createAttempt({
+        id: 'attempt-1',
+        userId: 'user-1',
+        questionId: 'q1',
+        practiceSessionId: 'session-1',
+        selectedChoiceId: 'q1-correct',
+        isCorrect: true,
+      }),
+    ]);
+    const writeTransaction: FinalizeExamAnswersWriteTransaction = async (fn) =>
+      fn({
+        questions,
+        attempts: txAttempts,
+        sessions: txSessions,
+      });
+    const useCase = new FinalizeExamAnswersUseCase(
+      questions,
+      new FakeAttemptRepository(),
+      outerSessions,
+      writeTransaction,
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: PracticeSessionConflictMessages.AlreadyEnded,
+      details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
+    });
+  });
+
+  it('keeps an already-answered finalize conflict unchanged when the fresh re-read is still active', async () => {
+    const activeSession = createPracticeSession({
+      id: 'session-1',
+      userId: 'user-1',
+      mode: 'exam',
+      questionIds: ['q1'],
+      questionStates: [
+        {
+          questionId: 'q1',
+          markedForReview: false,
+          latestSelectedChoiceId: null,
+          latestIsCorrect: null,
+          latestAnsweredAt: null,
+          draftSelectedChoiceId: 'q1-correct',
+          draftSavedAt: new Date('2026-03-17T12:00:00.000Z'),
+          draftCumulativeMs: 20_000,
+        },
+      ],
+    });
+    const questions = new FakeQuestionRepository([
+      createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+    ]);
+    const outerSessions = new SequencedFindPracticeSessionRepository(
+      activeSession,
+      activeSession,
+    );
+    const txSessions = new FakePracticeSessionRepository([activeSession]);
+    const txAttempts = new FakeAttemptRepository([
+      createAttempt({
+        id: 'attempt-1',
+        userId: 'user-1',
+        questionId: 'q1',
+        practiceSessionId: 'session-1',
+        selectedChoiceId: 'q1-correct',
+        isCorrect: true,
+      }),
+    ]);
+    const writeTransaction: FinalizeExamAnswersWriteTransaction = async (fn) =>
+      fn({
+        questions,
+        attempts: txAttempts,
+        sessions: txSessions,
+      });
+    const useCase = new FinalizeExamAnswersUseCase(
+      questions,
+      new FakeAttemptRepository(),
+      outerSessions,
+      writeTransaction,
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: AttemptConflictMessages.AlreadyAnsweredInSession,
+      details: undefined,
+    });
+  });
+
+  it('keeps an already-answered finalize conflict unchanged when the fresh re-read misses the session', async () => {
+    const activeSession = createPracticeSession({
+      id: 'session-1',
+      userId: 'user-1',
+      mode: 'exam',
+      questionIds: ['q1'],
+      questionStates: [
+        {
+          questionId: 'q1',
+          markedForReview: false,
+          latestSelectedChoiceId: null,
+          latestIsCorrect: null,
+          latestAnsweredAt: null,
+          draftSelectedChoiceId: 'q1-correct',
+          draftSavedAt: new Date('2026-03-17T12:00:00.000Z'),
+          draftCumulativeMs: 20_000,
+        },
+      ],
+    });
+    const questions = new FakeQuestionRepository([
+      createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+    ]);
+    const outerSessions = new SequencedFindPracticeSessionRepository(
+      activeSession,
+      null,
+    );
+    const txSessions = new FakePracticeSessionRepository([activeSession]);
+    const txAttempts = new FakeAttemptRepository([
+      createAttempt({
+        id: 'attempt-1',
+        userId: 'user-1',
+        questionId: 'q1',
+        practiceSessionId: 'session-1',
+        selectedChoiceId: 'q1-correct',
+        isCorrect: true,
+      }),
+    ]);
+    const writeTransaction: FinalizeExamAnswersWriteTransaction = async (fn) =>
+      fn({
+        questions,
+        attempts: txAttempts,
+        sessions: txSessions,
+      });
+    const useCase = new FinalizeExamAnswersUseCase(
+      questions,
+      new FakeAttemptRepository(),
+      outerSessions,
+      writeTransaction,
+    );
+
+    await expect(
+      useCase.execute({
+        userId: 'user-1',
+        sessionId: 'session-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: AttemptConflictMessages.AlreadyAnsweredInSession,
+      details: undefined,
+    });
+  });
+
   it('rejects missing sessions', async () => {
     const questions = new FakeQuestionRepository([]);
     const attempts = new FakeAttemptRepository();
@@ -832,6 +1057,7 @@ describe('FinalizeExamAnswersUseCase', () => {
     function createFlushUseCase(
       now: () => Date,
       question = createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+      logger?: FakeLogger,
     ) {
       const questions = new FakeQuestionRepository([question]);
       const attempts = new FakeAttemptRepository();
@@ -844,6 +1070,7 @@ describe('FinalizeExamAnswersUseCase', () => {
         sessions,
         passthroughTransaction(questions, attempts, sessions),
         now,
+        logger,
       );
       return { questions, attempts, sessions, useCase };
     }
@@ -995,7 +1222,46 @@ describe('FinalizeExamAnswersUseCase', () => {
       ).resolves.toEqual([]);
     });
 
-    it('rejects a flush arriving after the grace window (arbitrary-late answering)', async () => {
+    it('drops a flush arriving after the grace window and still finalizes', async () => {
+      const logger = new FakeLogger();
+      const { attempts, useCase } = createFlushUseCase(
+        () => new Date(DEADLINE_MS + FINALIZE_FLUSH_DEADLINE_GRACE_MS + 1),
+        createFinalizeQuestion('q1', 'q1-correct', 'q1-wrong'),
+        logger,
+      );
+
+      await expect(
+        useCase.execute({
+          userId: 'user-1',
+          sessionId: 'session-1',
+          finalDraftAnswer: {
+            questionId: 'q1',
+            selectedChoiceId: 'q1-correct',
+            cumulativeMs: 10_000,
+          },
+        }),
+      ).resolves.toMatchObject({ totals: { answered: 0, correct: 0 } });
+
+      await expect(
+        attempts.findBySessionId('session-1', 'user-1'),
+      ).resolves.toMatchObject([
+        {
+          questionId: 'q1',
+          outcome: { kind: 'omitted' },
+          isCorrect: false,
+          timeSpentSeconds: 0,
+        },
+      ]);
+      expect(logger.warnCalls).toContainEqual({
+        context: {
+          sessionId: 'session-1',
+          questionId: 'q1',
+        },
+        msg: 'Dropped stale final exam draft flush after grace window',
+      });
+    });
+
+    it('drops a late flush without requiring an injected logger', async () => {
       const { attempts, useCase } = createFlushUseCase(
         () => new Date(DEADLINE_MS + FINALIZE_FLUSH_DEADLINE_GRACE_MS + 1),
       );
@@ -1010,16 +1276,17 @@ describe('FinalizeExamAnswersUseCase', () => {
             cumulativeMs: 10_000,
           },
         }),
-      ).rejects.toEqual(
-        new ApplicationError(
-          'CONFLICT',
-          'Final exam answer flush is only allowed at exam expiry',
-        ),
-      );
+      ).resolves.toMatchObject({ totals: { answered: 0, correct: 0 } });
 
       await expect(
         attempts.findBySessionId('session-1', 'user-1'),
-      ).resolves.toEqual([]);
+      ).resolves.toMatchObject([
+        {
+          questionId: 'q1',
+          outcome: { kind: 'omitted' },
+          isCorrect: false,
+        },
+      ]);
     });
 
     it('rejects a flush for a question that is not in the session', async () => {

--- a/src/application/use-cases/finalize-exam-answers.test.ts
+++ b/src/application/use-cases/finalize-exam-answers.test.ts
@@ -1250,6 +1250,7 @@ describe('FinalizeExamAnswersUseCase', () => {
           outcome: { kind: 'omitted' },
           isCorrect: false,
           timeSpentSeconds: 0,
+          answeredAt: new Date(DEADLINE_MS),
         },
       ]);
       expect(logger.warnCalls).toContainEqual({
@@ -1285,6 +1286,7 @@ describe('FinalizeExamAnswersUseCase', () => {
           questionId: 'q1',
           outcome: { kind: 'omitted' },
           isCorrect: false,
+          answeredAt: new Date(DEADLINE_MS),
         },
       ]);
     });

--- a/src/application/use-cases/finalize-exam-answers.ts
+++ b/src/application/use-cases/finalize-exam-answers.ts
@@ -1,4 +1,10 @@
-import { ApplicationError } from '@/src/application/errors';
+import {
+  ApplicationError,
+  AttemptConflictMessages,
+  isApplicationError,
+  practiceSessionAlreadyEndedError,
+} from '@/src/application/errors';
+import type { Logger } from '@/src/application/ports/logger';
 import type {
   AttemptWriter,
   PracticeSessionRepository,
@@ -8,6 +14,7 @@ import { fetchSessionOwnedQuestionsById } from '@/src/application/shared/fetch-s
 import type { PracticeSession } from '@/src/domain/entities';
 import {
   computeExamDeadline,
+  EXAM_FINAL_DRAFT_FLUSH_GRACE_MS,
   gradeAnswer,
   MS_PER_SECOND,
 } from '@/src/domain/services';
@@ -35,7 +42,7 @@ import { SAVE_EXAM_DRAFT_MAX_CUMULATIVE_MS } from './save-exam-draft-answer';
  * (CodeRabbit PR #476 hardening: there is no server "active question" cursor in
  * free-navigation exam mode, so the tight window is the integrity bound).
  */
-export const FINALIZE_FLUSH_DEADLINE_GRACE_MS = 15_000;
+export const FINALIZE_FLUSH_DEADLINE_GRACE_MS = EXAM_FINAL_DRAFT_FLUSH_GRACE_MS;
 
 export type FinalizeExamFinalDraftAnswer = {
   questionId: string;
@@ -58,6 +65,18 @@ export type FinalizeExamAnswersWriteTransaction = <T>(
     sessions: PracticeSessionRepository;
   }) => Promise<T>,
 ) => Promise<T>;
+
+const noopFinalizeLogger: Pick<Logger, 'warn'> = {
+  warn: () => undefined,
+};
+
+function isAttemptAlreadyAnsweredConflict(error: unknown): boolean {
+  return (
+    isApplicationError(error) &&
+    error.code === 'CONFLICT' &&
+    error.message === AttemptConflictMessages.AlreadyAnsweredInSession
+  );
+}
 
 export function computeFinalExamEndedAt(input: {
   now: Date;
@@ -88,6 +107,7 @@ export class FinalizeExamAnswersUseCase {
     private readonly sessions: PracticeSessionRepository,
     private readonly writeTransaction: FinalizeExamAnswersWriteTransaction,
     private readonly now: () => Date = () => new Date(),
+    private readonly logger: Pick<Logger, 'warn'> = noopFinalizeLogger,
   ) {}
 
   async execute(
@@ -250,6 +270,9 @@ export class FinalizeExamAnswersUseCase {
         latestAnsweredAt,
       });
       return tx.sessions.end(input.sessionId, input.userId, effectiveEndedAt);
+    }).catch(async (error: unknown) => {
+      await this.throwAlreadyEndedForDoubleFinalizeLoser(input, error);
+      throw error;
     });
 
     const endedAt = endedSession.endedAt;
@@ -261,6 +284,21 @@ export class FinalizeExamAnswersUseCase {
     }
 
     return projectPracticeSessionSummary(endedSession, endedAt);
+  }
+
+  private async throwAlreadyEndedForDoubleFinalizeLoser(
+    input: FinalizeExamAnswersInput,
+    error: unknown,
+  ): Promise<void> {
+    if (!isAttemptAlreadyAnsweredConflict(error)) return;
+
+    const freshSession = await this.sessions.findByIdAndUserId(
+      input.sessionId,
+      input.userId,
+    );
+    if (!freshSession?.endedAt) return;
+
+    throw practiceSessionAlreadyEndedError({ cause: error });
   }
 
   private async applyFinalDraftAnswer(
@@ -284,6 +322,20 @@ export class FinalizeExamAnswersUseCase {
 
     const deadline = computeExamDeadline(session);
     const nowMs = now.getTime();
+    const isAfterGraceWindow =
+      deadline !== null &&
+      nowMs > deadline.getTime() + FINALIZE_FLUSH_DEADLINE_GRACE_MS;
+    if (isAfterGraceWindow) {
+      this.logger.warn(
+        {
+          sessionId: session.id,
+          questionId: finalDraftAnswer.questionId,
+        },
+        'Dropped stale final exam draft flush after grace window',
+      );
+      return session;
+    }
+
     const isWithinGraceWindow =
       deadline !== null &&
       nowMs >= deadline.getTime() &&

--- a/src/application/use-cases/finalize-exam-answers.ts
+++ b/src/application/use-cases/finalize-exam-answers.ts
@@ -58,6 +58,11 @@ export type FinalizeExamAnswersInput = {
 
 export type FinalizeExamAnswersOutput = PracticeSessionSummary;
 
+type FinalDraftAnswerApplication = {
+  session: PracticeSession;
+  applied: boolean;
+};
+
 export type FinalizeExamAnswersWriteTransaction = <T>(
   fn: (tx: {
     questions: QuestionRepository;
@@ -164,17 +169,18 @@ export class FinalizeExamAnswersUseCase {
       // selection visible on-screen at expiry is graded instead of omitted.
       // Grading below stays server-authoritative; this only persists the
       // validated candidate draft inside the same finalize transaction.
-      const activeSession = input.finalDraftAnswer
+      const finalDraftApplication = input.finalDraftAnswer
         ? await this.applyFinalDraftAnswer(
             tx,
             loadedSession,
             input.finalDraftAnswer,
             finalizationNow,
           )
-        : loadedSession;
+        : { session: loadedSession, applied: false };
+      const activeSession = finalDraftApplication.session;
       const deadline = computeExamDeadline(activeSession);
       const finalDraftFlushAfterDeadline =
-        input.finalDraftAnswer !== undefined &&
+        finalDraftApplication.applied &&
         deadline !== null &&
         finalizationNow.getTime() >= deadline.getTime();
       const finalAttemptAnsweredAt = finalDraftFlushAfterDeadline
@@ -309,7 +315,7 @@ export class FinalizeExamAnswersUseCase {
     session: PracticeSession,
     finalDraftAnswer: FinalizeExamFinalDraftAnswer,
     now: Date,
-  ): Promise<PracticeSession> {
+  ): Promise<FinalDraftAnswerApplication> {
     const questionState = session.questionStates.find(
       (state) => state.questionId === finalDraftAnswer.questionId,
     );
@@ -333,7 +339,7 @@ export class FinalizeExamAnswersUseCase {
         },
         'Dropped stale final exam draft flush after grace window',
       );
-      return session;
+      return { session, applied: false };
     }
 
     const isWithinGraceWindow =
@@ -392,6 +398,6 @@ export class FinalizeExamAnswersUseCase {
     if (!refreshedSession) {
       throw new ApplicationError('NOT_FOUND', 'Practice session not found');
     }
-    return refreshedSession;
+    return { session: refreshedSession, applied: true };
   }
 }

--- a/src/application/use-cases/get-next-question-explicit-question.test.ts
+++ b/src/application/use-cases/get-next-question-explicit-question.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { PracticeSessionConflictReasons } from '@/src/application/errors';
 import {
   ANSWERED_AT,
   createChoice,
@@ -319,6 +320,7 @@ describe('GetNextQuestionUseCase', () => {
     ).rejects.toMatchObject({
       code: 'CONFLICT',
       message: 'Practice session already ended',
+      details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
     });
   });
 });

--- a/src/application/use-cases/get-next-question-navigation.test.ts
+++ b/src/application/use-cases/get-next-question-navigation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { PracticeSessionConflictReasons } from '@/src/application/errors';
 import {
   ANSWERED_AT,
   ApplicationError,
@@ -107,6 +108,7 @@ describe('GetNextQuestionUseCase', () => {
     ).rejects.toMatchObject({
       code: 'CONFLICT',
       message: 'Practice session already ended',
+      details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
     });
   });
 

--- a/src/application/use-cases/get-next-question.ts
+++ b/src/application/use-cases/get-next-question.ts
@@ -12,7 +12,7 @@ import type {
   PracticeMode,
   QuestionDifficulty,
 } from '@/src/domain/value-objects';
-import { ApplicationError } from '../errors';
+import { ApplicationError, practiceSessionAlreadyEndedError } from '../errors';
 import type {
   AttemptMostRecentAnsweredAtReader,
   PracticeSessionRepository,
@@ -173,7 +173,7 @@ export class GetNextQuestionUseCase {
       throw new ApplicationError('NOT_FOUND', 'Practice session not found');
     }
     if (session.endedAt) {
-      throw new ApplicationError('CONFLICT', 'Practice session already ended');
+      throw practiceSessionAlreadyEndedError();
     }
     if (isExamExpired(session, this.now())) {
       if (!this.expiredExamFinalizer) {

--- a/src/application/use-cases/submit-answer-exam.test.ts
+++ b/src/application/use-cases/submit-answer-exam.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  PracticeSessionConflictMessages,
+  PracticeSessionConflictReasons,
+} from '@/src/application/errors';
+import {
   ApplicationError,
   createChoice,
   createPracticeSession,
@@ -126,9 +130,11 @@ describe('SubmitAnswerUseCase', () => {
         choiceId: 'c2',
         sessionId,
       }),
-    ).rejects.toEqual(
-      new ApplicationError('CONFLICT', 'Practice session already ended'),
-    );
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: PracticeSessionConflictMessages.AlreadyEnded,
+      details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
+    });
 
     expect(attempts.getAll()).toEqual([]);
   });

--- a/src/application/use-cases/submit-answer-tutor.test.ts
+++ b/src/application/use-cases/submit-answer-tutor.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  AttemptConflictMessages,
+  PracticeSessionConflictMessages,
+  PracticeSessionConflictReasons,
+} from '@/src/application/errors';
+import {
   ApplicationError,
   createChoice,
   createPracticeSession,
@@ -209,9 +214,11 @@ describe('SubmitAnswerUseCase', () => {
         choiceId: 'c2',
         sessionId,
       }),
-    ).rejects.toEqual(
-      new ApplicationError('CONFLICT', 'Practice session already ended'),
-    );
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: PracticeSessionConflictMessages.AlreadyEnded,
+      details: { reason: PracticeSessionConflictReasons.AlreadyEnded },
+    });
 
     expect(attempts.getAll()).toEqual([]);
   });
@@ -350,7 +357,7 @@ describe('SubmitAnswerUseCase', () => {
     ).rejects.toEqual(
       new ApplicationError(
         'CONFLICT',
-        'This question has already been answered in this session',
+        AttemptConflictMessages.AlreadyAnsweredInSession,
       ),
     );
 

--- a/src/application/use-cases/submit-answer.ts
+++ b/src/application/use-cases/submit-answer.ts
@@ -11,7 +11,7 @@ import {
   shouldShowExplanation as sessionShouldShowExplanation,
 } from '@/src/domain/services';
 import { answeredOutcome } from '@/src/domain/value-objects';
-import { ApplicationError } from '../errors';
+import { ApplicationError, practiceSessionAlreadyEndedError } from '../errors';
 import type {
   AttemptSingleQuestionReader,
   AttemptWriter,
@@ -187,7 +187,7 @@ export class SubmitAnswerUseCase {
     }
 
     if (session && session.endedAt !== null) {
-      throw new ApplicationError('CONFLICT', 'Practice session already ended');
+      throw practiceSessionAlreadyEndedError();
     }
 
     const rawTimeSpentSeconds = input.timeSpentSeconds;

--- a/src/domain/services/index.ts
+++ b/src/domain/services/index.ts
@@ -44,6 +44,7 @@ export {
 } from './subscription-write-guard';
 export {
   DAY_MS,
+  EXAM_FINAL_DRAFT_FLUSH_GRACE_MS,
   EXAM_SECONDS_PER_QUESTION,
   MS_PER_SECOND,
   SECONDS_PER_DAY,

--- a/src/domain/services/time-constants.test.ts
+++ b/src/domain/services/time-constants.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { DAY_MS, MS_PER_SECOND, SECONDS_PER_DAY } from './time-constants';
+import {
+  DAY_MS,
+  EXAM_FINAL_DRAFT_FLUSH_GRACE_MS,
+  MS_PER_SECOND,
+  SECONDS_PER_DAY,
+} from './time-constants';
 
 describe('time-constants', () => {
   it('exports canonical runtime time primitives', () => {
     expect(MS_PER_SECOND).toBe(1000);
+    expect(EXAM_FINAL_DRAFT_FLUSH_GRACE_MS).toBe(15_000);
     expect(SECONDS_PER_DAY).toBe(86_400);
     expect(DAY_MS).toBe(86_400_000);
   });

--- a/src/domain/services/time-constants.ts
+++ b/src/domain/services/time-constants.ts
@@ -1,4 +1,5 @@
 export const MS_PER_SECOND = 1000;
 export const EXAM_SECONDS_PER_QUESTION = 72;
+export const EXAM_FINAL_DRAFT_FLUSH_GRACE_MS = 15 * MS_PER_SECOND;
 export const DAY_MS = 86_400_000;
 export const SECONDS_PER_DAY = DAY_MS / MS_PER_SECOND;


### PR DESCRIPTION
## Summary\n- promote dev to main after BUG-278/279 and BUG-277/280/282 fixes\n- carries PR #562 squash c9e91b4b and PR #563 squash a3be3330\n\n## Verification\n- source PRs passed their full gates and CodeRabbit exact-head reviews before merging to dev\n- promotion PR is merge-only; no new code changes authored here\n\n## Deploy notes\n- production deploy should run the existing buildCommand; no new migrations are introduced by this promotion\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Practice sessions now better recover from “already ended” conflicts, helping users see the correct session summary instead of a generic error.
  * Abandoned incomplete sessions now use a safer retry key, improving reliability when a request fails.

* **Bug Fixes**
  * Final review and timer-expiry flows now return clearer success/failure results and retry more consistently after temporary issues.
  * Exam draft finalization now avoids saving stale answers after long background/resume delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->