### PR TITLE
Fix idempotency recovery and exam timer blockers

### DIFF
--- a/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.browser.spec.tsx
@@ -144,6 +144,27 @@ describe('useExamTimer', () => {
     expect(onExpire).toHaveBeenCalledTimes(2);
   });
 
+  it('retries an expired deadline when onExpire throws synchronously', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    const onExpire = vi.fn(() => {
+      throw new Error('Finalize failed');
+    });
+
+    await render(
+      <TimerProbe
+        initialDeadlineAt="2026-05-22T12:00:01.000Z"
+        onExpire={onExpire}
+      />,
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onExpire).toHaveBeenCalledTimes(2);
+  });
+
   it('re-latches when a future deadline is replaced by a past deadline', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));

--- a/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.ts
@@ -61,17 +61,18 @@ export function useExamTimer(input: UseExamTimerInput): ExamTimerState | null {
       }
 
       firedDeadlineMsRef.current = deadlineMs;
-      void Promise.resolve(onExpireRef.current())
-        .then((handled) => {
+      void (async () => {
+        try {
+          const handled = await onExpireRef.current();
           if (handled === false && firedDeadlineMsRef.current === deadlineMs) {
             firedDeadlineMsRef.current = null;
           }
-        })
-        .catch(() => {
+        } catch {
           if (firedDeadlineMsRef.current === deadlineMs) {
             firedDeadlineMsRef.current = null;
           }
-        });
+        }
+      })();
     }
 
     update();

--- a/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-exam-timer.ts
@@ -68,6 +68,8 @@ export function useExamTimer(input: UseExamTimerInput): ExamTimerState | null {
             firedDeadlineMsRef.current = null;
           }
         } catch {
+          // onExpire reports its own failures; clear the latch so the next tick
+          // can retry expiry finalization for the same deadline.
           if (firedDeadlineMsRef.current === deadlineMs) {
             firedDeadlineMsRef.current = null;
           }

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-ended-session-conflict.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-ended-session-conflict.browser.spec.tsx
@@ -15,6 +15,7 @@ import {
 } from './practice-session-page-model.browser.fixtures';
 import {
   BROWSER_QUESTION_1_ID,
+  BROWSER_QUESTION_2_ID,
   BROWSER_SESSION_ID,
   errorResult,
   getNextQuestionMock,
@@ -221,5 +222,70 @@ describe('usePracticeSessionPageModel ended-session conflict recovery', () => {
       .element(screen.getByTestId('active-view'))
       .toHaveTextContent('summary');
     expect(getPracticeSessionSummaryMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not let stale ended-session recovery overwrite a newer question load', async () => {
+    const recoverySummary = createDeferred<ActionResult<unknown>>();
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockImplementation(() => recoverySummary.promise);
+    getNextQuestionMock
+      .mockResolvedValueOnce(
+        ok(
+          createQuestionResponse({
+            questionId: BROWSER_QUESTION_1_ID,
+            session: {
+              mode: 'tutor',
+              deadlineAt: null,
+              index: 0,
+              total: 2,
+              isMarkedForReview: false,
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        ok(
+          createQuestionResponse({
+            questionId: BROWSER_QUESTION_2_ID,
+            session: {
+              mode: 'tutor',
+              deadlineAt: null,
+              index: 1,
+              total: 2,
+              isMarkedForReview: false,
+            },
+          }),
+        ),
+      );
+    submitAnswerMock.mockResolvedValue(alreadyEndedConflict());
+    mockTutorReview();
+
+    const screen = await render(<PracticeSessionPageModelNavigationProbe />);
+
+    await expect
+      .element(screen.getByTestId('question-id'))
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
+    await screen.getByRole('button', { name: 'select-choice-1' }).click();
+    await screen.getByRole('button', { name: 'submit-answer' }).click();
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+
+    await screen.getByRole('button', { name: 'next-question' }).click();
+    await expect
+      .element(screen.getByTestId('question-id'))
+      .toHaveTextContent(BROWSER_QUESTION_2_ID);
+
+    recoverySummary.resolve(mockTutorSummary());
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('question');
+    await expect
+      .element(screen.getByTestId('question-id'))
+      .toHaveTextContent(BROWSER_QUESTION_2_ID);
   });
 });

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-ended-session-conflict.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model-ended-session-conflict.browser.spec.tsx
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { useState } from 'react';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-react';
 import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import {
@@ -14,10 +15,12 @@ import {
   createReviewRow,
 } from './practice-session-page-model.browser.fixtures';
 import {
+  BROWSER_CHOICE_1_ID,
   BROWSER_QUESTION_1_ID,
   BROWSER_QUESTION_2_ID,
   BROWSER_SESSION_ID,
   errorResult,
+  getCompletedSessionQuestionsWithFeedbackMock,
   getNextQuestionMock,
   getPracticeSessionReviewMock,
   getPracticeSessionSummaryMock,
@@ -29,9 +32,19 @@ import {
 
 setupPracticeSessionPageModelBrowserSpec();
 
-function mockTutorSummary() {
+let usePracticeSessionPageModel: typeof import('./use-practice-session-page-model').usePracticeSessionPageModel;
+
+const BROWSER_SESSION_2_ID = crypto.randomUUID();
+
+beforeAll(async () => {
+  ({ usePracticeSessionPageModel } = await import(
+    './use-practice-session-page-model'
+  ));
+});
+
+function mockTutorSummary(sessionId = BROWSER_SESSION_ID) {
   return ok({
-    sessionId: BROWSER_SESSION_ID,
+    sessionId,
     endedAt: '2026-02-07T00:20:00.000Z',
     mode: 'tutor' as const,
     questionCount: 2,
@@ -44,10 +57,11 @@ function mockTutorSummary() {
   });
 }
 
-function mockTutorReview() {
+function mockTutorReview(sessionId = BROWSER_SESSION_ID) {
   getPracticeSessionReviewMock.mockResolvedValue(
     ok(
       createReviewResponse({
+        sessionId,
         mode: 'tutor',
         totalCount: 2,
         answeredCount: 1,
@@ -57,6 +71,42 @@ function mockTutorReview() {
         ],
       }),
     ),
+  );
+}
+
+function mockCompletedSessionQuestionsWithFeedback(
+  sessionId = BROWSER_SESSION_ID,
+) {
+  getCompletedSessionQuestionsWithFeedbackMock.mockResolvedValue(
+    ok({
+      sessionId,
+      mode: 'tutor',
+      totalCount: 2,
+      answeredCount: 1,
+      markedCount: 0,
+      rows: [
+        {
+          isAvailable: true,
+          questionId: BROWSER_QUESTION_1_ID,
+          slug: 'question-1',
+          stemMd: 'Question 1',
+          difficulty: 'easy',
+          order: 1,
+          isAnswered: true,
+          isCorrect: true,
+          isOmitted: false,
+          markedForReview: false,
+          choices: [
+            { id: BROWSER_CHOICE_1_ID, label: 'A', textMd: 'Choice A' },
+          ],
+          selectedChoiceId: BROWSER_CHOICE_1_ID,
+          correctChoiceId: BROWSER_CHOICE_1_ID,
+          explanationMd: 'Because A is correct.',
+          referenceMd: null,
+          choiceExplanations: [],
+        },
+      ],
+    }),
   );
 }
 
@@ -83,6 +133,45 @@ function mockActiveTutorQuestionThenEndedConflict() {
       ),
     )
     .mockResolvedValue(alreadyEndedConflict());
+}
+
+function getActiveView(output: ReturnType<typeof usePracticeSessionPageModel>) {
+  if (output.summary) return 'summary';
+  if (output.question) return 'question';
+  return '';
+}
+
+function MutableSessionRecoveryProbe() {
+  const [sessionId, setSessionId] = useState(BROWSER_SESSION_ID);
+  const output = usePracticeSessionPageModel(sessionId);
+
+  return (
+    <>
+      <div data-testid="current-session-id">{sessionId}</div>
+      <div data-testid="active-view">{getActiveView(output)}</div>
+      <div data-testid="question-id">{output.question?.questionId ?? ''}</div>
+      <div data-testid="summary-session-id">
+        {output.summary?.sessionId ?? ''}
+      </div>
+      <button
+        type="button"
+        onClick={() => output.onSelectChoice(BROWSER_CHOICE_1_ID)}
+      >
+        select-choice-1
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void output.onSubmit();
+        }}
+      >
+        submit-answer
+      </button>
+      <button type="button" onClick={() => setSessionId(BROWSER_SESSION_2_ID)}>
+        switch-session
+      </button>
+    </>
+  );
 }
 
 describe('usePracticeSessionPageModel ended-session conflict recovery', () => {
@@ -287,5 +376,57 @@ describe('usePracticeSessionPageModel ended-session conflict recovery', () => {
     await expect
       .element(screen.getByTestId('question-id'))
       .toHaveTextContent(BROWSER_QUESTION_2_ID);
+  });
+
+  it('does not let stale ended-session recovery overwrite a newer session summary', async () => {
+    const recoverySummary = createDeferred<ActionResult<unknown>>();
+    getPracticeSessionSummaryMock
+      .mockResolvedValueOnce(
+        errorResult('CONFLICT', 'Practice session has not ended'),
+      )
+      .mockImplementationOnce(() => recoverySummary.promise)
+      .mockResolvedValueOnce(mockTutorSummary(BROWSER_SESSION_2_ID));
+    getNextQuestionMock.mockResolvedValueOnce(
+      ok(
+        createQuestionResponse({
+          questionId: BROWSER_QUESTION_1_ID,
+          session: {
+            mode: 'tutor',
+            deadlineAt: null,
+            index: 0,
+            total: 2,
+            isMarkedForReview: false,
+          },
+        }),
+      ),
+    );
+    submitAnswerMock.mockResolvedValue(alreadyEndedConflict());
+    mockTutorReview(BROWSER_SESSION_2_ID);
+    mockCompletedSessionQuestionsWithFeedback(BROWSER_SESSION_2_ID);
+
+    const screen = await render(<MutableSessionRecoveryProbe />);
+
+    await expect
+      .element(screen.getByTestId('question-id'))
+      .toHaveTextContent(BROWSER_QUESTION_1_ID);
+    await screen.getByRole('button', { name: 'select-choice-1' }).click();
+    await screen.getByRole('button', { name: 'submit-answer' }).click();
+    await expect
+      .poll(() => getPracticeSessionSummaryMock.mock.calls.length)
+      .toBe(2);
+
+    await screen.getByRole('button', { name: 'switch-session' }).click();
+    await expect
+      .element(screen.getByTestId('summary-session-id'))
+      .toHaveTextContent(BROWSER_SESSION_2_ID);
+
+    recoverySummary.resolve(mockTutorSummary(BROWSER_SESSION_ID));
+
+    await expect
+      .element(screen.getByTestId('active-view'))
+      .toHaveTextContent('summary');
+    await expect
+      .element(screen.getByTestId('summary-session-id'))
+      .toHaveTextContent(BROWSER_SESSION_2_ID);
   });
 });

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
@@ -48,6 +48,13 @@ const BOOTSTRAP_SUMMARY_TIMEOUT_MS = STANDARD_READ_TIMEOUT_MS;
 const STALE_FINAL_DRAFT_FLUSH_AFTER_DEADLINE_MS =
   EXAM_FINAL_DRAFT_FLUSH_GRACE_MS;
 
+type EndedSessionSummaryRecovery = {
+  sessionId: string;
+  promise: Promise<Awaited<
+    ReturnType<typeof getPracticeSessionSummary>
+  > | null>;
+};
+
 type PracticeSessionPageModelOutput = Omit<
   PracticeSessionPageViewProps,
   'questionFeedback'
@@ -81,9 +88,10 @@ export function usePracticeSessionPageModel(
   >(null);
   const recoverEndedSessionConflictRef =
     useRef<EndedSessionConflictRecovery | null>(null);
-  const recoverEndedSessionSummaryPromiseRef = useRef<Promise<Awaited<
-    ReturnType<typeof getPracticeSessionSummary>
-  > | null> | null>(null);
+  const recoverEndedSessionSummaryPromiseRef =
+    useRef<EndedSessionSummaryRecovery | null>(null);
+  const currentSessionIdRef = useRef(sessionId);
+  currentSessionIdRef.current = sessionId;
   const [shouldRetryBootstrap, setShouldRetryBootstrap] = useState(false);
   const onExamServerExpiry = useCallback(
     async (finalDraftAnswer: ExamDraftAnswer | null): Promise<void> => {
@@ -97,6 +105,12 @@ export function usePracticeSessionPageModel(
     },
     [],
   );
+
+  useEffect(() => {
+    if (recoverEndedSessionSummaryPromiseRef.current?.sessionId !== sessionId) {
+      recoverEndedSessionSummaryPromiseRef.current = null;
+    }
+  }, [sessionId]);
 
   const questionFlow = usePracticeSessionQuestionFlow({
     sessionId,
@@ -341,13 +355,17 @@ export function usePracticeSessionPageModel(
         return Promise.resolve(true);
       }
       let recovery = recoverEndedSessionSummaryPromiseRef.current;
+      if (recovery?.sessionId !== sessionId) {
+        recovery = null;
+      }
       if (!recovery) {
-        recovery = (async (): Promise<Awaited<
+        const recoverySessionId = sessionId;
+        const promise = (async (): Promise<Awaited<
           ReturnType<typeof getPracticeSessionSummary>
         > | null> => {
           try {
             return await withTimeout(
-              getPracticeSessionSummary({ sessionId }),
+              getPracticeSessionSummary({ sessionId: recoverySessionId }),
               BOOTSTRAP_SUMMARY_TIMEOUT_MS,
             );
           } catch (error) {
@@ -360,15 +378,19 @@ export function usePracticeSessionPageModel(
             return null;
           }
         })();
+        recovery = { sessionId: recoverySessionId, promise };
         recoverEndedSessionSummaryPromiseRef.current = recovery;
-        void recovery.finally(() => {
-          if (recoverEndedSessionSummaryPromiseRef.current === recovery) {
+        const activeRecovery = recovery;
+        void promise.finally(() => {
+          if (recoverEndedSessionSummaryPromiseRef.current === activeRecovery) {
             recoverEndedSessionSummaryPromiseRef.current = null;
           }
         });
       }
 
-      return recovery.then((result) => {
+      const recoverySessionId = recovery.sessionId;
+      return recovery.promise.then((result) => {
+        if (currentSessionIdRef.current !== recoverySessionId) return false;
         if (!isMounted() || !input.canCommit()) return false;
         if (!result?.ok) return false;
 

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
@@ -372,7 +372,6 @@ export function usePracticeSessionPageModel(
         if (!isMounted() || !input.canCommit()) return false;
         if (!result?.ok) return false;
 
-        if (!input.canCommit()) return false;
         setShouldRetryBootstrap(false);
         applyBootstrapSummary(result.data);
         return true;

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-page-model.ts
@@ -81,9 +81,9 @@ export function usePracticeSessionPageModel(
   >(null);
   const recoverEndedSessionConflictRef =
     useRef<EndedSessionConflictRecovery | null>(null);
-  const recoverEndedSessionSummaryPromiseRef = useRef<Promise<boolean> | null>(
-    null,
-  );
+  const recoverEndedSessionSummaryPromiseRef = useRef<Promise<Awaited<
+    ReturnType<typeof getPracticeSessionSummary>
+  > | null> | null>(null);
   const [shouldRetryBootstrap, setShouldRetryBootstrap] = useState(false);
   const onExamServerExpiry = useCallback(
     async (finalDraftAnswer: ExamDraftAnswer | null): Promise<void> => {
@@ -91,10 +91,12 @@ export function usePracticeSessionPageModel(
     },
     [],
   );
-  const recoverEndedSessionConflict =
-    useCallback(async (): Promise<boolean> => {
-      return (await recoverEndedSessionConflictRef.current?.()) ?? false;
-    }, []);
+  const recoverEndedSessionConflict = useCallback(
+    async (input: { canCommit: () => boolean }): Promise<boolean> => {
+      return (await recoverEndedSessionConflictRef.current?.(input)) ?? false;
+    },
+    [],
+  );
 
   const questionFlow = usePracticeSessionQuestionFlow({
     sessionId,
@@ -333,53 +335,57 @@ export function usePracticeSessionPageModel(
     [applyBootstrapSummary, isMounted, sessionId],
   );
 
-  const recoverEndedSessionSummary = useCallback((): Promise<boolean> => {
-    if (reviewStage.summary || reviewStage.postExamSummary) {
-      return Promise.resolve(true);
-    }
-    if (recoverEndedSessionSummaryPromiseRef.current) {
-      return recoverEndedSessionSummaryPromiseRef.current;
-    }
-
-    const recovery = (async (): Promise<boolean> => {
-      let result: Awaited<ReturnType<typeof getPracticeSessionSummary>>;
-      try {
-        result = await withTimeout(
-          getPracticeSessionSummary({ sessionId }),
-          BOOTSTRAP_SUMMARY_TIMEOUT_MS,
-        );
-      } catch (error) {
-        if (isMounted()) {
-          reportClientError(error, {
-            component: 'UsePracticeSessionPageModel',
-            action: 'recoverEndedSessionSummary',
-          });
-        }
-        return false;
+  const recoverEndedSessionSummary = useCallback(
+    (input: { canCommit: () => boolean }): Promise<boolean> => {
+      if (reviewStage.summary || reviewStage.postExamSummary) {
+        return Promise.resolve(true);
+      }
+      let recovery = recoverEndedSessionSummaryPromiseRef.current;
+      if (!recovery) {
+        recovery = (async (): Promise<Awaited<
+          ReturnType<typeof getPracticeSessionSummary>
+        > | null> => {
+          try {
+            return await withTimeout(
+              getPracticeSessionSummary({ sessionId }),
+              BOOTSTRAP_SUMMARY_TIMEOUT_MS,
+            );
+          } catch (error) {
+            if (isMounted()) {
+              reportClientError(error, {
+                component: 'UsePracticeSessionPageModel',
+                action: 'recoverEndedSessionSummary',
+              });
+            }
+            return null;
+          }
+        })();
+        recoverEndedSessionSummaryPromiseRef.current = recovery;
+        void recovery.finally(() => {
+          if (recoverEndedSessionSummaryPromiseRef.current === recovery) {
+            recoverEndedSessionSummaryPromiseRef.current = null;
+          }
+        });
       }
 
-      if (!isMounted()) return false;
-      if (!result.ok) return false;
+      return recovery.then((result) => {
+        if (!isMounted() || !input.canCommit()) return false;
+        if (!result?.ok) return false;
 
-      setShouldRetryBootstrap(false);
-      applyBootstrapSummary(result.data);
-      return true;
-    })();
-
-    recoverEndedSessionSummaryPromiseRef.current = recovery;
-    void recovery.finally(() => {
-      if (recoverEndedSessionSummaryPromiseRef.current === recovery) {
-        recoverEndedSessionSummaryPromiseRef.current = null;
-      }
-    });
-    return recovery;
-  }, [
-    applyBootstrapSummary,
-    isMounted,
-    reviewStage.postExamSummary,
-    reviewStage.summary,
-    sessionId,
-  ]);
+        if (!input.canCommit()) return false;
+        setShouldRetryBootstrap(false);
+        applyBootstrapSummary(result.data);
+        return true;
+      });
+    },
+    [
+      applyBootstrapSummary,
+      isMounted,
+      reviewStage.postExamSummary,
+      reviewStage.summary,
+      sessionId,
+    ],
+  );
 
   useEffect(() => {
     recoverEndedSessionConflictRef.current = recoverEndedSessionSummary;

--- a/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.browser.spec.tsx
+++ b/app/(app)/app/practice/[sessionId]/hooks/use-practice-session-review-stage-state.browser.spec.tsx
@@ -41,7 +41,7 @@ function createInput(
     setSessionMode: vi.fn(),
     resetQuestionState: vi.fn(),
     loadSpecificQuestion: vi.fn(),
-    finalizeSession: vi.fn().mockResolvedValue(undefined),
+    finalizeSession: vi.fn().mockResolvedValue(true),
     getPracticeSessionReviewFn: getPracticeSessionReviewMock,
   };
 }

--- a/app/(app)/app/practice/shared/question-flow-actions.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions.ts
@@ -31,7 +31,9 @@ export type RequestSequencingHooks = {
 };
 
 export type NullQuestionRecovery = () => Promise<boolean>;
-export type EndedSessionConflictRecovery = () => Promise<boolean>;
+export type EndedSessionConflictRecovery = (input: {
+  canCommit: () => boolean;
+}) => Promise<boolean>;
 
 export type ExamDraftAnswer = {
   questionId: string;
@@ -79,7 +81,9 @@ async function tryRecoverEndedSessionConflict(input: {
     return 'not-handled';
   }
 
-  const handled = await input.recoverEndedSessionConflict();
+  const handled = await input.recoverEndedSessionConflict({
+    canCommit: input.canCommit,
+  });
   if (!input.canCommit()) return 'stale-request';
   return handled ? 'handled' : 'not-handled';
 }

--- a/src/adapters/controllers/practice-controller.ts
+++ b/src/adapters/controllers/practice-controller.ts
@@ -215,6 +215,7 @@ export const startPracticeSession = createAction({
       idempotencyKey,
       outputSchema: StartPracticeSessionOutputSchema,
       beforeExecute: enforceStartRateLimit,
+      outcomeStoreFailurePolicy: 'cache-error-and-throw',
       execute: createNewSession,
     });
   },

--- a/src/adapters/controllers/question-feedback-controller.ts
+++ b/src/adapters/controllers/question-feedback-controller.ts
@@ -214,6 +214,7 @@ export const submitQuestionReport = createAction({
       idempotencyKey,
       outputSchema: SubmitQuestionReportOutputSchema,
       beforeExecute: enforceReportRateLimit,
+      outcomeStoreFailurePolicy: 'cache-error-and-throw',
       execute: submit,
     });
   },

--- a/src/adapters/controllers/shared/execute-idempotent.ts
+++ b/src/adapters/controllers/shared/execute-idempotent.ts
@@ -1,5 +1,8 @@
 import type { ZodType } from 'zod';
-import { withIdempotency } from '@/src/adapters/shared/with-idempotency';
+import {
+  type IdempotencyOutcomeStoreFailurePolicy,
+  withIdempotency,
+} from '@/src/adapters/shared/with-idempotency';
 import type { Logger } from '@/src/application/ports/logger';
 import type { IdempotencyKeyRepository } from '@/src/application/ports/repositories';
 
@@ -25,6 +28,7 @@ export async function executeIdempotent<TOutput>({
   outputSchema,
   beforeExecute,
   shouldCacheError,
+  outcomeStoreFailurePolicy,
   execute,
 }: {
   d: IdempotentControllerDeps;
@@ -34,6 +38,7 @@ export async function executeIdempotent<TOutput>({
   outputSchema: ZodType<TOutput, unknown>;
   beforeExecute?: () => Promise<void>;
   shouldCacheError?: (error: unknown) => boolean;
+  outcomeStoreFailurePolicy?: IdempotencyOutcomeStoreFailurePolicy;
   execute: () => Promise<TOutput>;
 }): Promise<TOutput> {
   if (!idempotencyKey) {
@@ -51,6 +56,7 @@ export async function executeIdempotent<TOutput>({
     parseResult: (value) => outputSchema.parse(value),
     ...(beforeExecute ? { beforeExecute } : {}),
     ...(shouldCacheError ? { shouldCacheError } : {}),
+    ...(outcomeStoreFailurePolicy ? { outcomeStoreFailurePolicy } : {}),
     execute,
   });
 }

--- a/src/adapters/shared/with-idempotency-outcome-write.test.ts
+++ b/src/adapters/shared/with-idempotency-outcome-write.test.ts
@@ -185,4 +185,40 @@ describe('withIdempotency outcome writes', () => {
       },
     });
   });
+
+  it('caches an indeterminate error instead of replaying non-replayable actions after storeResult fails', async () => {
+    class StoreResultFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        throw new Error('store result failed');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new StoreResultFailingRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ feedbackId: crypto.randomUUID() }));
+    const key = '17171717-1717-1717-1717-171717171717';
+    const input = {
+      repo,
+      userId: appUserId,
+      action: 'question-feedback:submitQuestionReport',
+      key,
+      now,
+      logger,
+      outcomeStoreFailurePolicy: 'cache-error-and-throw' as const,
+      execute,
+    };
+
+    await expect(withIdempotency(input)).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message:
+        'Idempotency outcome could not be recorded after committed success',
+    });
+    await expect(withIdempotency(input)).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message:
+        'Idempotency outcome could not be recorded after committed success',
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/adapters/shared/with-idempotency-outcome-write.test.ts
+++ b/src/adapters/shared/with-idempotency-outcome-write.test.ts
@@ -222,6 +222,48 @@ describe('withIdempotency outcome writes', () => {
     expect(execute).toHaveBeenCalledTimes(1);
   });
 
+  it('logs when it caches an indeterminate error after storeResult fails', async () => {
+    class StoreResultFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        throw new Error('store result failed');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new StoreResultFailingRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ feedbackId: crypto.randomUUID() }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'question-feedback:submitQuestionReport',
+        key: '21212121-2121-2121-2121-212121212121',
+        now,
+        logger,
+        outcomeStoreFailurePolicy: 'cache-error-and-throw',
+        execute,
+      }),
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message:
+        'Idempotency outcome could not be recorded after committed success',
+    });
+
+    expect(logger.errorCalls).toEqual([
+      {
+        msg: 'Idempotency outcome write failed after committed success; cached indeterminate error',
+        context: {
+          action: 'question-feedback:submitQuestionReport',
+          key: '21212121-2121-2121-2121-212121212121',
+          storeResultError: 'store result failed',
+          userId: appUserId,
+        },
+      },
+    ]);
+  });
+
   it('throws the indeterminate error and logs when caching it also fails', async () => {
     class OutcomeWriteFailingRepo extends FakeIdempotencyKeyRepository {
       override async storeResult(): Promise<void> {

--- a/src/adapters/shared/with-idempotency-outcome-write.test.ts
+++ b/src/adapters/shared/with-idempotency-outcome-write.test.ts
@@ -268,4 +268,85 @@ describe('withIdempotency outcome writes', () => {
       },
     });
   });
+
+  it('logs non-error indeterminate outcome cache failures', async () => {
+    class OutcomeWriteFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        return Promise.reject('store result failed literal');
+      }
+
+      override async storeError(): Promise<void> {
+        return Promise.reject('store error failed literal');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new OutcomeWriteFailingRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ feedbackId: crypto.randomUUID() }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'question-feedback:submitQuestionReport',
+        key: '19191919-1919-1919-1919-191919191919',
+        now,
+        logger,
+        outcomeStoreFailurePolicy: 'cache-error-and-throw',
+        execute,
+      }),
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message:
+        'Idempotency outcome could not be recorded after committed success',
+    });
+
+    expect(logger.errorCalls[0]).toMatchObject({
+      context: {
+        storeError: 'store error failed literal',
+        storeResultError: 'store result failed literal',
+      },
+    });
+  });
+
+  it('preserves the indeterminate error when indeterminate outcome logging fails', async () => {
+    class OutcomeWriteFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        throw new Error('store result failed');
+      }
+
+      override async storeError(): Promise<void> {
+        throw new Error('store error failed');
+      }
+    }
+
+    class ThrowingErrorLogger extends FakeLogger {
+      override error(): void {
+        throw new Error('logger failed');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new OutcomeWriteFailingRepo(now);
+    const logger = new ThrowingErrorLogger();
+    const execute = vi.fn(async () => ({ feedbackId: crypto.randomUUID() }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'question-feedback:submitQuestionReport',
+        key: '20202020-2020-2020-2020-202020202020',
+        now,
+        logger,
+        outcomeStoreFailurePolicy: 'cache-error-and-throw',
+        execute,
+      }),
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message:
+        'Idempotency outcome could not be recorded after committed success',
+    });
+  });
 });

--- a/src/adapters/shared/with-idempotency-outcome-write.test.ts
+++ b/src/adapters/shared/with-idempotency-outcome-write.test.ts
@@ -221,4 +221,51 @@ describe('withIdempotency outcome writes', () => {
     });
     expect(execute).toHaveBeenCalledTimes(1);
   });
+
+  it('throws the indeterminate error and logs when caching it also fails', async () => {
+    class OutcomeWriteFailingRepo extends FakeIdempotencyKeyRepository {
+      override async storeResult(): Promise<void> {
+        throw new Error('store result failed');
+      }
+
+      override async storeError(): Promise<void> {
+        throw new Error('store error failed');
+      }
+    }
+
+    const now = () => new Date('2026-02-08T00:00:00.000Z');
+    const repo = new OutcomeWriteFailingRepo(now);
+    const logger = new FakeLogger();
+    const execute = vi.fn(async () => ({ feedbackId: crypto.randomUUID() }));
+
+    await expect(
+      withIdempotency({
+        repo,
+        userId: appUserId,
+        action: 'question-feedback:submitQuestionReport',
+        key: '18181818-1818-1818-1818-181818181818',
+        now,
+        logger,
+        outcomeStoreFailurePolicy: 'cache-error-and-throw',
+        execute,
+      }),
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message:
+        'Idempotency outcome could not be recorded after committed success',
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(logger.errorCalls).toHaveLength(1);
+    expect(logger.errorCalls[0]).toMatchObject({
+      msg: 'Failed to persist indeterminate idempotency outcome',
+      context: {
+        action: 'question-feedback:submitQuestionReport',
+        key: '18181818-1818-1818-1818-181818181818',
+        storeError: 'store error failed',
+        storeResultError: 'store result failed',
+        userId: appUserId,
+      },
+    });
+  });
 });

--- a/src/adapters/shared/with-idempotency.ts
+++ b/src/adapters/shared/with-idempotency.ts
@@ -14,6 +14,10 @@ const DEFAULT_MAX_WAIT_MS = 2_000;
 const DEFAULT_POLL_INTERVAL_MS = 50;
 const ERROR_MESSAGE_LIMIT = 1000;
 
+export type IdempotencyOutcomeStoreFailurePolicy =
+  | 'return-result'
+  | 'cache-error-and-throw';
+
 function toErrorMessage(error: unknown): string {
   if (error instanceof Error) {
     const message = error.message || error.name;
@@ -111,6 +115,7 @@ export async function withIdempotency<T>(input: {
   parseResult?: (value: unknown) => T;
   beforeExecute?: () => Promise<void>;
   shouldCacheError?: (error: unknown) => boolean;
+  outcomeStoreFailurePolicy?: IdempotencyOutcomeStoreFailurePolicy;
   execute: () => Promise<T>;
 }): Promise<T> {
   const ttlMs = input.ttlMs ?? DEFAULT_TTL_MS;
@@ -221,6 +226,47 @@ export async function withIdempotency<T>(input: {
           storeResultError.code === 'NOT_FOUND'
         ) {
           throw storeResultError;
+        }
+
+        const outcomeError = new ApplicationError(
+          'INTERNAL_ERROR',
+          'Idempotency outcome could not be recorded after committed success',
+          undefined,
+          { cause: storeResultError },
+        );
+
+        if (input.outcomeStoreFailurePolicy === 'cache-error-and-throw') {
+          try {
+            await input.repo.storeError({
+              userId: input.userId,
+              action: input.action,
+              key: input.key,
+              claimedAt,
+              error: toErrorRecord(outcomeError),
+            });
+          } catch (storeError) {
+            try {
+              input.logger.error(
+                {
+                  userId: input.userId,
+                  action: input.action,
+                  key: input.key,
+                  storeError:
+                    storeError instanceof Error
+                      ? storeError.message
+                      : String(storeError),
+                  storeResultError:
+                    storeResultError instanceof Error
+                      ? storeResultError.message
+                      : String(storeResultError),
+                },
+                'Failed to persist indeterminate idempotency outcome',
+              );
+            } catch {
+              // Preserve the indeterminate outcome error even if logging fails.
+            }
+          }
+          throw outcomeError;
         }
 
         try {

--- a/src/adapters/shared/with-idempotency.ts
+++ b/src/adapters/shared/with-idempotency.ts
@@ -1,6 +1,6 @@
 import { delay } from '@/src/adapters/shared/delay';
 import { ApplicationError, isApplicationError } from '@/src/application/errors';
-import type { Logger } from '@/src/application/ports/logger';
+import type { Logger, LoggerContext } from '@/src/application/ports/logger';
 import {
   DEFAULT_IDEMPOTENCY_ZOMBIE_THRESHOLD_MS,
   type IdempotencyKeyError,
@@ -44,6 +44,18 @@ function toErrorRecord(error: unknown): IdempotencyKeyError {
   return { code: 'INTERNAL_ERROR', message: toErrorMessage(error) };
 }
 
+function safeLogError(
+  logger: Logger,
+  context: LoggerContext,
+  msg: string,
+): void {
+  try {
+    logger.error(context, msg);
+  } catch {
+    // Preserve the primary outcome even if logging fails.
+  }
+}
+
 function shouldCacheExecutionError(
   shouldCacheError: ((error: unknown) => boolean) | undefined,
   error: unknown,
@@ -78,26 +90,21 @@ async function abortClaimPreservingOriginalError(
       claimedAt,
     );
   } catch (abortError) {
-    try {
-      input.logger.error(
-        {
-          userId: input.userId,
-          action: input.action,
-          key: input.key,
-          abortError:
-            abortError instanceof Error
-              ? abortError.message
-              : String(abortError),
-          originalError:
-            originalError instanceof Error
-              ? originalError.message
-              : String(originalError),
-        },
-        message,
-      );
-    } catch {
-      // Preserve the original error even if logging fails.
-    }
+    safeLogError(
+      input.logger,
+      {
+        userId: input.userId,
+        action: input.action,
+        key: input.key,
+        abortError:
+          abortError instanceof Error ? abortError.message : String(abortError),
+        originalError:
+          originalError instanceof Error
+            ? originalError.message
+            : String(originalError),
+      },
+      message,
+    );
   }
 }
 
@@ -190,24 +197,21 @@ export async function withIdempotency<T>(input: {
             error: toErrorRecord(error),
           });
         } catch (storeError) {
-          try {
-            input.logger.error(
-              {
-                userId: input.userId,
-                action: input.action,
-                key: input.key,
-                storeError:
-                  storeError instanceof Error
-                    ? storeError.message
-                    : String(storeError),
-                originalError:
-                  error instanceof Error ? error.message : String(error),
-              },
-              'Failed to persist idempotency error record',
-            );
-          } catch {
-            // Preserve original execute error even if logger.error throws.
-          }
+          safeLogError(
+            input.logger,
+            {
+              userId: input.userId,
+              action: input.action,
+              key: input.key,
+              storeError:
+                storeError instanceof Error
+                  ? storeError.message
+                  : String(storeError),
+              originalError:
+                error instanceof Error ? error.message : String(error),
+            },
+            'Failed to persist idempotency error record',
+          );
         }
         throw error;
       }
@@ -244,47 +248,42 @@ export async function withIdempotency<T>(input: {
               claimedAt,
               error: toErrorRecord(outcomeError),
             });
+            safeLogError(
+              input.logger,
+              {
+                userId: input.userId,
+                action: input.action,
+                key: input.key,
+                storeResultError: toErrorMessage(storeResultError),
+              },
+              'Idempotency outcome write failed after committed success; cached indeterminate error',
+            );
           } catch (storeError) {
-            try {
-              input.logger.error(
-                {
-                  userId: input.userId,
-                  action: input.action,
-                  key: input.key,
-                  storeError:
-                    storeError instanceof Error
-                      ? storeError.message
-                      : String(storeError),
-                  storeResultError:
-                    storeResultError instanceof Error
-                      ? storeResultError.message
-                      : String(storeResultError),
-                },
-                'Failed to persist indeterminate idempotency outcome',
-              );
-            } catch {
-              // Preserve the indeterminate outcome error even if logging fails.
-            }
+            safeLogError(
+              input.logger,
+              {
+                userId: input.userId,
+                action: input.action,
+                key: input.key,
+                storeError: toErrorMessage(storeError),
+                storeResultError: toErrorMessage(storeResultError),
+              },
+              'Failed to persist indeterminate idempotency outcome',
+            );
           }
           throw outcomeError;
         }
 
-        try {
-          input.logger.error(
-            {
-              userId: input.userId,
-              action: input.action,
-              key: input.key,
-              storeResultError:
-                storeResultError instanceof Error
-                  ? storeResultError.message
-                  : String(storeResultError),
-            },
-            'Idempotency outcome write failed after committed success',
-          );
-        } catch {
-          // Preserve the committed business result even if logging fails.
-        }
+        safeLogError(
+          input.logger,
+          {
+            userId: input.userId,
+            action: input.action,
+            key: input.key,
+            storeResultError: toErrorMessage(storeResultError),
+          },
+          'Idempotency outcome write failed after committed success',
+        );
       }
 
       return result;

--- a/src/application/use-cases/finalize-exam-answers.test.ts
+++ b/src/application/use-cases/finalize-exam-answers.test.ts
@@ -1250,6 +1250,7 @@ describe('FinalizeExamAnswersUseCase', () => {
           outcome: { kind: 'omitted' },
           isCorrect: false,
           timeSpentSeconds: 0,
+          answeredAt: new Date(DEADLINE_MS),
         },
       ]);
       expect(logger.warnCalls).toContainEqual({
@@ -1285,6 +1286,7 @@ describe('FinalizeExamAnswersUseCase', () => {
           questionId: 'q1',
           outcome: { kind: 'omitted' },
           isCorrect: false,
+          answeredAt: new Date(DEADLINE_MS),
         },
       ]);
     });

--- a/src/application/use-cases/finalize-exam-answers.ts
+++ b/src/application/use-cases/finalize-exam-answers.ts
@@ -58,6 +58,11 @@ export type FinalizeExamAnswersInput = {
 
 export type FinalizeExamAnswersOutput = PracticeSessionSummary;
 
+type FinalDraftAnswerApplication = {
+  session: PracticeSession;
+  applied: boolean;
+};
+
 export type FinalizeExamAnswersWriteTransaction = <T>(
   fn: (tx: {
     questions: QuestionRepository;
@@ -164,17 +169,18 @@ export class FinalizeExamAnswersUseCase {
       // selection visible on-screen at expiry is graded instead of omitted.
       // Grading below stays server-authoritative; this only persists the
       // validated candidate draft inside the same finalize transaction.
-      const activeSession = input.finalDraftAnswer
+      const finalDraftApplication = input.finalDraftAnswer
         ? await this.applyFinalDraftAnswer(
             tx,
             loadedSession,
             input.finalDraftAnswer,
             finalizationNow,
           )
-        : loadedSession;
+        : { session: loadedSession, applied: false };
+      const activeSession = finalDraftApplication.session;
       const deadline = computeExamDeadline(activeSession);
       const finalDraftFlushAfterDeadline =
-        input.finalDraftAnswer !== undefined &&
+        finalDraftApplication.applied &&
         deadline !== null &&
         finalizationNow.getTime() >= deadline.getTime();
       const finalAttemptAnsweredAt = finalDraftFlushAfterDeadline
@@ -309,7 +315,7 @@ export class FinalizeExamAnswersUseCase {
     session: PracticeSession,
     finalDraftAnswer: FinalizeExamFinalDraftAnswer,
     now: Date,
-  ): Promise<PracticeSession> {
+  ): Promise<FinalDraftAnswerApplication> {
     const questionState = session.questionStates.find(
       (state) => state.questionId === finalDraftAnswer.questionId,
     );
@@ -333,7 +339,7 @@ export class FinalizeExamAnswersUseCase {
         },
         'Dropped stale final exam draft flush after grace window',
       );
-      return session;
+      return { session, applied: false };
     }
 
     const isWithinGraceWindow =
@@ -392,6 +398,6 @@ export class FinalizeExamAnswersUseCase {
     if (!refreshedSession) {
       throw new ApplicationError('NOT_FOUND', 'Practice session not found');
     }
-    return refreshedSession;
+    return { session: refreshedSession, applied: true };
   }
 }


### PR DESCRIPTION
## Summary\n- handle synchronous exam-timer expiry failures so retry latches reset\n- guard ended-session recovery state commits with request freshness while preserving deduped summary fetches\n- distinguish applied vs dropped final draft flushes so stale drops keep answeredAt clamped to the deadline\n- add an explicit idempotency outcome-write failure policy for non-replayable local-create actions\n\n## Verification\n- pnpm typecheck\n- pnpm lint\n- pnpm test --run\n- pnpm test:browser\n- pnpm test:integration\n- pnpm build\n- pnpm test:e2e\n\n## Context\nAddresses CodeRabbit requested changes on promotion PR #564 before promoting dev to main.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exam timer reliability so expiration handlers that throw now trigger continued retries.
  * Prevented stale ended-session recovery from overwriting the newest question view during recovery races.
  * Final exam answer “final draft flush” logic now only treats grace-window flushes as applied, and records the correct `answeredAt` for omitted attempts.
* **New Features**
  * Added configurable idempotency outcome failure handling, including a mode that caches an indeterminate error and throws for consistent subsequent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->