### PR TITLE
Stop security-only Dependabot entries emitting version PRs at main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,13 @@ updates:
       interval: daily
       time: '09:00'
       timezone: America/New_York
+    # Security-only entry. Without this limit the entry also emits ungrouped
+    # version-update PRs against main (defaults: no target-branch, no cooldown,
+    # versioning-strategy increase), bypassing the dev-targeted flow above —
+    # that is how PRs #604/#605 and the #465 major arrived. Zero disables
+    # version updates only; security updates run under a separate internal
+    # limit of ten that this setting does not touch.
+    open-pull-requests-limit: 0
     commit-message:
       prefix: chore(deps)
     groups:
@@ -93,6 +100,8 @@ updates:
       interval: daily
       time: '09:00'
       timezone: America/New_York
+    # Security-only entry: same rationale as the npm security entry above.
+    open-pull-requests-limit: 0
     commit-message:
       prefix: chore(deps)
     groups:


### PR DESCRIPTION
## Problem

`.github/dependabot.yml` has two security-only entries (npm + github-actions, the `applies-to: security-updates` ones). Neither sets `target-branch` (so they default to `main`) and a Dependabot entry performs **version updates as well as security updates** by default — the group's `applies-to` only controls grouping. Result: a second, unconfigured pipe emitting ungrouped version-update PRs straight at `main`, with no cooldown and the default `increase` versioning strategy.

Evidence this pipe is live and harmful:
- #604/#605 (superseded by #610): opened Thu 09:13 ET matching the daily security schedule, 8 days after publish (bypassing the 7-day cooldown would-be-Monday sweep), with #605 rewriting the `lucide-react` range `^1.16.0` → `^1.23.0`.
- #465: `actions/checkout` 6.0.3 → 7.0.0 — a **major** — merged to `main` through this pipe, ungrouped, which `docs/dev/dependency-update-protocol.md` explicitly disallows.
- 14 of 16 resolved `main`-targeted Dependabot PRs were manually closed; the intended `dev` grouped flow merged 6 of 7.

## Solution

`open-pull-requests-limit: 0` on both security-only entries. Per GitHub docs this disables **version updates only**; security updates run under a separate internal limit of ten open PRs that this setting cannot change, and they keep targeting `main` un-delayed — which is exactly the design intent recorded in `docs/dev/dependency-update-protocol.md` → Dependabot Config Policy (DEBT-393).

## Verification

- YAML parses; 4 entries: npm→dev limit 5, npm→main limit 0, actions→dev limit 5, actions→main limit 0.
- Full local gate green: typecheck ✅ lint ✅ unit 3162 ✅ browser 363 ✅ integration 159 ✅ build ✅ e2e 36 ✅ (config-only diff; gate run per protocol).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to limit security-related pull requests and prevent unintended ungrouped version-update requests targeting the main branch.
  * Added configuration notes explaining the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->