### PR TITLE
Promote BUG-276 quick practice count refresh

### DIFF
--- a/app/(app)/app/practice/hooks/use-practice-question-answer-flow.ts
+++ b/app/(app)/app/practice/hooks/use-practice-question-answer-flow.ts
@@ -23,6 +23,7 @@ export type UsePracticeQuestionAnswerFlowInput = {
     input: unknown,
   ) => Promise<ActionResult<NextQuestion | null>>;
   submitAnswerFn: (input: unknown) => Promise<ActionResult<SubmitAnswerOutput>>;
+  onQuestionAnswered?: (() => void) | undefined;
 };
 
 export type UsePracticeQuestionAnswerFlowOutput = {
@@ -158,6 +159,7 @@ export function usePracticeQuestionAnswerFlow(
             nowMs: Date.now,
             setLoadState,
             setSubmitResult,
+            onSuccess: input.onQuestionAnswered,
             createRequestSequenceId,
             isLatestRequest,
             isMounted,
@@ -174,6 +176,7 @@ export function usePracticeQuestionAnswerFlow(
     },
     [
       createRequestSequenceId,
+      input.onQuestionAnswered,
       input.submitAnswerFn,
       isLatestRequest,
       isMounted,

--- a/app/(app)/app/practice/hooks/use-practice-question-bookmarks.ts
+++ b/app/(app)/app/practice/hooks/use-practice-question-bookmarks.ts
@@ -14,6 +14,7 @@ import {
 export type UsePracticeQuestionBookmarksInput = {
   question: BookmarkableQuestion | null;
   isMounted: () => boolean;
+  onBookmarkToggled?: ((bookmarked: boolean) => void) | undefined;
 };
 
 export type UsePracticeQuestionBookmarksOutput = {
@@ -98,6 +99,7 @@ export function usePracticeQuestionBookmarks(
           setBookmarkMessage,
           isMounted: input.isMounted,
         });
+        input.onBookmarkToggled?.(bookmarked);
       },
       onBookmarkError: (message: string) => {
         setBookmarkMessage(message);
@@ -116,7 +118,7 @@ export function usePracticeQuestionBookmarks(
       },
       isMounted: input.isMounted,
     });
-  }, [input.question, input.isMounted, isBookmarked]);
+  }, [input.question, input.isMounted, input.onBookmarkToggled, isBookmarked]);
 
   const onRetryBookmarks = useCallback(() => {
     setBookmarkRetryCount((prev) => prev + 1);

--- a/app/(app)/app/practice/hooks/use-practice-question-flow.ts
+++ b/app/(app)/app/practice/hooks/use-practice-question-flow.ts
@@ -18,6 +18,7 @@ import type { SubmitAnswerOutput } from '@/src/application/use-cases/submit-answ
 
 export type UsePracticeQuestionFlowInput = {
   filters: PracticeFilters;
+  onQuestionProgressChanged?: (() => void) | undefined;
 };
 
 export type UsePracticeQuestionFlowOutput = {
@@ -56,11 +57,13 @@ export function usePracticeQuestionFlow(
     isMounted,
     getNextQuestionFn: getNextQuestion,
     submitAnswerFn: submitAnswer,
+    onQuestionAnswered: input.onQuestionProgressChanged,
   });
 
   const bookmarks = usePracticeQuestionBookmarks({
     question: answerFlow.question,
     isMounted,
+    onBookmarkToggled: input.onQuestionProgressChanged,
   });
   const questionFeedback = usePracticeQuestionFeedback({
     question: answerFlow.question

--- a/app/(app)/app/practice/hooks/use-quick-practice-status-counts.ts
+++ b/app/(app)/app/practice/hooks/use-quick-practice-status-counts.ts
@@ -124,7 +124,9 @@ export function createQuickPracticeStatusCountsEffect(input: {
 
 export function useQuickPracticeStatusCounts(input: {
   filters: PracticeFilters;
+  refreshSignal?: number | undefined;
 }): QuickPracticeStatusCounts {
+  const refreshSignal = input.refreshSignal ?? 0;
   const [counts, setCounts] = useState<QuickPracticeStatusCounts>(() =>
     createEmptyQuickPracticeStatusCounts(),
   );
@@ -138,6 +140,8 @@ export function useQuickPracticeStatusCounts(input: {
   );
 
   useEffect(() => {
+    // Read solely to invalidate the effect after local answer/bookmark commits.
+    void refreshSignal;
     return createQuickPracticeStatusCountsEffect({
       countAvailableQuestionsFn: countAvailableQuestions,
       filters: serverFilters,
@@ -149,7 +153,7 @@ export function useQuickPracticeStatusCounts(input: {
         });
       },
     });
-  }, [serverFilters]);
+  }, [serverFilters, refreshSignal]);
 
   return counts;
 }

--- a/app/(app)/app/practice/practice-page-logic.ts
+++ b/app/(app)/app/practice/practice-page-logic.ts
@@ -119,6 +119,7 @@ export async function submitAnswerForQuestion(input: {
   nowMs: () => number;
   setLoadState: (state: LoadState) => void;
   setSubmitResult: (result: SubmitAnswerOutput | null) => void;
+  onSuccess?: ((result: SubmitAnswerOutput) => void) | undefined;
   createRequestSequenceId?: (() => number) | undefined;
   isLatestRequest?: ((requestId: number) => boolean) | undefined;
   isMounted?: (() => boolean) | undefined;
@@ -143,6 +144,7 @@ export async function submitAnswerForQuestion(input: {
     nowMs: input.nowMs,
     setLoadState: input.setLoadState,
     setSubmitResult: input.setSubmitResult,
+    onSuccess: input.onSuccess,
     createRequestSequenceId: input.createRequestSequenceId,
     isLatestRequest: input.isLatestRequest,
     isMounted: input.isMounted,

--- a/app/(app)/app/practice/quick/quick-practice-client-status-counts.browser.spec.tsx
+++ b/app/(app)/app/practice/quick/quick-practice-client-status-counts.browser.spec.tsx
@@ -1,0 +1,171 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import * as bookmarkController from '@/src/adapters/controllers/bookmark-controller';
+import * as practiceController from '@/src/adapters/controllers/practice-controller';
+import * as questionController from '@/src/adapters/controllers/question-controller';
+import { createNextQuestion } from '@/src/application/test-helpers/create-next-question';
+import {
+  isValidQuestionProgressStatus,
+  type QuestionProgressStatus,
+} from '@/src/domain/value-objects';
+import { ok } from '@/tests/test-helpers/ok';
+import QuickPracticeClient from './quick-practice-client';
+
+const { pushMock, useSearchParamsMock } = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+  useSearchParamsMock: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => useSearchParamsMock(),
+}));
+
+vi.mock('@/src/adapters/controllers/bookmark-controller', { spy: true });
+vi.mock('@/src/adapters/controllers/practice-controller', { spy: true });
+vi.mock('@/src/adapters/controllers/question-controller', { spy: true });
+
+const countAvailableQuestions = vi.mocked(
+  practiceController.countAvailableQuestions,
+);
+const getBookmarks = vi.mocked(bookmarkController.getBookmarks);
+const setBookmark = vi.mocked(bookmarkController.setBookmark);
+const getNextQuestion = vi.mocked(questionController.getNextQuestion);
+const submitAnswer = vi.mocked(questionController.submitAnswer);
+
+const fixtureQuestionId = crypto.randomUUID();
+const fixtureChoiceAId = crypto.randomUUID();
+const fixtureChoiceBId = crypto.randomUUID();
+
+function getRequestedStatus(input: unknown): QuestionProgressStatus {
+  const statuses =
+    typeof input === 'object' && input !== null && 'statuses' in input
+      ? (input as { statuses?: readonly unknown[] }).statuses
+      : undefined;
+  const status = statuses?.[0];
+  if (typeof status !== 'string' || !isValidQuestionProgressStatus(status)) {
+    throw new Error('Quick practice count request omitted a valid status');
+  }
+  return status;
+}
+
+function setupQuestion() {
+  getNextQuestion.mockResolvedValue(
+    ok(
+      createNextQuestion({
+        questionId: fixtureQuestionId,
+        choices: [
+          {
+            id: fixtureChoiceAId,
+            label: 'A',
+            textMd: 'Choice Alpha',
+            sortOrder: 1,
+          },
+          {
+            id: fixtureChoiceBId,
+            label: 'B',
+            textMd: 'Choice Bravo',
+            sortOrder: 2,
+          },
+        ],
+      }),
+    ),
+  );
+}
+
+function setupStatusCounts(
+  getCounts: () => {
+    unanswered: number;
+    incorrect: number;
+    bookmarked: number;
+  },
+) {
+  countAvailableQuestions.mockImplementation(async (input) => {
+    const status = getRequestedStatus(input);
+    const counts = getCounts();
+    return ok({ count: counts[status] });
+  });
+}
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+test('refreshes quick-practice status badges after an answer is committed', async () => {
+  let unansweredCount = 12;
+  setupQuestion();
+  setupStatusCounts(() => ({
+    unanswered: unansweredCount,
+    incorrect: 3,
+    bookmarked: 2,
+  }));
+  useSearchParamsMock.mockReturnValue(new URLSearchParams(''));
+  getBookmarks.mockResolvedValue(ok({ rows: [] }));
+  submitAnswer.mockImplementation(async () => {
+    unansweredCount = 11;
+    return ok({
+      attemptId: crypto.randomUUID(),
+      isCorrect: true,
+      correctChoiceId: fixtureChoiceBId,
+      explanationMd: null,
+      referenceMd: null,
+      choiceExplanations: [],
+    });
+  });
+
+  const screen = await render(<QuickPracticeClient />);
+
+  await expect
+    .element(screen.getByRole('button', { name: /^Unanswered \(12\)$/ }))
+    .toBeVisible();
+  const choiceA = screen.getByRole('radio', { name: 'Choice Alpha' });
+  choiceA.element().focus();
+  await userEvent.keyboard('{ArrowDown}');
+  await screen.getByRole('button', { name: 'Submit' }).click();
+
+  await expect
+    .element(screen.getByRole('button', { name: /^Unanswered \(11\)$/ }))
+    .toBeVisible();
+});
+
+test('refreshes quick-practice status badges after a bookmark is toggled', async () => {
+  let bookmarkedCount = 0;
+  setupQuestion();
+  setupStatusCounts(() => ({
+    unanswered: 12,
+    incorrect: 3,
+    bookmarked: bookmarkedCount,
+  }));
+  useSearchParamsMock.mockReturnValue(new URLSearchParams(''));
+  getBookmarks.mockResolvedValue(ok({ rows: [] }));
+  submitAnswer.mockResolvedValue(
+    ok({
+      attemptId: crypto.randomUUID(),
+      isCorrect: true,
+      correctChoiceId: fixtureChoiceBId,
+      explanationMd: null,
+      referenceMd: null,
+      choiceExplanations: [],
+    }),
+  );
+  setBookmark.mockImplementation(async () => {
+    bookmarkedCount = 1;
+    return ok({ bookmarked: true });
+  });
+
+  const screen = await render(<QuickPracticeClient />);
+
+  await expect
+    .element(screen.getByRole('button', { name: /^Bookmarked \(0\)$/ }))
+    .toBeVisible();
+  const choiceA = screen.getByRole('radio', { name: 'Choice Alpha' });
+  choiceA.element().focus();
+  await userEvent.keyboard('{ArrowDown}');
+  await screen.getByRole('button', { name: 'Submit' }).click();
+  await screen.getByRole('button', { name: /^Bookmark$/ }).click();
+
+  await expect
+    .element(screen.getByRole('button', { name: /^Bookmarked \(1\)$/ }))
+    .toBeVisible();
+});

--- a/app/(app)/app/practice/quick/quick-practice-client.tsx
+++ b/app/(app)/app/practice/quick/quick-practice-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { PracticeView } from '@/app/(app)/app/practice/components';
 import {
   fireAndForget,
@@ -52,6 +52,7 @@ export default function QuickPracticeClient() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const status = useMemo(() => parseStatusParam(searchParams), [searchParams]);
+  const [statusCountsRefreshSignal, setStatusCountsRefreshSignal] = useState(0);
 
   const filters: PracticeFilters = useMemo(
     () => ({
@@ -62,11 +63,17 @@ export default function QuickPracticeClient() {
     [status],
   );
 
+  const refreshStatusCounts = useCallback(() => {
+    setStatusCountsRefreshSignal((prev) => prev + 1);
+  }, []);
+
   const questionFlow = usePracticeQuestionFlow({
     filters,
+    onQuestionProgressChanged: refreshStatusCounts,
   });
   const counts = useQuickPracticeStatusCounts({
     filters,
+    refreshSignal: statusCountsRefreshSignal,
   });
 
   return (

--- a/docs/bugs/bug-276-quick-practice-status-counts-go-stale.md
+++ b/docs/bugs/bug-276-quick-practice-status-counts-go-stale.md
@@ -4,6 +4,7 @@
 **Severity:** P3
 **Date:** 2026-06-30
 **Confirmed:** 2026-06-30
+**Re-verified:** 2026-07-08 against `origin/dev`; fix implemented on `fix/bug-276-quick-practice-counts`, deploy proof pending
 **Component:** Practice / Quick Practice / UI State
 
 ---
@@ -28,8 +29,8 @@ Actual: the badges keep showing the stale numbers captured at initial mount. Onl
 
 ## Root Cause
 
-- [`use-quick-practice-status-counts.ts`](<../../app/(app)/app/practice/hooks/use-quick-practice-status-counts.ts#L132-L138>): `serverFilters` is a `useMemo` derived only from `input.filters.tagSlugs` and `input.filters.difficulty`.
-- [`use-quick-practice-status-counts.ts`](<../../app/(app)/app/practice/hooks/use-quick-practice-status-counts.ts#L140-L152>): the `useEffect` that fetches counts depends only on `[serverFilters]` — nothing in this hook's dependency array changes as a result of answering or bookmarking, so the effect never re-runs mid-visit.
+- Pre-fix, [`use-quick-practice-status-counts.ts`](<../../app/(app)/app/practice/hooks/use-quick-practice-status-counts.ts#L134-L156>) derived `serverFilters` only from `input.filters.tagSlugs` and `input.filters.difficulty`, and its fetch effect depended only on those filters.
+- Pre-fix, [`quick-practice-client.tsx`](<../../app/(app)/app/practice/quick/quick-practice-client.tsx#L65-L70>) wired `usePracticeQuestionFlow({ filters })` and `useQuickPracticeStatusCounts({ filters })` independently; no answer/bookmark completion signal crossed from the question-flow hook into the count hook.
 - There are exactly three status categories, not five: [`question-progress-status.ts`](../../src/domain/value-objects/question-progress-status.ts#L1) defines `AllQuestionProgressStatuses = ['unanswered', 'incorrect', 'bookmarked'] as const`, independently confirmed by the existing test `use-quick-practice-status-counts.test.ts#L42` (`toHaveBeenCalledTimes(3)`).
 
 ## Impact
@@ -45,6 +46,16 @@ Re-run (or otherwise invalidate) the status-count fetch whenever a question in t
 Rejected alternatives:
 - **Poll on an interval.** Adds unnecessary load and latency for a UI element that only needs to change in response to the user's own actions, not external state — though see the cost note above, since a naive per-commit refetch has its own, different cost profile worth designing around.
 - **Derive counts purely client-side from in-memory session state.** The counts must reflect the user's full historical status across all matching questions (not just ones touched this visit), which requires a server query; the fix should trigger that existing query more often, not replace it.
+
+## Resolution State
+
+Implemented on `fix/bug-276-quick-practice-counts`, pending merge and production proof:
+
+- [`quick-practice-client.tsx`](<../../app/(app)/app/practice/quick/quick-practice-client.tsx#L55-L77>) owns a `statusCountsRefreshSignal`, passes its incrementer into `usePracticeQuestionFlow`, and passes the signal into `useQuickPracticeStatusCounts`.
+- [`use-practice-question-flow.ts`](<../../app/(app)/app/practice/hooks/use-practice-question-flow.ts#L55-L67>) forwards that callback to both successful answer commits and successful bookmark toggles.
+- [`use-practice-question-answer-flow.ts`](<../../app/(app)/app/practice/hooks/use-practice-question-answer-flow.ts#L153-L163>) invokes the callback via the existing submit `onSuccess` seam only after `submitAnswer` succeeds.
+- [`use-practice-question-bookmarks.ts`](<../../app/(app)/app/practice/hooks/use-practice-question-bookmarks.ts#L92-L102>) invokes the callback only from `onBookmarkToggled`, the post-success bookmark path.
+- [`use-quick-practice-status-counts.ts`](<../../app/(app)/app/practice/hooks/use-quick-practice-status-counts.ts#L125-L156>) treats the signal as an invalidation-only effect dependency; the existing three-status server count query remains the source of truth.
 
 ## Failing Test Sketch
 

--- a/docs/bugs/bug-281-seed-reimport-rewrites-answer-key-under-graded-history.md
+++ b/docs/bugs/bug-281-seed-reimport-rewrites-answer-key-under-graded-history.md
@@ -4,6 +4,7 @@
 **Severity:** P3
 **Date:** 2026-07-05
 **Confirmed:** 2026-07-05
+**Re-verified:** 2026-07-08 against `origin/dev`; still decision-gated, no code fix implemented
 **Component:** Content Pipeline / Seed / Review Integrity
 
 ---
@@ -50,6 +51,16 @@ Decide the policy first; the code follows. Options, roughly in order of engineer
 3. **Block-and-fork:** refuse in-place key flips on questions with graded history (mirror the delete guard); require publishing a new question version. Strongest integrity, largest content-workflow change.
 
 Whichever is chosen, the import should at minimum **detect and log** key flips on referenced choices (count + question slugs) so the occurrence stops being silent.
+
+## Decision Required
+
+The owner needs to choose one product/data-integrity policy before implementation:
+
+1. **DISCLOSE.** Add an answer-key/content-change marker to the choice/question data model, then render a completed-review banner when a stored grade predates the key-changing import. Implementation touches the seed syncer, schema/migration, completed-session/post-exam review read models, and review UI copy. Data posture: preserves historical scores exactly as awarded, but makes the mismatch explicit to the user.
+2. **REGRADE.** During a key-changing import, recompute `attempts.is_correct` and `practice_session_question_states.latest_is_correct` for affected rows in the same transaction, with audited row counts and a durable import log. Implementation touches the seed syncer plus both graded-history tables. Data posture: removes the display contradiction, but mutates historical scores and needs a clear audit trail because past performance metrics will change.
+3. **BLOCK.** Refuse in-place `is_correct` flips when graded attempts or practice-session state rows reference the question, unless an explicit override/new-version workflow is provided. Implementation extends the existing delete-path reference guard into a key-change guard in the seed syncer. Data posture: strongest protection against silent history drift, but forces content operations to either fork/version the question or make an explicit override decision.
+
+**Recommendation:** choose **BLOCK** for default seed behavior, with a later explicit override/versioning workflow if the owner wants to support live corrections under history; it makes the integrity invariant impossible to violate silently and keeps regrade/disclosure as deliberate exceptional operations rather than background side effects.
 
 ## Failing Test Sketch
 


### PR DESCRIPTION
## Summary
- promote BUG-276 Quick Practice status-count refresh from dev to main
- includes BUG-281 owner decision brief documentation; BUG-281 remains active

## Included dev commits
- e71c7334 Fix quick practice status count refresh

## Verification before dev merge
- pnpm typecheck && pnpm lint && pnpm test --run && pnpm test:browser && local DB migrate/seed + pnpm test:integration && pnpm build && pnpm test:e2e
- PR #592 CI, Vercel, Codecov, and CodeRabbit exact-head approval passed

## Notes
- no migrations
- after production deploy proof, BUG-276 should be archived; BUG-281 remains active pending owner decision

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick Practice status counts now refresh immediately after answering a question or toggling a bookmark, so badge counts stay up to date.
* **Bug Fixes**
  * Fixed stale count displays in Quick Practice after progress changes.
* **Tests**
  * Added browser coverage for status count updates after answer submission and bookmark changes.
* **Documentation**
  * Updated bug notes to reflect the verified fix and current status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->