### PR TITLE
Sync dependency-update-protocol Config Policy with shipped config

### DIFF
--- a/docs/dev/dependency-update-protocol.md
+++ b/docs/dev/dependency-update-protocol.md
@@ -107,6 +107,7 @@ The current `.github/dependabot.yml` intentionally separates concerns:
 - `versioning-strategy: increase-if-necessary` keeps `package.json` ranges stable when the existing range already admits the update, reducing manifest churn.
 - Group-level `applies-to: version-updates` makes it explicit that routine grouped PRs target freshness, not advisories.
 - Separate `applies-to: security-updates` entries omit cooldown so security advisories are not delayed by the maturity window.
+- The security-only entries set `open-pull-requests-limit: 0` (PR #611). A Dependabot entry emits version updates as well as security updates by default, so without the limit these no-`target-branch` entries also opened ungrouped version PRs straight at `main` with default `increase` semantics (the #604/#605 leak; the #465 `actions/checkout` major merged that way). Zero disables version updates only: per GitHub's dependabot-options-reference, `open-pull-requests-limit` does not carry the security-updates badge, and security updates run under a separate internal limit of ten — GitHub's own security-updates guide recommends exactly this limit-0 + `applies-to: security-updates` + no-`target-branch` shape for "security updates only" entries.
 - `@types/node` semver-major updates are ignored until a deliberate runtime-alignment PR moves the repo to a new active LTS major.
 - `@biomejs/biome` is split from the catch-all npm group so lint contract changes arrive as their own reviewable PR.
 
@@ -116,4 +117,4 @@ These settings do not prove package contents are benign. They only shape Dependa
 
 Dependabot tells us a version exists. It does not vouch for the package contents.
 
-Malicious-publish defenses are tracked in DEBT-394: pnpm `minimumReleaseAge`, `blockExoticSubdeps`, `trustPolicy`, and `strictDepBuilds` / `allowBuilds`. Keep Dependabot `cooldown.default-days: 7` matched to DEBT-394's planned `minimumReleaseAge: 10080` so Dependabot does not open PRs for versions pnpm policy intentionally refuses to install.
+Malicious-publish defenses shipped under DEBT-394 and are live in `pnpm-workspace.yaml`: `minimumReleaseAge: 10080`, `blockExoticSubdeps`, `trustPolicy`, and `strictDepBuilds` / `allowBuilds`. Keep Dependabot `cooldown.default-days: 7` matched to `minimumReleaseAge: 10080` so Dependabot does not open PRs for versions pnpm policy intentionally refuses to install. Age-gate exceptions (`minimumReleaseAgeExclude`) are temporary by design — see docs/dev/supply-chain-overrides.md; the block is removed entirely when its last entry ages in (issue #539 precedent).


### PR DESCRIPTION
Final-sweep crumb from tonight's arc: `docs/dev/dependency-update-protocol.md` → Dependabot Config Policy described the config but omitted the `open-pull-requests-limit: 0` setting #611 added to the security-only entries. Adds that bullet with the primary-source semantics (GitHub options-reference badge rule + security-updates guide's canonical limit-0 pattern — the same evidence that resolved the #616 review dispute). Also fixes pre-existing staleness: DEBT-394's supply-chain settings are live in `pnpm-workspace.yaml`, not 'planned', and notes the #539 age-exclude-removal precedent.

Docs-only, provably inert (single .md). Full local gate green (3162 unit / 363 browser / 159 integration / build / e2e 36 passed). Merging under the owner's docs-only waiver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how security-only dependency updates behave when version-update pull requests are disabled.
  * Documented safeguards against malicious package publishes, including package release delays, dependency restrictions, and build-script controls.
  * Added guidance for configuring release cooldowns and managing temporary dependency exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->