### PR TITLE
Assert literal pricing redirect URLs in the unauthenticated e2e

### DIFF
--- a/tests/e2e/pricing-unauthenticated.spec.ts
+++ b/tests/e2e/pricing-unauthenticated.spec.ts
@@ -1,9 +1,4 @@
 import { expect, test } from '@playwright/test';
-import {
-  AUTH_REDIRECT_QUERY_PARAM,
-  toPricingRoute,
-  toSignUpRedirectRoute,
-} from '@/lib/routes';
 
 test('unauthenticated pricing CTA links to sign-up with selected plan context', async ({
   page,
@@ -14,9 +9,9 @@ test('unauthenticated pricing CTA links to sign-up with selected plan context', 
   const startTrial = page.getByRole('link', {
     name: 'Start 7-day free trial',
   });
-  const expectedHref = toSignUpRedirectRoute(
-    toPricingRoute({ plan: 'monthly' }),
-  );
+  // Literal expectations on purpose: deriving them from the same route
+  // helpers production uses would let a helper regression pass silently.
+  const expectedHref = '/sign-up?redirect_url=%2Fpricing%3Fplan%3Dmonthly';
   await expect(startTrial.first()).toBeVisible();
   await expect(startTrial.first()).toHaveAttribute('href', expectedHref);
 
@@ -24,7 +19,5 @@ test('unauthenticated pricing CTA links to sign-up with selected plan context', 
 
   await expect(page).toHaveURL(/\/sign-up/, { timeout: 15_000 });
   const url = new URL(page.url());
-  expect(url.searchParams.get(AUTH_REDIRECT_QUERY_PARAM)).toBe(
-    toPricingRoute({ plan: 'monthly' }),
-  );
+  expect(url.searchParams.get('redirect_url')).toBe('/pricing?plan=monthly');
 });


### PR DESCRIPTION
## Problem

Pre-promotion wave review of PR #581's surface: the rewritten `pricing-unauthenticated` e2e derived its expected sign-up href from the same `toPricingRoute`/`toSignUpRedirectRoute` helpers production uses — a tautology. If a helper regressed (dropped the plan param, changed the redirect param name), production and the test would agree on the wrong value and the test would pass.

## Solution

Literal string expectations (`/sign-up?redirect_url=%2Fpricing%3Fplan%3Dmonthly`; `redirect_url=/pricing?plan=monthly` after navigation), with a comment stating why they are deliberately not helper-derived.

Also investigated and **deliberately not changed** from the same review: the claim that authenticated users ignoring the pricing `reason` query param creates a recovery-card gap. Refuted at the product level — the only production emitter of `reason=payment_processing` is the entitlement service itself, derived from the same subscription row the pricing page re-reads, so the server re-derives the recovery context end-to-end and URL-param authority would reintroduce the stale-bookmark confusion the existing `uses authenticated entitlement state over stale return reason params` test deliberately pins.

## Verification

Full gate: typecheck, lint, unit 3136/3136, browser 351/351, integration 154/2 skipped, build, E2E 36/36 (including this spec against the literals).

https://claude.ai/code/session_01AND8DhkyKL44snLEXW2wq1