### PR TITLE
Fix pricing auth redirect context

### DIFF
--- a/app/not-found.test.tsx
+++ b/app/not-found.test.tsx
@@ -4,12 +4,21 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { findMainLandmarkById, parseHtml } from '@/tests/shared/dom-helpers';
 
 let NotFound: typeof import('./not-found').default;
+let metadata: typeof import('./not-found').metadata;
 
 beforeAll(async () => {
-  NotFound = (await import('./not-found')).default;
+  const notFoundModule = await import('./not-found');
+  NotFound = notFoundModule.default;
+  metadata = notFoundModule.metadata;
 });
 
 describe('app/not-found', () => {
+  it('exports distinct metadata matching the app page-title convention', () => {
+    expect(metadata).toMatchObject({
+      title: 'Page Not Found - Addiction Boards',
+    });
+  });
+
   it('renders a 404 page with a valid skip-link target landmark', () => {
     const html = renderToStaticMarkup(<NotFound />);
     const doc = parseHtml(html);

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,7 +1,12 @@
 import { CircleIcon } from 'lucide-react';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { ROUTES } from '@/lib/routes';
+
+export const metadata: Metadata = {
+  title: 'Page Not Found - Addiction Boards',
+};
 
 export default function NotFound() {
   return (

--- a/app/pricing/manage-billing-action.test.ts
+++ b/app/pricing/manage-billing-action.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { runManageBillingAction } from '@/app/pricing/manage-billing-action';
+import { toPricingRoute, toSignUpRedirectRoute } from '@/lib/routes';
 import { FakeLogger } from '@/src/application/test-helpers/fakes';
 
 class RedirectError extends Error {
@@ -31,7 +32,7 @@ describe('runManageBillingAction', () => {
     });
   });
 
-  it('returns redirect to /sign-up when portal session creation is unauthenticated', async () => {
+  it('returns redirect to sign-up with the manage-billing return destination when portal session creation is unauthenticated', async () => {
     const redirectFn = (url: string): never => {
       throw new RedirectError(url);
     };
@@ -49,7 +50,7 @@ describe('runManageBillingAction', () => {
       });
 
     await expect(action()).rejects.toMatchObject({
-      url: '/sign-up',
+      url: toSignUpRedirectRoute(toPricingRoute({ reason: 'manage_billing' })),
     });
   });
 

--- a/app/pricing/manage-billing-action.ts
+++ b/app/pricing/manage-billing-action.ts
@@ -4,7 +4,7 @@ import type {
   ManageBillingLogger,
   RedirectFn,
 } from '@/lib/manage-billing/manage-billing-types';
-import { ROUTES } from '@/lib/routes';
+import { toPricingRoute, toSignUpRedirectRoute } from '@/lib/routes';
 
 export async function runManageBillingAction(deps: {
   createPortalSessionFn: CreatePortalSessionFn;
@@ -15,8 +15,10 @@ export async function runManageBillingAction(deps: {
   return runManageBillingActionCore({
     ...deps,
     redirects: {
-      failure: `${ROUTES.PRICING}?portal=error`,
-      unauthenticated: ROUTES.SIGN_UP,
+      failure: toPricingRoute({ portal: 'error' }),
+      unauthenticated: toSignUpRedirectRoute(
+        toPricingRoute({ reason: 'manage_billing' }),
+      ),
     },
   });
 }

--- a/app/pricing/manage-billing-actions.test.ts
+++ b/app/pricing/manage-billing-actions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { manageBillingAction } from '@/app/pricing/manage-billing-actions';
+import { toPricingRoute, toSignUpRedirectRoute } from '@/lib/routes';
 import { err, ok } from '@/src/adapters/controllers/action-result';
 
 function createRedirectFn(): (url: string) => never {
@@ -25,7 +26,7 @@ describe('app/pricing/manage-billing-actions', () => {
     });
   });
 
-  it('returns redirect to sign-up when portal session creation is unauthenticated', async () => {
+  it('returns a sign-up redirect that preserves the manage-billing destination when portal session creation is unauthenticated', async () => {
     const createPortalSessionFn = async () =>
       err('UNAUTHENTICATED', 'Not signed in');
 
@@ -37,7 +38,9 @@ describe('app/pricing/manage-billing-actions', () => {
         redirectFn,
       }),
     ).rejects.toMatchObject({
-      message: 'redirect:/sign-up',
+      message: `redirect:${toSignUpRedirectRoute(
+        toPricingRoute({ reason: 'manage_billing' }),
+      )}`,
     });
   });
 

--- a/app/pricing/page.test.tsx
+++ b/app/pricing/page.test.tsx
@@ -1140,6 +1140,40 @@ describe('app/pricing', () => {
     );
   });
 
+  it('renders anonymous standard subscribe links and annual selection when trial copy is disabled', () => {
+    const html = renderToStaticMarkup(
+      <PricingView
+        isAuthenticated={false}
+        isEntitled={false}
+        banner={null}
+        selectedPlan="annual"
+        subscribeMonthlyAction={async () => undefined}
+        subscribeAnnualAction={async () => undefined}
+      />,
+    );
+    const doc = parseHtml(html);
+    const monthlyHref = toSignUpRedirectRoute(
+      toPricingRoute({ plan: 'monthly' }),
+    );
+    const annualHref = toSignUpRedirectRoute(
+      toPricingRoute({ plan: 'annual' }),
+    );
+    const annualCard = findHeadingByText(doc, PRICING_DATA.annual.name, {
+      level: 3,
+    })?.closest('[data-slot="card"]');
+
+    expect(findAnchorByHref(doc, monthlyHref)?.textContent).toContain(
+      'Subscribe Monthly',
+    );
+    expect(findAnchorByHref(doc, annualHref)?.textContent).toContain(
+      'Subscribe Annual',
+    );
+    expect(annualCard?.getAttribute('aria-current')).toBe('true');
+    expect(annualCard?.textContent).toContain('Selected plan');
+    expect(html).not.toContain(PRICING_DATA.monthly.postTrialNote);
+    expect(html).not.toContain(PRICING_DATA.annual.postTrialNote);
+  });
+
   it('renders trial CTAs for signed-in first-time users', async () => {
     const html = await renderPricingPageWithEntitlement({
       isEntitled: false,

--- a/app/pricing/page.test.tsx
+++ b/app/pricing/page.test.tsx
@@ -1295,6 +1295,25 @@ describe('app/pricing', () => {
     expect(bareSignUpManageBillingLinks).toHaveLength(0);
   });
 
+  it('renders anonymous payment-processing recovery as a sign-up link carrying its return destination', async () => {
+    const { html } = await renderAnonymousPricingPage({
+      reason: 'payment_processing',
+    });
+    const doc = parseHtml(html);
+    const paymentProcessingHref = toSignUpRedirectRoute(
+      toPricingRoute({ reason: 'payment_processing' }),
+    );
+    const manageBillingHref = toSignUpRedirectRoute(
+      toPricingRoute({ reason: 'manage_billing' }),
+    );
+    const paymentProcessingLink = findAnchorByHref(doc, paymentProcessingHref);
+    const staleManageBillingLink = findAnchorByHref(doc, manageBillingHref);
+
+    expect(paymentProcessingLink?.textContent).toContain('Manage Billing');
+    expect(staleManageBillingLink).toBeNull();
+    expect(doc.querySelector('form button[type="submit"]')).toBeNull();
+  });
+
   it('renders ended-access copy and standard CTAs for lapsed subscriptions', async () => {
     const html = await renderPricingPageWithEntitlement({
       isEntitled: false,

--- a/app/pricing/page.test.tsx
+++ b/app/pricing/page.test.tsx
@@ -10,6 +10,7 @@ import {
   vi,
 } from 'vitest';
 import { PRICING_DATA } from '@/lib/pricing-data';
+import { ROUTES, toPricingRoute, toSignUpRedirectRoute } from '@/lib/routes';
 import type { AuthGateway } from '@/src/application/ports/gateways';
 import { FakeAuthGateway } from '@/src/application/test-helpers/fakes';
 import { FakeUseCase } from '@/src/application/test-helpers/fakes/fake-use-cases';
@@ -17,6 +18,11 @@ import type {
   CheckEntitlementInput,
   CheckEntitlementOutput,
 } from '@/src/application/use-cases/check-entitlement';
+import {
+  findAnchorByHref,
+  findHeadingByText,
+  parseHtml,
+} from '@/tests/shared/dom-helpers';
 import {
   restoreProcessEnv,
   snapshotProcessEnv,
@@ -597,6 +603,7 @@ describe('app/pricing', () => {
         checkEntitlementUseCase,
       }),
     ).resolves.toEqual({
+      isAuthenticated: false,
       isEntitled: false,
       reason: null,
       subscriptionStatus: null,
@@ -624,6 +631,7 @@ describe('app/pricing', () => {
     await expect(
       loadPricingData({ authGateway, checkEntitlementUseCase }),
     ).resolves.toEqual({
+      isAuthenticated: true,
       isEntitled: true,
       reason: null,
       subscriptionStatus: null,
@@ -653,6 +661,7 @@ describe('app/pricing', () => {
     await expect(
       loadPricingData({ authGateway, checkEntitlementUseCase }),
     ).resolves.toEqual({
+      isAuthenticated: true,
       isEntitled: false,
       reason: 'manage_billing',
       subscriptionStatus: null,
@@ -680,6 +689,7 @@ describe('app/pricing', () => {
     await expect(
       loadPricingData({ authGateway, checkEntitlementUseCase }),
     ).resolves.toEqual({
+      isAuthenticated: true,
       isEntitled: false,
       reason: 'subscription_required',
       subscriptionStatus: 'canceled',
@@ -714,7 +724,7 @@ describe('app/pricing', () => {
     });
   });
 
-  it('runSubscribeAction redirects to /sign-up when unauthenticated', async () => {
+  it('runSubscribeAction redirects to sign-up with the selected plan return destination when unauthenticated', async () => {
     const createCheckoutSessionFn = vi.fn<CreateCheckoutSessionFn>(
       async () => ({
         ok: false,
@@ -735,7 +745,9 @@ describe('app/pricing', () => {
         },
       );
 
-    await expect(action()).rejects.toThrow('/sign-up');
+    await expect(action()).rejects.toThrow(
+      toSignUpRedirectRoute(toPricingRoute({ plan: 'annual' })),
+    );
     expect(createCheckoutSessionFn).toHaveBeenCalledWith({
       plan: 'annual',
       idempotencyKey: undefined,
@@ -1102,6 +1114,32 @@ describe('app/pricing', () => {
     expect(html).not.toContain('Subscribe Annual');
   });
 
+  it('renders anonymous trial CTAs as sign-up links carrying the selected plan', async () => {
+    const { html } = await renderAnonymousPricingPage({
+      reason: 'subscription_required',
+    });
+    const doc = parseHtml(html);
+    const monthlyHref = toSignUpRedirectRoute(
+      toPricingRoute({ plan: 'monthly' }),
+    );
+    const annualHref = toSignUpRedirectRoute(
+      toPricingRoute({ plan: 'annual' }),
+    );
+
+    expect(findAnchorByHref(doc, monthlyHref)?.textContent).toContain(
+      PRICING_DATA.monthly.trialCta,
+    );
+    expect(findAnchorByHref(doc, annualHref)?.textContent).toContain(
+      PRICING_DATA.annual.trialCta,
+    );
+    expect(doc.querySelector('form[aria-label="Subscribe monthly plan"]')).toBe(
+      null,
+    );
+    expect(doc.querySelector('form[aria-label="Subscribe annual plan"]')).toBe(
+      null,
+    );
+  });
+
   it('renders trial CTAs for signed-in first-time users', async () => {
     const html = await renderPricingPageWithEntitlement({
       isEntitled: false,
@@ -1116,6 +1154,80 @@ describe('app/pricing', () => {
     );
     expect(html).toContain('Start 7-day free trial');
     expect(html).not.toContain('Subscribe Monthly');
+  });
+
+  it('keeps signed-in first-time trial CTAs as checkout submit actions', async () => {
+    const html = await renderPricingPageWithEntitlement({
+      isEntitled: false,
+      reason: 'subscription_required',
+      subscriptionStatus: null,
+      hasActiveSubscriptionPeriod: false,
+      trialEndsAt: null,
+    });
+    const doc = parseHtml(html);
+
+    expect(
+      findAnchorByHref(
+        doc,
+        toSignUpRedirectRoute(toPricingRoute({ plan: 'monthly' })),
+      ),
+    ).toBeNull();
+    expect(
+      doc.querySelector('form[aria-label="Subscribe monthly plan"]'),
+    ).not.toBeNull();
+    expect(
+      doc.querySelector('form[aria-label="Subscribe annual plan"]'),
+    ).not.toBeNull();
+  });
+
+  it('marks the returned plan from the pricing query string', async () => {
+    const checkEntitlementUseCase = new FakeUseCase<
+      CheckEntitlementInput,
+      CheckEntitlementOutput
+    >({
+      isEntitled: false,
+      reason: 'subscription_required',
+      subscriptionStatus: null,
+      hasActiveSubscriptionPeriod: false,
+      trialEndsAt: null,
+    });
+    const element = await PricingPage({
+      searchParams: Promise.resolve({ plan: 'monthly' }),
+      authNavFn: () => <div>AuthNav</div>,
+      deps: {
+        authGateway: new FakeAuthGateway(pricingTestUser),
+        checkEntitlementUseCase,
+      },
+    });
+    const doc = parseHtml(renderToStaticMarkup(element));
+    const monthlyCard = findHeadingByText(doc, PRICING_DATA.monthly.name, {
+      level: 3,
+    })?.closest('[data-slot="card"]');
+    const annualCard = findHeadingByText(doc, PRICING_DATA.annual.name, {
+      level: 3,
+    })?.closest('[data-slot="card"]');
+
+    expect(monthlyCard?.getAttribute('aria-current')).toBe('true');
+    expect(monthlyCard?.textContent).toContain('Selected plan');
+    expect(annualCard?.getAttribute('aria-current')).toBeNull();
+  });
+
+  it('renders anonymous manage-billing recovery as a sign-up link carrying its return destination', async () => {
+    const { html } = await renderAnonymousPricingPage({
+      reason: 'manage_billing',
+    });
+    const doc = parseHtml(html);
+    const manageBillingHref = toSignUpRedirectRoute(
+      toPricingRoute({ reason: 'manage_billing' }),
+    );
+    const manageBillingLink = findAnchorByHref(doc, manageBillingHref);
+    const bareSignUpManageBillingLinks = Array.from(
+      doc.querySelectorAll<HTMLAnchorElement>(`a[href="${ROUTES.SIGN_UP}"]`),
+    ).filter((anchor) => anchor.textContent?.includes('Manage Billing'));
+
+    expect(manageBillingLink?.textContent).toContain('Manage Billing');
+    expect(doc.querySelector('form button[type="submit"]')).toBeNull();
+    expect(bareSignUpManageBillingLinks).toHaveLength(0);
   });
 
   it('renders ended-access copy and standard CTAs for lapsed subscriptions', async () => {

--- a/app/pricing/page.test.tsx
+++ b/app/pricing/page.test.tsx
@@ -1098,6 +1098,37 @@ describe('app/pricing', () => {
     expect(html).not.toContain('Subscribe Annual');
   });
 
+  it('uses authenticated entitlement state over stale return reason params', async () => {
+    const checkEntitlementUseCase = new FakeUseCase<
+      CheckEntitlementInput,
+      CheckEntitlementOutput
+    >({
+      isEntitled: false,
+      reason: 'subscription_required',
+      subscriptionStatus: null,
+      hasActiveSubscriptionPeriod: false,
+      trialEndsAt: null,
+    });
+    const element = await PricingPage({
+      searchParams: Promise.resolve({ reason: 'manage_billing' }),
+      authNavFn: () => <div>AuthNav</div>,
+      deps: {
+        authGateway: new FakeAuthGateway(pricingTestUser),
+        checkEntitlementUseCase,
+      },
+    });
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain(
+      'Start your free trial to access the app — no card required.',
+    );
+    expect(html).toContain('Start 7-day free trial');
+    expect(html).not.toContain(
+      'Subscription found. Manage billing to resolve payment issues.',
+    );
+    expect(html).not.toContain('Manage Billing');
+  });
+
   it('renders trial CTAs and trial-forward copy for anonymous visitors', async () => {
     const { html } = await renderAnonymousPricingPage({
       reason: 'subscription_required',

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -11,7 +11,7 @@ import {
 import type { PricingBanner } from '@/app/pricing/types';
 import { MarketingLayout } from '@/components/marketing/marketing-layout';
 import { getRequestAuthState } from '@/lib/auth-request-cache';
-import { ROUTES } from '@/lib/routes';
+import { type PricingPlan, ROUTES } from '@/lib/routes';
 import { normalizeSearchParam } from '@/lib/search-params';
 import type { AuthGateway } from '@/src/application/ports/gateways';
 import type { CheckEntitlementUseCase } from '@/src/application/ports/use-cases';
@@ -36,6 +36,7 @@ export type PricingPageDeps = {
 };
 
 export type PricingData = {
+  isAuthenticated: boolean;
   isEntitled: boolean;
   reason: NonEntitledReason | null;
   /** null means no subscription record exists (trial-eligible per DEBT-410 D9). */
@@ -48,6 +49,7 @@ export async function loadPricingData(
   const authState = await getRequestAuthState({ deps });
   if (!authState.user) {
     return {
+      isAuthenticated: false,
       // Anonymous pricing visits should not show a banner (DEBT-410 PR-1).
       isEntitled: false,
       reason: null,
@@ -56,6 +58,7 @@ export async function loadPricingData(
   }
 
   return {
+    isAuthenticated: true,
     isEntitled: authState.entitlement.isEntitled,
     reason: authState.entitlement.reason ?? null,
     subscriptionStatus: authState.entitlement.subscriptionStatus ?? null,
@@ -66,7 +69,7 @@ type PricingSearchParams = {
   checkout?: string | string[] | undefined;
   portal?: string | string[] | undefined;
   reason?: string | string[] | undefined;
-  plan?: string;
+  plan?: string | string[] | undefined;
 };
 
 export type PricingTrialContext = {
@@ -158,16 +161,25 @@ export function getPricingBanner(
   return null;
 }
 
+function normalizePricingPlanParam(
+  plan: PricingSearchParams['plan'],
+): PricingPlan | null {
+  const value = normalizeSearchParam(plan);
+  return value === 'monthly' || value === 'annual' ? value : null;
+}
+
 // Shared by both render paths so banner/CTA decisions cannot drift apart.
 function buildPricingPresentation(
   pricingData: PricingData,
   resolvedSearchParams: PricingSearchParams,
 ): {
   banner: PricingBanner | null;
+  selectedPlan: PricingPlan | null;
   showManageBillingAction: boolean;
   showTrialCtas: boolean;
 } {
   const reason = normalizeSearchParam(resolvedSearchParams.reason);
+  const selectedPlan = normalizePricingPlanParam(resolvedSearchParams.plan);
   const effectiveReason = reason ?? pricingData.reason ?? undefined;
   const banner = getPricingBanner(
     {
@@ -181,6 +193,7 @@ function buildPricingPresentation(
 
   return {
     banner,
+    selectedPlan,
     showManageBillingAction:
       effectiveReason === 'manage_billing' ||
       effectiveReason === 'payment_processing',
@@ -200,13 +213,15 @@ export async function DeferredPricingView({
     loadPricingData(deps),
     searchParams,
   ]);
-  const { banner, showManageBillingAction, showTrialCtas } =
+  const { banner, selectedPlan, showManageBillingAction, showTrialCtas } =
     buildPricingPresentation(pricingData, resolvedSearchParams);
 
   return (
     <PricingView
+      isAuthenticated={pricingData.isAuthenticated}
       isEntitled={pricingData.isEntitled}
       banner={banner}
+      selectedPlan={selectedPlan}
       showTrialCtas={showTrialCtas}
       {...(showManageBillingAction ? { manageBillingAction } : {})}
       subscribeMonthlyAction={subscribeMonthlyAction}
@@ -234,7 +249,7 @@ async function renderInjectedPricingPage(input: {
     input.searchParams,
     resolvedAuthNavFn(),
   ]);
-  const { banner, showManageBillingAction, showTrialCtas } =
+  const { banner, selectedPlan, showManageBillingAction, showTrialCtas } =
     buildPricingPresentation(pricingData, resolvedSearchParams);
 
   return MarketingLayout({
@@ -242,8 +257,10 @@ async function renderInjectedPricingPage(input: {
     featuresHref: `${ROUTES.HOME}#features`,
     children: (
       <PricingView
+        isAuthenticated={pricingData.isAuthenticated}
         isEntitled={pricingData.isEntitled}
         banner={banner}
+        selectedPlan={selectedPlan}
         showTrialCtas={showTrialCtas}
         {...(showManageBillingAction ? { manageBillingAction } : {})}
         subscribeMonthlyAction={subscribeMonthlyAction}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -180,7 +180,9 @@ function buildPricingPresentation(
 } {
   const reason = normalizeSearchParam(resolvedSearchParams.reason);
   const selectedPlan = normalizePricingPlanParam(resolvedSearchParams.plan);
-  const effectiveReason = reason ?? pricingData.reason ?? undefined;
+  const effectiveReason = pricingData.isAuthenticated
+    ? (pricingData.reason ?? undefined)
+    : (reason ?? undefined);
   const banner = getPricingBanner(
     {
       ...resolvedSearchParams,

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -11,7 +11,11 @@ import {
 import type { PricingBanner } from '@/app/pricing/types';
 import { MarketingLayout } from '@/components/marketing/marketing-layout';
 import { getRequestAuthState } from '@/lib/auth-request-cache';
-import { type PricingPlan, ROUTES } from '@/lib/routes';
+import {
+  type PricingBillingRecoveryReason,
+  type PricingPlan,
+  ROUTES,
+} from '@/lib/routes';
 import { normalizeSearchParam } from '@/lib/search-params';
 import type { AuthGateway } from '@/src/application/ports/gateways';
 import type { CheckEntitlementUseCase } from '@/src/application/ports/use-cases';
@@ -168,14 +172,22 @@ function normalizePricingPlanParam(
   return value === 'monthly' || value === 'annual' ? value : null;
 }
 
+function normalizeBillingRecoveryReason(
+  reason: string | undefined,
+): PricingBillingRecoveryReason | null {
+  return reason === 'manage_billing' || reason === 'payment_processing'
+    ? reason
+    : null;
+}
+
 // Shared by both render paths so banner/CTA decisions cannot drift apart.
 function buildPricingPresentation(
   pricingData: PricingData,
   resolvedSearchParams: PricingSearchParams,
 ): {
   banner: PricingBanner | null;
+  manageBillingReason: PricingBillingRecoveryReason | null;
   selectedPlan: PricingPlan | null;
-  showManageBillingAction: boolean;
   showTrialCtas: boolean;
 } {
   const reason = normalizeSearchParam(resolvedSearchParams.reason);
@@ -183,6 +195,7 @@ function buildPricingPresentation(
   const effectiveReason = pricingData.isAuthenticated
     ? (pricingData.reason ?? undefined)
     : (reason ?? undefined);
+  const manageBillingReason = normalizeBillingRecoveryReason(effectiveReason);
   const banner = getPricingBanner(
     {
       ...resolvedSearchParams,
@@ -195,10 +208,8 @@ function buildPricingPresentation(
 
   return {
     banner,
+    manageBillingReason,
     selectedPlan,
-    showManageBillingAction:
-      effectiveReason === 'manage_billing' ||
-      effectiveReason === 'payment_processing',
     showTrialCtas:
       !pricingData.isEntitled && pricingData.subscriptionStatus === null,
   };
@@ -215,7 +226,7 @@ export async function DeferredPricingView({
     loadPricingData(deps),
     searchParams,
   ]);
-  const { banner, selectedPlan, showManageBillingAction, showTrialCtas } =
+  const { banner, manageBillingReason, selectedPlan, showTrialCtas } =
     buildPricingPresentation(pricingData, resolvedSearchParams);
 
   return (
@@ -225,7 +236,9 @@ export async function DeferredPricingView({
       banner={banner}
       selectedPlan={selectedPlan}
       showTrialCtas={showTrialCtas}
-      {...(showManageBillingAction ? { manageBillingAction } : {})}
+      {...(manageBillingReason
+        ? { manageBillingAction, manageBillingReason }
+        : {})}
       subscribeMonthlyAction={subscribeMonthlyAction}
       subscribeAnnualAction={subscribeAnnualAction}
       SubscribeButtonComponent={SubscribeButton}
@@ -251,7 +264,7 @@ async function renderInjectedPricingPage(input: {
     input.searchParams,
     resolvedAuthNavFn(),
   ]);
-  const { banner, selectedPlan, showManageBillingAction, showTrialCtas } =
+  const { banner, manageBillingReason, selectedPlan, showTrialCtas } =
     buildPricingPresentation(pricingData, resolvedSearchParams);
 
   return MarketingLayout({
@@ -264,7 +277,9 @@ async function renderInjectedPricingPage(input: {
         banner={banner}
         selectedPlan={selectedPlan}
         showTrialCtas={showTrialCtas}
-        {...(showManageBillingAction ? { manageBillingAction } : {})}
+        {...(manageBillingReason
+          ? { manageBillingAction, manageBillingReason }
+          : {})}
         subscribeMonthlyAction={subscribeMonthlyAction}
         subscribeAnnualAction={subscribeAnnualAction}
         SubscribeButtonComponent={SubscribeButton}

--- a/app/pricing/pricing-auth-cta.tsx
+++ b/app/pricing/pricing-auth-cta.tsx
@@ -1,0 +1,95 @@
+import Link from 'next/link';
+import type { ComponentProps, ComponentType, ReactNode } from 'react';
+import { IdempotencyKeyField } from '@/components/idempotency-key-field';
+import { Button } from '@/components/ui/button';
+
+export type PricingAction = (formData: FormData) => Promise<void>;
+
+type AuthAwareCtaProps = {
+  isAuthenticated: boolean;
+  formAction: PricingAction;
+  signUpHref: string;
+  children: ReactNode;
+  formAriaLabel?: string;
+  buttonProps?: Omit<ComponentProps<typeof Button>, 'asChild' | 'children'>;
+  AuthenticatedButtonComponent?: ComponentType<{ children: ReactNode }>;
+  footer?: ReactNode;
+};
+
+export function AuthAwareCta({
+  isAuthenticated,
+  formAction,
+  signUpHref,
+  children,
+  formAriaLabel,
+  buttonProps,
+  AuthenticatedButtonComponent,
+  footer,
+}: AuthAwareCtaProps) {
+  if (isAuthenticated) {
+    return (
+      <form action={formAction} aria-label={formAriaLabel}>
+        <IdempotencyKeyField />
+        {AuthenticatedButtonComponent ? (
+          <AuthenticatedButtonComponent>
+            {children}
+          </AuthenticatedButtonComponent>
+        ) : (
+          <Button type="submit" {...buttonProps}>
+            {children}
+          </Button>
+        )}
+        {footer}
+      </form>
+    );
+  }
+
+  return (
+    <>
+      <Button asChild {...buttonProps}>
+        <Link href={signUpHref}>{children}</Link>
+      </Button>
+      {footer}
+    </>
+  );
+}
+
+export function SubscribePlanCta({
+  isAuthenticated,
+  formAction,
+  signUpHref,
+  formAriaLabel,
+  label,
+  postTrialNote,
+  SubscribeButtonComponent,
+}: {
+  isAuthenticated: boolean;
+  formAction: PricingAction;
+  signUpHref: string;
+  formAriaLabel: string;
+  label: string;
+  postTrialNote: string | null;
+  SubscribeButtonComponent: ComponentType<{ children: ReactNode }>;
+}) {
+  const footer = postTrialNote ? (
+    <p className="mt-3 text-center text-sm text-muted-foreground">
+      {postTrialNote}
+    </p>
+  ) : null;
+
+  return (
+    <AuthAwareCta
+      isAuthenticated={isAuthenticated}
+      formAction={formAction}
+      signUpHref={signUpHref}
+      formAriaLabel={formAriaLabel}
+      AuthenticatedButtonComponent={SubscribeButtonComponent}
+      buttonProps={{
+        className: 'mt-8 h-auto w-full rounded-full py-3 text-base',
+      }}
+      footer={footer}
+    >
+      {label}
+    </AuthAwareCta>
+  );
+}

--- a/app/pricing/pricing-view.tsx
+++ b/app/pricing/pricing-view.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { PRICING_DATA } from '@/lib/pricing-data';
 import {
+  type PricingBillingRecoveryReason,
   type PricingPlan,
   ROUTES,
   toPricingRoute,
@@ -20,6 +21,7 @@ export type PricingViewProps = {
   /** Render trial CTAs for trial-eligible visitors (no subscription row, not entitled). */
   showTrialCtas?: boolean;
   manageBillingAction?: (formData: FormData) => Promise<void>;
+  manageBillingReason?: PricingBillingRecoveryReason;
   subscribeMonthlyAction: (formData: FormData) => Promise<void>;
   subscribeAnnualAction: (formData: FormData) => Promise<void>;
   SubscribeButtonComponent?: ComponentType<{ children: ReactNode }>;
@@ -37,8 +39,10 @@ function getPlanSignUpHref(plan: PricingPlan): string {
   return toSignUpRedirectRoute(toPricingRoute({ plan }));
 }
 
-function getManageBillingSignUpHref(): string {
-  return toSignUpRedirectRoute(toPricingRoute({ reason: 'manage_billing' }));
+function getManageBillingSignUpHref(
+  reason: PricingBillingRecoveryReason = 'manage_billing',
+): string {
+  return toSignUpRedirectRoute(toPricingRoute({ reason }));
 }
 
 export function PricingView({
@@ -48,6 +52,7 @@ export function PricingView({
   selectedPlan = null,
   showTrialCtas = false,
   manageBillingAction,
+  manageBillingReason = 'manage_billing',
   subscribeMonthlyAction,
   subscribeAnnualAction,
   SubscribeButtonComponent = DefaultButton,
@@ -83,7 +88,7 @@ export function PricingView({
                 <AuthAwareCta
                   isAuthenticated={isAuthenticated}
                   formAction={manageBillingAction}
-                  signUpHref={getManageBillingSignUpHref()}
+                  signUpHref={getManageBillingSignUpHref(manageBillingReason)}
                   buttonProps={{
                     variant: 'outline',
                     size: 'sm',
@@ -133,7 +138,7 @@ export function PricingView({
               <AuthAwareCta
                 isAuthenticated={isAuthenticated}
                 formAction={manageBillingAction}
-                signUpHref={getManageBillingSignUpHref()}
+                signUpHref={getManageBillingSignUpHref(manageBillingReason)}
                 buttonProps={{ className: 'rounded-full' }}
               >
                 Manage Billing

--- a/app/pricing/pricing-view.tsx
+++ b/app/pricing/pricing-view.tsx
@@ -5,11 +5,18 @@ import { IdempotencyKeyField } from '@/components/idempotency-key-field';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { PRICING_DATA } from '@/lib/pricing-data';
-import { ROUTES } from '@/lib/routes';
+import {
+  type PricingPlan,
+  ROUTES,
+  toPricingRoute,
+  toSignUpRedirectRoute,
+} from '@/lib/routes';
 
 export type PricingViewProps = {
+  isAuthenticated?: boolean;
   isEntitled: boolean;
   banner: PricingBanner | null;
+  selectedPlan?: PricingPlan | null;
   /** Render trial CTAs for trial-eligible visitors (no subscription row, not entitled). */
   showTrialCtas?: boolean;
   manageBillingAction?: (formData: FormData) => Promise<void>;
@@ -26,15 +33,28 @@ function DefaultButton({ children }: { children: ReactNode }) {
   );
 }
 
+function getPlanSignUpHref(plan: PricingPlan): string {
+  return toSignUpRedirectRoute(toPricingRoute({ plan }));
+}
+
+function getManageBillingSignUpHref(): string {
+  return toSignUpRedirectRoute(toPricingRoute({ reason: 'manage_billing' }));
+}
+
 export function PricingView({
+  isAuthenticated = true,
   isEntitled,
   banner,
+  selectedPlan = null,
   showTrialCtas = false,
   manageBillingAction,
   subscribeMonthlyAction,
   subscribeAnnualAction,
   SubscribeButtonComponent = DefaultButton,
 }: PricingViewProps) {
+  const isMonthlySelected = selectedPlan === 'monthly';
+  const isAnnualSelected = selectedPlan === 'annual';
+
   return (
     <div data-testid="pricing-root" className="bg-background py-16">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -60,17 +80,30 @@ export function PricingView({
             <span>{banner.message}</span>
             <div className="ml-4 flex items-center gap-3">
               {manageBillingAction ? (
-                <form action={manageBillingAction}>
-                  <IdempotencyKeyField />
+                isAuthenticated ? (
+                  <form action={manageBillingAction}>
+                    <IdempotencyKeyField />
+                    <Button
+                      type="submit"
+                      variant="outline"
+                      size="sm"
+                      className="rounded-full"
+                    >
+                      Manage Billing
+                    </Button>
+                  </form>
+                ) : (
                   <Button
-                    type="submit"
+                    asChild
                     variant="outline"
                     size="sm"
                     className="rounded-full"
                   >
-                    Manage Billing
+                    <Link href={getManageBillingSignUpHref()}>
+                      Manage Billing
+                    </Link>
                   </Button>
-                </form>
+                )
               ) : null}
               <Link
                 href={ROUTES.PRICING}
@@ -109,12 +142,20 @@ export function PricingView({
               Manage billing in Stripe to restore access.
             </p>
             <div className="mt-6">
-              <form action={manageBillingAction}>
-                <IdempotencyKeyField />
-                <Button type="submit" className="rounded-full">
-                  Manage Billing
+              {isAuthenticated ? (
+                <form action={manageBillingAction}>
+                  <IdempotencyKeyField />
+                  <Button type="submit" className="rounded-full">
+                    Manage Billing
+                  </Button>
+                </form>
+              ) : (
+                <Button asChild className="rounded-full">
+                  <Link href={getManageBillingSignUpHref()}>
+                    Manage Billing
+                  </Link>
                 </Button>
-              </form>
+              )}
             </div>
           </Card>
         ) : (
@@ -126,10 +167,20 @@ export function PricingView({
               Plans
             </h2>
             <div className="mt-6 grid gap-8 md:grid-cols-2">
-              <Card className="p-8">
+              <Card
+                aria-current={isMonthlySelected ? 'true' : undefined}
+                className={
+                  isMonthlySelected ? 'border-2 border-primary p-8' : 'p-8'
+                }
+              >
                 <h3 className="font-heading font-semibold text-foreground">
                   {PRICING_DATA.monthly.name}
                 </h3>
+                {isMonthlySelected ? (
+                  <p className="mt-2 text-sm font-medium text-primary">
+                    Selected plan
+                  </p>
+                ) : null}
                 <p className="mt-4 font-display text-4xl font-bold text-foreground">
                   {PRICING_DATA.monthly.price}
                   <span className="text-lg font-normal text-muted-foreground">
@@ -141,27 +192,55 @@ export function PricingView({
                     <li key={feature}>{feature}</li>
                   ))}
                 </ul>
-                <form
-                  action={subscribeMonthlyAction}
-                  aria-label="Subscribe monthly plan"
-                >
-                  <IdempotencyKeyField />
-                  <SubscribeButtonComponent>
-                    {showTrialCtas
-                      ? PRICING_DATA.monthly.trialCta
-                      : 'Subscribe Monthly'}
-                  </SubscribeButtonComponent>
-                  {showTrialCtas ? (
-                    <p className="mt-3 text-center text-sm text-muted-foreground">
-                      {PRICING_DATA.monthly.postTrialNote}
-                    </p>
-                  ) : null}
-                </form>
+                {isAuthenticated ? (
+                  <form
+                    action={subscribeMonthlyAction}
+                    aria-label="Subscribe monthly plan"
+                  >
+                    <IdempotencyKeyField />
+                    <SubscribeButtonComponent>
+                      {showTrialCtas
+                        ? PRICING_DATA.monthly.trialCta
+                        : 'Subscribe Monthly'}
+                    </SubscribeButtonComponent>
+                    {showTrialCtas ? (
+                      <p className="mt-3 text-center text-sm text-muted-foreground">
+                        {PRICING_DATA.monthly.postTrialNote}
+                      </p>
+                    ) : null}
+                  </form>
+                ) : (
+                  <>
+                    <Button
+                      asChild
+                      className="mt-8 h-auto w-full rounded-full py-3 text-base"
+                    >
+                      <Link href={getPlanSignUpHref('monthly')}>
+                        {showTrialCtas
+                          ? PRICING_DATA.monthly.trialCta
+                          : 'Subscribe Monthly'}
+                      </Link>
+                    </Button>
+                    {showTrialCtas ? (
+                      <p className="mt-3 text-center text-sm text-muted-foreground">
+                        {PRICING_DATA.monthly.postTrialNote}
+                      </p>
+                    ) : null}
+                  </>
+                )}
               </Card>
-              <Card className="border-2 border-primary p-8">
+              <Card
+                aria-current={isAnnualSelected ? 'true' : undefined}
+                className="border-2 border-primary p-8"
+              >
                 <h3 className="font-heading font-semibold text-foreground">
                   {PRICING_DATA.annual.name}
                 </h3>
+                {isAnnualSelected ? (
+                  <p className="mt-2 text-sm font-medium text-primary">
+                    Selected plan
+                  </p>
+                ) : null}
                 <p className="mt-4 font-display text-4xl font-bold text-foreground">
                   {PRICING_DATA.annual.price}
                   <span className="text-lg font-normal text-muted-foreground">
@@ -176,22 +255,42 @@ export function PricingView({
                     <li key={feature}>{feature}</li>
                   ))}
                 </ul>
-                <form
-                  action={subscribeAnnualAction}
-                  aria-label="Subscribe annual plan"
-                >
-                  <IdempotencyKeyField />
-                  <SubscribeButtonComponent>
-                    {showTrialCtas
-                      ? PRICING_DATA.annual.trialCta
-                      : 'Subscribe Annual'}
-                  </SubscribeButtonComponent>
-                  {showTrialCtas ? (
-                    <p className="mt-3 text-center text-sm text-muted-foreground">
-                      {PRICING_DATA.annual.postTrialNote}
-                    </p>
-                  ) : null}
-                </form>
+                {isAuthenticated ? (
+                  <form
+                    action={subscribeAnnualAction}
+                    aria-label="Subscribe annual plan"
+                  >
+                    <IdempotencyKeyField />
+                    <SubscribeButtonComponent>
+                      {showTrialCtas
+                        ? PRICING_DATA.annual.trialCta
+                        : 'Subscribe Annual'}
+                    </SubscribeButtonComponent>
+                    {showTrialCtas ? (
+                      <p className="mt-3 text-center text-sm text-muted-foreground">
+                        {PRICING_DATA.annual.postTrialNote}
+                      </p>
+                    ) : null}
+                  </form>
+                ) : (
+                  <>
+                    <Button
+                      asChild
+                      className="mt-8 h-auto w-full rounded-full py-3 text-base"
+                    >
+                      <Link href={getPlanSignUpHref('annual')}>
+                        {showTrialCtas
+                          ? PRICING_DATA.annual.trialCta
+                          : 'Subscribe Annual'}
+                      </Link>
+                    </Button>
+                    {showTrialCtas ? (
+                      <p className="mt-3 text-center text-sm text-muted-foreground">
+                        {PRICING_DATA.annual.postTrialNote}
+                      </p>
+                    ) : null}
+                  </>
+                )}
               </Card>
             </div>
           </section>

--- a/app/pricing/pricing-view.tsx
+++ b/app/pricing/pricing-view.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import type { ComponentType, ReactNode } from 'react';
+import { AuthAwareCta, SubscribePlanCta } from '@/app/pricing/pricing-auth-cta';
 import type { PricingBanner } from '@/app/pricing/types';
-import { IdempotencyKeyField } from '@/components/idempotency-key-field';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { PRICING_DATA } from '@/lib/pricing-data';
@@ -80,30 +80,18 @@ export function PricingView({
             <span>{banner.message}</span>
             <div className="ml-4 flex items-center gap-3">
               {manageBillingAction ? (
-                isAuthenticated ? (
-                  <form action={manageBillingAction}>
-                    <IdempotencyKeyField />
-                    <Button
-                      type="submit"
-                      variant="outline"
-                      size="sm"
-                      className="rounded-full"
-                    >
-                      Manage Billing
-                    </Button>
-                  </form>
-                ) : (
-                  <Button
-                    asChild
-                    variant="outline"
-                    size="sm"
-                    className="rounded-full"
-                  >
-                    <Link href={getManageBillingSignUpHref()}>
-                      Manage Billing
-                    </Link>
-                  </Button>
-                )
+                <AuthAwareCta
+                  isAuthenticated={isAuthenticated}
+                  formAction={manageBillingAction}
+                  signUpHref={getManageBillingSignUpHref()}
+                  buttonProps={{
+                    variant: 'outline',
+                    size: 'sm',
+                    className: 'rounded-full',
+                  }}
+                >
+                  Manage Billing
+                </AuthAwareCta>
               ) : null}
               <Link
                 href={ROUTES.PRICING}
@@ -142,20 +130,14 @@ export function PricingView({
               Manage billing in Stripe to restore access.
             </p>
             <div className="mt-6">
-              {isAuthenticated ? (
-                <form action={manageBillingAction}>
-                  <IdempotencyKeyField />
-                  <Button type="submit" className="rounded-full">
-                    Manage Billing
-                  </Button>
-                </form>
-              ) : (
-                <Button asChild className="rounded-full">
-                  <Link href={getManageBillingSignUpHref()}>
-                    Manage Billing
-                  </Link>
-                </Button>
-              )}
+              <AuthAwareCta
+                isAuthenticated={isAuthenticated}
+                formAction={manageBillingAction}
+                signUpHref={getManageBillingSignUpHref()}
+                buttonProps={{ className: 'rounded-full' }}
+              >
+                Manage Billing
+              </AuthAwareCta>
             </div>
           </Card>
         ) : (
@@ -192,42 +174,21 @@ export function PricingView({
                     <li key={feature}>{feature}</li>
                   ))}
                 </ul>
-                {isAuthenticated ? (
-                  <form
-                    action={subscribeMonthlyAction}
-                    aria-label="Subscribe monthly plan"
-                  >
-                    <IdempotencyKeyField />
-                    <SubscribeButtonComponent>
-                      {showTrialCtas
-                        ? PRICING_DATA.monthly.trialCta
-                        : 'Subscribe Monthly'}
-                    </SubscribeButtonComponent>
-                    {showTrialCtas ? (
-                      <p className="mt-3 text-center text-sm text-muted-foreground">
-                        {PRICING_DATA.monthly.postTrialNote}
-                      </p>
-                    ) : null}
-                  </form>
-                ) : (
-                  <>
-                    <Button
-                      asChild
-                      className="mt-8 h-auto w-full rounded-full py-3 text-base"
-                    >
-                      <Link href={getPlanSignUpHref('monthly')}>
-                        {showTrialCtas
-                          ? PRICING_DATA.monthly.trialCta
-                          : 'Subscribe Monthly'}
-                      </Link>
-                    </Button>
-                    {showTrialCtas ? (
-                      <p className="mt-3 text-center text-sm text-muted-foreground">
-                        {PRICING_DATA.monthly.postTrialNote}
-                      </p>
-                    ) : null}
-                  </>
-                )}
+                <SubscribePlanCta
+                  isAuthenticated={isAuthenticated}
+                  formAction={subscribeMonthlyAction}
+                  signUpHref={getPlanSignUpHref('monthly')}
+                  formAriaLabel="Subscribe monthly plan"
+                  label={
+                    showTrialCtas
+                      ? PRICING_DATA.monthly.trialCta
+                      : 'Subscribe Monthly'
+                  }
+                  postTrialNote={
+                    showTrialCtas ? PRICING_DATA.monthly.postTrialNote : null
+                  }
+                  SubscribeButtonComponent={SubscribeButtonComponent}
+                />
               </Card>
               <Card
                 aria-current={isAnnualSelected ? 'true' : undefined}
@@ -255,42 +216,21 @@ export function PricingView({
                     <li key={feature}>{feature}</li>
                   ))}
                 </ul>
-                {isAuthenticated ? (
-                  <form
-                    action={subscribeAnnualAction}
-                    aria-label="Subscribe annual plan"
-                  >
-                    <IdempotencyKeyField />
-                    <SubscribeButtonComponent>
-                      {showTrialCtas
-                        ? PRICING_DATA.annual.trialCta
-                        : 'Subscribe Annual'}
-                    </SubscribeButtonComponent>
-                    {showTrialCtas ? (
-                      <p className="mt-3 text-center text-sm text-muted-foreground">
-                        {PRICING_DATA.annual.postTrialNote}
-                      </p>
-                    ) : null}
-                  </form>
-                ) : (
-                  <>
-                    <Button
-                      asChild
-                      className="mt-8 h-auto w-full rounded-full py-3 text-base"
-                    >
-                      <Link href={getPlanSignUpHref('annual')}>
-                        {showTrialCtas
-                          ? PRICING_DATA.annual.trialCta
-                          : 'Subscribe Annual'}
-                      </Link>
-                    </Button>
-                    {showTrialCtas ? (
-                      <p className="mt-3 text-center text-sm text-muted-foreground">
-                        {PRICING_DATA.annual.postTrialNote}
-                      </p>
-                    ) : null}
-                  </>
-                )}
+                <SubscribePlanCta
+                  isAuthenticated={isAuthenticated}
+                  formAction={subscribeAnnualAction}
+                  signUpHref={getPlanSignUpHref('annual')}
+                  formAriaLabel="Subscribe annual plan"
+                  label={
+                    showTrialCtas
+                      ? PRICING_DATA.annual.trialCta
+                      : 'Subscribe Annual'
+                  }
+                  postTrialNote={
+                    showTrialCtas ? PRICING_DATA.annual.postTrialNote : null
+                  }
+                  SubscribeButtonComponent={SubscribeButtonComponent}
+                />
               </Card>
             </div>
           </section>

--- a/app/pricing/subscribe-action.ts
+++ b/app/pricing/subscribe-action.ts
@@ -1,4 +1,4 @@
-import { ROUTES } from '@/lib/routes';
+import { toPricingRoute, toSignUpRedirectRoute } from '@/lib/routes';
 import type { ActionResult } from '@/src/adapters/controllers/action-result';
 
 type RedirectFn = (url: string) => never;
@@ -31,15 +31,17 @@ export async function runSubscribeAction(
   if (result.ok) return deps.redirectFn(result.data.url);
 
   if (result.error.code === 'UNAUTHENTICATED') {
-    return deps.redirectFn(ROUTES.SIGN_UP);
+    return deps.redirectFn(
+      toSignUpRedirectRoute(toPricingRoute({ plan: input.plan })),
+    );
   }
 
   if (result.error.code === 'ALREADY_SUBSCRIBED') {
-    return deps.redirectFn(`${ROUTES.PRICING}?reason=manage_billing`);
+    return deps.redirectFn(toPricingRoute({ reason: 'manage_billing' }));
   }
 
   if (result.error.code === 'RATE_LIMITED') {
-    return deps.redirectFn(`${ROUTES.PRICING}?checkout=rate_limited`);
+    return deps.redirectFn(toPricingRoute({ checkout: 'rate_limited' }));
   }
 
   deps.logError?.(
@@ -52,9 +54,7 @@ export async function runSubscribeAction(
     'Stripe checkout failed',
   );
 
-  const url = new URL(ROUTES.PRICING, 'https://example.com');
-  url.searchParams.set('checkout', 'error');
-  url.searchParams.set('plan', input.plan);
-
-  return deps.redirectFn(`${url.pathname}${url.search}`);
+  return deps.redirectFn(
+    toPricingRoute({ checkout: 'error', plan: input.plan }),
+  );
 }

--- a/app/pricing/subscribe-actions.test.ts
+++ b/app/pricing/subscribe-actions.test.ts
@@ -4,6 +4,12 @@ import {
   subscribeAnnualAction,
   subscribeMonthlyAction,
 } from '@/app/pricing/subscribe-actions';
+import {
+  AUTH_REDIRECT_QUERY_PARAM,
+  ROUTES,
+  toPricingRoute,
+  toSignUpRedirectRoute,
+} from '@/lib/routes';
 import { err, ok } from '@/src/adapters/controllers/action-result';
 
 function createRedirectFn() {
@@ -57,7 +63,7 @@ describe('app/pricing/subscribe-actions', () => {
     });
   });
 
-  it('redirects to sign-up when checkout session returns UNAUTHENTICATED', async () => {
+  it('preserves the selected plan and return destination when redirecting an unauthenticated checkout attempt', async () => {
     const createCheckoutSessionFn = vi.fn(async () =>
       err('UNAUTHENTICATED', 'Not signed in'),
     );
@@ -70,9 +76,18 @@ describe('app/pricing/subscribe-actions', () => {
         redirectFn,
       }),
     ).rejects.toMatchObject({
-      message: 'redirect:/sign-up',
+      message: `redirect:${toSignUpRedirectRoute(
+        toPricingRoute({ plan: 'monthly' }),
+      )}`,
     });
 
+    const redirectUrl = redirectFn.mock.calls[0]?.[0];
+    if (!redirectUrl) throw new Error('Expected redirect url');
+    const url = new URL(redirectUrl, 'https://example.com');
+    expect(url.pathname).toBe(ROUTES.SIGN_UP);
+    expect(url.searchParams.get(AUTH_REDIRECT_QUERY_PARAM)).toBe(
+      toPricingRoute({ plan: 'monthly' }),
+    );
     expect(createCheckoutSessionFn).toHaveBeenCalledWith({
       plan: 'monthly',
       idempotencyKey: undefined,

--- a/docs/bugs/bug-273-not-found-missing-page-metadata.md
+++ b/docs/bugs/bug-273-not-found-missing-page-metadata.md
@@ -10,7 +10,7 @@
 
 ## Summary
 
-Every route in the app exports a distinct `metadata` object except `app/not-found.tsx`, which has none. A 404 therefore renders with the root layout's generic title ("Addiction Boards Question Bank") instead of a distinct, accurate title.
+Before the fix on this branch, every route in the app exported a distinct `metadata` object except `app/not-found.tsx`, which had none. A 404 therefore rendered with the root layout's generic title ("Addiction Boards Question Bank") instead of a distinct, accurate title. This branch adds the missing export; the bug remains **Open** until merge and deploy proof are recorded.
 
 ## Reachability
 
@@ -23,20 +23,22 @@ Reachable on every 404 — a typo'd URL, a stale bookmark, or a link to removed 
 
 Expected: a distinct title indicating the page was not found, consistent with how every other page titles itself.
 
-Actual: the tab shows the generic site title inherited from the root layout, with no indication this is a 404 until the page body is read.
+Pre-fix actual: the tab showed the generic site title inherited from the root layout, with no indication this was a 404 until the page body was read.
 
 ## Root Cause
 
-- [`app/not-found.tsx`](../../app/not-found.tsx) has no `export const metadata`. It is a plain Server Component (no `'use client'` directive), so nothing prevents adding one — unlike `app/error.tsx`/`app/global-error.tsx`, which both open with `'use client';` as their first line and therefore genuinely cannot export Next.js `metadata` (and `global-error.tsx` correctly compensates by hand-rendering its own `<title>` in its required full HTML document shell, per the already-shipped FE-039/DEBT-179 fix).
-- All 13 other `page.tsx` files in `app/` export `metadata` — `not-found.tsx` is the sole exception — and every one of them follows the identical convention `'<Page Title> - Addiction Boards'` (e.g. `'Home - Addiction Boards'`, `'Pricing - Addiction Boards'`, `'Dashboard - Addiction Boards'`, `'Practice - Addiction Boards'`, `'Question - Addiction Boards'`). There is no `title: { template }` on the root layout, so this suffix is applied manually per page, not automatically.
+- Pre-fix, [`app/not-found.tsx`](../../app/not-found.tsx) had no `export const metadata`. It is a plain Server Component (no `'use client'` directive), so nothing prevented adding one — unlike `app/error.tsx`/`app/global-error.tsx`, which both open with `'use client';` as their first line and therefore genuinely cannot export Next.js `metadata` (and `global-error.tsx` correctly compensates by hand-rendering its own `<title>` in its required full HTML document shell, per the already-shipped FE-039/DEBT-179 fix).
+- All 13 other `page.tsx` files in `app/` exported `metadata`, and every one of them follows the identical convention `'<Page Title> - Addiction Boards'` (e.g. `'Home - Addiction Boards'`, `'Pricing - Addiction Boards'`, `'Dashboard - Addiction Boards'`, `'Practice - Addiction Boards'`, `'Question - Addiction Boards'`). There is no `title: { template }` on the root layout, so this suffix is applied manually per page, not automatically.
 
 ## Impact
 
 Cosmetic / SEO-only. No functional impact — the page renders correctly and is fully usable; only the browser tab title and any SEO/social-preview metadata for a 404 response are generic instead of distinct. Graded P3 (not P4) per this repo's own rubric wording — "minor issue, cosmetic" — matching how every other UX/cosmetic finding in this same sweep (BUG-271, BUG-275, BUG-276) was graded, rather than P4 ("trivial, nice to have").
 
-## Proposed Fix
+## Proposed Fix / Resolution
 
-Add `export const metadata: Metadata = { title: 'Page Not Found - Addiction Boards' };` to `app/not-found.tsx`, matching the naming convention followed by all 13 other pages (a bare `'Page Not Found'` would be the only page in the app breaking that convention). No other page sets a `description`, so omitting one here is consistent. A `robots: { index: false }` addition is a defensible real-world 404 best practice, but Next's `not-found.tsx` already returns a true HTTP 404 status, so this is optional polish, not a functional gap.
+Implemented on this branch: [`app/not-found.tsx`](../../app/not-found.tsx#L1-L9) now exports `metadata: Metadata = { title: 'Page Not Found - Addiction Boards' }`, matching the naming convention followed by sibling page metadata such as `app/page.tsx`, `app/pricing/page.tsx`, and `app/(app)/app/dashboard/page.tsx`. No other page sets a `description`, so omitting one here is consistent. A `robots: { index: false }` addition remains optional polish, not a functional gap, because Next's `not-found.tsx` returns a true HTTP 404 status.
+
+Regression coverage: [`app/not-found.test.tsx`](../../app/not-found.test.tsx#L15-L20) pins the metadata export alongside the existing render/landmark checks. Status stays Open until this branch merges and deploy proof is recorded, then this bug can be archived.
 
 Rejected alternatives:
 - None considered — this is a single-line, low-risk addition with no meaningful alternative approach.
@@ -50,7 +52,7 @@ it('exports distinct metadata for the not-found page, matching the app-wide titl
 });
 ```
 
-Today this fails because `app/not-found.tsx` exports no `metadata`.
+This was the red-first failing test: before the implementation, `app/not-found.tsx` exported no `metadata`.
 
 ## Related
 

--- a/docs/bugs/bug-275-pricing-cta-drops-redirect-context-unauthenticated.md
+++ b/docs/bugs/bug-275-pricing-cta-drops-redirect-context-unauthenticated.md
@@ -10,7 +10,7 @@
 
 ## Summary
 
-The primary, always-visible conversion CTAs on `/pricing` ("Subscribe"/"Start free trial" for both monthly and annual plans) redirect an unauthenticated click to a bare `/sign-up` with no `redirect_url` and no plan context. After completing sign-up, Clerk's configured fallback sends the user to the dashboard, which immediately bounces them back to `/pricing?reason=subscription_required` because they still have no subscription — forcing them to reselect their plan and click Subscribe a second time. The generic checkout-error redirect path in the same file already preserves `?plan=...`, showing the team intended to carry this context but never wired it through the unauthenticated path specifically.
+Before the fix on this branch, the primary, always-visible conversion CTAs on `/pricing` ("Subscribe"/"Start free trial" for both monthly and annual plans) redirected an unauthenticated click to a bare `/sign-up` with no `redirect_url` and no plan context. After completing sign-up, Clerk's configured fallback sent the user to the dashboard, which immediately bounced them back to `/pricing?reason=subscription_required` because they still had no subscription — forcing them to reselect their plan and click Subscribe a second time. The generic checkout-error redirect path in the same file already preserved `?plan=...`, showing the team intended to carry this context but never wired it through the unauthenticated path specifically.
 
 The "Manage Billing" action has the identical bare-redirect defect, but that button is **not** part of the always-visible anonymous funnel (see Reachability) — it only appears under a narrower, query-string-gated condition.
 
@@ -26,16 +26,16 @@ A second, narrower variant affects "Manage Billing": that button is not shown on
 2. Click "Start free trial" (or "Subscribe") under either the monthly or annual plan.
 3. Complete Clerk sign-up.
 
-Expected: land back on a flow that remembers the plan just chosen and proceeds toward checkout (or at minimum returns to `/pricing` with the plan pre-selected), in one pass.
+Expected: land back on a flow that remembers the plan just chosen and proceeds toward checkout (or at minimum returns to `/pricing` with the plan intact), in one pass.
 
-Actual: `createCheckoutSession` throws `UNAUTHENTICATED` for the signed-out caller, and the action redirects to a bare `/sign-up` with no `redirect_url` and no plan parameter. Post-sign-up, Clerk's `signUpFallbackRedirectUrl` (since no `redirect_url` overrides it) sends the user to `/app/dashboard`; `enforceEntitledAppUser()` immediately redirects again to `/pricing?reason=subscription_required` because no subscription exists yet (confirmed via `CheckEntitlementUseCase`: a user with zero subscription rows resolves to exactly this reason). The user must reselect their plan and click Subscribe a second time — their original plan choice is not preserved anywhere across the round trip, and the round trip itself is a full extra page navigation through the dashboard, not merely "one extra click."
+Pre-fix actual: `createCheckoutSession` threw `UNAUTHENTICATED` for the signed-out caller, and the action redirected to a bare `/sign-up` with no `redirect_url` and no plan parameter. Post-sign-up, Clerk's `signUpFallbackRedirectUrl` (since no `redirect_url` overrode it) sent the user to `/app/dashboard`; `enforceEntitledAppUser()` immediately redirected again to `/pricing?reason=subscription_required` because no subscription existed yet (confirmed via `CheckEntitlementUseCase`: a user with zero subscription rows resolves to exactly this reason). The user had to reselect their plan and click Subscribe a second time — their original plan choice was not preserved anywhere across the round trip, and the round trip itself was a full extra page navigation through the dashboard, not merely "one extra click."
 
 ## Root Cause
 
-- [`app/pricing/subscribe-action.ts`](../../app/pricing/subscribe-action.ts#L33-L34): on `result.error.code === 'UNAUTHENTICATED'`, the action calls `deps.redirectFn(ROUTES.SIGN_UP)` — a bare route, no query string.
-- Contrast with the same file's generic-failure path, [`subscribe-action.ts#L55-L59`](../../app/pricing/subscribe-action.ts#L55-L59), which explicitly builds `?checkout=error&plan=${input.plan}` — proving the team already has the plan value in scope at the point of redirect and preserves it on one path but not the other.
-- This exact bare-redirect behavior is pinned by an existing test: [`subscribe-actions.test.ts#L60-L79`](../../app/pricing/subscribe-actions.test.ts#L60-L79) (`'redirects to sign-up when checkout session returns UNAUTHENTICATED'`) asserts `message: 'redirect:/sign-up'` with nothing appended — any fix must update this test's expectation deliberately, not accidentally.
-- The same bare-redirect pattern recurs for the sibling "Manage Billing" action, and is independently pinned in **four** places, all of which a fix must update: [`manage-billing-action.ts#L19`](../../app/pricing/manage-billing-action.ts#L19) (`unauthenticated: ROUTES.SIGN_UP`), [`manage-billing-actions.test.ts#L40`](../../app/pricing/manage-billing-actions.test.ts#L40) (`message: 'redirect:/sign-up'`), [`manage-billing-action.test.ts#L52`](../../app/pricing/manage-billing-action.test.ts#L52) (`url: '/sign-up'`), and [`manage-billing-core.test.ts#L88-L97`](../../lib/manage-billing/manage-billing-core.test.ts#L88-L97) (two assertions of `'/sign-up'`).
+- Pre-fix, [`app/pricing/subscribe-action.ts`](../../app/pricing/subscribe-action.ts) called `deps.redirectFn(ROUTES.SIGN_UP)` on `result.error.code === 'UNAUTHENTICATED'` — a bare route, no query string. This branch hardens that fallback at [`subscribe-action.ts#L33-L36`](../../app/pricing/subscribe-action.ts#L33-L36) with `toSignUpRedirectRoute(toPricingRoute({ plan: input.plan }))`.
+- The same file's generic-failure path already preserved `?plan=...`; this branch also routes that path through the same shared helper at [`subscribe-action.ts#L57-L59`](../../app/pricing/subscribe-action.ts#L57-L59), so pricing query names are no longer duplicated there.
+- The old bare-redirect behavior was pinned by an existing test in `subscribe-actions.test.ts`; this branch updates it to assert the explicit Clerk `redirect_url` and selected plan at [`subscribe-actions.test.ts#L66-L95`](../../app/pricing/subscribe-actions.test.ts#L66-L95).
+- The same bare-redirect pattern recurred for the sibling "Manage Billing" action. This branch updates [`app/pricing/manage-billing-action.ts#L17-L22`](../../app/pricing/manage-billing-action.ts#L17-L22), [`manage-billing-actions.test.ts#L29-L45`](../../app/pricing/manage-billing-actions.test.ts#L29-L45), and [`manage-billing-action.test.ts#L35-L54`](../../app/pricing/manage-billing-action.test.ts#L35-L54). The shared `lib/manage-billing/manage-billing-core.ts` remains route-agnostic by design; it still forwards whichever route-specific unauthenticated redirect its caller supplies.
 - The `redirect_url` mechanism itself is real and already relied upon elsewhere in this codebase: `proxy.ts`'s `auth.protect()` already redirects to `/sign-in?redirect_url=<returnBackUrl>` for protected-route deep links (regression-tested at [`proxy.test.ts#L315-L454`](../../proxy.test.ts#L315-L454)), and [`components/providers.tsx#L75`](../../components/providers.tsx#L75)'s `signUpFallbackRedirectUrl` is documented (in installed `@clerk/shared` type declarations) as a fallback used only "if there's no `redirect_url` in the path already" — confirming an explicit `redirect_url` on the initial `/sign-up` navigation would be honored, not overridden.
 - [`app/(app)/app/layout.tsx`](<../../app/(app)/app/layout.tsx#L32-L51>) (`enforceEntitledAppUser`) is what then bounces the freshly-signed-up, still-unsubscribed user from the dashboard back to `/pricing?reason=subscription_required` — correct behavior given no subscription exists, but it's what turns the missing redirect context into a visible double round-trip for the user.
 
@@ -45,11 +45,24 @@ This is unrelated to, and does not regress, the already-verified-correct deep-li
 
 Every anonymous visitor who converts through the primary "Subscribe"/"Start free trial" CTA experiences an avoidable extra full page round-trip (through `/app/dashboard` and back) and loses their plan selection, landing back on `/pricing` to choose and click again. This is friction on the primary monetization path, not a correctness or security defect — fully recoverable, so it is P3 rather than higher.
 
-## Proposed Fix
+## Proposed Fix / Resolution
 
-Carry the chosen plan (and a return-to-checkout intent) through the unauthenticated redirect, e.g. `deps.redirectFn(`${ROUTES.SIGN_UP}?redirect_url=${encodeURIComponent(`${ROUTES.PRICING}?plan=${input.plan}`)}`)`, and have `/pricing` accept a `?plan=` param on load. Apply the same fix to `manage-billing-action.ts`'s unauthenticated branch, updating all four pinned tests listed above deliberately.
+Implemented on this branch:
 
-**Scope note:** `PricingView` currently has **no plan-selection UI to read `?plan=` back into** — both plan cards ([`pricing-view.tsx`](../../app/pricing/pricing-view.tsx)) are always rendered independently as separate `<form>`s, with no toggle, radio group, or shared "selected plan" concept to highlight. This fix therefore requires adding a new visual affordance (e.g., emphasizing the previously-chosen card) from scratch, not wiring up an existing selector.
+- [`lib/routes.ts#L17-L58`](../../lib/routes.ts#L17-L58) centralizes the Clerk `redirect_url` query name, pricing query names, `toPricingRoute()`, and `toSignUpRedirectRoute()`.
+- [`app/pricing/pricing-view.tsx#L15-L56`](../../app/pricing/pricing-view.tsx#L15-L56), [`#L82-L106`](../../app/pricing/pricing-view.tsx#L82-L106), [`#L144-L158`](../../app/pricing/pricing-view.tsx#L144-L158), and [`#L170-L285`](../../app/pricing/pricing-view.tsx#L170-L285) render anonymous pricing and manage-billing CTAs as `<Button asChild><Link>` sign-up links carrying the intended `/pricing?...` return destination, and mark a returned `?plan=` card with `aria-current="true"` plus visible `Selected plan` text. Signed-in users keep the existing server-action forms.
+- [`app/pricing/page.tsx#L38-L65`](../../app/pricing/page.tsx#L38-L65) now preserves `isAuthenticated` in pricing data, and [`app/pricing/page.tsx#L164-L229`](../../app/pricing/page.tsx#L164-L229) normalizes the `plan` query parameter into the shared pricing presentation so the view can distinguish anonymous sign-up links, authenticated checkout actions, and the returned selected plan.
+- [`app/pricing/subscribe-action.ts#L33-L36`](../../app/pricing/subscribe-action.ts#L33-L36) and [`app/pricing/manage-billing-action.ts#L17-L22`](../../app/pricing/manage-billing-action.ts#L17-L22) harden server-action unauthenticated fallbacks for session-expiry-between-render-and-submit cases.
+
+**Scope note:** `PricingView` still has no separate plan-selection control — both plan cards are always rendered independently. This fix preserves the selected plan in the post-auth return URL and marks the returned card; adding richer visual emphasis beyond the small selected-plan marker would be optional follow-up polish, not required to repair the lost-context bug.
+
+Regression coverage:
+
+- [`lib/routes.test.ts`](../../lib/routes.test.ts#L126-L145) pins the route/query helpers.
+- [`app/pricing/page.test.tsx`](../../app/pricing/page.test.tsx#L1117-L1231) pins anonymous plan and manage-billing links, signed-in checkout-form preservation, and returned-plan selection.
+- [`app/pricing/subscribe-actions.test.ts`](../../app/pricing/subscribe-actions.test.ts#L66-L95), [`app/pricing/manage-billing-actions.test.ts`](../../app/pricing/manage-billing-actions.test.ts#L29-L45), and [`app/pricing/manage-billing-action.test.ts`](../../app/pricing/manage-billing-action.test.ts#L35-L54) pin the server-action fallbacks.
+
+Status stays Open until this branch merges and deploy proof is recorded, then this bug can be archived.
 
 Rejected alternatives:
 - **Rely solely on Clerk's `signUpFallbackRedirectUrl`.** This is correctly fallback-only and must stay that way (BUG-055 precedent, verified: the archived doc explicitly states fallback-not-force preserves return-URL flows); the fix belongs in supplying an explicit `redirect_url` from the pricing action, not in changing the fallback.
@@ -72,7 +85,7 @@ it('preserves the selected plan and a return destination when redirecting an una
 });
 ```
 
-Today this fails because the redirect target is the literal string `redirect:/sign-up` with no query string.
+This was the red-first failing test: before the implementation, the redirect target was the literal string `redirect:/sign-up` with no query string.
 
 ## Related
 

--- a/lib/routes.test.ts
+++ b/lib/routes.test.ts
@@ -130,6 +130,12 @@ describe('lib/routes', () => {
     expect(toPricingRoute({ reason: 'manage_billing' })).toBe(
       '/pricing?reason=manage_billing',
     );
+    expect(toPricingRoute({ reason: 'payment_processing' })).toBe(
+      '/pricing?reason=payment_processing',
+    );
+    expect(toPricingRoute({ checkout: 'cancel' })).toBe(
+      '/pricing?checkout=cancel',
+    );
   });
 
   it('builds Clerk sign-up redirects with an explicit return destination', () => {

--- a/lib/routes.test.ts
+++ b/lib/routes.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { ROUTES, toPracticeSessionRoute, toQuestionRoute } from './routes';
+import {
+  AUTH_REDIRECT_QUERY_PARAM,
+  PRICING_QUERY_PARAMS,
+  ROUTES,
+  toPracticeSessionRoute,
+  toPricingRoute,
+  toQuestionRoute,
+  toSignUpRedirectRoute,
+} from './routes';
 
 describe('lib/routes', () => {
   it('builds question routes from a slash-free base constant', () => {
@@ -113,6 +121,24 @@ describe('lib/routes', () => {
 
   it('exports a history route constant', () => {
     expect(ROUTES.APP_HISTORY).toBe('/app/history');
+  });
+
+  it('builds pricing routes with shared query parameter names', () => {
+    expect(PRICING_QUERY_PARAMS.plan).toBe('plan');
+    expect(PRICING_QUERY_PARAMS.reason).toBe('reason');
+    expect(toPricingRoute({ plan: 'monthly' })).toBe('/pricing?plan=monthly');
+    expect(toPricingRoute({ reason: 'manage_billing' })).toBe(
+      '/pricing?reason=manage_billing',
+    );
+  });
+
+  it('builds Clerk sign-up redirects with an explicit return destination', () => {
+    const returnDestination = toPricingRoute({ plan: 'annual' });
+
+    expect(AUTH_REDIRECT_QUERY_PARAM).toBe('redirect_url');
+    expect(toSignUpRedirectRoute(returnDestination)).toBe(
+      '/sign-up?redirect_url=%2Fpricing%3Fplan%3Dannual',
+    );
   });
 
   it('builds practice session routes from the practice base path', () => {

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -14,6 +14,49 @@ export const ROUTES = {
   APP_QUESTIONS: '/app/questions',
 } as const;
 
+export const AUTH_REDIRECT_QUERY_PARAM = 'redirect_url';
+
+export const PRICING_QUERY_PARAMS = {
+  checkout: 'checkout',
+  plan: 'plan',
+  portal: 'portal',
+  reason: 'reason',
+} as const;
+
+export type PricingPlan = 'monthly' | 'annual';
+
+export type PricingRouteOptions = {
+  checkout?: string | undefined;
+  plan?: PricingPlan | undefined;
+  portal?: string | undefined;
+  reason?: string | undefined;
+};
+
+export function toPricingRoute(options: PricingRouteOptions = {}): string {
+  const params = new URLSearchParams();
+  if (options.checkout) {
+    params.set(PRICING_QUERY_PARAMS.checkout, options.checkout);
+  }
+  if (options.portal) {
+    params.set(PRICING_QUERY_PARAMS.portal, options.portal);
+  }
+  if (options.reason) {
+    params.set(PRICING_QUERY_PARAMS.reason, options.reason);
+  }
+  if (options.plan) {
+    params.set(PRICING_QUERY_PARAMS.plan, options.plan);
+  }
+
+  const qs = params.toString();
+  return qs ? `${ROUTES.PRICING}?${qs}` : ROUTES.PRICING;
+}
+
+export function toSignUpRedirectRoute(returnDestination: string): string {
+  const params = new URLSearchParams();
+  params.set(AUTH_REDIRECT_QUERY_PARAM, returnDestination);
+  return `${ROUTES.SIGN_UP}?${params.toString()}`;
+}
+
 export function toPracticeSessionRoute(sessionId: string): string {
   return `${ROUTES.APP_PRACTICE}/${sessionId}`;
 }

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -24,12 +24,23 @@ export const PRICING_QUERY_PARAMS = {
 } as const;
 
 export type PricingPlan = 'monthly' | 'annual';
+export type PricingCheckoutStatus = 'cancel' | 'error' | 'rate_limited';
+export type PricingPortalStatus = 'error';
+export type PricingRedirectReason =
+  | 'manage_billing'
+  | 'payment_processing'
+  | 'subscription_canceled'
+  | 'subscription_required';
+export type PricingBillingRecoveryReason = Extract<
+  PricingRedirectReason,
+  'manage_billing' | 'payment_processing'
+>;
 
 export type PricingRouteOptions = {
-  checkout?: string | undefined;
+  checkout?: PricingCheckoutStatus | undefined;
   plan?: PricingPlan | undefined;
-  portal?: string | undefined;
-  reason?: string | undefined;
+  portal?: PricingPortalStatus | undefined;
+  reason?: PricingRedirectReason | undefined;
 };
 
 export function toPricingRoute(options: PricingRouteOptions = {}): string {

--- a/tests/e2e/pricing-unauthenticated.spec.ts
+++ b/tests/e2e/pricing-unauthenticated.spec.ts
@@ -3,7 +3,7 @@ import {
   AUTH_REDIRECT_QUERY_PARAM,
   toPricingRoute,
   toSignUpRedirectRoute,
-} from '../../lib/routes';
+} from '@/lib/routes';
 
 test('unauthenticated pricing CTA links to sign-up with selected plan context', async ({
   page,

--- a/tests/e2e/pricing-unauthenticated.spec.ts
+++ b/tests/e2e/pricing-unauthenticated.spec.ts
@@ -1,17 +1,30 @@
 import { expect, test } from '@playwright/test';
+import {
+  AUTH_REDIRECT_QUERY_PARAM,
+  toPricingRoute,
+  toSignUpRedirectRoute,
+} from '../../lib/routes';
 
-test('unauthenticated user is redirected to sign-up when starting checkout', async ({
+test('unauthenticated pricing CTA links to sign-up with selected plan context', async ({
   page,
 }) => {
   await page.goto('/pricing');
   await expect(page.getByRole('heading', { name: 'Pricing' })).toBeVisible();
 
-  const startTrial = page.getByRole('button', {
+  const startTrial = page.getByRole('link', {
     name: 'Start 7-day free trial',
   });
+  const expectedHref = toSignUpRedirectRoute(
+    toPricingRoute({ plan: 'monthly' }),
+  );
   await expect(startTrial.first()).toBeVisible();
+  await expect(startTrial.first()).toHaveAttribute('href', expectedHref);
 
   await startTrial.first().click();
 
   await expect(page).toHaveURL(/\/sign-up/, { timeout: 15_000 });
+  const url = new URL(page.url());
+  expect(url.searchParams.get(AUTH_REDIRECT_QUERY_PARAM)).toBe(
+    toPricingRoute({ plan: 'monthly' }),
+  );
 });


### PR DESCRIPTION
## Summary
- add `app/not-found.tsx` metadata using the existing `'<Page Title> - Addiction Boards'` convention verified from `app/page.tsx`, `app/pricing/page.tsx`, and `app/(app)/app/dashboard/page.tsx`
- centralize pricing/auth redirect URL helpers in `lib/routes.ts`
- render anonymous pricing/manage-billing CTAs as Clerk sign-up links with `redirect_url` carrying `/pricing?...` plan/reason context, while preserving signed-in checkout/portal server-action forms
- mark a returned `?plan=` card with `aria-current="true"` and `Selected plan`
- update BUG-273 and BUG-275 docs with fix-implemented notes while leaving both Open pending deploy proof

## Red-first proof
- `app/not-found.test.tsx` failed before implementation because `metadata` was missing
- route/pricing action tests failed before implementation because shared redirect helpers did not exist and unauthenticated paths returned bare `/sign-up`
- pricing page test failed before implementation because anonymous CTAs were submit forms and returned `?plan=` did not mark a selected plan
- E2E initially failed after the behavior fix because the anonymous pricing CTA is now correctly a link instead of a submit button; updated the E2E to assert the link href and redirect context

## Verification
- `pnpm typecheck`
- `pnpm lint` (passes with existing long-file warnings)
- `pnpm test --run` (370 files, 3129 tests)
- `pnpm test:browser` (58 files, 331 tests)
- local DB bootstrap + `pnpm test:integration` (154 passed, 2 skipped)
- `pnpm build`
- `pnpm test:e2e` (36 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pricing pages now preserve the selected plan and return destination through sign-up and manage billing flows.
  * Authentication-aware CTAs now render sign-up links for anonymous visitors and keep checkout actions for signed-in users.
  * The 404 page now uses a page-specific browser title.

* **Bug Fixes**
  * Fixed unauthenticated pricing redirects to include the intended return destination and plan context.
  * Improved redirect behavior for checkout/billing recovery states so users land on the correct follow-up screens.

* **Documentation**
  * Updated bug reports with clarified before/after behavior and regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->