### PR TITLE
Fix stale fixed-port test-DB instructions in live docs

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,9 +1,13 @@
 # Test environment variables
 # Used by integration tests (loaded via tests/integration/setup.ts)
-# Matches CI environment in .github/workflows/ci.yml
 # This file is committed - it contains NO secrets
 
-# Database (local Docker postgres, matches CI)
+# Database — FALLBACK ONLY, loaded without override. The real URL is injected
+# per clone: pnpm test:integration / test:e2e / db:test:* resolve a dynamic
+# host port via scripts/resolve-local-test-target.ts, and CI sets its own
+# service URL (port 5432). This value only applies to raw vitest invocations
+# that bypass the wrappers, where 5434 matches docker-compose.yml's raw-compose
+# fallback. See docs/dev/integration-tests.md.
 DATABASE_URL=postgresql://postgres:postgres@localhost:5434/addiction_boards_test
 
 # App URL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,25 +82,19 @@ pnpm build                  # Production build
 
 ### Integration Test DB (Local Only)
 
-Integration tests require a local Postgres container with migrations **and** seed data. All steps are mandatory:
-
-```bash
-pnpm db:test:up                                    # Start Docker Postgres (port 5434)
-DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:migrate
-DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:seed
-pnpm test:integration                              # Now tests will pass
-```
+Integration tests require a local Postgres container with migrations **and** seed data. The test DB uses a **per-clone dynamic host port** (resolved by `scripts/resolve-local-test-target.ts`) — never hardcode a port. Canonical guide: `docs/dev/integration-tests.md`.
 
 ```bash
 # One-liner: local setup from scratch (matches CI order)
-pnpm db:test:up && DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:migrate && SEED_INCLUDE_PLACEHOLDERS=true DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test" pnpm db:seed && pnpm test:integration
+TEST_DATABASE_URL="$(pnpm exec tsx scripts/resolve-local-test-target.ts database-url)" && pnpm db:test:up && DATABASE_URL="$TEST_DATABASE_URL" pnpm db:migrate && SEED_INCLUDE_PLACEHOLDERS=true DATABASE_URL="$TEST_DATABASE_URL" pnpm db:seed && pnpm test:integration
 ```
 
+- **Never hardcode `localhost:5434`** — that is only `docker-compose.yml`'s raw-compose fallback; the wrappers override it per clone. A wrong port fails *silently*: drizzle-kit swallows the connection error and exits 1 with no message, then `pnpm test:integration` fails en masse on missing tables. Inspect the real target with `pnpm local:test:target` (formats: `json`, `database-url`, `app-url`, `env`).
 - **Never use `drizzle-kit push`** — it skips migration files (missing `pgcrypto`, constraints)
-- **Always prefix with `DATABASE_URL=...`** — without it, drizzle-kit reads `.env.local` (remote Neon DB)
+- **Always prefix with the resolved `DATABASE_URL=...`** — without it, drizzle-kit reads `.env.local` (remote Neon DB)
 - **Seeding is required** — `tag-taxonomy-census` tests fail without it
 - **CI seeds with `SEED_INCLUDE_PLACEHOLDERS=true`** — plain `pnpm db:seed` is enough locally, but the flag gives exact CI seed parity
-- Only needed for `pnpm test:integration`. Unit/browser/build tests don't touch the DB.
+- Only needed for `pnpm test:integration` (it self-resolves the target when `DATABASE_URL` is unset, but migrate/seed prep is manual). `pnpm test:e2e` is hermetic — it starts, migrates, and seeds the same per-clone DB itself. Unit/browser/build tests don't touch the DB.
 
 ### ⚠️ Full Quality Gate (BEFORE EVERY PUSH — not just PRs)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Integration tests require a local Postgres container with migrations **and** see
 TEST_DATABASE_URL="$(pnpm exec tsx scripts/resolve-local-test-target.ts database-url)" && pnpm db:test:up && DATABASE_URL="$TEST_DATABASE_URL" pnpm db:migrate && SEED_INCLUDE_PLACEHOLDERS=true DATABASE_URL="$TEST_DATABASE_URL" pnpm db:seed && pnpm test:integration
 ```
 
-- **Never hardcode `localhost:5434`** — that is only `docker-compose.yml`'s raw-compose fallback; the wrappers override it per clone. A wrong port fails *silently*: drizzle-kit swallows the connection error and exits 1 with no message, then `pnpm test:integration` fails en masse on missing tables. Inspect the real target with `pnpm local:test:target` (formats: `json`, `database-url`, `app-url`, `env`).
+- **Never hardcode `localhost:5434`** — that is only a raw-invocation fallback (`docker-compose.yml`'s `${DB_TEST_PORT:-5434}` mapping and `.env.test`'s matching no-override URL); the wrappers override both per clone. A wrong port fails *silently*: drizzle-kit swallows the connection error and exits 1 with no message, then `pnpm test:integration` fails en masse on missing tables. Inspect the real target with `pnpm local:test:target` (formats: `json`, `database-url`, `app-url`, `env`).
 - **Never use `drizzle-kit push`** — it skips migration files (missing `pgcrypto`, constraints)
 - **Always prefix with the resolved `DATABASE_URL=...`** — without it, drizzle-kit reads `.env.local` (remote Neon DB)
 - **Seeding is required** — `tag-taxonomy-census` tests fail without it

--- a/docs/practice-engine/content-pipeline.md
+++ b/docs/practice-engine/content-pipeline.md
@@ -434,11 +434,14 @@ Recommended end-to-end sanity check:
 
 ```bash
 pnpm db:test:reset
-DATABASE_URL=postgresql://postgres:postgres@localhost:5434/addiction_boards_test pnpm db:migrate
+TEST_DATABASE_URL="$(pnpm exec tsx scripts/resolve-local-test-target.ts database-url)"
+DATABASE_URL="$TEST_DATABASE_URL" pnpm db:migrate
 pnpm content:import:drafts -- --status published
-SEED_INCLUDE_PLACEHOLDERS=false DATABASE_URL=postgresql://postgres:postgres@localhost:5434/addiction_boards_test pnpm db:seed
+SEED_INCLUDE_PLACEHOLDERS=false DATABASE_URL="$TEST_DATABASE_URL" pnpm db:seed
 pnpm dev
 ```
+
+The test DB host port is per-clone (resolved by `scripts/resolve-local-test-target.ts`); never hardcode `localhost:5434`. See `docs/dev/integration-tests.md`.
 
 ---
 

--- a/docs/vendor-docs/postgres.md
+++ b/docs/vendor-docs/postgres.md
@@ -79,11 +79,11 @@ Create a `dev` branch in Neon Console. Branches are isolated and cheap.
 ### Option 2: Local Postgres (Docker)
 
 ```bash
-# Start local Postgres
+# Start local Postgres (per-clone dynamic host port — see docs/dev/integration-tests.md)
 pnpm db:test:up
 
-# Run with local connection
-DATABASE_URL="postgresql://postgres:postgres@localhost:5434/addiction_boards_test"
+# Run with the resolved local connection
+DATABASE_URL="$(pnpm exec tsx scripts/resolve-local-test-target.ts database-url)"
 ```
 
 ---


### PR DESCRIPTION
## Problem

DEBT-417 (PR #421) moved the local test DB to **per-clone dynamic host ports** (base 55400 + hash offset, resolved by `scripts/resolve-local-test-target.ts`). AGENTS.md and `docs/dev/integration-tests.md` were updated then — but four live surfaces still teach the old fixed `localhost:5434` flow. Following them produces a nasty failure mode observed today while prepping #610: `drizzle-kit migrate` swallows the ECONNREFUSED and exits 1 **with zero output**, then `pnpm test:integration` fails en masse (150 failures) on missing tables — looking like a real regression.

A full audit of live docs (archives excluded as historical records) found exactly these stale surfaces; AGENTS.md, `docs/dev/integration-tests.md`, `database-rollbacks.md`, `deployment-procedure.md`, README, `.claude/rules/*`, and the master specs were verified current and left untouched.

## Changes

- **CLAUDE.md** — Integration Test DB section rewritten to the resolver-based one-liner (matching AGENTS.md and the canonical `docs/dev/integration-tests.md`), plus the silent-failure warning, the `pnpm local:test:target` inspection alias, and the note that `pnpm test:e2e` is hermetic (self-migrating/seeding) while integration prep is manual. This also honors CLAUDE.md's own maintenance rule that it be updated in the same patch when AGENTS.md changes — the step DEBT-417 missed.
- **docs/vendor-docs/postgres.md** — local-connection snippet now derives `DATABASE_URL` from the resolver.
- **docs/practice-engine/content-pipeline.md** — § 13 seeding sanity-check now derives `TEST_DATABASE_URL` from the resolver (keeps its intentional `SEED_INCLUDE_PLACEHOLDERS=false`).
- **.env.test** — comments only: value is unchanged, but it's now labeled as the raw-vitest fallback it actually is (loaded without override; wrappers inject the per-clone URL, CI injects 5432) instead of claiming to "match CI".

## Verification

Full local gate green: typecheck ✅ lint ✅ unit 3162 ✅ browser 363 ✅ integration 159 ✅ build ✅ e2e 36 ✅. The corrected one-liner is exactly the flow used (successfully) to run integration tests on this machine today.