### PR TITLE
Promote DEBT-442 migration ledger content hashes

### DIFF
--- a/docs/debt/debt-442-applied-migration-ledger-content-blind.md
+++ b/docs/debt/debt-442-applied-migration-ledger-content-blind.md
@@ -43,21 +43,79 @@ until an application path depends on the missing object or constraint.
 Extend the DEBT-391 migration-ledger verification to compare applied migration
 content, not just migration presence.
 
-Proposed shape:
+### Measurement Gate — 2026-07-08
+
+Hash algorithm proof:
+
+- Drizzle ORM `readMigrationFiles()` reads each
+  `db/migrations/<tag>.sql` file as UTF-8 text and records
+  `crypto.createHash("sha256").update(query).digest("hex")` for that full SQL
+  text before splitting statements on `--> statement-breakpoint`.
+- The Postgres migrator inserts that value into
+  `drizzle.__drizzle_migrations.hash` beside `created_at = entries[].when`.
+- Empirical proof against a freshly reset resolver-scoped local Docker Postgres
+  (`127.0.0.1:63363` during measurement): after explicit
+  `DATABASE_URL="$TEST_DATABASE_URL" pnpm db:migrate`, every one of the 29
+  ledger rows matched `sha256(readFileSync("db/migrations/<tag>.sql", "utf8"))`.
+
+Current preflight seam and run-mode proof:
+
+- `tests/e2e/helpers/credential-health-check.ts` wires
+  `verifyMigrationLedger(sql)` between database connectivity and the
+  idempotency-schema check on the same single Postgres connection.
+- `verifyMigrationLedger` currently queries only `created_at`, compares it with
+  `_journal.json` `entries[].when`, and therefore detects missing migrations
+  but not content drift.
+- Normal local `pnpm test:e2e` is hermetic: `scripts/run-local-e2e.ts` delegates
+  to `scripts/e2e-local-orchestrator.ts`, which starts the resolver-scoped
+  Docker Postgres, runs `pnpm db:migrate`, seeds, then runs Playwright.
+  Content drift should therefore be trivial there because the same checkout
+  just applied the migration files.
+- CI similarly migrates its throwaway Postgres before E2E. The high-value path
+  is any persistent target (`E2E_USE_EXISTING_DATABASE=true DATABASE_URL=...`
+  locally, or another deploy-target health check) where the database ledger can
+  predate the current checkout.
+
+Read-only ledger/hash measurement against current repo files:
+
+| Environment | Host / target | Ledger rows | Missing journal rows | Ledger-only rows | Content mismatches |
+|-------------|---------------|-------------|----------------------|------------------|--------------------|
+| Local test DB | `127.0.0.1:63363` | 29 | none | none | none |
+| Development Neon | `ep-still-frog-ahx7bp6y-pooler.c-3.us-east-1.aws.neon.tech` | 29 | none | none | `0027_early_wallow` (`created_at = 1783355955875`), expected prefix `983c3458e8aadd6a`, applied prefix `15124dc7eab8b5ab` |
+| Production Neon | `ep-withered-cell-ah14ik13-pooler.c-3.us-east-1.aws.neon.tech` | 29 | none | none | none |
+
+The single Development mismatch is explained by the known incident: Development
+applied an early `0027_early_wallow.sql`; `0028_repair_attempts_selected_choice_index.sql`
+then repaired the missing supporting index. No unexplained mismatch was found.
+
+### Implementation Design
 
 1. Reuse the existing `verifyMigrationLedger(sql)` preflight as the single
-   schema-drift seam.
-2. Read the local migration SQL files named by `db/migrations/meta/_journal.json`.
-3. Compute the same hash representation Drizzle records in
+   schema-drift seam. Do not add a second checker.
+2. Read the local migration SQL files named by `db/migrations/meta/_journal.json`
+   and compute the same full-file UTF-8 SHA-256 hash Drizzle records in
    `drizzle.__drizzle_migrations.hash`.
-4. Query `created_at` and `hash` from `drizzle.__drizzle_migrations`.
-5. Fail with a secret-free schema-drift error when a journal entry is missing
-   **or** when the stored hash for an applied entry does not match the local
-   file content.
-6. Add unit tests for matching hashes, missing rows, hash mismatch, and
+3. Query `created_at` and `hash` from `drizzle.__drizzle_migrations` on the same
+   single connection already used by the preflight.
+4. Preserve missing-row behavior: if a journal entry is absent from the ledger,
+   keep failing with `E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS`.
+5. Treat ledger-only rows as drift too. A database whose ledger contains
+   migrations unknown to the current checkout is ahead of this codebase; the
+   preflight should fail rather than silently validate an unreviewed schema.
+6. Add a distinct content-drift failure marker:
+   `E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATION_CONTENT`. Its message must name the
+   offending migration tag(s) and expected/applied hash prefixes only, with no
+   `DATABASE_URL`, hostnames, passwords, provider ids, or full Drizzle hashes.
+7. Allowlist only measured legacy content drift. The allowlist is checked into
+   the repo as tag + `when` + expected local full hash + applied legacy full
+   hash + repair migration, initially only Development's early
+   `0027_early_wallow` hash repaired by
+   `0028_repair_attempts_selected_choice_index`. Silent skips are forbidden:
+   any allowlisted entry must still match the tag, `when`, expected hash, and
+   known applied hash.
+8. Add red-first unit coverage for matching hashes, missing rows, ledger-only
+   rows, non-allowlisted content mismatch, allowlisted legacy mismatch, and
    secret-free formatting.
-7. Consider promoting the same comparison into a CI/deploy preflight so Preview
-   and Production fail before serving a code/schema mismatch.
 
 The guard must preserve DEBT-391's existing public-safety boundary: never print
 `DATABASE_URL`, hostnames, passwords, provider ids, or raw Drizzle hashes in
@@ -65,12 +123,21 @@ failure output.
 
 ## Verification
 
-- Current source proof: `verifyMigrationLedger` compares journal
-  `entries[].when` to applied `created_at` only; it does not read or compare
+- Pre-implementation source proof: `verifyMigrationLedger` compared journal
+  `entries[].when` to applied `created_at` only; it did not read or compare
   `drizzle.__drizzle_migrations.hash`.
 - Incident proof: `0028_repair_attempts_selected_choice_index.sql` exists only
   because dev recorded the early 0027 as applied before the checked-in 0027 file
   was amended with `attempts_selected_choice_question_idx`.
+- 2026-07-08 measurement proof: local fresh Docker and Production match all 29
+  local migration file hashes; Development has exactly the known
+  `0027_early_wallow` content mismatch and no missing or ledger-only rows.
+- Implementation proof: `verifyMigrationLedger` now selects both `created_at`
+  and `hash`, computes local full-file SHA-256 values through
+  `computeMigrationContentDrift()`, fails non-allowlisted content drift with
+  `E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATION_CONTENT`, and allows only the measured
+  Development early-0027 hash tied to repair migration
+  `0028_repair_attempts_selected_choice_index`.
 
 ## Related
 

--- a/tests/e2e/helpers/credential-health-check-migration-ledger.test.ts
+++ b/tests/e2e/helpers/credential-health-check-migration-ledger.test.ts
@@ -1,0 +1,302 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import type postgres from 'postgres';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  computeMigrationContentDrift,
+  computeMissingMigrations,
+  formatSchemaDriftMessage,
+  verifyMigrationLedger,
+} from './credential-health-check';
+
+describe('migration ledger schema-drift preflight', () => {
+  const hashA =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const hashB =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const hashC =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+  const journalEntries = [
+    {
+      idx: 0,
+      tag: '0000_jazzy_vermin',
+      when: 1769893923091,
+      hash: hashA,
+    },
+    {
+      idx: 1,
+      tag: '0001_attempts_selected_choice_not_null',
+      when: 1769942859252,
+      hash: hashB,
+    },
+    {
+      idx: 2,
+      tag: '0002_curious_firelord',
+      when: 1770067162278,
+      hash: hashC,
+    },
+  ] as const;
+
+  it('passes through silently when every journal migration exists in the ledger', async () => {
+    expect(
+      computeMissingMigrations(journalEntries, [
+        1769893923091,
+        '1769942859252',
+        1770067162278n,
+      ]),
+    ).toEqual([]);
+
+    const sql = vi.fn(async () => [
+      { createdAt: 1769893923091, hash: hashA },
+      { createdAt: '1769942859252', hash: hashB },
+      { createdAt: 1770067162278n, hash: hashC },
+    ]);
+
+    await expect(
+      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws the content-drift code when a ledger row hash differs from the local migration file hash', async () => {
+    const sql = vi.fn(async () => [
+      { createdAt: 1769893923091, hash: hashA },
+      {
+        createdAt: '1769942859252',
+        hash: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+      },
+      { createdAt: 1770067162278n, hash: hashC },
+    ]);
+
+    await expect(
+      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
+    ).rejects.toMatchObject({
+      code: 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATION_CONTENT',
+      message: expect.stringContaining(
+        'Content drift: 0001_attempts_selected_choice_not_null',
+      ),
+      fix: expect.stringContaining('Do not amend applied migrations'),
+    });
+  });
+
+  it('throws the content-drift code when the ledger contains a migration unknown to the local journal', async () => {
+    const sql = vi.fn(async () => [
+      { createdAt: 1769893923091, hash: hashA },
+      { createdAt: '1769942859252', hash: hashB },
+      { createdAt: 1770067162278n, hash: hashC },
+      {
+        createdAt: 1999999999999,
+        hash: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      },
+    ]);
+
+    await expect(
+      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
+    ).rejects.toMatchObject({
+      code: 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATION_CONTENT',
+      message: expect.stringContaining('Ledger-only migrations: 1999999999999'),
+    });
+  });
+
+  it('allows the measured legacy 0027 dev hash repaired by 0028', async () => {
+    const measuredEarly0027Hash =
+      '15124dc7eab8b5ab3e239d13ee1011ea515b96567771270658b47de84b9faf3c';
+    const current0027Hash =
+      '983c3458e8aadd6acaddbce0b514321f0cec4f0a2767b3a74b6442e9f0d4d35d';
+    const sql = vi.fn(async () => [
+      {
+        createdAt: 1783355955875,
+        hash: measuredEarly0027Hash,
+      },
+    ]);
+
+    await expect(
+      verifyMigrationLedger(sql as unknown as postgres.Sql, [
+        {
+          idx: 27,
+          tag: '0027_early_wallow',
+          when: 1783355955875,
+          hash: current0027Hash,
+        },
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  it('reads local migration file hashes when journal entries do not inject fixture hashes', async () => {
+    const migrationTag = '0000_jazzy_vermin';
+    const migrationHash = createHash('sha256')
+      .update(readFileSync(`db/migrations/${migrationTag}.sql`, 'utf8'))
+      .digest('hex');
+    const sql = vi.fn(async () => [
+      { createdAt: 1769893923091, hash: migrationHash },
+    ]);
+
+    await expect(
+      verifyMigrationLedger(sql as unknown as postgres.Sql, [
+        {
+          idx: 0,
+          tag: migrationTag,
+          when: 1769893923091,
+        },
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  it('formats content-drift failures without leaking secrets, hostnames, or full hashes', async () => {
+    const appliedHash =
+      'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+    const databaseUrl =
+      'postgresql://e2e_owner:super-secret-password@ep-private-host.neon.tech/addiction_boards';
+    const sql = vi.fn(async () => [
+      { createdAt: 1769893923091, hash: appliedHash },
+      { createdAt: '1769942859252', hash: hashB },
+      { createdAt: 1770067162278n, hash: hashC },
+    ]);
+
+    try {
+      await verifyMigrationLedger(
+        sql as unknown as postgres.Sql,
+        journalEntries,
+      );
+      throw new Error('Expected verifyMigrationLedger to reject');
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATION_CONTENT',
+      });
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toContain('expected aaaaaaaaaaaaaaaa');
+      expect(message).toContain('applied dddddddddddddddd');
+      expect(message).not.toContain(databaseUrl);
+      expect(message).not.toContain('ep-private-host.neon.tech');
+      expect(message).not.toContain('super-secret-password');
+      expect(message).not.toContain(hashA);
+      expect(message).not.toContain(appliedHash);
+    }
+  });
+
+  it('computes content drift from local hashes and applied ledger rows', () => {
+    expect(
+      computeMigrationContentDrift(journalEntries, [
+        { createdAt: 1769893923091, hash: hashA },
+        {
+          createdAt: 1769942859252,
+          hash: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        },
+        { createdAt: 1770067162278, hash: hashC },
+        {
+          createdAt: 1999999999999,
+          hash: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        },
+      ]),
+    ).toEqual([
+      {
+        kind: 'hash-mismatch',
+        tag: '0001_attempts_selected_choice_not_null',
+        expectedHashPrefix: 'bbbbbbbbbbbbbbbb',
+        appliedHashPrefix: 'dddddddddddddddd',
+      },
+      {
+        kind: 'ledger-only',
+        createdAt: '1999999999999',
+      },
+    ]);
+  });
+
+  it('reports a missing applied ledger hash as content drift', () => {
+    expect(
+      computeMigrationContentDrift(
+        [
+          {
+            idx: 0,
+            tag: '0000_jazzy_vermin',
+            when: 1769893923091,
+            hash: hashA,
+          },
+        ],
+        [{ createdAt: 1769893923091, hash: null }],
+      ),
+    ).toEqual([
+      {
+        kind: 'hash-mismatch',
+        tag: '0000_jazzy_vermin',
+        expectedHashPrefix: 'aaaaaaaaaaaaaaaa',
+        appliedHashPrefix: 'missing',
+      },
+    ]);
+  });
+
+  it('throws the schema-drift code when one or more journal migrations are absent from the ledger', async () => {
+    expect(computeMissingMigrations(journalEntries, [1769893923091])).toEqual([
+      '0001_attempts_selected_choice_not_null',
+      '0002_curious_firelord',
+    ]);
+
+    const sql = vi.fn(async () => [{ createdAt: 1769893923091 }]);
+
+    await expect(
+      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
+    ).rejects.toMatchObject({
+      code: 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS',
+      message:
+        'The database used by E2E is behind the repo migration journal. Missing migrations: 0001_attempts_selected_choice_not_null, 0002_curious_firelord.',
+      fix: expect.stringContaining(
+        'DATABASE_URL="<verified target>" pnpm db:migrate',
+      ),
+    });
+  });
+
+  it('treats an absent drizzle schema as schema drift with all journal migrations missing', async () => {
+    const missingSchemaError = Object.assign(
+      new Error('schema "drizzle" does not exist'),
+      { code: '3F000' },
+    );
+    const sql = vi.fn(async () => {
+      throw missingSchemaError;
+    });
+
+    await expect(
+      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
+    ).rejects.toMatchObject({
+      code: 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS',
+      message:
+        'The database used by E2E is behind the repo migration journal. Missing migrations: 0000_jazzy_vermin, 0001_attempts_selected_choice_not_null, 0002_curious_firelord.',
+    });
+  });
+
+  it('treats an absent drizzle migration table as schema drift with all journal migrations missing', async () => {
+    const missingTableError = Object.assign(
+      new Error('relation "drizzle.__drizzle_migrations" does not exist'),
+      { code: '42P01' },
+    );
+    const sql = vi.fn(async () => {
+      throw missingTableError;
+    });
+
+    await expect(
+      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
+    ).rejects.toMatchObject({
+      code: 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS',
+      message:
+        'The database used by E2E is behind the repo migration journal. Missing migrations: 0000_jazzy_vermin, 0001_attempts_selected_choice_not_null, 0002_curious_firelord.',
+    });
+  });
+
+  it('formats missing migration messages without leaking secrets, hostnames, passwords, or Drizzle hashes', () => {
+    const databaseUrl =
+      'postgresql://e2e_owner:super-secret-password@ep-private-host.neon.tech/addiction_boards';
+    const drizzleHash =
+      'bd3f2c7ad0212ddc9fbb7c2c07bdc4c7b4f9cce34638f93af18c0218cdd7e4e5';
+    const message = formatSchemaDriftMessage([
+      '0019_illegal_warbound',
+      '0020_fat_ironclad',
+    ]);
+
+    expect(message).toContain(
+      'Missing migrations: 0019_illegal_warbound, 0020_fat_ironclad.',
+    );
+    expect(message).not.toContain(databaseUrl);
+    expect(message).not.toContain('ep-private-host.neon.tech');
+    expect(message).not.toContain('super-secret-password');
+    expect(message).not.toContain(drizzleHash);
+  });
+});

--- a/tests/e2e/helpers/credential-health-check.test.ts
+++ b/tests/e2e/helpers/credential-health-check.test.ts
@@ -1,14 +1,10 @@
-import type postgres from 'postgres';
 import Stripe from 'stripe';
 import { describe, expect, it, vi } from 'vitest';
 import {
   type CredentialHealthCheckServices,
   CredentialValidationError,
-  computeMissingMigrations,
   fetchWithTimeout,
-  formatSchemaDriftMessage,
   runE2ECredentialHealthCheck,
-  verifyMigrationLedger,
 } from './credential-health-check';
 
 type RequiredEnvKey =
@@ -574,112 +570,5 @@ describe('runE2ECredentialHealthCheck', () => {
       priceRetrieveSpy.mockRestore();
       accountRetrieveSpy.mockRestore();
     }
-  });
-});
-
-describe('migration ledger schema-drift preflight', () => {
-  const journalEntries = [
-    { idx: 0, tag: '0000_jazzy_vermin', when: 1769893923091 },
-    {
-      idx: 1,
-      tag: '0001_attempts_selected_choice_not_null',
-      when: 1769942859252,
-    },
-    { idx: 2, tag: '0002_curious_firelord', when: 1770067162278 },
-  ] as const;
-
-  it('passes through silently when every journal migration exists in the ledger', async () => {
-    expect(
-      computeMissingMigrations(journalEntries, [
-        1769893923091,
-        '1769942859252',
-        1770067162278n,
-      ]),
-    ).toEqual([]);
-
-    const sql = vi.fn(async () => [
-      { createdAt: 1769893923091 },
-      { createdAt: '1769942859252' },
-      { createdAt: 1770067162278n },
-    ]);
-
-    await expect(
-      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
-    ).resolves.toBeUndefined();
-  });
-
-  it('throws the schema-drift code when one or more journal migrations are absent from the ledger', async () => {
-    expect(computeMissingMigrations(journalEntries, [1769893923091])).toEqual([
-      '0001_attempts_selected_choice_not_null',
-      '0002_curious_firelord',
-    ]);
-
-    const sql = vi.fn(async () => [{ createdAt: 1769893923091 }]);
-
-    await expect(
-      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
-    ).rejects.toMatchObject({
-      code: 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS',
-      message:
-        'The database used by E2E is behind the repo migration journal. Missing migrations: 0001_attempts_selected_choice_not_null, 0002_curious_firelord.',
-      fix: expect.stringContaining(
-        'DATABASE_URL="<verified target>" pnpm db:migrate',
-      ),
-    });
-  });
-
-  it('treats an absent drizzle schema as schema drift with all journal migrations missing', async () => {
-    const missingSchemaError = Object.assign(
-      new Error('schema "drizzle" does not exist'),
-      { code: '3F000' },
-    );
-    const sql = vi.fn(async () => {
-      throw missingSchemaError;
-    });
-
-    await expect(
-      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
-    ).rejects.toMatchObject({
-      code: 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS',
-      message:
-        'The database used by E2E is behind the repo migration journal. Missing migrations: 0000_jazzy_vermin, 0001_attempts_selected_choice_not_null, 0002_curious_firelord.',
-    });
-  });
-
-  it('treats an absent drizzle migration table as schema drift with all journal migrations missing', async () => {
-    const missingTableError = Object.assign(
-      new Error('relation "drizzle.__drizzle_migrations" does not exist'),
-      { code: '42P01' },
-    );
-    const sql = vi.fn(async () => {
-      throw missingTableError;
-    });
-
-    await expect(
-      verifyMigrationLedger(sql as unknown as postgres.Sql, journalEntries),
-    ).rejects.toMatchObject({
-      code: 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS',
-      message:
-        'The database used by E2E is behind the repo migration journal. Missing migrations: 0000_jazzy_vermin, 0001_attempts_selected_choice_not_null, 0002_curious_firelord.',
-    });
-  });
-
-  it('formats missing migration messages without leaking secrets, hostnames, passwords, or Drizzle hashes', () => {
-    const databaseUrl =
-      'postgresql://e2e_owner:super-secret-password@ep-private-host.neon.tech/addiction_boards';
-    const drizzleHash =
-      'bd3f2c7ad0212ddc9fbb7c2c07bdc4c7b4f9cce34638f93af18c0218cdd7e4e5';
-    const message = formatSchemaDriftMessage([
-      '0019_illegal_warbound',
-      '0020_fat_ironclad',
-    ]);
-
-    expect(message).toContain(
-      'Missing migrations: 0019_illegal_warbound, 0020_fat_ironclad.',
-    );
-    expect(message).not.toContain(databaseUrl);
-    expect(message).not.toContain('ep-private-host.neon.tech');
-    expect(message).not.toContain('super-secret-password');
-    expect(message).not.toContain(drizzleHash);
   });
 });

--- a/tests/e2e/helpers/credential-health-check.ts
+++ b/tests/e2e/helpers/credential-health-check.ts
@@ -1,3 +1,6 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import postgres from 'postgres';
 import Stripe from 'stripe';
 import migrationJournal from '../../../db/migrations/meta/_journal.json';
@@ -73,13 +76,57 @@ export type MigrationJournalEntry = {
   idx: number;
   tag: string;
   when: number;
+  hash?: string;
 };
 
 type MigrationLedgerCreatedAt = number | string | bigint | null | undefined;
+type MigrationLedgerHash = string | null | undefined;
+type MigrationLedgerRow = {
+  createdAt: MigrationLedgerCreatedAt;
+  hash: MigrationLedgerHash;
+};
+type MigrationJournalHashEntry = MigrationJournalEntry & { hash: string };
+type KnownLegacyMigrationHashDrift = {
+  tag: string;
+  when: number;
+  expectedHash: string;
+  appliedHash: string;
+  repairMigrationTag: string;
+};
+type MigrationContentDrift =
+  | {
+      kind: 'hash-mismatch';
+      tag: string;
+      expectedHashPrefix: string;
+      appliedHashPrefix: string;
+    }
+  | {
+      kind: 'ledger-only';
+      createdAt: string;
+    };
 
 const SCHEMA_DRIFT_MIGRATIONS_CODE = 'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATIONS';
 const SCHEMA_DRIFT_MIGRATIONS_FIX =
   'For local runs, confirm .env.local points at the intended non-production database, then run: DATABASE_URL="<verified target>" pnpm db:migrate';
+const SCHEMA_DRIFT_MIGRATION_CONTENT_CODE =
+  'E2E_PREFLIGHT:SCHEMA_DRIFT_MIGRATION_CONTENT';
+const SCHEMA_DRIFT_MIGRATION_CONTENT_FIX =
+  'Do not amend applied migrations. Restore the migration file to the applied content or add a new forward repair migration; update the legacy allowlist only for a measured repaired drift.';
+
+const HASH_PREFIX_LENGTH = 16;
+
+const KNOWN_LEGACY_MIGRATION_HASH_DRIFTS: readonly KnownLegacyMigrationHashDrift[] =
+  [
+    {
+      tag: '0027_early_wallow',
+      when: 1783355955875,
+      expectedHash:
+        '983c3458e8aadd6acaddbce0b514321f0cec4f0a2767b3a74b6442e9f0d4d35d',
+      appliedHash:
+        '15124dc7eab8b5ab3e239d13ee1011ea515b96567771270658b47de84b9faf3c',
+      repairMigrationTag: '0028_repair_attempts_selected_choice_index',
+    },
+  ] as const;
 
 const MIGRATION_JOURNAL_ENTRIES: readonly MigrationJournalEntry[] =
   migrationJournal.entries.map(({ idx, tag, when }) => ({
@@ -179,6 +226,46 @@ export function formatSchemaDriftMessage(
   return `The database used by E2E is behind the repo migration journal. Missing migrations: ${missingMigrationTags.join(', ')}.`;
 }
 
+function hashPrefix(hash: MigrationLedgerHash): string {
+  return typeof hash === 'string' && hash.length > 0
+    ? hash.slice(0, HASH_PREFIX_LENGTH)
+    : 'missing';
+}
+
+export function formatMigrationContentDriftMessage(
+  contentDrifts: readonly MigrationContentDrift[],
+): string {
+  const hashMismatches = contentDrifts
+    .filter((drift) => drift.kind === 'hash-mismatch')
+    .map(
+      (drift) =>
+        `${drift.tag} (expected ${drift.expectedHashPrefix}, applied ${drift.appliedHashPrefix})`,
+    );
+  const ledgerOnlyRows = contentDrifts
+    .filter((drift) => drift.kind === 'ledger-only')
+    .map((drift) => drift.createdAt);
+
+  const parts = [];
+  if (hashMismatches.length > 0) {
+    parts.push(`Content drift: ${hashMismatches.join(', ')}.`);
+  }
+  if (ledgerOnlyRows.length > 0) {
+    parts.push(`Ledger-only migrations: ${ledgerOnlyRows.join(', ')}.`);
+  }
+
+  return `The database used by E2E has migration ledger content drift. ${parts.join(' ')}`;
+}
+
+function createMigrationContentDriftError(
+  contentDrifts: readonly MigrationContentDrift[],
+): CredentialValidationError {
+  return new CredentialValidationError(
+    SCHEMA_DRIFT_MIGRATION_CONTENT_CODE,
+    formatMigrationContentDriftMessage(contentDrifts),
+    SCHEMA_DRIFT_MIGRATION_CONTENT_FIX,
+  );
+}
+
 function createSchemaDriftMigrationsError(
   missingMigrationTags: readonly string[],
   options?: ErrorOptions,
@@ -197,15 +284,88 @@ function isMissingMigrationLedgerError(error: unknown): boolean {
   return code === '3F000' || code === '42P01';
 }
 
+function readMigrationFileHash(entry: MigrationJournalEntry): string {
+  if (typeof entry.hash === 'string') return entry.hash;
+
+  const migrationPath = join(
+    process.cwd(),
+    'db',
+    'migrations',
+    `${entry.tag}.sql`,
+  );
+  const query = readFileSync(migrationPath, 'utf8');
+  return createHash('sha256').update(query).digest('hex');
+}
+
+function withMigrationFileHashes(
+  journalEntries: readonly MigrationJournalEntry[],
+): MigrationJournalHashEntry[] {
+  return journalEntries.map((entry) => ({
+    ...entry,
+    hash: readMigrationFileHash(entry),
+  }));
+}
+
+function isAllowedLegacyMigrationHashDrift(
+  journalEntry: MigrationJournalHashEntry,
+  appliedHash: MigrationLedgerHash,
+  allowlist: readonly KnownLegacyMigrationHashDrift[],
+): boolean {
+  if (typeof appliedHash !== 'string') return false;
+
+  return allowlist.some(
+    (allowed) =>
+      allowed.tag === journalEntry.tag &&
+      allowed.when === journalEntry.when &&
+      allowed.expectedHash === journalEntry.hash &&
+      allowed.appliedHash === appliedHash,
+  );
+}
+
+export function computeMigrationContentDrift(
+  journalEntries: readonly MigrationJournalHashEntry[],
+  appliedMigrations: readonly MigrationLedgerRow[],
+  allowlist: readonly KnownLegacyMigrationHashDrift[] = KNOWN_LEGACY_MIGRATION_HASH_DRIFTS,
+): MigrationContentDrift[] {
+  const journalByCreatedAt = new Map(
+    journalEntries.map((entry) => [String(entry.when), entry]),
+  );
+  const contentDrifts: MigrationContentDrift[] = [];
+
+  for (const migration of appliedMigrations) {
+    const createdAt = String(migration.createdAt);
+    const journalEntry = journalByCreatedAt.get(createdAt);
+
+    if (!journalEntry) {
+      contentDrifts.push({ kind: 'ledger-only', createdAt });
+      continue;
+    }
+
+    if (journalEntry.hash === migration.hash) continue;
+    if (
+      isAllowedLegacyMigrationHashDrift(journalEntry, migration.hash, allowlist)
+    ) {
+      continue;
+    }
+
+    contentDrifts.push({
+      kind: 'hash-mismatch',
+      tag: journalEntry.tag,
+      expectedHashPrefix: hashPrefix(journalEntry.hash),
+      appliedHashPrefix: hashPrefix(migration.hash),
+    });
+  }
+
+  return contentDrifts;
+}
+
 export async function verifyMigrationLedger(
   sql: postgres.Sql,
   journalEntries: readonly MigrationJournalEntry[] = MIGRATION_JOURNAL_ENTRIES,
 ): Promise<void> {
   try {
-    const appliedMigrations = await sql<
-      { createdAt: number | string | bigint }[]
-    >`
-      SELECT created_at AS "createdAt"
+    const appliedMigrations = await sql<MigrationLedgerRow[]>`
+      SELECT created_at AS "createdAt", hash
       FROM drizzle.__drizzle_migrations
     `;
     const missingMigrationTags = computeMissingMigrations(
@@ -215,6 +375,14 @@ export async function verifyMigrationLedger(
 
     if (missingMigrationTags.length > 0) {
       throw createSchemaDriftMigrationsError(missingMigrationTags);
+    }
+
+    const contentDrifts = computeMigrationContentDrift(
+      withMigrationFileHashes(journalEntries),
+      appliedMigrations,
+    );
+    if (contentDrifts.length > 0) {
+      throw createMigrationContentDriftError(contentDrifts);
     }
   } catch (error) {
     if (error instanceof CredentialValidationError) {


### PR DESCRIPTION
## Summary
- promote the DEBT-442 migration ledger content-hash preflight from dev to main
- includes PR #600 squash 0ccad08b
- no schema migrations; this is test-helper/docs hardening for existing E2E preflight

## Verification
- PR #600 full local gate passed before push: typecheck, lint, unit, browser, integration, build, e2e
- PR #600 CI passed on head b319b3b7
- CodeRabbit approved PR #600 on exact head b319b3b7

## Post-merge
- wait for production deploy, verify site 200, then archive DEBT-442 with deploy proof


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration preflight checks to catch both missing migrations and migration content mismatches.
  * Added clearer, safer error messages for schema drift while avoiding exposure of sensitive details.
  * Preserved a legacy exception for one known migration repair case.
* **Documentation**
  * Updated the migration verification guidance to reflect the new content-aware validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->