### PR TITLE
Fix BUG-285/286: durable Stripe webhook failure state + canonical subscription-writer lock order

### DIFF
--- a/app/(marketing)/checkout/success/checkout-success-sync.tsx
+++ b/app/(marketing)/checkout/success/checkout-success-sync.tsx
@@ -238,6 +238,9 @@ export async function syncCheckoutSuccess(
 
   const currentPeriodEnd = new Date(currentPeriodEndSeconds * MS_PER_SECOND);
 
+  // Canonical multi-repository lock order: advisory(user) in
+  // subscriptions.upsert -> stripe_subscriptions row -> stripe_customers row.
+  // Keep every writer in this order to avoid AB-BA deadlocks.
   const write = await d.transaction(
     async ({ stripeCustomers, subscriptions }) => {
       const result = await subscriptions.upsert({

--- a/docs/bugs/bug-285-stripe-webhook-markfailed-on-aborted-transaction.md
+++ b/docs/bugs/bug-285-stripe-webhook-markfailed-on-aborted-transaction.md
@@ -5,7 +5,7 @@
 **Date:** 2026-07-09
 **Confirmed:** 2026-07-09 (multi-agent adversarial sweep; Cycle B1 re-audit confirmed the failure-domain defect and narrowed its production reachability/logging claims)
 **Component:** Stripe webhook / event ledger
-**Resolution State:** Implemented on branch `fix/bug-285-286-stripe-failure-domain-lock-order` for PR "Fix BUG-285/286: durable Stripe webhook failure state + canonical subscription-writer lock order" (pending review, merge, and production proof). Phase A moves failure persistence to a fresh transaction, preserves the original processing error, and adds unit plus real-Postgres aborted-transaction regressions.
+**Resolution State:** Implemented on branch `fix/bug-285-286-stripe-failure-domain-lock-order` in [PR #626](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/626), "Fix BUG-285/286: durable Stripe webhook failure state + canonical subscription-writer lock order" (pending review, merge, and production proof). Phase A moves failure persistence to a fresh transaction, preserves the original processing error, and adds unit plus real-Postgres aborted-transaction regressions.
 
 ---
 

--- a/docs/bugs/bug-285-stripe-webhook-markfailed-on-aborted-transaction.md
+++ b/docs/bugs/bug-285-stripe-webhook-markfailed-on-aborted-transaction.md
@@ -5,6 +5,7 @@
 **Date:** 2026-07-09
 **Confirmed:** 2026-07-09 (multi-agent adversarial sweep; Cycle B1 re-audit confirmed the failure-domain defect and narrowed its production reachability/logging claims)
 **Component:** Stripe webhook / event ledger
+**Resolution State:** Implemented on branch `fix/bug-285-286-stripe-failure-domain-lock-order` for PR "Fix BUG-285/286: durable Stripe webhook failure state + canonical subscription-writer lock order" (pending review, merge, and production proof). Phase A moves failure persistence to a fresh transaction, preserves the original processing error, and adds unit plus real-Postgres aborted-transaction regressions.
 
 ---
 

--- a/docs/bugs/bug-286-webhook-vs-reconcile-lock-order-deadlock.md
+++ b/docs/bugs/bug-286-webhook-vs-reconcile-lock-order-deadlock.md
@@ -5,6 +5,7 @@
 **Date:** 2026-07-09
 **Confirmed:** 2026-07-09 (Cycle B2 independently re-derived the AB-BA cycle from source, installed driver behavior, and PostgreSQL lock semantics)
 **Component:** Stripe webhook / checkout success / reconcile cron
+**Resolution State:** Implemented on branch `fix/bug-285-286-stripe-failure-domain-lock-order` for PR "Fix BUG-285/286: durable Stripe webhook failure state + canonical subscription-writer lock order" (pending review, merge, and production proof). Phase B makes all three writers acquire advisory(user) → `stripe_subscriptions` → `stripe_customers`, pins the job call order in unit coverage, and proves both writer pairs complete under deterministic real-Postgres interleavings.
 
 ---
 

--- a/docs/bugs/bug-286-webhook-vs-reconcile-lock-order-deadlock.md
+++ b/docs/bugs/bug-286-webhook-vs-reconcile-lock-order-deadlock.md
@@ -5,7 +5,7 @@
 **Date:** 2026-07-09
 **Confirmed:** 2026-07-09 (Cycle B2 independently re-derived the AB-BA cycle from source, installed driver behavior, and PostgreSQL lock semantics)
 **Component:** Stripe webhook / checkout success / reconcile cron
-**Resolution State:** Implemented on branch `fix/bug-285-286-stripe-failure-domain-lock-order` for PR "Fix BUG-285/286: durable Stripe webhook failure state + canonical subscription-writer lock order" (pending review, merge, and production proof). Phase B makes all three writers acquire advisory(user) → `stripe_subscriptions` → `stripe_customers`, pins the job call order in unit coverage, and proves both writer pairs complete under deterministic real-Postgres interleavings.
+**Resolution State:** Implemented on branch `fix/bug-285-286-stripe-failure-domain-lock-order` in [PR #626](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/626), "Fix BUG-285/286: durable Stripe webhook failure state + canonical subscription-writer lock order" (pending review, merge, and production proof). Phase B makes all three writers acquire advisory(user) → `stripe_subscriptions` → `stripe_customers`, pins the job call order in unit coverage, and proves both writer pairs complete under deterministic real-Postgres interleavings.
 
 ---
 

--- a/src/adapters/controllers/stripe-webhook-controller-failure-boundary.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller-failure-boundary.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ApplicationError } from '@/src/application/errors';
+import {
+  FakeLogger,
+  FakePaymentGateway,
+  FakeStripeCustomerRepository,
+  FakeStripeEventRepository,
+  FakeSubscriptionRepository,
+} from '@/src/application/test-helpers/fakes';
+import {
+  processStripeWebhook,
+  type StripeWebhookDeps,
+} from './stripe-webhook-controller';
+
+class ThrowingStripeCustomerRepository extends FakeStripeCustomerRepository {
+  constructor(private readonly error: unknown) {
+    super();
+  }
+
+  override async insert(): Promise<never> {
+    throw this.error;
+  }
+}
+
+function createPaymentGateway(eventId: string): FakePaymentGateway {
+  return new FakePaymentGateway({
+    externalCustomerId: 'cus_test',
+    checkoutUrl: 'https://stripe/checkout',
+    portalUrl: 'https://stripe/portal',
+    webhookResult: {
+      eventId,
+      type: 'customer.subscription.updated',
+      subscriptionUpdate: {
+        userId: crypto.randomUUID(),
+        externalCustomerId: 'cus_123',
+        externalSubscriptionId: 'sub_123',
+        plan: 'monthly',
+        status: 'active',
+        currentPeriodEnd: new Date('2026-03-01T00:00:00.000Z'),
+        cancelAtPeriodEnd: false,
+      },
+    },
+  });
+}
+
+function createAbortedTransactionDeps(input: {
+  paymentGateway: FakePaymentGateway;
+  processingError: unknown;
+  transactionError: unknown;
+  persistenceError?: unknown;
+  stripeEvents?: FakeStripeEventRepository;
+}): {
+  deps: StripeWebhookDeps;
+  stripeEvents: FakeStripeEventRepository;
+  logger: FakeLogger;
+  transactionCallCount: () => number;
+} {
+  const stripeEvents = input.stripeEvents ?? new FakeStripeEventRepository();
+  const logger = new FakeLogger();
+  let transactionCallCount = 0;
+
+  return {
+    deps: {
+      paymentGateway: input.paymentGateway,
+      logger,
+      now: () => new Date(),
+      transaction: async (fn) => {
+        transactionCallCount += 1;
+
+        if (transactionCallCount === 1) {
+          try {
+            await fn({
+              stripeEvents: new FakeStripeEventRepository(),
+              subscriptions: new FakeSubscriptionRepository(),
+              stripeCustomers: new ThrowingStripeCustomerRepository(
+                input.processingError,
+              ),
+            });
+          } catch {
+            // postgres.js can surface the scope's first statement error instead
+            // of the mapped error thrown by the transaction callback.
+          }
+
+          throw input.transactionError;
+        }
+
+        if (input.persistenceError !== undefined) {
+          throw input.persistenceError;
+        }
+
+        return fn({
+          stripeEvents,
+          subscriptions: new FakeSubscriptionRepository(),
+          stripeCustomers: new FakeStripeCustomerRepository(),
+        });
+      },
+    },
+    stripeEvents,
+    logger,
+    transactionCallCount: () => transactionCallCount,
+  };
+}
+
+describe('processStripeWebhook failure boundary', () => {
+  it('persists processing failure in a fresh transaction and throws the original mapped error', async () => {
+    const processingError = new ApplicationError(
+      'CONFLICT',
+      'Stripe customer id is already mapped to a different user',
+    );
+    const eventId = 'evt_aborted_transaction_failure';
+    const harness = createAbortedTransactionDeps({
+      paymentGateway: createPaymentGateway(eventId),
+      processingError,
+      transactionError: new Error('raw Postgres 23505'),
+    });
+
+    await expect(
+      processStripeWebhook(harness.deps, {
+        rawBody: 'raw',
+        signature: 'sig',
+      }),
+    ).rejects.toBe(processingError);
+
+    expect(harness.transactionCallCount()).toBe(2);
+    const stored = await harness.stripeEvents.lock(eventId);
+    expect(JSON.parse(stored.error ?? '{}')).toMatchObject({
+      name: 'ApplicationError',
+      code: 'CONFLICT',
+      message: 'Stripe customer id is already mapped to a different user',
+    });
+  });
+
+  it('throws the original processing error when fresh failure persistence also fails', async () => {
+    const processingError = new ApplicationError(
+      'CONFLICT',
+      'Stripe customer id is already mapped to a different user',
+    );
+    const persistenceError = new Error('failure ledger unavailable');
+    const harness = createAbortedTransactionDeps({
+      paymentGateway: createPaymentGateway('evt_persistence_failure'),
+      processingError,
+      transactionError: new Error('raw Postgres 23505'),
+      persistenceError,
+    });
+
+    await expect(
+      processStripeWebhook(harness.deps, {
+        rawBody: 'raw',
+        signature: 'sig',
+      }),
+    ).rejects.toBe(processingError);
+
+    expect(harness.transactionCallCount()).toBe(2);
+    expect(harness.logger.errorCalls).toContainEqual({
+      context: {
+        eventId: 'evt_persistence_failure',
+        error: persistenceError.message,
+      },
+      msg: 'Failed to persist Stripe webhook failure state',
+    });
+  });
+
+  it('does not overwrite an event completed before fresh failure persistence locks it', async () => {
+    const eventId = 'evt_concurrently_processed';
+    const stripeEvents = new FakeStripeEventRepository();
+    await stripeEvents.claim(eventId, 'customer.subscription.updated');
+    await stripeEvents.markProcessed(eventId);
+    const markFailedSpy = vi.spyOn(stripeEvents, 'markFailed');
+    const processingError = new ApplicationError(
+      'CONFLICT',
+      'Stripe customer id is already mapped to a different user',
+    );
+    const harness = createAbortedTransactionDeps({
+      paymentGateway: createPaymentGateway(eventId),
+      processingError,
+      transactionError: new Error('raw Postgres 23505'),
+      stripeEvents,
+    });
+
+    await expect(
+      processStripeWebhook(harness.deps, {
+        rawBody: 'raw',
+        signature: 'sig',
+      }),
+    ).rejects.toBe(processingError);
+
+    expect(harness.transactionCallCount()).toBe(2);
+    expect(markFailedSpy).not.toHaveBeenCalled();
+    await expect(stripeEvents.lock(eventId)).resolves.toMatchObject({
+      processedAt: expect.any(Date),
+      error: null,
+    });
+  });
+});

--- a/src/adapters/controllers/stripe-webhook-controller-failure-boundary.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller-failure-boundary.test.ts
@@ -160,6 +160,71 @@ describe('processStripeWebhook failure boundary', () => {
     });
   });
 
+  it('logs a non-Error failure-persistence rejection without replacing the processing error', async () => {
+    const processingError = new ApplicationError(
+      'CONFLICT',
+      'Stripe customer id is already mapped to a different user',
+    );
+    const persistenceError = 'failure ledger unavailable';
+    const harness = createAbortedTransactionDeps({
+      paymentGateway: createPaymentGateway('evt_non_error_persistence_failure'),
+      processingError,
+      transactionError: new Error('raw Postgres 23505'),
+      persistenceError,
+    });
+
+    await expect(
+      processStripeWebhook(harness.deps, {
+        rawBody: 'raw',
+        signature: 'sig',
+      }),
+    ).rejects.toBe(processingError);
+
+    expect(harness.logger.errorCalls).toContainEqual({
+      context: {
+        eventId: 'evt_non_error_persistence_failure',
+        error: persistenceError,
+      },
+      msg: 'Failed to persist Stripe webhook failure state',
+    });
+  });
+
+  it('persists and rethrows a transaction rejection when no processing error was captured', async () => {
+    const eventId = 'evt_transaction_rejection';
+    const stripeEvents = new FakeStripeEventRepository();
+    const transactionError = new Error('transaction could not start');
+    let transactionCallCount = 0;
+    const deps: StripeWebhookDeps = {
+      paymentGateway: createPaymentGateway(eventId),
+      logger: new FakeLogger(),
+      now: () => new Date(),
+      transaction: async (fn) => {
+        transactionCallCount += 1;
+        if (transactionCallCount === 1) throw transactionError;
+
+        return fn({
+          stripeEvents,
+          subscriptions: new FakeSubscriptionRepository(),
+          stripeCustomers: new FakeStripeCustomerRepository(),
+        });
+      },
+    };
+
+    await expect(
+      processStripeWebhook(deps, {
+        rawBody: 'raw',
+        signature: 'sig',
+      }),
+    ).rejects.toBe(transactionError);
+
+    expect(transactionCallCount).toBe(2);
+    const stored = await stripeEvents.lock(eventId);
+    expect(JSON.parse(stored.error ?? '{}')).toMatchObject({
+      name: 'Error',
+      message: transactionError.message,
+    });
+  });
+
   it('persists and rethrows a non-Error processing failure without replacing it', async () => {
     const processingError = 'raw processing failure';
     const eventId = 'evt_non_error_failure';

--- a/src/adapters/controllers/stripe-webhook-controller-failure-boundary.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller-failure-boundary.test.ts
@@ -160,6 +160,29 @@ describe('processStripeWebhook failure boundary', () => {
     });
   });
 
+  it('persists and rethrows a non-Error processing failure without replacing it', async () => {
+    const processingError = 'raw processing failure';
+    const eventId = 'evt_non_error_failure';
+    const harness = createAbortedTransactionDeps({
+      paymentGateway: createPaymentGateway(eventId),
+      processingError,
+      transactionError: new Error('raw Postgres statement error'),
+    });
+
+    await expect(
+      processStripeWebhook(harness.deps, {
+        rawBody: 'raw',
+        signature: 'sig',
+      }),
+    ).rejects.toBe(processingError);
+
+    const stored = await harness.stripeEvents.lock(eventId);
+    expect(JSON.parse(stored.error ?? '{}')).toEqual({
+      message: 'Unknown error',
+      raw: processingError,
+    });
+  });
+
   it('does not overwrite an event completed before fresh failure persistence locks it', async () => {
     const eventId = 'evt_concurrently_processed';
     const stripeEvents = new FakeStripeEventRepository();

--- a/src/adapters/controllers/stripe-webhook-controller.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.test.ts
@@ -28,6 +28,14 @@ class FailingSubscriptionRepository extends FakeSubscriptionRepository {
   }
 }
 
+class ConcurrentlyCompletingStripeEventRepository extends FakeStripeEventRepository {
+  override async peek(eventId: string) {
+    const snapshot = await super.peek(eventId);
+    await this.markProcessed(eventId);
+    return snapshot;
+  }
+}
+
 class ThrowingPaymentGateway extends FakePaymentGateway {
   constructor(private readonly error: unknown) {
     super({
@@ -575,6 +583,50 @@ describe('processStripeWebhook', () => {
 
     expect(insertSpy).not.toHaveBeenCalled();
     expect(lockSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not reprocess an event completed between peek and lock', async () => {
+    const userId = crypto.randomUUID();
+    const paymentGateway = new FakePaymentGateway({
+      externalCustomerId: 'cus_test',
+      checkoutUrl: 'https://stripe/checkout',
+      portalUrl: 'https://stripe/portal',
+      webhookResult: {
+        eventId: 'evt_concurrent_completion',
+        type: 'customer.subscription.updated',
+        subscriptionUpdate: {
+          userId,
+          externalCustomerId: 'cus_123',
+          externalSubscriptionId: 'sub_123',
+          plan: 'monthly',
+          status: 'active',
+          currentPeriodEnd: new Date('2026-03-01T00:00:00.000Z'),
+          cancelAtPeriodEnd: false,
+        },
+      },
+    });
+    const stripeEvents = new ConcurrentlyCompletingStripeEventRepository();
+    await stripeEvents.claim(
+      'evt_concurrent_completion',
+      'customer.subscription.updated',
+    );
+    const { deps, subscriptions } = createDeps({
+      paymentGateway,
+      stripeEvents,
+    });
+    const upsertSpy = vi.spyOn(subscriptions, 'upsert');
+
+    await expect(
+      processStripeWebhook(deps, { rawBody: 'raw', signature: 'sig' }),
+    ).resolves.toBeUndefined();
+
+    expect(upsertSpy).not.toHaveBeenCalled();
+    await expect(
+      stripeEvents.lock('evt_concurrent_completion'),
+    ).resolves.toMatchObject({
+      processedAt: expect.any(Date),
+      error: null,
+    });
   });
 
   it('returns call to prune processed stripe events when event already processed', async () => {

--- a/src/adapters/controllers/stripe-webhook-controller.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.ts
@@ -40,6 +40,13 @@ type StripeWebhookEvent = Awaited<
 const STRIPE_EVENTS_RETENTION_MS = 90 * DAY_MS;
 const STRIPE_EVENTS_PRUNE_LIMIT = 100;
 
+function isSuccessfullyProcessed(event: {
+  processedAt: Date | null;
+  error: string | null;
+}): boolean {
+  return event.processedAt !== null && event.error === null;
+}
+
 function toErrorData(error: unknown): string {
   if (isApplicationError(error)) {
     return JSON.stringify({
@@ -74,7 +81,7 @@ async function persistFailure(
       await stripeEvents.claim(event.eventId, event.type);
       const current = await stripeEvents.lock(event.eventId);
 
-      if (current.processedAt !== null && current.error === null) {
+      if (isSuccessfullyProcessed(current)) {
         return;
       }
 
@@ -141,17 +148,13 @@ export async function processStripeWebhook(
         const claimed = await stripeEvents.claim(event.eventId, event.type);
         if (!claimed) {
           const snapshot = await stripeEvents.peek(event.eventId);
-          if (
-            snapshot &&
-            snapshot.processedAt !== null &&
-            snapshot.error === null
-          ) {
+          if (snapshot && isSuccessfullyProcessed(snapshot)) {
             return;
           }
         }
 
         const current = await stripeEvents.lock(event.eventId);
-        if (current.processedAt !== null && current.error === null) {
+        if (isSuccessfullyProcessed(current)) {
           return;
         }
 

--- a/src/adapters/controllers/stripe-webhook-controller.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.ts
@@ -157,6 +157,9 @@ export async function processStripeWebhook(
 
         try {
           if (event.subscriptionUpdate) {
+            // Canonical multi-repository lock order: advisory(user) in
+            // subscriptions.upsert -> stripe_subscriptions row ->
+            // stripe_customers row. Keep every writer in this order.
             const write = await subscriptions.upsert({
               userId: event.subscriptionUpdate.userId,
               externalSubscriptionId:

--- a/src/adapters/controllers/stripe-webhook-controller.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.ts
@@ -33,7 +33,9 @@ export type StripeWebhookDeps = {
   now: () => Date;
 };
 
-type StripeWebhookTxResult = { ok: true } | { ok: false; error: unknown };
+type StripeWebhookEvent = Awaited<
+  ReturnType<PaymentGateway['processWebhookEvent']>
+>;
 
 const STRIPE_EVENTS_RETENTION_MS = 90 * DAY_MS;
 const STRIPE_EVENTS_PRUNE_LIMIT = 100;
@@ -60,11 +62,43 @@ function toErrorData(error: unknown): string {
   return JSON.stringify({ message: 'Unknown error', raw: String(error) });
 }
 
+async function persistFailure(
+  deps: StripeWebhookDeps,
+  event: StripeWebhookEvent,
+  error: unknown,
+): Promise<void> {
+  const errorData = toErrorData(error);
+
+  try {
+    await deps.transaction(async ({ stripeEvents }) => {
+      await stripeEvents.claim(event.eventId, event.type);
+      const current = await stripeEvents.lock(event.eventId);
+
+      if (current.processedAt !== null && current.error === null) {
+        return;
+      }
+
+      await stripeEvents.markFailed(event.eventId, errorData);
+    });
+  } catch (persistError) {
+    deps.logger.error(
+      {
+        eventId: event.eventId,
+        error:
+          persistError instanceof Error
+            ? persistError.message
+            : String(persistError),
+      },
+      'Failed to persist Stripe webhook failure state',
+    );
+  }
+}
+
 export async function processStripeWebhook(
   deps: StripeWebhookDeps,
   input: StripeWebhookInput,
 ): Promise<void> {
-  let event: Awaited<ReturnType<PaymentGateway['processWebhookEvent']>>;
+  let event: StripeWebhookEvent;
   try {
     event = await deps.paymentGateway.processWebhookEvent(
       input.rawBody,
@@ -98,61 +132,64 @@ export async function processStripeWebhook(
     throw error;
   }
 
-  const txResult = await deps.transaction(
-    async ({
-      stripeEvents,
-      subscriptions,
-      stripeCustomers,
-    }): Promise<StripeWebhookTxResult> => {
-      const claimed = await stripeEvents.claim(event.eventId, event.type);
-      if (!claimed) {
-        const snapshot = await stripeEvents.peek(event.eventId);
-        if (
-          snapshot &&
-          snapshot.processedAt !== null &&
-          snapshot.error === null
-        ) {
-          return { ok: true };
-        }
-      }
+  let processingError: unknown;
+  let hasProcessingError = false;
 
-      const current = await stripeEvents.lock(event.eventId);
-      if (current.processedAt !== null && current.error === null) {
-        return { ok: true };
-      }
-
-      try {
-        if (event.subscriptionUpdate) {
-          const write = await subscriptions.upsert({
-            userId: event.subscriptionUpdate.userId,
-            externalSubscriptionId:
-              event.subscriptionUpdate.externalSubscriptionId,
-            plan: event.subscriptionUpdate.plan,
-            status: event.subscriptionUpdate.status,
-            currentPeriodEnd: event.subscriptionUpdate.currentPeriodEnd,
-            cancelAtPeriodEnd: event.subscriptionUpdate.cancelAtPeriodEnd,
-          });
-
-          if (write.persisted) {
-            await stripeCustomers.insert(
-              event.subscriptionUpdate.userId,
-              event.subscriptionUpdate.externalCustomerId,
-              { conflictStrategy: 'authoritative' },
-            );
+  try {
+    await deps.transaction(
+      async ({ stripeEvents, subscriptions, stripeCustomers }) => {
+        const claimed = await stripeEvents.claim(event.eventId, event.type);
+        if (!claimed) {
+          const snapshot = await stripeEvents.peek(event.eventId);
+          if (
+            snapshot &&
+            snapshot.processedAt !== null &&
+            snapshot.error === null
+          ) {
+            return;
           }
         }
 
-        await stripeEvents.markProcessed(event.eventId);
-        return { ok: true };
-      } catch (error) {
-        await stripeEvents.markFailed(event.eventId, toErrorData(error));
-        return { ok: false, error };
-      }
-    },
-  );
+        const current = await stripeEvents.lock(event.eventId);
+        if (current.processedAt !== null && current.error === null) {
+          return;
+        }
 
-  if (!txResult.ok) {
-    throw txResult.error;
+        try {
+          if (event.subscriptionUpdate) {
+            const write = await subscriptions.upsert({
+              userId: event.subscriptionUpdate.userId,
+              externalSubscriptionId:
+                event.subscriptionUpdate.externalSubscriptionId,
+              plan: event.subscriptionUpdate.plan,
+              status: event.subscriptionUpdate.status,
+              currentPeriodEnd: event.subscriptionUpdate.currentPeriodEnd,
+              cancelAtPeriodEnd: event.subscriptionUpdate.cancelAtPeriodEnd,
+            });
+
+            if (write.persisted) {
+              await stripeCustomers.insert(
+                event.subscriptionUpdate.userId,
+                event.subscriptionUpdate.externalCustomerId,
+                { conflictStrategy: 'authoritative' },
+              );
+            }
+          }
+
+          await stripeEvents.markProcessed(event.eventId);
+        } catch (error) {
+          processingError = error;
+          hasProcessingError = true;
+          throw error;
+        }
+      },
+    );
+  } catch (transactionError) {
+    const originalError = hasProcessingError
+      ? processingError
+      : transactionError;
+    await persistFailure(deps, event, originalError);
+    throw originalError;
   }
 
   // Best-effort cleanup: prune old stripe events.

--- a/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
@@ -1277,6 +1277,40 @@ describe('reconcileStripeSubscriptions', () => {
     ).resolves.toBeNull();
   });
 
+  it('acquires the subscription lock before writing the Stripe customer mapping', async () => {
+    const calls: string[] = [];
+    class OrderedSubscriptionRepository extends FakeSubscriptionRepository {
+      override async upsert(
+        input: Parameters<FakeSubscriptionRepository['upsert']>[0],
+      ) {
+        calls.push('subscriptions.upsert');
+        return super.upsert(input);
+      }
+    }
+    class OrderedStripeCustomerRepository extends FakeStripeCustomerRepository {
+      override async insert(
+        ...args: Parameters<FakeStripeCustomerRepository['insert']>
+      ) {
+        calls.push('stripeCustomers.insert');
+        return super.insert(...args);
+      }
+    }
+    const local = createUserSubscriptionFixture('sub_lock_order');
+    const scenario = createReconciliationTestScenario({
+      stripe: createStripeFromFixtures({ fixtures: [{ fixture: local }] }),
+      localSubscriptions: [row(primaryUserId, local.id)],
+      subscriptions: new OrderedSubscriptionRepository(),
+      stripeCustomers: new OrderedStripeCustomerRepository(),
+    });
+
+    await expect(scenario.run({ dryRun: true })).resolves.toMatchObject({
+      updated: 1,
+      failed: 0,
+    });
+
+    expect(calls).toEqual(['subscriptions.upsert', 'stripeCustomers.insert']);
+  });
+
   it('selects canonical by highest currentPeriodEnd even when local row is blocking', async () => {
     const local = createUserSubscriptionFixture('sub_local', {
       status: 'active',

--- a/src/adapters/jobs/reconcile-stripe-subscriptions.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions.ts
@@ -229,12 +229,10 @@ export async function reconcileStripeSubscriptions(
         }
 
         // Phase 4: persist canonical subscription and customer mapping atomically.
+        // Canonical multi-repository lock order: advisory(user) in
+        // subscriptions.upsert -> stripe_subscriptions row -> stripe_customers
+        // row. Keep every writer in this order to avoid AB-BA deadlocks.
         await deps.transaction(async ({ stripeCustomers, subscriptions }) => {
-          await stripeCustomers.insert(
-            canonical.userId,
-            canonical.externalCustomerId,
-            { conflictStrategy: 'authoritative' },
-          );
           await subscriptions.upsert({
             userId: canonical.userId,
             externalSubscriptionId: canonical.externalSubscriptionId,
@@ -243,6 +241,11 @@ export async function reconcileStripeSubscriptions(
             currentPeriodEnd: canonical.currentPeriodEnd,
             cancelAtPeriodEnd: canonical.cancelAtPeriodEnd,
           });
+          await stripeCustomers.insert(
+            canonical.userId,
+            canonical.externalCustomerId,
+            { conflictStrategy: 'authoritative' },
+          );
         });
 
         if (duplicateIds.length > 0) {

--- a/src/adapters/repositories/drizzle-stripe-customer-repository.test.ts
+++ b/src/adapters/repositories/drizzle-stripe-customer-repository.test.ts
@@ -99,6 +99,8 @@ describe('DrizzleStripeCustomerRepository', () => {
 
     await expect(repo.insert(userId, 'cus_new')).rejects.toMatchObject({
       code: 'CONFLICT',
+      message:
+        'Stripe customer already exists with a different stripeCustomerId',
     });
   });
 
@@ -184,6 +186,7 @@ describe('DrizzleStripeCustomerRepository', () => {
     );
     await expect(repo.insert(userId, 'cus_123')).rejects.toMatchObject({
       code: 'CONFLICT',
+      message: 'Stripe customer id is already mapped to a different user',
     });
   });
 

--- a/src/application/test-helpers/fakes/fake-stripe-customer-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-stripe-customer-repository.test.ts
@@ -45,6 +45,8 @@ describe('FakeStripeCustomerRepository', () => {
 
       await expect(repo.insert('user-1', 'cus_456')).rejects.toMatchObject({
         code: 'CONFLICT',
+        message:
+          'Stripe customer already exists with a different stripeCustomerId',
       });
     });
 
@@ -54,6 +56,7 @@ describe('FakeStripeCustomerRepository', () => {
 
       await expect(repo.insert('user-2', 'cus_123')).rejects.toMatchObject({
         code: 'CONFLICT',
+        message: 'Stripe customer id is already mapped to a different user',
       });
     });
   });

--- a/src/application/test-helpers/fakes/fake-stripe-customer-repository.ts
+++ b/src/application/test-helpers/fakes/fake-stripe-customer-repository.ts
@@ -35,7 +35,7 @@ export class FakeStripeCustomerRepository implements StripeCustomerRepository {
       if (conflictStrategy !== 'authoritative') {
         throw new ApplicationError(
           'CONFLICT',
-          'User is already mapped to a different Stripe customer',
+          'Stripe customer already exists with a different stripeCustomerId',
         );
       }
       this.customerIdToUserId.delete(existingCustomerId);
@@ -44,7 +44,7 @@ export class FakeStripeCustomerRepository implements StripeCustomerRepository {
     if (existingUserId && existingUserId !== userId) {
       throw new ApplicationError(
         'CONFLICT',
-        'Stripe customer is already mapped to a different user',
+        'Stripe customer id is already mapped to a different user',
       );
     }
 

--- a/src/application/use-cases/create-checkout-session.test.ts
+++ b/src/application/use-cases/create-checkout-session.test.ts
@@ -82,7 +82,7 @@ class EmptyAfterConflictStripeCustomerRepository extends FakeStripeCustomerRepos
   override async insert(): Promise<void> {
     throw new ApplicationError(
       'CONFLICT',
-      'User is already mapped to a different Stripe customer',
+      'Stripe customer already exists with a different stripeCustomerId',
     );
   }
 }
@@ -667,7 +667,8 @@ describe('CreateCheckoutSessionUseCase', () => {
       message: 'Stripe customer mapping disappeared after conflict',
       cause: expect.objectContaining({
         code: 'CONFLICT',
-        message: 'User is already mapped to a different Stripe customer',
+        message:
+          'Stripe customer already exists with a different stripeCustomerId',
       }),
     });
 

--- a/tests/integration/stripe-subscription-writer-lock-order.integration.test.ts
+++ b/tests/integration/stripe-subscription-writer-lock-order.integration.test.ts
@@ -152,6 +152,43 @@ function stripeSubscription(input: {
   };
 }
 
+function createReconciliationStripeClient(
+  subscription: ReturnType<typeof stripeSubscription>,
+): ReconcileStripeSubscriptionsDeps['stripe'] {
+  function unexpectedCall(operation: string): never {
+    throw new Error(`Unexpected Stripe call: ${operation}`);
+  }
+
+  return {
+    customers: {
+      create: async () => unexpectedCall('customers.create'),
+    },
+    checkout: {
+      sessions: {
+        create: async () => unexpectedCall('checkout.sessions.create'),
+        list: async () => unexpectedCall('checkout.sessions.list'),
+        retrieve: async () => unexpectedCall('checkout.sessions.retrieve'),
+        expire: async () => unexpectedCall('checkout.sessions.expire'),
+      },
+    },
+    subscriptions: {
+      retrieve: async () => subscription,
+      list: async () => ({
+        data: [{ id: subscription.id, status: subscription.status }],
+      }),
+      cancel: async () => subscription,
+    },
+    billingPortal: {
+      sessions: {
+        create: async () => unexpectedCall('billingPortal.sessions.create'),
+      },
+    },
+    webhooks: {
+      constructEvent: () => unexpectedCall('webhooks.constructEvent'),
+    },
+  };
+}
+
 async function runWebhookWriter(input: {
   userId: string;
   externalCustomerId: string;
@@ -318,15 +355,7 @@ describe('Stripe subscription writer lock order', () => {
       externalCustomerId,
       externalSubscriptionId,
     });
-    const stripe = {
-      subscriptions: {
-        retrieve: async () => normalizedSubscription,
-        list: async () => ({
-          data: [{ id: externalSubscriptionId, status: 'active' as const }],
-        }),
-        cancel: async () => normalizedSubscription,
-      },
-    } as unknown as ReconcileStripeSubscriptionsDeps['stripe'];
+    const stripe = createReconciliationStripeClient(normalizedSubscription);
 
     const reconciliationPromise = reconcileStripeSubscriptions(
       { limit: 1, offset: 0, dryRun: true, concurrency: 1 },

--- a/tests/integration/stripe-subscription-writer-lock-order.integration.test.ts
+++ b/tests/integration/stripe-subscription-writer-lock-order.integration.test.ts
@@ -1,0 +1,393 @@
+import { randomUUID } from 'node:crypto';
+import { sql as drizzleSql } from 'drizzle-orm';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import {
+  type CheckoutSuccessDeps,
+  syncCheckoutSuccess,
+} from '@/app/(marketing)/checkout/success/checkout-success-sync';
+import { processStripeWebhook } from '@/src/adapters/controllers/stripe-webhook-controller';
+import { reconcileStripeSubscriptions } from '@/src/adapters/jobs/reconcile-stripe-subscriptions';
+import type { ReconcileStripeSubscriptionsDeps } from '@/src/adapters/jobs/reconcile-stripe-subscriptions-types';
+import { DrizzleStripeCustomerRepository } from '@/src/adapters/repositories/drizzle-stripe-customer-repository';
+import { DrizzleStripeEventRepository } from '@/src/adapters/repositories/drizzle-stripe-event-repository';
+import { DrizzleSubscriptionRepository } from '@/src/adapters/repositories/drizzle-subscription-repository';
+import type { DrizzleDb } from '@/src/adapters/shared/database-types';
+import {
+  FakeAuthGateway,
+  FakeLogger,
+  FakePaymentGateway,
+} from '@/src/application/test-helpers/fakes';
+import { createDeferred } from '@/tests/test-helpers/create-deferred';
+import {
+  cleanupAfterEach,
+  closeConnection,
+  createCleanupState,
+  createIntegrationDb,
+  createUser,
+} from './helpers';
+
+const control = createIntegrationDb();
+const subscriptionWriter = createIntegrationDb();
+const reconciliationWriter = createIntegrationDb();
+const cleanup = createCleanupState();
+
+const priceIds = {
+  monthly: 'price_test_monthly',
+  annual: 'price_test_annual',
+} as const;
+
+class PausingSubscriptionRepository extends DrizzleSubscriptionRepository {
+  constructor(
+    db: DrizzleDb,
+    private readonly lockHeld: () => void,
+    private readonly release: Promise<void>,
+  ) {
+    super(db, priceIds);
+  }
+
+  override async upsert(
+    input: Parameters<DrizzleSubscriptionRepository['upsert']>[0],
+  ) {
+    const result = await super.upsert(input);
+    this.lockHeld();
+    await this.release;
+    return result;
+  }
+}
+
+class ObservedStripeCustomerRepository extends DrizzleStripeCustomerRepository {
+  constructor(
+    db: DrizzleDb,
+    private readonly lockHeld: () => void,
+  ) {
+    super(db);
+  }
+
+  override async insert(
+    ...args: Parameters<DrizzleStripeCustomerRepository['insert']>
+  ): Promise<void> {
+    await super.insert(...args);
+    this.lockHeld();
+  }
+}
+
+async function configureSubscriptionWriter(tx: DrizzleDb): Promise<void> {
+  await tx.execute(drizzleSql`set local deadlock_timeout = '5s'`);
+  await tx.execute(drizzleSql`set local lock_timeout = '4s'`);
+  await tx.execute(drizzleSql`set local statement_timeout = '6s'`);
+}
+
+async function configureReconciliationWriter(tx: DrizzleDb): Promise<void> {
+  await tx.execute(drizzleSql`set local deadlock_timeout = '50ms'`);
+  await tx.execute(drizzleSql`set local lock_timeout = '4s'`);
+  await tx.execute(drizzleSql`set local statement_timeout = '6s'`);
+}
+
+async function getBackendPid(tx: DrizzleDb): Promise<number> {
+  const rows = await tx.execute<{ pid: number }>(
+    drizzleSql`select pg_backend_pid()::int as pid`,
+  );
+  const pid = rows[0]?.pid;
+  if (pid === undefined)
+    throw new Error('Failed to read PostgreSQL backend pid');
+  return pid;
+}
+
+async function waitForReconciliationState(input: {
+  pid: number;
+  customerLockObserved: () => boolean;
+}): Promise<'customer-lock-held' | 'waiting-on-advisory'> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (input.customerLockObserved()) return 'customer-lock-held';
+
+    const rows = await control.db.execute<{ waiting: boolean }>(drizzleSql`
+      select exists (
+        select 1
+        from pg_locks
+        where pid = ${input.pid}
+          and locktype = 'advisory'
+          and not granted
+      ) as waiting
+    `);
+    if (rows[0]?.waiting) return 'waiting-on-advisory';
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error('Reconciliation writer did not reach a lock wait');
+}
+
+function findPostgresErrorCode(error: unknown): string | null {
+  let current = error;
+  for (let depth = 0; depth < 8; depth += 1) {
+    if (typeof current !== 'object' || current === null) return null;
+    const record = current as { code?: unknown; cause?: unknown };
+    if (typeof record.code === 'string' && /^[0-9A-Z]{5}$/.test(record.code)) {
+      return record.code;
+    }
+    current = record.cause;
+  }
+  return null;
+}
+
+function stripeSubscription(input: {
+  userId: string;
+  externalCustomerId: string;
+  externalSubscriptionId: string;
+}) {
+  return {
+    id: input.externalSubscriptionId,
+    customer: input.externalCustomerId,
+    status: 'active' as const,
+    cancel_at_period_end: false,
+    metadata: { user_id: input.userId },
+    items: {
+      data: [
+        {
+          current_period_end: 1_893_456_000,
+          price: { id: priceIds.monthly },
+        },
+      ],
+    },
+  };
+}
+
+async function runWebhookWriter(input: {
+  userId: string;
+  externalCustomerId: string;
+  externalSubscriptionId: string;
+  eventId: string;
+  lockHeld: () => void;
+  release: Promise<void>;
+}): Promise<void> {
+  const paymentGateway = new FakePaymentGateway({
+    externalCustomerId: input.externalCustomerId,
+    checkoutUrl: 'https://stripe.test/checkout',
+    portalUrl: 'https://stripe.test/portal',
+    webhookResult: {
+      eventId: input.eventId,
+      type: 'customer.subscription.updated',
+      subscriptionUpdate: {
+        userId: input.userId,
+        externalCustomerId: input.externalCustomerId,
+        externalSubscriptionId: input.externalSubscriptionId,
+        plan: 'monthly',
+        status: 'active',
+        currentPeriodEnd: new Date('2030-01-01T00:00:00.000Z'),
+        cancelAtPeriodEnd: false,
+      },
+    },
+  });
+
+  await processStripeWebhook(
+    {
+      paymentGateway,
+      logger: new FakeLogger(),
+      now: () => new Date(),
+      transaction: async (fn) =>
+        subscriptionWriter.db.transaction(async (tx) => {
+          await configureSubscriptionWriter(tx);
+          return fn({
+            stripeEvents: new DrizzleStripeEventRepository(tx),
+            subscriptions: new PausingSubscriptionRepository(
+              tx,
+              input.lockHeld,
+              input.release,
+            ),
+            stripeCustomers: new DrizzleStripeCustomerRepository(tx),
+          });
+        }),
+    },
+    { rawBody: 'raw', signature: 'sig_lock_order' },
+  );
+}
+
+async function runCheckoutSuccessWriter(input: {
+  userId: string;
+  email: string;
+  externalCustomerId: string;
+  externalSubscriptionId: string;
+  lockHeld: () => void;
+  release: Promise<void>;
+}): Promise<void> {
+  const subscription = stripeSubscription(input);
+  const authGateway = new FakeAuthGateway({
+    id: input.userId,
+    email: input.email,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  const deps: CheckoutSuccessDeps = {
+    authGateway,
+    getClerkAuth: async () => ({
+      userId: input.userId,
+      redirectToSignIn: () => {
+        throw new Error('Unexpected sign-in redirect');
+      },
+    }),
+    logger: new FakeLogger(),
+    stripe: {
+      checkout: {
+        sessions: {
+          retrieve: async () => ({
+            customer: input.externalCustomerId,
+            subscription: input.externalSubscriptionId,
+          }),
+        },
+      },
+      subscriptions: { retrieve: async () => subscription },
+    },
+    priceIds,
+    appUrl: 'http://localhost:3000',
+    transaction: async (fn) =>
+      subscriptionWriter.db.transaction(async (tx) => {
+        await configureSubscriptionWriter(tx);
+        return fn({
+          subscriptions: new PausingSubscriptionRepository(
+            tx,
+            input.lockHeld,
+            input.release,
+          ),
+          stripeCustomers: new DrizzleStripeCustomerRepository(tx),
+        });
+      }),
+  };
+
+  await syncCheckoutSuccess({ sessionId: 'cs_lock_order' }, deps, () => {
+    throw new Error('Unexpected checkout redirect');
+  });
+}
+
+afterEach(async () => {
+  await cleanupAfterEach(control.db, cleanup);
+});
+
+afterAll(async () => {
+  await Promise.all([
+    closeConnection(control.sql),
+    closeConnection(subscriptionWriter.sql),
+    closeConnection(reconciliationWriter.sql),
+  ]);
+});
+
+describe('Stripe subscription writer lock order', () => {
+  it.each([
+    'webhook',
+    'checkout-success',
+  ] as const)('serializes the %s and reconcile writers without a 40P01 deadlock', async (writerKind) => {
+    const user = await createUser(control.db, cleanup);
+    const externalCustomerId = `cus_${randomUUID().replaceAll('-', '')}`;
+    const externalSubscriptionId = `sub_${randomUUID().replaceAll('-', '')}`;
+    const eventId = `evt_${randomUUID().replaceAll('-', '')}`;
+    if (writerKind === 'webhook') cleanup.stripeEventIds.push(eventId);
+
+    await new DrizzleStripeCustomerRepository(control.db).insert(
+      user.id,
+      externalCustomerId,
+    );
+
+    const writerLockHeld = createDeferred<void>();
+    const releaseWriter = createDeferred<void>();
+    const reconciliationPid = createDeferred<number>();
+    let customerLockObserved = false;
+    let reconciliationTransactionError: unknown;
+
+    const writerPromise =
+      writerKind === 'webhook'
+        ? runWebhookWriter({
+            userId: user.id,
+            externalCustomerId,
+            externalSubscriptionId,
+            eventId,
+            lockHeld: () => writerLockHeld.resolve(),
+            release: releaseWriter.promise,
+          })
+        : runCheckoutSuccessWriter({
+            userId: user.id,
+            email: user.email,
+            externalCustomerId,
+            externalSubscriptionId,
+            lockHeld: () => writerLockHeld.resolve(),
+            release: releaseWriter.promise,
+          });
+
+    await writerLockHeld.promise;
+
+    const normalizedSubscription = stripeSubscription({
+      userId: user.id,
+      externalCustomerId,
+      externalSubscriptionId,
+    });
+    const stripe = {
+      subscriptions: {
+        retrieve: async () => normalizedSubscription,
+        list: async () => ({
+          data: [{ id: externalSubscriptionId, status: 'active' as const }],
+        }),
+        cancel: async () => normalizedSubscription,
+      },
+    } as unknown as ReconcileStripeSubscriptionsDeps['stripe'];
+
+    const reconciliationPromise = reconcileStripeSubscriptions(
+      { limit: 1, offset: 0, dryRun: true, concurrency: 1 },
+      {
+        stripe,
+        priceIds,
+        logger: new FakeLogger(),
+        listLocalSubscriptions: async () => [
+          { userId: user.id, stripeSubscriptionId: externalSubscriptionId },
+        ],
+        transaction: async (fn) => {
+          try {
+            return await reconciliationWriter.db.transaction(async (tx) => {
+              await configureReconciliationWriter(tx);
+              reconciliationPid.resolve(await getBackendPid(tx));
+              return fn({
+                subscriptions: new DrizzleSubscriptionRepository(tx, priceIds),
+                stripeCustomers: new ObservedStripeCustomerRepository(
+                  tx,
+                  () => {
+                    customerLockObserved = true;
+                  },
+                ),
+              });
+            });
+          } catch (error) {
+            reconciliationTransactionError = error;
+            throw error;
+          }
+        },
+      },
+    );
+
+    const pid = await reconciliationPid.promise;
+    let state: Awaited<ReturnType<typeof waitForReconciliationState>>;
+    try {
+      state = await waitForReconciliationState({
+        pid,
+        customerLockObserved: () => customerLockObserved,
+      });
+    } finally {
+      releaseWriter.resolve();
+    }
+
+    const [writerResult, reconciliationResult] = await Promise.allSettled([
+      writerPromise,
+      reconciliationPromise,
+    ]);
+    const postgresErrorCodes = [
+      reconciliationTransactionError,
+      writerResult.status === 'rejected' ? writerResult.reason : null,
+    ]
+      .map(findPostgresErrorCode)
+      .filter((code): code is string => code !== null);
+
+    expect(postgresErrorCodes).toEqual([]);
+    expect(state).toBe('waiting-on-advisory');
+    expect(writerResult.status).toBe('fulfilled');
+    expect(reconciliationResult).toMatchObject({
+      status: 'fulfilled',
+      value: { updated: 1, failed: 0 },
+    });
+  });
+});

--- a/tests/integration/stripe-webhook-failure-boundary.integration.test.ts
+++ b/tests/integration/stripe-webhook-failure-boundary.integration.test.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import * as schema from '@/db/schema';
+import { processStripeWebhook } from '@/src/adapters/controllers/stripe-webhook-controller';
+import { DrizzleStripeCustomerRepository } from '@/src/adapters/repositories/drizzle-stripe-customer-repository';
+import { DrizzleStripeEventRepository } from '@/src/adapters/repositories/drizzle-stripe-event-repository';
+import { DrizzleSubscriptionRepository } from '@/src/adapters/repositories/drizzle-subscription-repository';
+import { ApplicationError } from '@/src/application/errors';
+import {
+  FakeLogger,
+  FakePaymentGateway,
+} from '@/src/application/test-helpers/fakes';
+import {
+  cleanupAfterEach,
+  closeConnection,
+  createCleanupState,
+  createIntegrationDb,
+  createUser,
+} from './helpers';
+
+const { db, sql } = createIntegrationDb();
+const cleanup = createCleanupState();
+
+afterEach(async () => {
+  await cleanupAfterEach(db, cleanup);
+});
+
+afterAll(async () => {
+  await closeConnection(sql);
+});
+
+describe('Stripe webhook failure boundary', () => {
+  it('BUG-285 persists the original failure after a statement aborts the processing transaction', async () => {
+    const mappedUser = await createUser(db, cleanup);
+    const processingUser = await createUser(db, cleanup);
+    const eventId = `evt_${randomUUID().replaceAll('-', '')}`;
+    const externalCustomerId = `cus_${randomUUID().replaceAll('-', '')}`;
+    cleanup.stripeEventIds.push(eventId);
+
+    await new DrizzleStripeCustomerRepository(db).insert(
+      mappedUser.id,
+      externalCustomerId,
+    );
+
+    const paymentGateway = new FakePaymentGateway({
+      externalCustomerId: 'cus_unused',
+      checkoutUrl: 'https://stripe.test/checkout',
+      portalUrl: 'https://stripe.test/portal',
+      webhookResult: {
+        eventId,
+        type: 'customer.subscription.updated',
+        subscriptionUpdate: {
+          userId: processingUser.id,
+          externalCustomerId,
+          externalSubscriptionId: `sub_${randomUUID().replaceAll('-', '')}`,
+          plan: 'monthly',
+          status: 'active',
+          currentPeriodEnd: new Date('2027-03-01T00:00:00.000Z'),
+          cancelAtPeriodEnd: false,
+        },
+      },
+    });
+    const priceIds = {
+      monthly: 'price_test_monthly',
+      annual: 'price_test_annual',
+    } as const;
+
+    let surfacedError: unknown;
+    try {
+      await processStripeWebhook(
+        {
+          paymentGateway,
+          logger: new FakeLogger(),
+          now: () => new Date(),
+          transaction: async (fn) =>
+            db.transaction(async (tx) =>
+              fn({
+                stripeEvents: new DrizzleStripeEventRepository(tx),
+                subscriptions: new DrizzleSubscriptionRepository(tx, priceIds),
+                stripeCustomers: new DrizzleStripeCustomerRepository(tx),
+              }),
+            ),
+        },
+        { rawBody: 'raw', signature: 'sig_bug_285' },
+      );
+    } catch (error) {
+      surfacedError = error;
+    }
+
+    expect(surfacedError).toBeInstanceOf(ApplicationError);
+    expect(surfacedError).toMatchObject({
+      code: 'CONFLICT',
+      message: 'Stripe customer id is already mapped to a different user',
+    });
+
+    const failedEvent = await db.query.stripeEvents.findFirst({
+      where: eq(schema.stripeEvents.id, eventId),
+    });
+    expect(failedEvent).toMatchObject({
+      id: eventId,
+      type: 'customer.subscription.updated',
+      processedAt: null,
+    });
+    expect(JSON.parse(failedEvent?.error ?? '{}')).toMatchObject({
+      name: 'ApplicationError',
+      code: 'CONFLICT',
+      message: 'Stripe customer id is already mapped to a different user',
+    });
+
+    await expect(
+      new DrizzleSubscriptionRepository(db, priceIds).findByUserId(
+        processingUser.id,
+      ),
+    ).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

- **BUG-285:** a PostgreSQL statement error aborts the Stripe webhook transaction, so the in-transaction `markFailed` hits `25P02`, no durable failure state commits, and the original mapped processing error is replaced.
- **BUG-286:** reconcile Phase 4 wrote `stripe_customers` before taking the subscription repository's per-user advisory lock, inverting the webhook/checkout-success order and enabling an AB-BA `40P01` deadlock.

## Solution

- Roll back the failed webhook processing transaction, prefer the captured mapped processing error over the driver's transaction-scope error, and persist failure state in a fresh transaction using claim + lock + successful-event guard + `markFailed`.
- Keep failure-state persistence best-effort: log a persistence failure without replacing the original error, then rethrow the original so Stripe still receives a 500 and retries.
- Reorder reconcile Phase 4 to `subscriptions.upsert` before the unconditional `stripeCustomers.insert`.
- Document the canonical order beside all three coordinators: advisory(user) → `stripe_subscriptions` → `stripe_customers`.
- Align the Stripe-customer fake's conflict messages with the real adapter contract.

The failure-domain rule is deliberate: an outcome is never recorded inside the transaction whose failure it records.

## PostgreSQL proof

- BUG-285 red baseline: the real adapter path surfaced a `25P02` after a `stripe_customers` second-unique-index violation; post-fix, the fresh transaction durably stores the original `CONFLICT` while the subscription write remains rolled back.
- BUG-286 red baseline: deterministic barrier-controlled interleavings produced `40P01` for both webhook-vs-reconcile and checkout-success-vs-reconcile pairs with reconcile's test-session `deadlock_timeout` set to 50 ms.
- Post-fix: both identical interleavings complete, reconciliation reports `{ updated: 1, failed: 0 }`, and no PostgreSQL error code is observed.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test --run` — 3,166 passed
- `pnpm test:browser` — 363 passed
- `pnpm test:integration` — 162 passed, 2 skipped
- `pnpm build`
- `pnpm test:e2e` — 36 passed

## Tracking

- [BUG-285](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/blob/fix/bug-285-286-stripe-failure-domain-lock-order/docs/bugs/bug-285-stripe-webhook-markfailed-on-aborted-transaction.md)
- [BUG-286](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/blob/fix/bug-285-286-stripe-failure-domain-lock-order/docs/bugs/bug-286-webhook-vs-reconcile-lock-order-deadlock.md)

Both bug documents remain Open pending merge and production proof.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe webhook failure handling so processing errors are preserved and failure status is recorded reliably.
  * Prevented duplicate processing when an event is completed concurrently.
  * Reduced the risk of database deadlocks across checkout, webhook, and subscription reconciliation workflows.
  * Clarified Stripe customer mapping conflict messages.
* **Tests**
  * Added unit and integration coverage for webhook failures, idempotency, lock ordering, and reconciliation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->