### PR TITLE
Reconcile archived-doc status notes with resolved state

### DIFF
--- a/docs/_archive/bugs/bug-271-no-focus-management-on-session-summary-transition.md
+++ b/docs/_archive/bugs/bug-271-no-focus-management-on-session-summary-transition.md
@@ -15,7 +15,7 @@
 
 Manual Tutor-mode session end and automatic exam-timer expiry reach this view directly and immediately. Manual exam submission does **not** reach it directly: confirming the "Submit exam" dialog first transitions to `PostExamReviewView`, which already has its own deliberate focus management (shipped as DEBT-326) — the real originally-unmanaged transition for the exam path is a separate, later click on that view's plain "View Summary" button.
 
-**Fix note (2026-07-07):** Implemented in branch; status remains **Open** pending deploy proof. The current implementation focuses the summary heading on mount via the existing focus helper and does not refocus on ordinary re-renders of an already-mounted summary.
+**Fix note (2026-07-07, closed out 2026-07-08):** Resolved and archived 2026-07-08 — see the Resolution State header for the full fix/promotion/deploy proof chain. The current implementation focuses the summary heading on mount via the existing focus helper and does not refocus on ordinary re-renders of an already-mounted summary.
 
 ## Reachability
 

--- a/docs/_archive/bugs/bug-272-exam-timer-milestone-announcements-can-skip.md
+++ b/docs/_archive/bugs/bug-272-exam-timer-milestone-announcements-can-skip.md
@@ -13,7 +13,7 @@
 
 The exam timer announces "5 minutes remaining" / "1 minute remaining" / "30 seconds remaining" via a visually-hidden (`sr-only`), `aria-live="polite"` region — this is a screen-reader-only feature; sighted users have no equivalent announcement and are unaffected by this bug (see Impact). The original check was an exact-equality comparison against the current `remainingSeconds` value, with no tracking of whether a threshold was crossed since the last check. The timer recomputes `remainingSeconds` from `Date.now()` whenever the tab regains visibility/focus (in addition to its 1-second interval), so a screen-reader user who backgrounded the exam tab across one of these exact values never received that milestone's announcement — it was simply skipped, not deferred. The safety-critical final "time is up" announcement is structurally immune to this same gap (it is a floor/level condition via `Math.max(0, ...)`, not an exact-equality point condition, so it cannot be "jumped past"), so no exam can fail to warn at expiry; only the non-critical advance warnings could be lost.
 
-**Fix note (2026-07-07):** Implemented in branch; status remains **Open** pending deploy proof. The current implementation announces on threshold crossing in `use-exam-timer.ts` and keeps the existing `sr-only` live-region markup in `exam-timer.tsx`.
+**Fix note (2026-07-07, closed out 2026-07-08):** Resolved and archived 2026-07-08 — see the Resolution State header for the full fix/promotion/deploy proof chain. The current implementation announces on threshold crossing in `use-exam-timer.ts` and keeps the existing `sr-only` live-region markup in `exam-timer.tsx`.
 
 ## Reachability
 

--- a/docs/_archive/bugs/bug-273-not-found-missing-page-metadata.md
+++ b/docs/_archive/bugs/bug-273-not-found-missing-page-metadata.md
@@ -11,7 +11,7 @@
 
 ## Summary
 
-Before the fix on this branch, every route in the app exported a distinct `metadata` object except `app/not-found.tsx`, which had none. A 404 therefore rendered with the root layout's generic title ("Addiction Boards Question Bank") instead of a distinct, accurate title. This branch adds the missing export; the bug remains **Open** until merge and deploy proof are recorded.
+Before the fix on this branch, every route in the app exported a distinct `metadata` object except `app/not-found.tsx`, which had none. A 404 therefore rendered with the root layout's generic title ("Addiction Boards Question Bank") instead of a distinct, accurate title. This branch added the missing export; resolved and archived 2026-07-08 — see the Resolution State header for the full fix/promotion/deploy proof chain.
 
 ## Reachability
 
@@ -39,7 +39,7 @@ Cosmetic / SEO-only. No functional impact — the page renders correctly and is 
 
 Implemented on this branch: [`app/not-found.tsx`](../../../app/not-found.tsx#L1-L9) now exports `metadata: Metadata = { title: 'Page Not Found - Addiction Boards' }`, matching the naming convention followed by sibling page metadata such as `app/page.tsx`, `app/pricing/page.tsx`, and `app/(app)/app/dashboard/page.tsx`. No other page sets a `description`, so omitting one here is consistent. A `robots: { index: false }` addition remains optional polish, not a functional gap, because Next's `not-found.tsx` returns a true HTTP 404 status.
 
-Regression coverage: [`app/not-found.test.tsx`](../../../app/not-found.test.tsx#L15-L20) pins the metadata export alongside the existing render/landmark checks. Status stays Open until this branch merges and deploy proof is recorded, then this bug can be archived.
+Regression coverage: [`app/not-found.test.tsx`](../../../app/not-found.test.tsx#L15-L20) pins the metadata export alongside the existing render/landmark checks. Resolved and archived 2026-07-08 — see the Resolution State header for the full fix/promotion/deploy proof chain.
 
 Rejected alternatives:
 - None considered — this is a single-line, low-risk addition with no meaningful alternative approach.

--- a/docs/_archive/bugs/bug-275-pricing-cta-drops-redirect-context-unauthenticated.md
+++ b/docs/_archive/bugs/bug-275-pricing-cta-drops-redirect-context-unauthenticated.md
@@ -63,7 +63,7 @@ Regression coverage:
 - [`app/pricing/page.test.tsx`](../../../app/pricing/page.test.tsx#L1117-L1231) pins anonymous plan and manage-billing links, signed-in checkout-form preservation, and returned-plan selection.
 - [`app/pricing/subscribe-actions.test.ts`](../../../app/pricing/subscribe-actions.test.ts#L66-L95), [`app/pricing/manage-billing-actions.test.ts`](../../../app/pricing/manage-billing-actions.test.ts#L29-L45), and [`app/pricing/manage-billing-action.test.ts`](../../../app/pricing/manage-billing-action.test.ts#L35-L54) pin the server-action fallbacks.
 
-Status stays Open until this branch merges and deploy proof is recorded, then this bug can be archived.
+Resolved and archived 2026-07-08 — see the Resolution State header for the full fix/promotion/deploy proof chain.
 
 Rejected alternatives:
 - **Rely solely on Clerk's `signUpFallbackRedirectUrl`.** This is correctly fallback-only and must stay that way (BUG-055 precedent, verified: the archived doc explicitly states fallback-not-force preserves return-URL flows); the fix belongs in supplying an explicit `redirect_url` from the pricing action, not in changing the fallback.


### PR DESCRIPTION
CodeRabbit's review of promo #590 flagged one stale in-body 'stays Open pending deploy proof' note in an archived bug doc; sweeping the class found five instances across four of the newly archived docs, all contradicting their Resolved headers. All five now reference the Resolution State proof chain. Docs-only; typecheck+unit+lint green.

https://claude.ai/code/session_01AND8DhkyKL44snLEXW2wq1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several archived bug reports to show they are resolved and archived.
  * Clarified resolution notes with proof-chain references and archive dates.
  * Added an entry confirming the not-found page now includes page-specific metadata, with regression coverage noted in the archive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->