### PR TITLE
Make postgres.md local-connection snippet executable

### DIFF
--- a/docs/vendor-docs/postgres.md
+++ b/docs/vendor-docs/postgres.md
@@ -82,8 +82,9 @@ Create a `dev` branch in Neon Console. Branches are isolated and cheap.
 # Start local Postgres (per-clone dynamic host port — see docs/dev/integration-tests.md)
 pnpm db:test:up
 
-# Run with the resolved local connection
-DATABASE_URL="$(pnpm exec tsx scripts/resolve-local-test-target.ts database-url)"
+# Prefix commands with the resolved local connection (a bare assignment
+# is not exported to child processes)
+DATABASE_URL="$(pnpm exec tsx scripts/resolve-local-test-target.ts database-url)" pnpm db:migrate
 ```
 
 ---


### PR DESCRIPTION
Addresses the valid finding from promo review #616: the `DATABASE_URL="$(...)"` bare assignment in docs/vendor-docs/postgres.md is not exported to child processes, so the snippet was non-functional as written. Now prefixes the resolved URL onto `pnpm db:migrate`, matching every other doc's pattern (the form the #612 audit verified executable).

The review's other finding (dependabot `open-pull-requests-limit: 0` allegedly blocking security PRs) was rebutted with primary-source GitHub docs on the review thread — the config matches GitHub's canonical security-updates-only example; no change.

Docs-only. Full local gate green (e2e 36/36 with one Clerk-FAPI retry-pass, exit 0 twice). Merging under the owner's docs-only waiver.