### PR TITLE
Drop aged-in js-yaml age-gate exclude and empty exclude block

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,6 @@
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true # v11-only: fail when no version satisfies the 7-day age threshold.
 minimumReleaseAgeIgnoreMissingTime: false # v11-only: fail when registry metadata lacks package publish time.
-minimumReleaseAgeExclude:
-  - js-yaml@3.15.0 # Security: CVE-2026-53550 / GHSA-h67p-54hq-rp68 quadratic-complexity DoS patch (v3-legacy backport) published 2026-06-26, ~3 days old at fix time. Exact, narrow exception so the security patch lands now instead of waiting out the 7-day gate. Safe to drop after it ages in (~2026-07-03).
 blockExoticSubdeps: true
 overrides:
   postcss: 8.5.15
@@ -25,8 +23,9 @@ overrides:
   # v3-legacy backport. js-yaml is transitive-only — gray-matter (seed/build scripts over
   # first-party markdown) and @clerk/ui's react-native test tooling — with no runtime
   # attacker-controlled YAML path, so this is defense-in-depth. 3.15.0 satisfies both
-  # consumers' ^3.13.1; it's an upgrade (no-downgrade safe). Fresh release; see the
-  # minimumReleaseAgeExclude entry above for the 7-day age-gate exception.
+  # consumers' ^3.13.1; it's an upgrade (no-downgrade safe). Aged past the 7-day
+  # release gate ~2026-07-03; the temporary minimumReleaseAgeExclude entry was
+  # removed once it aged in (#539).
   js-yaml: 3.15.0
 trustPolicy: no-downgrade
 trustPolicyExclude:


### PR DESCRIPTION
## Problem

Issue #539: PR #538 shipped the js-yaml CVE-2026-53550 fix with a temporary `minimumReleaseAgeExclude` entry because 3.15.0 was ~3 days old at fix time. It aged past the 7-day gate ~2026-07-03, making the exclude inert dead-config.

## Changes

- Delete the `js-yaml@3.15.0` exclude entry — and the now-empty `minimumReleaseAgeExclude:` key, completing the block cleanup anticipated by issue #471 (undici tail).
- Keep `js-yaml: 3.15.0` under `overrides:` — that is the security pin, untouched.
- Update the override's comment to stop referencing the deleted exclude block.

## Verification (per #539's action spec)

- `rm -rf node_modules && pnpm install --frozen-lockfile` ✅ passes the strict age gate (3.15.0 ages in on its own), **zero lockfile drift**, `pnpm why js-yaml` resolves exactly one version: 3.15.0.
- Full local gate green: typecheck ✅ lint ✅ unit 3162 ✅ browser 363 ✅ integration 159 ✅ build ✅ e2e 36 ✅

Refs #539, #471, #538, #536. (#539 will be closed manually once this reaches main via the standard dev→main promo.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a temporary release-age exception from workspace settings.
  * Updated notes to reflect that the dependency is now past the waiting period and no longer needs special handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->