### PR TITLE
Promote dev to main: BUG-287 subscription observation-version fence

### DIFF
--- a/app/(marketing)/checkout/success/checkout-success-deps.ts
+++ b/app/(marketing)/checkout/success/checkout-success-deps.ts
@@ -24,6 +24,7 @@ export async function getCheckoutSuccessDeps(
 
   return {
     authGateway: container.createAuthGateway(),
+    subscriptionVersions: container.createSubscriptionRepository(),
     getClerkAuth: auth,
     logger: container.logger,
     stripe: getStripe(),

--- a/app/(marketing)/checkout/success/checkout-success-sync-version-fence.test.ts
+++ b/app/(marketing)/checkout/success/checkout-success-sync-version-fence.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  SubscriptionUpsertInput,
+  SubscriptionUpsertResult,
+} from '@/src/application/ports/repositories';
+import { SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS } from '@/src/application/shared/persist-subscription-observation';
+import {
+  FakeAuthGateway,
+  FakeLogger,
+  FakeStripeCustomerRepository,
+  FakeSubscriptionRepository,
+} from '@/src/application/test-helpers/fakes';
+import {
+  type CheckoutSuccessDeps,
+  syncCheckoutSuccess,
+} from './checkout-success-sync';
+
+class AlwaysConflictingSubscriptionRepository extends FakeSubscriptionRepository {
+  readonly inputs: SubscriptionUpsertInput[] = [];
+
+  override async findObservationVersionByUserId(): Promise<number> {
+    return this.inputs.length;
+  }
+
+  override async upsert(
+    input: SubscriptionUpsertInput,
+  ): Promise<SubscriptionUpsertResult> {
+    this.inputs.push(input);
+    return { persisted: false, reason: 'version_conflict' };
+  }
+}
+
+describe('syncCheckoutSuccess observation-version fence', () => {
+  it('preserves the thrown error path after bounded version conflicts', async () => {
+    const user = {
+      id: crypto.randomUUID(),
+      email: 'version-fence@example.com',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+    const subscriptions = new AlwaysConflictingSubscriptionRepository();
+    const stripeCustomers = new FakeStripeCustomerRepository();
+    let subscriptionRetrieveCount = 0;
+    const deps: CheckoutSuccessDeps = {
+      authGateway: new FakeAuthGateway(user),
+      subscriptionVersions: subscriptions,
+      getClerkAuth: async () => ({
+        userId: 'clerk_user_1',
+        redirectToSignIn: () => {
+          throw new Error('Unexpected sign-in redirect');
+        },
+      }),
+      logger: new FakeLogger(),
+      stripe: {
+        checkout: {
+          sessions: {
+            retrieve: async () => ({
+              customer: 'cus_123',
+              subscription: 'sub_123',
+            }),
+          },
+        },
+        subscriptions: {
+          retrieve: async () => {
+            subscriptionRetrieveCount += 1;
+            return {
+              id: 'sub_123',
+              customer: 'cus_123',
+              status: 'active',
+              cancel_at_period_end: false,
+              metadata: { user_id: user.id },
+              items: {
+                data: [
+                  {
+                    current_period_end: 1_893_456_000,
+                    price: { id: 'price_monthly' },
+                  },
+                ],
+              },
+            };
+          },
+        },
+      },
+      priceIds: { monthly: 'price_monthly', annual: 'price_annual' },
+      appUrl: 'http://localhost:3000',
+      transaction: async (fn) => fn({ subscriptions, stripeCustomers }),
+    };
+
+    await expect(
+      syncCheckoutSuccess({ sessionId: 'cs_123' }, deps, () => {
+        throw new Error('Unexpected redirect');
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: `Subscription observation version conflicted after ${SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS} attempts`,
+    });
+
+    expect(subscriptionRetrieveCount).toBe(
+      SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS,
+    );
+    expect(subscriptions.inputs).toHaveLength(
+      SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS,
+    );
+  });
+});

--- a/app/(marketing)/checkout/success/checkout-success-sync.tsx
+++ b/app/(marketing)/checkout/success/checkout-success-sync.tsx
@@ -4,6 +4,7 @@ import { getSubscriptionPlanFromPriceId } from '@/src/adapters/config/stripe-pri
 import { stripeSubscriptionStatusToSubscriptionStatus } from '@/src/adapters/gateways/stripe';
 import { isTransientExternalError, retry } from '@/src/adapters/shared/retry';
 import { DEFAULT_RETRY_OPTIONS } from '@/src/adapters/shared/retry-defaults';
+import { persistSubscriptionObservation } from '@/src/application/shared/persist-subscription-observation';
 import {
   determineNonEntitledReason,
   MS_PER_SECOND,
@@ -161,106 +162,130 @@ export async function syncCheckoutSuccess(
     subscriptionId,
   });
 
-  const subscription = await retry(
-    () => d.stripe.subscriptions.retrieve(subscriptionId),
-    {
-      ...DEFAULT_RETRY_OPTIONS,
-      shouldRetry: isTransientExternalError,
-      onRetry: createStripeOnRetry(d.logger, { subscriptionId }),
-    },
-  );
+  const retrieveObservation = async () => {
+    const subscription = await retry(
+      () => d.stripe.subscriptions.retrieve(subscriptionId),
+      {
+        ...DEFAULT_RETRY_OPTIONS,
+        shouldRetry: isTransientExternalError,
+        onRetry: createStripeOnRetry(d.logger, { subscriptionId }),
+      },
+    );
 
-  const metadataUserId = subscription.metadata?.user_id;
-  assertions.assertNonEmptyString(metadataUserId, 'missing_user_id', {
-    sessionId,
-    metadataUserId: metadataUserId ?? null,
-  });
-  // Prevent cross-account leakage if the user switches accounts mid-checkout.
-  if (metadataUserId !== user.id) {
-    fail('user_id_mismatch', {
+    const metadataUserId = subscription.metadata?.user_id;
+    assertions.assertNonEmptyString(metadataUserId, 'missing_user_id', {
       sessionId,
-      metadataUserId,
-      userId: user.id,
+      metadataUserId: metadataUserId ?? null,
     });
-  }
-
-  const stripeStatus = subscription.status;
-  // Reject malformed subscription objects and unexpected statuses.
-  assertions.assertNonEmptyString(stripeStatus, 'invalid_subscription_status', {
-    sessionId,
-    status: stripeStatus ?? null,
-  });
-  assertions.assertStripeSubscriptionStatus(
-    stripeStatus,
-    'invalid_subscription_status',
-    {
-      sessionId,
-      status: stripeStatus,
-    },
-  );
-  const status: SubscriptionStatus =
-    stripeSubscriptionStatusToSubscriptionStatus(stripeStatus);
-
-  const subscriptionItem = subscription.items?.data?.[0];
-
-  const currentPeriodEndSeconds = subscriptionItem?.current_period_end;
-  // Entitlement depends on a current billing period end timestamp.
-  assertions.assertNumber(
-    currentPeriodEndSeconds,
-    'missing_current_period_end',
-    {
-      sessionId,
-      currentPeriodEndSeconds: currentPeriodEndSeconds ?? null,
-    },
-  );
-
-  const cancelAtPeriodEnd = subscription.cancel_at_period_end;
-  // We persist cancel-at-period-end to display accurately in billing UI.
-  assertions.assertBoolean(cancelAtPeriodEnd, 'missing_cancel_at_period_end', {
-    sessionId,
-    cancelAtPeriodEnd: cancelAtPeriodEnd ?? null,
-  });
-
-  const priceId = subscriptionItem?.price?.id;
-  // We map the Stripe price id back to a domain plan (monthly/annual).
-  assertions.assertNonEmptyString(priceId, 'missing_price_id', {
-    sessionId,
-    priceId: priceId ?? null,
-  });
-
-  const plan = getSubscriptionPlanFromPriceId(priceId, d.priceIds);
-  // Mismatched price IDs usually means environment misconfiguration.
-  assertions.assertNotNull(plan, 'unknown_plan', {
-    sessionId,
-    priceId,
-    configuredPriceIds: d.priceIds,
-  });
-
-  const currentPeriodEnd = new Date(currentPeriodEndSeconds * MS_PER_SECOND);
-
-  // Canonical multi-repository lock order: advisory(user) in
-  // subscriptions.upsert -> stripe_subscriptions row -> stripe_customers row.
-  // Keep every writer in this order to avoid AB-BA deadlocks.
-  const write = await d.transaction(
-    async ({ stripeCustomers, subscriptions }) => {
-      const result = await subscriptions.upsert({
+    // Prevent cross-account leakage if the user switches accounts mid-checkout.
+    if (metadataUserId !== user.id) {
+      fail('user_id_mismatch', {
+        sessionId,
+        metadataUserId,
         userId: user.id,
-        externalSubscriptionId: subscriptionId,
-        plan,
-        status,
-        currentPeriodEnd,
-        cancelAtPeriodEnd,
       });
+    }
 
-      if (result.persisted) {
-        await stripeCustomers.insert(user.id, stripeCustomerId, {
-          conflictStrategy: 'authoritative',
+    const stripeStatus = subscription.status;
+    // Reject malformed subscription objects and unexpected statuses.
+    assertions.assertNonEmptyString(
+      stripeStatus,
+      'invalid_subscription_status',
+      {
+        sessionId,
+        status: stripeStatus ?? null,
+      },
+    );
+    assertions.assertStripeSubscriptionStatus(
+      stripeStatus,
+      'invalid_subscription_status',
+      {
+        sessionId,
+        status: stripeStatus,
+      },
+    );
+    const status: SubscriptionStatus =
+      stripeSubscriptionStatusToSubscriptionStatus(stripeStatus);
+
+    const subscriptionItem = subscription.items?.data?.[0];
+    const currentPeriodEndSeconds = subscriptionItem?.current_period_end;
+    // Entitlement depends on a current billing period end timestamp.
+    assertions.assertNumber(
+      currentPeriodEndSeconds,
+      'missing_current_period_end',
+      {
+        sessionId,
+        currentPeriodEndSeconds: currentPeriodEndSeconds ?? null,
+      },
+    );
+
+    const cancelAtPeriodEnd = subscription.cancel_at_period_end;
+    // We persist cancel-at-period-end to display accurately in billing UI.
+    assertions.assertBoolean(
+      cancelAtPeriodEnd,
+      'missing_cancel_at_period_end',
+      {
+        sessionId,
+        cancelAtPeriodEnd: cancelAtPeriodEnd ?? null,
+      },
+    );
+
+    const priceId = subscriptionItem?.price?.id;
+    // We map the Stripe price id back to a domain plan (monthly/annual).
+    assertions.assertNonEmptyString(priceId, 'missing_price_id', {
+      sessionId,
+      priceId: priceId ?? null,
+    });
+
+    const plan = getSubscriptionPlanFromPriceId(priceId, d.priceIds);
+    // Mismatched price IDs usually means environment misconfiguration.
+    assertions.assertNotNull(plan, 'unknown_plan', {
+      sessionId,
+      priceId,
+      configuredPriceIds: d.priceIds,
+    });
+
+    return {
+      cancelAtPeriodEnd,
+      currentPeriodEnd: new Date(currentPeriodEndSeconds * MS_PER_SECOND),
+      externalSubscriptionId: subscriptionId,
+      plan,
+      status,
+      userId: metadataUserId,
+    };
+  };
+
+  const { observation, write } = await persistSubscriptionObservation({
+    userId: user.id,
+    readVersion: (userId) =>
+      d.subscriptionVersions.findObservationVersionByUserId(userId),
+    retrieve: retrieveObservation,
+    getUserId: (subscription) => subscription.userId,
+    persist: (subscription, expectedVersion) =>
+      d.transaction(async ({ stripeCustomers, subscriptions }) => {
+        // Canonical multi-repository lock order: advisory(user) in
+        // subscriptions.upsert -> stripe_subscriptions row -> stripe_customers
+        // row. Keep every writer in this order to avoid AB-BA deadlocks.
+        const result = await subscriptions.upsert({
+          userId: subscription.userId,
+          externalSubscriptionId: subscription.externalSubscriptionId,
+          plan: subscription.plan,
+          status: subscription.status,
+          currentPeriodEnd: subscription.currentPeriodEnd,
+          cancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
+          expectedVersion,
         });
-      }
 
-      return result;
-    },
-  );
+        if (result.persisted) {
+          await stripeCustomers.insert(user.id, stripeCustomerId, {
+            conflictStrategy: 'authoritative',
+          });
+        }
+
+        return result;
+      }),
+  });
+  const { currentPeriodEnd, status } = observation;
 
   const effectiveStatus = write.persisted ? status : write.current.status;
   const effectiveCurrentPeriodEnd = write.persisted

--- a/app/(marketing)/checkout/success/checkout-success-types.ts
+++ b/app/(marketing)/checkout/success/checkout-success-types.ts
@@ -57,6 +57,10 @@ export type CheckoutSuccessTransaction = {
 
 export type CheckoutSuccessDeps = {
   authGateway: AuthGateway;
+  subscriptionVersions: Pick<
+    SubscriptionRepository,
+    'findObservationVersionByUserId'
+  >;
   getClerkAuth: () => Promise<ClerkAuthLike>;
   logger: CheckoutSuccessLogger;
   stripe: StripeClientLike;
@@ -98,7 +102,7 @@ export type CheckoutSuccessContainerLike = {
     transaction: <T>(fn: (tx: unknown) => Promise<T>) => Promise<T>;
   };
   createStripeCustomerRepository: (tx: unknown) => StripeCustomerRepository;
-  createSubscriptionRepository: (tx: unknown) => SubscriptionRepository;
+  createSubscriptionRepository: (tx?: unknown) => SubscriptionRepository;
 };
 
 export type CheckoutSuccessModuleLoaders = {

--- a/app/(marketing)/checkout/success/page.test.ts
+++ b/app/(marketing)/checkout/success/page.test.ts
@@ -61,6 +61,9 @@ describe('runCheckoutSuccessPage', () => {
 
     const deps = {
       authGateway,
+      subscriptionVersions: {
+        findObservationVersionByUserId: async () => null,
+      },
       getClerkAuth: async () => ({
         userId: null,
         redirectToSignIn,
@@ -132,6 +135,7 @@ describe('runCheckoutSuccessPage', () => {
 
     const deps = {
       authGateway: new FakeAuthGateway(user),
+      subscriptionVersions: subscriptions,
       getClerkAuth: async () => ({
         userId: 'clerk_user_1',
         redirectToSignIn: () => {
@@ -225,6 +229,7 @@ describe('runCheckoutSuccessPage', () => {
 
     const deps = {
       authGateway: new FakeAuthGateway(user),
+      subscriptionVersions: subscriptions,
       getClerkAuth: async () => ({
         userId: 'clerk_user_1',
         redirectToSignIn: () => {
@@ -309,6 +314,7 @@ describe('runCheckoutSuccessPage', () => {
 
     const deps = {
       authGateway: new FakeAuthGateway(user),
+      subscriptionVersions: subscriptions,
       getClerkAuth: async () => ({
         userId: 'clerk_user_1',
         redirectToSignIn: () => {
@@ -395,6 +401,7 @@ describe('runCheckoutSuccessPage', () => {
 
     const deps = {
       authGateway: new FakeAuthGateway(user),
+      subscriptionVersions: subscriptions,
       getClerkAuth: async () => ({
         userId: 'clerk_user_1',
         redirectToSignIn: () => {
@@ -558,6 +565,7 @@ describe('syncCheckoutSuccess retry logging', () => {
 
       const deps = {
         authGateway: new FakeAuthGateway(user),
+        subscriptionVersions: subscriptions,
         getClerkAuth: async () => ({
           userId: 'clerk_user_1',
           redirectToSignIn: () => {
@@ -650,6 +658,7 @@ describe('syncCheckoutSuccess retry logging', () => {
 
       const deps = {
         authGateway: new FakeAuthGateway(user),
+        subscriptionVersions: subscriptions,
         getClerkAuth: async () => ({
           userId: 'clerk_user_1',
           redirectToSignIn: () => {
@@ -818,6 +827,9 @@ describe('syncCheckoutSuccess', () => {
 
     const deps = {
       authGateway,
+      subscriptionVersions: {
+        findObservationVersionByUserId: async () => null,
+      },
       getClerkAuth: async () => ({
         userId: 'clerk_user_1',
         redirectToSignIn: () => {
@@ -903,6 +915,7 @@ describe('syncCheckoutSuccess', () => {
 
     const deps = {
       authGateway: new FakeAuthGateway(user),
+      subscriptionVersions: subscriptions,
       getClerkAuth: async () => ({
         userId: 'clerk_user_1',
         redirectToSignIn: () => {
@@ -983,6 +996,7 @@ describe('syncCheckoutSuccess', () => {
 
     const deps = {
       authGateway: new FakeAuthGateway(user),
+      subscriptionVersions: subscriptions,
       getClerkAuth: async () => ({
         userId: 'clerk_user_1',
         redirectToSignIn: () => {
@@ -1063,6 +1077,7 @@ describe('syncCheckoutSuccess', () => {
 
     const deps = {
       authGateway: new FakeAuthGateway(user),
+      subscriptionVersions: subscriptions,
       getClerkAuth: async () => ({
         userId: 'clerk_user_1',
         redirectToSignIn: () => {
@@ -1133,6 +1148,7 @@ describe('syncCheckoutSuccess', () => {
     await subscriptions.upsert({
       userId: user.id,
       externalSubscriptionId: 'sub_current',
+      expectedVersion: null,
       plan: 'annual',
       status: 'active',
       currentPeriodEnd: protectedPeriodEnd,
@@ -1141,6 +1157,7 @@ describe('syncCheckoutSuccess', () => {
 
     const deps = {
       authGateway: new FakeAuthGateway(user),
+      subscriptionVersions: subscriptions,
       getClerkAuth: async () => ({
         userId: 'clerk_user_1',
         redirectToSignIn: () => {
@@ -1222,6 +1239,7 @@ describe('syncCheckoutSuccess', () => {
     await subscriptions.upsert({
       userId: user.id,
       externalSubscriptionId: 'sub_current',
+      expectedVersion: null,
       plan: 'annual',
       status: 'active',
       currentPeriodEnd: protectedPeriodEnd,
@@ -1230,6 +1248,7 @@ describe('syncCheckoutSuccess', () => {
 
     const deps = {
       authGateway: new FakeAuthGateway(user),
+      subscriptionVersions: subscriptions,
       getClerkAuth: async () => ({
         userId: 'clerk_user_1',
         redirectToSignIn: () => {
@@ -1309,6 +1328,7 @@ describe('syncCheckoutSuccess', () => {
 
     const deps = {
       authGateway: new FakeAuthGateway(user),
+      subscriptionVersions: subscriptions,
       getClerkAuth: async () => ({
         userId: 'clerk_user_1',
         redirectToSignIn: () => {
@@ -1388,6 +1408,7 @@ describe('syncCheckoutSuccess', () => {
 
     const deps = {
       authGateway: new FakeAuthGateway(user),
+      subscriptionVersions: subscriptions,
       getClerkAuth: async () => ({
         userId: 'clerk_user_1',
         redirectToSignIn: () => {
@@ -1466,6 +1487,7 @@ describe('syncCheckoutSuccess', () => {
 
     const deps = {
       authGateway: new FakeAuthGateway(user),
+      subscriptionVersions: subscriptions,
       getClerkAuth: async () => ({
         userId: 'clerk_user_1',
         redirectToSignIn: () => {

--- a/app/api/cron/reconcile-stripe-subscriptions/route.test.ts
+++ b/app/api/cron/reconcile-stripe-subscriptions/route.test.ts
@@ -235,15 +235,17 @@ describe('POST /api/cron/reconcile-stripe-subscriptions', () => {
     const pageDeps = reconcileStripeSubscriptions.mock.calls[0]?.[1];
     if (!pageDeps) throw new Error('expected single-page deps');
     container.db.query.stripeSubscriptions.findMany.mockResolvedValueOnce([
-      { userId: 'user_1', stripeSubscriptionId: 'sub_1' },
+      { userId: 'user_1', stripeSubscriptionId: 'sub_1', version: 3 },
     ]);
     await expect(
       pageDeps.listLocalSubscriptions({ limit: 2, offset: 3 }),
-    ).resolves.toEqual([{ userId: 'user_1', stripeSubscriptionId: 'sub_1' }]);
+    ).resolves.toEqual([
+      { userId: 'user_1', stripeSubscriptionId: 'sub_1', version: 3 },
+    ]);
     const query =
       container.db.query.stripeSubscriptions.findMany.mock.calls.at(-1)?.[0];
     expect(query).toMatchObject({
-      columns: { userId: true, stripeSubscriptionId: true },
+      columns: { userId: true, stripeSubscriptionId: true, version: true },
       limit: 2,
       offset: 3,
     });

--- a/app/api/cron/reconcile-stripe-subscriptions/route.ts
+++ b/app/api/cron/reconcile-stripe-subscriptions/route.ts
@@ -199,6 +199,7 @@ async function handleCronRequest(req: Request): Promise<NextResponse> {
           columns: {
             userId: true,
             stripeSubscriptionId: true,
+            version: true,
           },
           orderBy: (subs, { asc }) => [asc(subs.userId)],
           limit,
@@ -208,6 +209,7 @@ async function handleCronRequest(req: Request): Promise<NextResponse> {
         return rows.map((row) => ({
           userId: row.userId,
           stripeSubscriptionId: row.stripeSubscriptionId,
+          version: row.version,
         }));
       },
       transaction: async (fn) =>

--- a/app/api/stripe/webhook/route.test.ts
+++ b/app/api/stripe/webhook/route.test.ts
@@ -45,6 +45,7 @@ function createTestDeps() {
     },
     subscriptions: {
       findByUserId: async () => null,
+      findObservationVersionByUserId: async () => null,
       findByExternalSubscriptionId: async () => null,
       upsert: async () => ({ persisted: true }) as const,
     },
@@ -57,6 +58,7 @@ function createTestDeps() {
   const logger = new FakeLogger();
   const deps: StripeWebhookDeps = {
     paymentGateway: createPaymentGatewayStub(),
+    subscriptionVersions: tx.subscriptions,
     logger,
     now: () => new Date('2026-02-01T00:00:00.000Z'),
     transaction: async (fn) => fn(tx),
@@ -246,6 +248,9 @@ describe('POST /api/stripe/webhook', () => {
 
     const deps: StripeWebhookDeps = {
       paymentGateway: createPaymentGatewayStub(),
+      subscriptionVersions: {
+        findObservationVersionByUserId: async () => null,
+      },
       logger: new FakeLogger(),
       now: () => new Date('2026-02-01T00:00:00.000Z'),
       transaction:

--- a/db/migrations/0029_medical_starfox.sql
+++ b/db/migrations/0029_medical_starfox.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "stripe_subscriptions" ADD COLUMN "version" integer DEFAULT 0 NOT NULL;

--- a/db/migrations/meta/0029_snapshot.json
+++ b/db/migrations/meta/0029_snapshot.json
@@ -1,0 +1,2465 @@
+{
+  "id": "f1466855-a7ea-446c-92cf-383860ad76fe",
+  "prevId": "2dbc64c4-10fc-41d3-8521-313cff18ba5b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.attempts": {
+      "name": "attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_choice_id": {
+          "name": "selected_choice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_omitted": {
+          "name": "is_omitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_spent_seconds": {
+          "name": "time_spent_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_of_attempt_id": {
+          "name": "retry_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_origin": {
+          "name": "retry_origin",
+          "type": "attempt_retry_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_session_id": {
+          "name": "retry_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attempts_user_answered_at_idx": {
+          "name": "attempts_user_answered_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_user_question_answered_at_idx": {
+          "name": "attempts_user_question_answered_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_user_is_correct_answered_at_idx": {
+          "name": "attempts_user_is_correct_answered_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_correct",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_session_answered_at_idx": {
+          "name": "attempts_session_answered_at_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_session_user_answered_at_idx": {
+          "name": "attempts_session_user_answered_at_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_question_id_idx": {
+          "name": "attempts_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_selected_choice_question_idx": {
+          "name": "attempts_selected_choice_question_idx",
+          "columns": [
+            {
+              "expression": "selected_choice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_retry_of_attempt_id_idx": {
+          "name": "attempts_retry_of_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "retry_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_session_question_uq": {
+          "name": "attempts_session_question_uq",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "practice_session_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attempts_user_id_users_id_fk": {
+          "name": "attempts_user_id_users_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_question_id_questions_id_fk": {
+          "name": "attempts_question_id_questions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_practice_session_id_practice_sessions_id_fk": {
+          "name": "attempts_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "practice_sessions",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "attempts_selected_choice_question_fk": {
+          "name": "attempts_selected_choice_question_fk",
+          "tableFrom": "attempts",
+          "tableTo": "choices",
+          "columnsFrom": [
+            "selected_choice_id",
+            "question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "question_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attempts_selected_choice_or_omitted_chk": {
+          "name": "attempts_selected_choice_or_omitted_chk",
+          "value": "(\"attempts\".\"selected_choice_id\" IS NOT NULL) <> \"attempts\".\"is_omitted\""
+        },
+        "attempts_omitted_incorrect_chk": {
+          "name": "attempts_omitted_incorrect_chk",
+          "value": "NOT \"attempts\".\"is_omitted\" OR \"attempts\".\"is_correct\" = false"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_created_at_idx": {
+          "name": "bookmarks_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_question_id_idx": {
+          "name": "bookmarks_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_question_id_questions_id_fk": {
+          "name": "bookmarks_question_id_questions_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bookmarks_user_id_question_id_pk": {
+          "name": "bookmarks_user_id_question_id_pk",
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.choices": {
+      "name": "choices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_md": {
+          "name": "text_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation_md": {
+          "name": "explanation_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "choices_id_question_id_uq": {
+          "name": "choices_id_question_id_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "choices_question_id_idx": {
+          "name": "choices_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "choices_question_id_label_uq": {
+          "name": "choices_question_id_label_uq",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "choices_question_id_sort_order_uq": {
+          "name": "choices_question_id_sort_order_uq",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "choices_question_id_questions_id_fk": {
+          "name": "choices_question_id_questions_id_fk",
+          "tableFrom": "choices",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clerk_events": {
+      "name": "clerk_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clerk_events_type_idx": {
+          "name": "clerk_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clerk_events_processed_at_idx": {
+          "name": "clerk_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deleted_clerk_users": {
+      "name": "deleted_clerk_users",
+      "schema": "",
+      "columns": {
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deleted_clerk_users_deleted_at_idx": {
+          "name": "deleted_clerk_users_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idempotency_keys_expires_at_idx": {
+          "name": "idempotency_keys_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_user_id_users_id_fk": {
+          "name": "idempotency_keys_user_id_users_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotency_keys_user_id_action_key_pk": {
+          "name": "idempotency_keys_user_id_action_key_pk",
+          "columns": [
+            "user_id",
+            "action",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_stripe_cancellations": {
+      "name": "pending_stripe_cancellations",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_stripe_cancellations_created_at_idx": {
+          "name": "pending_stripe_cancellations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_stripe_cancellations_event_id_clerk_events_id_fk": {
+          "name": "pending_stripe_cancellations_event_id_clerk_events_id_fk",
+          "tableFrom": "pending_stripe_cancellations",
+          "tableTo": "clerk_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_session_question_states": {
+      "name": "practice_session_question_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marked_for_review": {
+          "name": "marked_for_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "latest_selected_choice_id": {
+          "name": "latest_selected_choice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_is_correct": {
+          "name": "latest_is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_answered_at": {
+          "name": "latest_answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_selected_choice_id": {
+          "name": "draft_selected_choice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_saved_at": {
+          "name": "draft_saved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_cumulative_ms": {
+          "name": "draft_cumulative_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "practice_session_question_states_session_question_uq": {
+          "name": "practice_session_question_states_session_question_uq",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_question_states_session_position_uq": {
+          "name": "practice_session_question_states_session_position_uq",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_question_states_question_id_idx": {
+          "name": "practice_session_question_states_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_question_states_latest_choice_question_idx": {
+          "name": "practice_session_question_states_latest_choice_question_idx",
+          "columns": [
+            {
+              "expression": "latest_selected_choice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_question_states_draft_choice_question_idx": {
+          "name": "practice_session_question_states_draft_choice_question_idx",
+          "columns": [
+            {
+              "expression": "draft_selected_choice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_session_question_states_practice_session_id_practice_sessions_id_fk": {
+          "name": "practice_session_question_states_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "practice_session_question_states",
+          "tableTo": "practice_sessions",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "practice_session_question_states_question_id_questions_id_fk": {
+          "name": "practice_session_question_states_question_id_questions_id_fk",
+          "tableFrom": "practice_session_question_states",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "practice_session_question_states_latest_choice_question_fk": {
+          "name": "practice_session_question_states_latest_choice_question_fk",
+          "tableFrom": "practice_session_question_states",
+          "tableTo": "choices",
+          "columnsFrom": [
+            "latest_selected_choice_id",
+            "question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "question_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "practice_session_question_states_draft_choice_question_fk": {
+          "name": "practice_session_question_states_draft_choice_question_fk",
+          "tableFrom": "practice_session_question_states",
+          "tableTo": "choices",
+          "columnsFrom": [
+            "draft_selected_choice_id",
+            "question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "question_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_session_question_states_draft_cumulative_ms_chk": {
+          "name": "practice_session_question_states_draft_cumulative_ms_chk",
+          "value": "\"practice_session_question_states\".\"draft_cumulative_ms\" BETWEEN 0 AND 86400000"
+        },
+        "practice_session_question_states_latest_answer_chk": {
+          "name": "practice_session_question_states_latest_answer_chk",
+          "value": "(\"practice_session_question_states\".\"latest_is_correct\" IS NULL) = (\"practice_session_question_states\".\"latest_answered_at\" IS NULL)\n          AND (\"practice_session_question_states\".\"latest_selected_choice_id\" IS NOT NULL OR \"practice_session_question_states\".\"latest_is_correct\" IS NOT TRUE)\n          AND (\"practice_session_question_states\".\"latest_selected_choice_id\" IS NULL OR (\"practice_session_question_states\".\"latest_is_correct\" IS NOT NULL AND \"practice_session_question_states\".\"latest_answered_at\" IS NOT NULL))"
+        },
+        "practice_session_question_states_draft_saved_chk": {
+          "name": "practice_session_question_states_draft_saved_chk",
+          "value": "(\"practice_session_question_states\".\"draft_selected_choice_id\" IS NULL AND \"practice_session_question_states\".\"draft_cumulative_ms\" = 0)\n          OR \"practice_session_question_states\".\"draft_saved_at\" IS NOT NULL"
+        },
+        "practice_session_question_states_position_chk": {
+          "name": "practice_session_question_states_position_chk",
+          "value": "\"practice_session_question_states\".\"position\" >= 0"
+        },
+        "practice_session_question_states_version_chk": {
+          "name": "practice_session_question_states_version_chk",
+          "value": "\"practice_session_question_states\".\"version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.practice_sessions": {
+      "name": "practice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "practice_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_json": {
+          "name": "params_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_sessions_user_started_at_idx": {
+          "name": "practice_sessions_user_started_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"started_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_sessions_user_ended_at_idx": {
+          "name": "practice_sessions_user_ended_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"ended_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_sessions_user_incomplete_uq": {
+          "name": "practice_sessions_user_incomplete_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "ended_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_sessions_user_id_users_id_fk": {
+          "name": "practice_sessions_user_id_users_id_fk",
+          "tableFrom": "practice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_sessions_params_json_object_chk": {
+          "name": "practice_sessions_params_json_object_chk",
+          "value": "jsonb_typeof(\"practice_sessions\".\"params_json\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.question_feedback": {
+      "name": "question_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "question_feedback_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "question_feedback_rating",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "question_feedback_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_feedback_user_created_at_idx": {
+          "name": "question_feedback_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_question_created_at_idx": {
+          "name": "question_feedback_question_created_at_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_attempt_created_at_idx": {
+          "name": "question_feedback_attempt_created_at_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_practice_session_created_at_idx": {
+          "name": "question_feedback_practice_session_created_at_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_rating_user_question_created_at_idx": {
+          "name": "question_feedback_rating_user_question_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"question_feedback\".\"kind\" = 'rating'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_kind_created_at_idx": {
+          "name": "question_feedback_kind_created_at_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_feedback_user_id_users_id_fk": {
+          "name": "question_feedback_user_id_users_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_feedback_question_id_questions_id_fk": {
+          "name": "question_feedback_question_id_questions_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_feedback_attempt_id_attempts_id_fk": {
+          "name": "question_feedback_attempt_id_attempts_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "question_feedback_practice_session_id_practice_sessions_id_fk": {
+          "name": "question_feedback_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "practice_sessions",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "question_feedback_kind_shape_chk": {
+          "name": "question_feedback_kind_shape_chk",
+          "value": "(\"question_feedback\".\"kind\" = 'rating' AND \"question_feedback\".\"category\" IS NULL AND \"question_feedback\".\"comment\" IS NULL)\n          OR (\"question_feedback\".\"kind\" = 'report' AND \"question_feedback\".\"category\" IS NOT NULL AND \"question_feedback\".\"rating\" IS NULL)"
+        },
+        "question_feedback_comment_len_chk": {
+          "name": "question_feedback_comment_len_chk",
+          "value": "\"question_feedback\".\"comment\" IS NULL OR char_length(\"question_feedback\".\"comment\") <= 2000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.question_tags": {
+      "name": "question_tags",
+      "schema": "",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "question_tags_tag_id_idx": {
+          "name": "question_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_tags_question_id_idx": {
+          "name": "question_tags_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_tags_question_id_questions_id_fk": {
+          "name": "question_tags_question_id_questions_id_fk",
+          "tableFrom": "question_tags",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_tags_tag_id_tags_id_fk": {
+          "name": "question_tags_tag_id_tags_id_fk",
+          "tableFrom": "question_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "question_tags_question_id_tag_id_pk": {
+          "name": "question_tags_question_id_tag_id_pk",
+          "columns": [
+            "question_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stem_md": {
+          "name": "stem_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation_md": {
+          "name": "explanation_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_md": {
+          "name": "reference_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_slug_uq": {
+          "name": "questions_slug_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_status_difficulty_idx": {
+          "name": "questions_status_difficulty_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_status_created_at_idx": {
+          "name": "questions_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limits_window_start_idx": {
+          "name": "rate_limits_window_start_idx",
+          "columns": [
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limits_key_window_start_pk": {
+          "name": "rate_limits_key_window_start_pk",
+          "columns": [
+            "key",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_customers": {
+      "name": "stripe_customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_customers_user_id_uq": {
+          "name": "stripe_customers_user_id_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_customers_stripe_customer_id_uq": {
+          "name": "stripe_customers_stripe_customer_id_uq",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_customers_user_id_users_id_fk": {
+          "name": "stripe_customers_user_id_users_id_fk",
+          "tableFrom": "stripe_customers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "stripe_events_type_idx": {
+          "name": "stripe_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_events_processed_at_idx": {
+          "name": "stripe_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_subscriptions": {
+      "name": "stripe_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_subscriptions_user_id_uq": {
+          "name": "stripe_subscriptions_user_id_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_subscriptions_stripe_subscription_id_uq": {
+          "name": "stripe_subscriptions_stripe_subscription_id_uq",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_subscriptions_user_status_idx": {
+          "name": "stripe_subscriptions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_subscriptions_user_id_users_id_fk": {
+          "name": "stripe_subscriptions_user_id_users_id_fk",
+          "tableFrom": "stripe_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "tag_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_slug_uq": {
+          "name": "tags_slug_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_kind_slug_idx": {
+          "name": "tags_kind_slug_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_uq": {
+          "name": "users_clerk_user_id_uq",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_uq": {
+          "name": "users_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attempt_retry_origin": {
+      "name": "attempt_retry_origin",
+      "schema": "public",
+      "values": [
+        "history",
+        "dashboard",
+        "bookmarks",
+        "session_review",
+        "other"
+      ]
+    },
+    "public.practice_mode": {
+      "name": "practice_mode",
+      "schema": "public",
+      "values": [
+        "tutor",
+        "exam"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "easy",
+        "medium",
+        "hard"
+      ]
+    },
+    "public.question_feedback_category": {
+      "name": "question_feedback_category",
+      "schema": "public",
+      "values": [
+        "incorrect_answer",
+        "ambiguous_wording",
+        "typo_formatting",
+        "outdated_reference",
+        "other"
+      ]
+    },
+    "public.question_feedback_kind": {
+      "name": "question_feedback_kind",
+      "schema": "public",
+      "values": [
+        "rating",
+        "report"
+      ]
+    },
+    "public.question_feedback_rating": {
+      "name": "question_feedback_rating",
+      "schema": "public",
+      "values": [
+        "helpful",
+        "not_helpful"
+      ]
+    },
+    "public.question_status": {
+      "name": "question_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.stripe_subscription_status": {
+      "name": "stripe_subscription_status",
+      "schema": "public",
+      "values": [
+        "incomplete",
+        "incomplete_expired",
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid",
+        "paused"
+      ]
+    },
+    "public.tag_kind": {
+      "name": "tag_kind",
+      "schema": "public",
+      "values": [
+        "topic",
+        "substance",
+        "treatment",
+        "diagnosis"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1783386691489,
       "tag": "0028_repair_attempts_selected_choice_index",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1783792133462,
+      "tag": "0029_medical_starfox",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.test.ts
+++ b/db/schema.test.ts
@@ -1,3 +1,4 @@
+import { getTableColumns } from 'drizzle-orm';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import { DAY_MS } from '@/src/domain/services/time-constants';
 import type {
@@ -10,6 +11,7 @@ import {
   PRACTICE_SESSIONS_USER_INCOMPLETE_UQ,
   practiceSessionQuestionStates,
   practiceSessions,
+  stripeSubscriptions,
 } from './schema';
 
 // Drizzle stores extra config (indexes, constraints) behind internal Symbols.
@@ -201,5 +203,19 @@ describe('db schema exports', () => {
     expectTypeOf<NewPendingStripeCancellation>().toEqualTypeOf<
       typeof pendingStripeCancellations.$inferInsert
     >();
+  });
+});
+
+describe('stripeSubscriptions schema', () => {
+  it('stores a non-null observation version starting at zero', () => {
+    const columns = getTableColumns(stripeSubscriptions) as Record<
+      string,
+      { default: unknown; notNull: boolean }
+    >;
+
+    expect(columns.version).toMatchObject({
+      default: 0,
+      notNull: true,
+    });
   });
 });

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -186,6 +186,7 @@ export const stripeSubscriptions = pgTable(
       withTimezone: true,
     }).notNull(),
     cancelAtPeriodEnd: boolean('cancel_at_period_end').notNull().default(false),
+    version: integer('version').notNull().default(0),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/docs/bugs/bug-287-reconcile-cron-stale-snapshot-overwrites-newer-webhook-state.md
+++ b/docs/bugs/bug-287-reconcile-cron-stale-snapshot-overwrites-newer-webhook-state.md
@@ -8,6 +8,13 @@
 
 ---
 
+## Resolution State
+
+- Implementation branch: `fix/bug-287-subscription-version-fence`.
+- Pull request: [#635 — Fix BUG-287: optimistic observation-version fence for subscription writes](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/635).
+- The implementation uses the decided monotonic observation-version CAS and bounded whole-operation retries across reconcile, webhook, and checkout-success writers. It does not add or consult local request timestamps, Stripe event `created`, or a Stripe-state timestamp.
+- Status remains **Open** until the merged change has post-deploy production proof.
+
 ## Summary
 
 [`shouldPersistSubscriptionWrite`](../../src/domain/services/subscription-write-guard.ts#L38-L42) unconditionally persists any write whose `subscriptionIdentity` matches the stored row, and [`stripe_subscriptions`](../../db/schema.ts#L173-L194) stores no Stripe-side version or state timestamp — [`updatedAt` is set to the database write time](../../src/adapters/repositories/drizzle-subscription-repository.ts#L84), not the time the state was observed at Stripe. The daily production reconcile cron ([`vercel.json`](../../vercel.json#L6-L7): `dryRun=false&scope=all`, `0 8 * * *` UTC) snapshots each subscription in [Phase 1](../../src/adapters/jobs/reconcile-stripe-subscriptions.ts#L91-L102) but writes it only in [Phase 4](../../src/adapters/jobs/reconcile-stripe-subscriptions.ts#L232-L246), after a `subscriptions.list` round-trip plus sequential per-blocking-subscription retrieves under retry/backoff — and when the customer has no blocking subscriptions, [the canonical value remains the stale Phase-1 snapshot](../../src/adapters/jobs/reconcile-stripe-subscriptions.ts#L136). [Vercel invokes configured cron jobs against the production deployment](https://vercel.com/docs/cron-jobs#how-cron-jobs-work).

--- a/lib/container.test.ts
+++ b/lib/container.test.ts
@@ -548,6 +548,7 @@ describe('container factories', () => {
     }));
     const createSubscriptionRepository = vi.fn(() => ({
       findByUserId: async () => null,
+      findObservationVersionByUserId: async () => null,
       findByExternalSubscriptionId: async () => null,
       upsert: async () => ({ persisted: true }) as const,
     }));
@@ -588,13 +589,16 @@ describe('container factories', () => {
     });
 
     const deps: StripeWebhookDeps = container.createStripeWebhookDeps();
+    expect(deps.subscriptionVersions).toBe(
+      createSubscriptionRepository.mock.results[0]?.value,
+    );
 
     await deps.transaction(async (repoDeps) => {
       expect(repoDeps.stripeEvents).toBe(
         createStripeEventRepository.mock.results[0]?.value,
       );
       expect(repoDeps.subscriptions).toBe(
-        createSubscriptionRepository.mock.results[0]?.value,
+        createSubscriptionRepository.mock.results[1]?.value,
       );
       expect(repoDeps.stripeCustomers).toBe(
         createStripeCustomerRepository.mock.results[0]?.value,
@@ -603,7 +607,7 @@ describe('container factories', () => {
 
     expect(transaction).toHaveBeenCalledTimes(1);
     expect(createStripeEventRepository).toHaveBeenCalledWith(tx);
-    expect(createSubscriptionRepository).toHaveBeenCalledWith(tx);
+    expect(createSubscriptionRepository.mock.calls).toEqual([[], [tx]]);
     expect(createStripeCustomerRepository).toHaveBeenCalledWith(tx);
   });
 });

--- a/lib/container/controllers.ts
+++ b/lib/container/controllers.ts
@@ -19,6 +19,7 @@ export function createControllerFactories(input: {
   return {
     createStripeWebhookDeps: () => ({
       paymentGateway: gateways.createPaymentGateway(),
+      subscriptionVersions: repositories.createSubscriptionRepository(),
       logger: primitives.logger,
       now: primitives.now,
       transaction: async (fn) =>

--- a/src/adapters/controllers/stripe-webhook-controller-failure-boundary.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller-failure-boundary.test.ts
@@ -56,12 +56,14 @@ function createAbortedTransactionDeps(input: {
   transactionCallCount: () => number;
 } {
   const stripeEvents = input.stripeEvents ?? new FakeStripeEventRepository();
+  const subscriptionVersions = new FakeSubscriptionRepository();
   const logger = new FakeLogger();
   let transactionCallCount = 0;
 
   return {
     deps: {
       paymentGateway: input.paymentGateway,
+      subscriptionVersions,
       logger,
       now: () => new Date(),
       transaction: async (fn) => {
@@ -196,6 +198,7 @@ describe('processStripeWebhook failure boundary', () => {
     let transactionCallCount = 0;
     const deps: StripeWebhookDeps = {
       paymentGateway: createPaymentGateway(eventId),
+      subscriptionVersions: new FakeSubscriptionRepository(),
       logger: new FakeLogger(),
       now: () => new Date(),
       transaction: async (fn) => {

--- a/src/adapters/controllers/stripe-webhook-controller-version-fence.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller-version-fence.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  processStripeWebhook,
+  type StripeWebhookDeps,
+} from '@/src/adapters/controllers/stripe-webhook-controller';
+import type {
+  SubscriptionUpsertInput,
+  SubscriptionUpsertResult,
+} from '@/src/application/ports/repositories';
+import { SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS } from '@/src/application/shared/persist-subscription-observation';
+import {
+  FakeLogger,
+  FakePaymentGateway,
+  FakeStripeCustomerRepository,
+  FakeStripeEventRepository,
+  FakeSubscriptionRepository,
+} from '@/src/application/test-helpers/fakes';
+
+class AlwaysConflictingSubscriptionRepository extends FakeSubscriptionRepository {
+  readonly inputs: SubscriptionUpsertInput[] = [];
+
+  override async findObservationVersionByUserId(): Promise<number> {
+    return this.inputs.length;
+  }
+
+  override async upsert(
+    input: SubscriptionUpsertInput,
+  ): Promise<SubscriptionUpsertResult> {
+    this.inputs.push(input);
+    return { persisted: false, reason: 'version_conflict' };
+  }
+}
+
+describe('processStripeWebhook observation-version fence', () => {
+  it('re-fetches after discovery and persists exhaustion through the failure ledger', async () => {
+    const userId = crypto.randomUUID();
+    const eventId = 'evt_webhook_version_exhaustion';
+    const paymentGateway = new FakePaymentGateway({
+      externalCustomerId: 'cus_test',
+      checkoutUrl: 'https://stripe.test/checkout',
+      portalUrl: 'https://stripe.test/portal',
+      webhookResult: {
+        eventId,
+        type: 'customer.subscription.updated',
+        subscriptionUpdate: {
+          userId,
+          externalCustomerId: 'cus_123',
+          externalSubscriptionId: 'sub_123',
+          plan: 'monthly',
+          status: 'active',
+          currentPeriodEnd: new Date('2030-01-01T00:00:00.000Z'),
+          cancelAtPeriodEnd: false,
+        },
+      },
+    });
+    const stripeEvents = new FakeStripeEventRepository();
+    const subscriptions = new AlwaysConflictingSubscriptionRepository();
+    const stripeCustomers = new FakeStripeCustomerRepository();
+    const deps = {
+      paymentGateway,
+      subscriptionVersions: subscriptions,
+      logger: new FakeLogger(),
+      now: () => new Date('2026-01-01T00:00:00.000Z'),
+      transaction: async (fn) =>
+        fn({ stripeEvents, subscriptions, stripeCustomers }),
+    } as StripeWebhookDeps;
+
+    await expect(
+      processStripeWebhook(deps, { rawBody: 'raw', signature: 'sig' }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: `Subscription observation version conflicted after ${SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS} attempts`,
+    });
+
+    expect(paymentGateway.webhookInputs).toHaveLength(
+      SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS + 1,
+    );
+    expect(subscriptions.inputs).toHaveLength(
+      SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS,
+    );
+    const storedEvent = await stripeEvents.lock(eventId);
+    expect(storedEvent.processedAt).toBeNull();
+    expect(JSON.parse(storedEvent.error ?? '{}')).toMatchObject({
+      code: 'CONFLICT',
+      message: `Subscription observation version conflicted after ${SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS} attempts`,
+    });
+  });
+});

--- a/src/adapters/controllers/stripe-webhook-controller.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.test.ts
@@ -78,6 +78,7 @@ function createDeps(overrides: {
   return {
     deps: {
       paymentGateway: overrides.paymentGateway,
+      subscriptionVersions: subscriptions,
       logger,
       now: () => new Date(),
       transaction: async (fn) =>
@@ -280,6 +281,7 @@ describe('processStripeWebhook', () => {
       status: 'active',
       currentPeriodEnd: new Date('2026-06-13T00:00:00.000Z'),
       cancelAtPeriodEnd: false,
+      expectedVersion: null,
     });
     const paymentGateway = new FakePaymentGateway({
       externalCustomerId: 'cus_test',
@@ -339,6 +341,7 @@ describe('processStripeWebhook', () => {
       status: 'active',
       currentPeriodEnd: new Date('2026-06-13T00:00:00.000Z'),
       cancelAtPeriodEnd: false,
+      expectedVersion: null,
     });
     const paymentGateway = new FakePaymentGateway({
       externalCustomerId: 'cus_test',

--- a/src/adapters/controllers/stripe-webhook-controller.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.ts
@@ -3,7 +3,7 @@ import {
   isE2EOwnerMismatchEvent,
   isMissingStripeSubscriptionUserIdError,
 } from '@/src/adapters/shared/stripe-subscription-errors';
-import { isApplicationError } from '@/src/application/errors';
+import { ApplicationError, isApplicationError } from '@/src/application/errors';
 import type { PaymentGateway } from '@/src/application/ports/gateways';
 import type { Logger } from '@/src/application/ports/logger';
 import type {
@@ -11,6 +11,7 @@ import type {
   StripeEventRepository,
   SubscriptionRepository,
 } from '@/src/application/ports/repositories';
+import { persistSubscriptionObservation } from '@/src/application/shared/persist-subscription-observation';
 import { DAY_MS } from '@/src/domain/services';
 
 export type StripeWebhookInput = {
@@ -26,6 +27,10 @@ export type StripeWebhookTransaction = {
 
 export type StripeWebhookDeps = {
   paymentGateway: PaymentGateway;
+  subscriptionVersions: Pick<
+    SubscriptionRepository,
+    'findObservationVersionByUserId'
+  >;
   transaction: <T>(
     fn: (tx: StripeWebhookTransaction) => Promise<T>,
   ) => Promise<T>;
@@ -36,6 +41,11 @@ export type StripeWebhookDeps = {
 type StripeWebhookEvent = Awaited<
   ReturnType<PaymentGateway['processWebhookEvent']>
 >;
+type StripeSubscriptionUpdate = NonNullable<
+  StripeWebhookEvent['subscriptionUpdate']
+>;
+
+class StripeWebhookAlreadyProcessed extends Error {}
 
 const STRIPE_EVENTS_RETENTION_MS = 90 * DAY_MS;
 const STRIPE_EVENTS_PRUNE_LIMIT = 100;
@@ -143,8 +153,99 @@ export async function processStripeWebhook(
   let hasProcessingError = false;
 
   try {
-    await deps.transaction(
-      async ({ stripeEvents, subscriptions, stripeCustomers }) => {
+    if (event.subscriptionUpdate) {
+      const discoveredUserId = event.subscriptionUpdate.userId;
+      const retrieveSubscriptionUpdate =
+        async (): Promise<StripeSubscriptionUpdate> => {
+          const refreshedEvent = await deps.paymentGateway.processWebhookEvent(
+            input.rawBody,
+            input.signature,
+          );
+          if (
+            refreshedEvent.eventId !== event.eventId ||
+            refreshedEvent.type !== event.type ||
+            !refreshedEvent.subscriptionUpdate
+          ) {
+            throw new ApplicationError(
+              'CONFLICT',
+              'Stripe webhook changed during subscription refresh',
+            );
+          }
+          return refreshedEvent.subscriptionUpdate;
+        };
+
+      try {
+        await persistSubscriptionObservation({
+          userId: discoveredUserId,
+          readVersion: (userId) =>
+            deps.subscriptionVersions.findObservationVersionByUserId(userId),
+          retrieve: retrieveSubscriptionUpdate,
+          getUserId: (subscriptionUpdate) => subscriptionUpdate.userId,
+          persist: (subscriptionUpdate, expectedVersion) =>
+            deps.transaction(
+              async ({ stripeEvents, subscriptions, stripeCustomers }) => {
+                const claimed = await stripeEvents.claim(
+                  event.eventId,
+                  event.type,
+                );
+                if (!claimed) {
+                  const snapshot = await stripeEvents.peek(event.eventId);
+                  if (snapshot && isSuccessfullyProcessed(snapshot)) {
+                    throw new StripeWebhookAlreadyProcessed();
+                  }
+                }
+
+                const current = await stripeEvents.lock(event.eventId);
+                if (isSuccessfullyProcessed(current)) {
+                  throw new StripeWebhookAlreadyProcessed();
+                }
+
+                try {
+                  // Canonical multi-repository lock order: advisory(user) in
+                  // subscriptions.upsert -> stripe_subscriptions row ->
+                  // stripe_customers row. Keep every writer in this order.
+                  const write = await subscriptions.upsert({
+                    userId: subscriptionUpdate.userId,
+                    externalSubscriptionId:
+                      subscriptionUpdate.externalSubscriptionId,
+                    plan: subscriptionUpdate.plan,
+                    status: subscriptionUpdate.status,
+                    currentPeriodEnd: subscriptionUpdate.currentPeriodEnd,
+                    cancelAtPeriodEnd: subscriptionUpdate.cancelAtPeriodEnd,
+                    expectedVersion,
+                  });
+                  if (!write.persisted && write.reason === 'version_conflict') {
+                    return write;
+                  }
+
+                  if (write.persisted) {
+                    await stripeCustomers.insert(
+                      subscriptionUpdate.userId,
+                      subscriptionUpdate.externalCustomerId,
+                      { conflictStrategy: 'authoritative' },
+                    );
+                  }
+
+                  await stripeEvents.markProcessed(event.eventId);
+                  return write;
+                } catch (error) {
+                  if (error instanceof StripeWebhookAlreadyProcessed) {
+                    throw error;
+                  }
+                  processingError = error;
+                  hasProcessingError = true;
+                  throw error;
+                }
+              },
+            ),
+        });
+      } catch (error) {
+        if (!(error instanceof StripeWebhookAlreadyProcessed)) {
+          throw error;
+        }
+      }
+    } else {
+      await deps.transaction(async ({ stripeEvents }) => {
         const claimed = await stripeEvents.claim(event.eventId, event.type);
         if (!claimed) {
           const snapshot = await stripeEvents.peek(event.eventId);
@@ -159,37 +260,14 @@ export async function processStripeWebhook(
         }
 
         try {
-          if (event.subscriptionUpdate) {
-            // Canonical multi-repository lock order: advisory(user) in
-            // subscriptions.upsert -> stripe_subscriptions row ->
-            // stripe_customers row. Keep every writer in this order.
-            const write = await subscriptions.upsert({
-              userId: event.subscriptionUpdate.userId,
-              externalSubscriptionId:
-                event.subscriptionUpdate.externalSubscriptionId,
-              plan: event.subscriptionUpdate.plan,
-              status: event.subscriptionUpdate.status,
-              currentPeriodEnd: event.subscriptionUpdate.currentPeriodEnd,
-              cancelAtPeriodEnd: event.subscriptionUpdate.cancelAtPeriodEnd,
-            });
-
-            if (write.persisted) {
-              await stripeCustomers.insert(
-                event.subscriptionUpdate.userId,
-                event.subscriptionUpdate.externalCustomerId,
-                { conflictStrategy: 'authoritative' },
-              );
-            }
-          }
-
           await stripeEvents.markProcessed(event.eventId);
         } catch (error) {
           processingError = error;
           hasProcessingError = true;
           throw error;
         }
-      },
-    );
+      });
+    }
   } catch (transactionError) {
     const originalError = hasProcessingError
       ? processingError

--- a/src/adapters/jobs/reconcile-stripe-subscriptions-types.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions-types.ts
@@ -9,6 +9,7 @@ import type {
 export type StripeSubscriptionRefRow = {
   userId: string;
   stripeSubscriptionId: string;
+  version: number | null;
 };
 
 export type ReconcileStripeSubscriptionsInput = {

--- a/src/adapters/jobs/reconcile-stripe-subscriptions-version-fence.test.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions-version-fence.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import type { ReconcileStripeSubscriptionsDeps } from '@/src/adapters/jobs/reconcile-stripe-subscriptions-types';
+import type {
+  SubscriptionUpsertInput,
+  SubscriptionUpsertResult,
+} from '@/src/application/ports/repositories';
+import { SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS } from '@/src/application/shared/persist-subscription-observation';
+import {
+  FakeLogger,
+  FakeStripeCustomerRepository,
+  FakeSubscriptionRepository,
+} from '@/src/application/test-helpers/fakes';
+import { reconcileStripeSubscriptions } from './reconcile-stripe-subscriptions';
+
+const userId = crypto.randomUUID();
+const externalSubscriptionId = 'sub_reconcile_version_fence';
+
+function stripeSubscription() {
+  return {
+    id: externalSubscriptionId,
+    customer: 'cus_reconcile_version_fence',
+    status: 'active' as const,
+    cancel_at_period_end: false,
+    metadata: { user_id: userId },
+    items: {
+      data: [
+        {
+          current_period_end: 1_893_456_000,
+          price: { id: 'price_monthly' },
+        },
+      ],
+    },
+  };
+}
+
+function createStripe() {
+  const subscription = stripeSubscription();
+  let retrieveCount = 0;
+  let listCount = 0;
+
+  const stripe: ReconcileStripeSubscriptionsDeps['stripe'] = {
+    customers: {
+      create: async () => {
+        throw new Error('Unexpected customers.create');
+      },
+    },
+    checkout: {
+      sessions: {
+        create: async () => {
+          throw new Error('Unexpected checkout.sessions.create');
+        },
+        list: async () => {
+          throw new Error('Unexpected checkout.sessions.list');
+        },
+        retrieve: async () => {
+          throw new Error('Unexpected checkout.sessions.retrieve');
+        },
+        expire: async () => {
+          throw new Error('Unexpected checkout.sessions.expire');
+        },
+      },
+    },
+    subscriptions: {
+      retrieve: async () => {
+        retrieveCount += 1;
+        return subscription;
+      },
+      list: async () => {
+        listCount += 1;
+        return { data: [] };
+      },
+      cancel: async () => subscription,
+    },
+    billingPortal: {
+      sessions: {
+        create: async () => {
+          throw new Error('Unexpected billingPortal.sessions.create');
+        },
+      },
+    },
+    webhooks: {
+      constructEvent: () => {
+        throw new Error('Unexpected webhooks.constructEvent');
+      },
+    },
+  };
+
+  return {
+    stripe,
+    retrieveCount: () => retrieveCount,
+    listCount: () => listCount,
+  };
+}
+
+class VersionConflictSubscriptionRepository extends FakeSubscriptionRepository {
+  readonly inputs: SubscriptionUpsertInput[] = [];
+  private versionReadCount = 0;
+
+  constructor(private readonly conflictsBeforeSuccess: number) {
+    super();
+  }
+
+  override async findObservationVersionByUserId(): Promise<number> {
+    this.versionReadCount += 1;
+    return 4 + this.versionReadCount;
+  }
+
+  override async upsert(
+    input: SubscriptionUpsertInput,
+  ): Promise<SubscriptionUpsertResult> {
+    this.inputs.push(input);
+    if (this.inputs.length <= this.conflictsBeforeSuccess) {
+      return { persisted: false, reason: 'version_conflict' };
+    }
+    return { persisted: true };
+  }
+}
+
+function createDeps(input: {
+  subscriptions: VersionConflictSubscriptionRepository;
+  stripe: ReconcileStripeSubscriptionsDeps['stripe'];
+  initialVersion: number;
+}): ReconcileStripeSubscriptionsDeps {
+  const stripeCustomers = new FakeStripeCustomerRepository();
+
+  return {
+    stripe: input.stripe,
+    priceIds: { monthly: 'price_monthly', annual: 'price_annual' },
+    logger: new FakeLogger(),
+    listLocalSubscriptions: async () => [
+      {
+        userId,
+        stripeSubscriptionId: externalSubscriptionId,
+        version: input.initialVersion,
+      },
+    ],
+    transaction: async (fn) =>
+      fn({ subscriptions: input.subscriptions, stripeCustomers }),
+  } as ReconcileStripeSubscriptionsDeps;
+}
+
+describe('reconcileStripeSubscriptions observation-version fence', () => {
+  it('re-runs retrieval and converges after a version conflict', async () => {
+    const stripe = createStripe();
+    const subscriptions = new VersionConflictSubscriptionRepository(1);
+
+    await expect(
+      reconcileStripeSubscriptions(
+        { limit: 1, offset: 0, dryRun: true, concurrency: 1 },
+        createDeps({
+          subscriptions,
+          stripe: stripe.stripe,
+          initialVersion: 4,
+        }),
+      ),
+    ).resolves.toMatchObject({ updated: 1, failed: 0 });
+
+    expect(stripe.retrieveCount()).toBe(2);
+    expect(stripe.listCount()).toBe(2);
+    expect(subscriptions.inputs.map((input) => input.expectedVersion)).toEqual([
+      4, 5,
+    ]);
+  });
+
+  it('counts retry exhaustion as the existing per-row failure shape', async () => {
+    const stripe = createStripe();
+    const subscriptions = new VersionConflictSubscriptionRepository(
+      SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS,
+    );
+
+    const result = await reconcileStripeSubscriptions(
+      { limit: 1, offset: 0, dryRun: true, concurrency: 1 },
+      createDeps({
+        subscriptions,
+        stripe: stripe.stripe,
+        initialVersion: 4,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      updated: 0,
+      failed: 1,
+      failures: [
+        {
+          stripeSubscriptionId: externalSubscriptionId,
+          error: `Subscription observation version conflicted after ${SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS} attempts`,
+        },
+      ],
+    });
+    expect(stripe.retrieveCount()).toBe(SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS);
+    expect(stripe.listCount()).toBe(SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS);
+    expect(subscriptions.inputs).toHaveLength(
+      SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS,
+    );
+  });
+});

--- a/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
@@ -23,7 +23,11 @@ type StripeSubscriptionFixture = {
   };
 };
 
-type LocalSubscriptionRow = { userId: string; stripeSubscriptionId: string };
+type LocalSubscriptionRow = {
+  userId: string;
+  stripeSubscriptionId: string;
+  version: number | null;
+};
 
 const primaryUserId = crypto.randomUUID();
 const secondaryUserId = crypto.randomUUID();
@@ -237,7 +241,7 @@ function row(
   userId: string,
   stripeSubscriptionId: string,
 ): LocalSubscriptionRow {
-  return { userId, stripeSubscriptionId };
+  return { userId, stripeSubscriptionId, version: null };
 }
 
 function createSingleRowScenario(input: {
@@ -293,6 +297,7 @@ describe('reconcileStripeSubscriptions', () => {
     const rows = Array.from({ length: 12 }, (_, i) => ({
       userId: crypto.randomUUID(),
       stripeSubscriptionId: `sub_${i + 1}`,
+      version: null,
     }));
 
     const subscriptionsById: Record<string, StripeSubscriptionFixture> = {};
@@ -1249,6 +1254,7 @@ describe('reconcileStripeSubscriptions', () => {
       status: 'active',
       currentPeriodEnd: new Date(localPeriodEnd * 1000),
       cancelAtPeriodEnd: false,
+      expectedVersion: null,
     });
 
     const scenario = createReconciliationTestScenario({
@@ -1469,6 +1475,7 @@ describe('reconcileStripeSubscriptions', () => {
       status: 'active',
       currentPeriodEnd: new Date(1_700_000_000 * 1000),
       cancelAtPeriodEnd: false,
+      expectedVersion: null,
     });
 
     const scenario = createReconciliationTestScenario({
@@ -1524,6 +1531,7 @@ describe('reconcileStripeSubscriptions', () => {
       status: 'active',
       currentPeriodEnd: new Date(1_700_000_000 * 1000),
       cancelAtPeriodEnd: false,
+      expectedVersion: null,
     });
 
     const scenario = createReconciliationTestScenario({

--- a/src/adapters/jobs/reconcile-stripe-subscriptions.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions.ts
@@ -10,6 +10,7 @@ import type {
 } from '@/src/adapters/jobs/reconcile-stripe-subscriptions-types';
 import { mapWithConcurrencyLimit } from '@/src/adapters/shared/concurrency';
 import { ApplicationError } from '@/src/application/errors';
+import { persistSubscriptionObservation } from '@/src/application/shared/persist-subscription-observation';
 import { compareCanonicalSubscriptionCandidates } from '@/src/application/shared/subscription-canonicalization';
 
 export const RECONCILE_STRIPE_SUBSCRIPTIONS_DEFAULT_LIMIT = 100;
@@ -87,166 +88,202 @@ export async function reconcileStripeSubscriptions(
     safeConcurrency,
     async (row) => {
       try {
-        // Phase 1: normalize the local row's Stripe subscription and validate user identity.
-        const localSubscriptionUpdate =
-          await retrieveAndNormalizeStripeSubscription({
-            stripe: deps.stripe,
-            subscriptionRef: row.stripeSubscriptionId,
-            event: {
-              id: `cron_reconcile:${row.stripeSubscriptionId}`,
-              type: 'cron.reconcile_stripe_subscriptions',
-            },
-            priceIds: deps.priceIds,
-            logger: deps.logger,
-            webhookE2EOwner: deps.webhookE2EOwner,
-          });
+        const retrieveObservation = async () => {
+          // Phase 1: normalize the local row's Stripe subscription and validate user identity.
+          const localSubscriptionUpdate =
+            await retrieveAndNormalizeStripeSubscription({
+              stripe: deps.stripe,
+              subscriptionRef: row.stripeSubscriptionId,
+              event: {
+                id: `cron_reconcile:${row.stripeSubscriptionId}`,
+                type: 'cron.reconcile_stripe_subscriptions',
+              },
+              priceIds: deps.priceIds,
+              logger: deps.logger,
+              webhookE2EOwner: deps.webhookE2EOwner,
+            });
 
-        if (localSubscriptionUpdate.userId !== row.userId) {
-          deps.logger.error(
-            {
-              stripeSubscriptionId: row.stripeSubscriptionId,
-              expectedUserId: row.userId,
-              actualUserId: localSubscriptionUpdate.userId,
-            },
-            'Stripe subscription metadata.user_id does not match local user id',
-          );
-          throw new ApplicationError(
-            'CONFLICT',
-            'Stripe subscription user id mismatch',
-          );
-        }
-
-        // Phase 2: fetch and normalize all blocking subscriptions for the same customer.
-        const listedSubscriptions = await callStripeWithRetry({
-          operation: 'subscriptions.list',
-          fn: () =>
-            listSubscriptions({
-              customer: localSubscriptionUpdate.externalCustomerId,
-              status: 'all',
-              limit: SUBSCRIPTION_LIST_LIMIT,
-            }),
-          logger: deps.logger,
-        });
-
-        const blockingSubscriptionIds = listedSubscriptions.data
-          .filter((subscription) => isBlockingStatus(subscription.status))
-          .map((subscription) => subscription.id)
-          .filter((id): id is string => typeof id === 'string');
-
-        let canonical = localSubscriptionUpdate;
-        const canonicalById = new Map<string, typeof localSubscriptionUpdate>([
-          [
-            localSubscriptionUpdate.externalSubscriptionId,
-            localSubscriptionUpdate,
-          ],
-        ]);
-        let duplicateIds: string[] = [];
-        const alreadyCanceledDuplicateIds: string[] = [];
-        let keptSubscriptionId: string | null = null;
-
-        // Intentionally sequential: in this per-row callback we iterate
-        // blockingSubscriptionIds one-at-a-time. retrieveAndNormalizeStripeSubscription
-        // still runs concurrently across rows (bounded by safeConcurrency), but
-        // keeping this loop sequential avoids hammering Stripe for a single
-        // customer while building canonicalById.
-        for (const blockingId of blockingSubscriptionIds) {
-          if (canonicalById.has(blockingId)) continue;
-          const blockingUpdate = await retrieveAndNormalizeStripeSubscription({
-            stripe: deps.stripe,
-            subscriptionRef: blockingId,
-            event: {
-              id: `cron_reconcile:${blockingId}`,
-              type: 'cron.reconcile_stripe_subscriptions',
-            },
-            priceIds: deps.priceIds,
-            logger: deps.logger,
-            webhookE2EOwner: deps.webhookE2EOwner,
-          });
-
-          if (blockingUpdate.userId !== row.userId) {
+          if (localSubscriptionUpdate.userId !== row.userId) {
             deps.logger.error(
               {
-                stripeSubscriptionId: blockingId,
+                stripeSubscriptionId: row.stripeSubscriptionId,
                 expectedUserId: row.userId,
-                actualUserId: blockingUpdate.userId,
+                actualUserId: localSubscriptionUpdate.userId,
               },
-              'Blocking Stripe subscription metadata.user_id mismatch during reconciliation',
+              'Stripe subscription metadata.user_id does not match local user id',
             );
             throw new ApplicationError(
               'CONFLICT',
-              'Blocking Stripe subscription user id mismatch',
+              'Stripe subscription user id mismatch',
             );
           }
 
-          canonicalById.set(blockingId, blockingUpdate);
-        }
-
-        if (blockingSubscriptionIds.length > 0) {
-          // Phase 3: select the canonical subscription via entitlement tier,
-          // period-end sort, and deterministic tie-break.
-          const keptSubscription = blockingSubscriptionIds
-            .map((id) => canonicalById.get(id))
-            .filter((subscription): subscription is typeof canonical => {
-              return subscription !== undefined;
-            })
-            .sort((a, b) =>
-              compareCanonicalSubscriptionCandidates(
-                {
-                  subscriptionIdentity: a.externalSubscriptionId,
-                  status: a.status,
-                  currentPeriodEnd: a.currentPeriodEnd,
-                },
-                {
-                  subscriptionIdentity: b.externalSubscriptionId,
-                  status: b.status,
-                  currentPeriodEnd: b.currentPeriodEnd,
-                },
-              ),
-            )[0];
-
-          const keptSubscriptionIdCandidate =
-            keptSubscription?.externalSubscriptionId;
-          if (!keptSubscriptionIdCandidate) {
-            throw new ApplicationError(
-              'STRIPE_ERROR',
-              'Unable to determine canonical Stripe subscription',
-            );
-          }
-
-          keptSubscriptionId = keptSubscriptionIdCandidate;
-          const kept = canonicalById.get(keptSubscriptionId);
-          if (!kept) {
-            throw new ApplicationError(
-              'STRIPE_ERROR',
-              'Canonical Stripe subscription data is missing',
-            );
-          }
-          canonical = kept;
-
-          duplicateIds = blockingSubscriptionIds.filter(
-            (id) => id !== keptSubscriptionId,
-          );
-        }
-
-        // Phase 4: persist canonical subscription and customer mapping atomically.
-        // Canonical multi-repository lock order: advisory(user) in
-        // subscriptions.upsert -> stripe_subscriptions row -> stripe_customers
-        // row. Keep every writer in this order to avoid AB-BA deadlocks.
-        await deps.transaction(async ({ stripeCustomers, subscriptions }) => {
-          await subscriptions.upsert({
-            userId: canonical.userId,
-            externalSubscriptionId: canonical.externalSubscriptionId,
-            plan: canonical.plan,
-            status: canonical.status,
-            currentPeriodEnd: canonical.currentPeriodEnd,
-            cancelAtPeriodEnd: canonical.cancelAtPeriodEnd,
+          // Phase 2: fetch and normalize all blocking subscriptions for the same customer.
+          const listedSubscriptions = await callStripeWithRetry({
+            operation: 'subscriptions.list',
+            fn: () =>
+              listSubscriptions({
+                customer: localSubscriptionUpdate.externalCustomerId,
+                status: 'all',
+                limit: SUBSCRIPTION_LIST_LIMIT,
+              }),
+            logger: deps.logger,
           });
-          await stripeCustomers.insert(
-            canonical.userId,
-            canonical.externalCustomerId,
-            { conflictStrategy: 'authoritative' },
+
+          const blockingSubscriptionIds = listedSubscriptions.data
+            .filter((subscription) => isBlockingStatus(subscription.status))
+            .map((subscription) => subscription.id)
+            .filter((id): id is string => typeof id === 'string');
+
+          let canonical = localSubscriptionUpdate;
+          const canonicalById = new Map<string, typeof localSubscriptionUpdate>(
+            [
+              [
+                localSubscriptionUpdate.externalSubscriptionId,
+                localSubscriptionUpdate,
+              ],
+            ],
           );
+          let duplicateIds: string[] = [];
+          let keptSubscriptionId: string | null = null;
+
+          // Intentionally sequential: in this per-row callback we iterate
+          // blockingSubscriptionIds one-at-a-time. retrieveAndNormalizeStripeSubscription
+          // still runs concurrently across rows (bounded by safeConcurrency), but
+          // keeping this loop sequential avoids hammering Stripe for a single
+          // customer while building canonicalById.
+          for (const blockingId of blockingSubscriptionIds) {
+            if (canonicalById.has(blockingId)) continue;
+            const blockingUpdate = await retrieveAndNormalizeStripeSubscription(
+              {
+                stripe: deps.stripe,
+                subscriptionRef: blockingId,
+                event: {
+                  id: `cron_reconcile:${blockingId}`,
+                  type: 'cron.reconcile_stripe_subscriptions',
+                },
+                priceIds: deps.priceIds,
+                logger: deps.logger,
+                webhookE2EOwner: deps.webhookE2EOwner,
+              },
+            );
+
+            if (blockingUpdate.userId !== row.userId) {
+              deps.logger.error(
+                {
+                  stripeSubscriptionId: blockingId,
+                  expectedUserId: row.userId,
+                  actualUserId: blockingUpdate.userId,
+                },
+                'Blocking Stripe subscription metadata.user_id mismatch during reconciliation',
+              );
+              throw new ApplicationError(
+                'CONFLICT',
+                'Blocking Stripe subscription user id mismatch',
+              );
+            }
+
+            canonicalById.set(blockingId, blockingUpdate);
+          }
+
+          if (blockingSubscriptionIds.length > 0) {
+            // Phase 3: select the canonical subscription via entitlement tier,
+            // period-end sort, and deterministic tie-break.
+            const keptSubscription = blockingSubscriptionIds
+              .map((id) => canonicalById.get(id))
+              .filter((subscription): subscription is typeof canonical => {
+                return subscription !== undefined;
+              })
+              .sort((a, b) =>
+                compareCanonicalSubscriptionCandidates(
+                  {
+                    subscriptionIdentity: a.externalSubscriptionId,
+                    status: a.status,
+                    currentPeriodEnd: a.currentPeriodEnd,
+                  },
+                  {
+                    subscriptionIdentity: b.externalSubscriptionId,
+                    status: b.status,
+                    currentPeriodEnd: b.currentPeriodEnd,
+                  },
+                ),
+              )[0];
+
+            const keptSubscriptionIdCandidate =
+              keptSubscription?.externalSubscriptionId;
+            if (!keptSubscriptionIdCandidate) {
+              throw new ApplicationError(
+                'STRIPE_ERROR',
+                'Unable to determine canonical Stripe subscription',
+              );
+            }
+
+            keptSubscriptionId = keptSubscriptionIdCandidate;
+            const kept = canonicalById.get(keptSubscriptionId);
+            if (!kept) {
+              throw new ApplicationError(
+                'STRIPE_ERROR',
+                'Canonical Stripe subscription data is missing',
+              );
+            }
+            canonical = kept;
+
+            duplicateIds = blockingSubscriptionIds.filter(
+              (id) => id !== keptSubscriptionId,
+            );
+          }
+
+          return {
+            canonical,
+            duplicateIds,
+            keptSubscriptionId,
+            localSubscriptionUpdate,
+          };
+        };
+
+        const { observation } = await persistSubscriptionObservation({
+          userId: row.userId,
+          initialExpectedVersion: row.version,
+          readVersion: (userId) =>
+            deps.transaction(({ subscriptions }) =>
+              subscriptions.findObservationVersionByUserId(userId),
+            ),
+          retrieve: retrieveObservation,
+          getUserId: ({ canonical }) => canonical.userId,
+          persist: ({ canonical }, expectedVersion) =>
+            deps.transaction(async ({ stripeCustomers, subscriptions }) => {
+              // Phase 4: persist canonical subscription and customer mapping atomically.
+              // Canonical multi-repository lock order: advisory(user) in
+              // subscriptions.upsert -> stripe_subscriptions row -> stripe_customers
+              // row. Keep every writer in this order to avoid AB-BA deadlocks.
+              const write = await subscriptions.upsert({
+                userId: canonical.userId,
+                externalSubscriptionId: canonical.externalSubscriptionId,
+                plan: canonical.plan,
+                status: canonical.status,
+                currentPeriodEnd: canonical.currentPeriodEnd,
+                cancelAtPeriodEnd: canonical.cancelAtPeriodEnd,
+                expectedVersion,
+              });
+              if (!write.persisted && write.reason === 'version_conflict') {
+                return write;
+              }
+
+              await stripeCustomers.insert(
+                canonical.userId,
+                canonical.externalCustomerId,
+                { conflictStrategy: 'authoritative' },
+              );
+              return write;
+            }),
         });
+        const {
+          canonical,
+          duplicateIds,
+          keptSubscriptionId,
+          localSubscriptionUpdate,
+        } = observation;
+        const alreadyCanceledDuplicateIds: string[] = [];
 
         if (duplicateIds.length > 0) {
           // Phase 5: cancel duplicate blocking subscriptions when not in dry-run mode.

--- a/src/adapters/repositories/drizzle-subscription-repository.test.ts
+++ b/src/adapters/repositories/drizzle-subscription-repository.test.ts
@@ -172,6 +172,7 @@ describe('DrizzleSubscriptionRepository', () => {
         status: 'active',
         currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
         cancelAtPeriodEnd: false,
+        expectedVersion: null,
       }),
     ).resolves.toEqual({ persisted: true });
     expect(nowFn).toHaveBeenCalledTimes(1);
@@ -224,6 +225,7 @@ describe('DrizzleSubscriptionRepository', () => {
         status: 'active',
         currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
         cancelAtPeriodEnd: false,
+        expectedVersion: null,
       }),
     ).resolves.toEqual({ persisted: true });
 
@@ -274,6 +276,7 @@ describe('DrizzleSubscriptionRepository', () => {
         status: 'active',
         currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
         cancelAtPeriodEnd: false,
+        expectedVersion: null,
       }),
     ).rejects.toMatchObject({ code: 'CONFLICT' });
   });
@@ -319,6 +322,7 @@ describe('DrizzleSubscriptionRepository', () => {
         status: 'active',
         currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
         cancelAtPeriodEnd: false,
+        expectedVersion: null,
       });
       expect.unreachable('Expected upsert to throw');
     } catch (error) {

--- a/src/adapters/repositories/drizzle-subscription-repository.ts
+++ b/src/adapters/repositories/drizzle-subscription-repository.ts
@@ -58,6 +58,15 @@ export class DrizzleSubscriptionRepository implements SubscriptionRepository {
     return row ? this.toDomain(row) : null;
   }
 
+  async findObservationVersionByUserId(userId: string) {
+    const row = await this.db.query.stripeSubscriptions.findFirst({
+      columns: { version: true },
+      where: eq(stripeSubscriptions.userId, userId),
+    });
+
+    return row?.version ?? null;
+  }
+
   async findByExternalSubscriptionId(externalSubscriptionId: string) {
     const row = await this.db.query.stripeSubscriptions.findFirst({
       where: eq(
@@ -87,6 +96,11 @@ export class DrizzleSubscriptionRepository implements SubscriptionRepository {
           .from(stripeSubscriptions)
           .where(eq(stripeSubscriptions.userId, input.userId))
           .for('update');
+        const storedVersion = existingRow ? existingRow.version : null;
+        if (storedVersion !== input.expectedVersion) {
+          return { persisted: false, reason: 'version_conflict' };
+        }
+
         if (
           existingRow &&
           !shouldPersistSubscriptionWrite({
@@ -105,9 +119,14 @@ export class DrizzleSubscriptionRepository implements SubscriptionRepository {
             now: updatedAt,
           })
         ) {
-          return { persisted: false, current: this.toDomain(existingRow) };
+          return {
+            persisted: false,
+            reason: 'write_guard_rejected',
+            current: this.toDomain(existingRow),
+          };
         }
 
+        const nextVersion = (storedVersion ?? 0) + 1;
         await tx
           .insert(stripeSubscriptions)
           .values({
@@ -117,6 +136,7 @@ export class DrizzleSubscriptionRepository implements SubscriptionRepository {
             priceId,
             currentPeriodEnd: input.currentPeriodEnd,
             cancelAtPeriodEnd: input.cancelAtPeriodEnd,
+            version: nextVersion,
             updatedAt,
           })
           .onConflictDoUpdate({
@@ -127,6 +147,7 @@ export class DrizzleSubscriptionRepository implements SubscriptionRepository {
               priceId,
               currentPeriodEnd: input.currentPeriodEnd,
               cancelAtPeriodEnd: input.cancelAtPeriodEnd,
+              version: nextVersion,
               updatedAt,
             },
           });

--- a/src/application/ports/subscription-repository.ts
+++ b/src/application/ports/subscription-repository.ts
@@ -11,14 +11,22 @@ export type SubscriptionUpsertInput = {
   status: SubscriptionStatus;
   currentPeriodEnd: Date;
   cancelAtPeriodEnd: boolean;
+  expectedVersion: number | null;
 };
 
 export type SubscriptionUpsertResult =
   | { persisted: true }
-  | { persisted: false; current: Subscription };
+  | {
+      persisted: false;
+      reason: 'write_guard_rejected';
+      current: Subscription;
+    }
+  | { persisted: false; reason: 'version_conflict' };
 
 export interface SubscriptionRepository {
   findByUserId(userId: string): Promise<Subscription | null>;
+
+  findObservationVersionByUserId(userId: string): Promise<number | null>;
 
   findByExternalSubscriptionId(
     externalSubscriptionId: string,

--- a/src/application/shared/persist-subscription-observation.test.ts
+++ b/src/application/shared/persist-subscription-observation.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SubscriptionUpsertResult } from '@/src/application/ports/repositories';
+import {
+  persistSubscriptionObservation,
+  SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS,
+} from './persist-subscription-observation';
+
+type Observation = {
+  sequence: number;
+  userId: string;
+};
+
+const userId = 'user_1';
+
+function persisted(): SubscriptionUpsertResult {
+  return { persisted: true };
+}
+
+function versionConflict(): SubscriptionUpsertResult {
+  return { persisted: false, reason: 'version_conflict' };
+}
+
+describe('persistSubscriptionObservation', () => {
+  it('reads the version before every retrieve and retries the whole operation', async () => {
+    const operations: string[] = [];
+    const versions = [3, 4, 5];
+    let retrieveCount = 0;
+    let persistCount = 0;
+
+    const result = await persistSubscriptionObservation<Observation>({
+      userId,
+      readVersion: async () => {
+        const version = versions.shift();
+        if (version === undefined) throw new Error('Missing version');
+        operations.push(`read:${version}`);
+        return version;
+      },
+      retrieve: async () => {
+        retrieveCount += 1;
+        operations.push(`retrieve:${retrieveCount}`);
+        return { sequence: retrieveCount, userId };
+      },
+      getUserId: (observation) => observation.userId,
+      persist: async (observation, expectedVersion) => {
+        persistCount += 1;
+        operations.push(
+          `persist:${observation.sequence}:${String(expectedVersion)}`,
+        );
+        return persistCount < 3 ? versionConflict() : persisted();
+      },
+    });
+
+    expect(result).toEqual({
+      observation: { sequence: 3, userId },
+      write: { persisted: true },
+    });
+    expect(operations).toEqual([
+      'read:3',
+      'retrieve:1',
+      'persist:1:3',
+      'read:4',
+      'retrieve:2',
+      'persist:2:4',
+      'read:5',
+      'retrieve:3',
+      'persist:3:5',
+    ]);
+  });
+
+  it('uses a supplied Phase-1 version before the first retrieve', async () => {
+    const operations: string[] = [];
+    let retrieveCount = 0;
+    let persistCount = 0;
+
+    await persistSubscriptionObservation<Observation>({
+      userId,
+      initialExpectedVersion: 7,
+      readVersion: async () => {
+        operations.push('read:8');
+        return 8;
+      },
+      retrieve: async () => {
+        retrieveCount += 1;
+        operations.push(`retrieve:${retrieveCount}`);
+        return { sequence: retrieveCount, userId };
+      },
+      getUserId: (observation) => observation.userId,
+      persist: async (_observation, expectedVersion) => {
+        persistCount += 1;
+        operations.push(`persist:${String(expectedVersion)}`);
+        return persistCount === 1 ? versionConflict() : persisted();
+      },
+    });
+
+    expect(operations).toEqual([
+      'retrieve:1',
+      'persist:7',
+      'read:8',
+      'retrieve:2',
+      'persist:8',
+    ]);
+  });
+
+  it('preserves a supplied absent-row expectation without reading again', async () => {
+    const readVersion = vi.fn(async () => 9);
+    const persist = vi.fn(async () => persisted());
+
+    await persistSubscriptionObservation<Observation>({
+      userId,
+      initialExpectedVersion: null,
+      readVersion,
+      retrieve: async () => ({ sequence: 1, userId }),
+      getUserId: (observation) => observation.userId,
+      persist,
+    });
+
+    expect(readVersion).not.toHaveBeenCalled();
+    expect(persist).toHaveBeenCalledWith({ sequence: 1, userId }, null);
+  });
+
+  it('uses the first retrieve only for user discovery before a fenced re-retrieve', async () => {
+    const operations: string[] = [];
+    let retrieveCount = 0;
+
+    const result = await persistSubscriptionObservation<Observation>({
+      userId: null,
+      readVersion: async (discoveredUserId) => {
+        operations.push(`read:${discoveredUserId}`);
+        return null;
+      },
+      retrieve: async () => {
+        retrieveCount += 1;
+        operations.push(`retrieve:${retrieveCount}`);
+        return { sequence: retrieveCount, userId };
+      },
+      getUserId: (observation) => observation.userId,
+      persist: async (observation, expectedVersion) => {
+        operations.push(
+          `persist:${observation.sequence}:${String(expectedVersion)}`,
+        );
+        return persisted();
+      },
+    });
+
+    expect(result.observation.sequence).toBe(2);
+    expect(operations).toEqual([
+      'retrieve:1',
+      `read:${userId}`,
+      'retrieve:2',
+      'persist:2:null',
+    ]);
+  });
+
+  it('returns a write-guard rejection without retrying', async () => {
+    const retrieve = vi.fn(async () => ({ sequence: 1, userId }));
+    const readVersion = vi.fn(async () => 2);
+    const write: SubscriptionUpsertResult = {
+      persisted: false,
+      reason: 'write_guard_rejected',
+      current: {
+        id: 'subscription_row_1',
+        userId,
+        plan: 'monthly',
+        status: 'active',
+        currentPeriodEnd: new Date('2030-01-01T00:00:00.000Z'),
+        cancelAtPeriodEnd: false,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    };
+    const persist = vi.fn(async () => write);
+
+    await expect(
+      persistSubscriptionObservation<Observation>({
+        userId,
+        readVersion,
+        retrieve,
+        getUserId: (observation) => observation.userId,
+        persist,
+      }),
+    ).resolves.toEqual({
+      observation: { sequence: 1, userId },
+      write,
+    });
+    expect(readVersion).toHaveBeenCalledTimes(1);
+    expect(retrieve).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when the refreshed observation changes user identity', async () => {
+    const retrieve = vi
+      .fn<() => Promise<Observation>>()
+      .mockResolvedValueOnce({ sequence: 1, userId })
+      .mockResolvedValueOnce({ sequence: 2, userId: 'user_2' });
+    const persist = vi.fn(async () => persisted());
+
+    await expect(
+      persistSubscriptionObservation<Observation>({
+        userId: null,
+        readVersion: async () => 4,
+        retrieve,
+        getUserId: (observation) => observation.userId,
+        persist,
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Subscription observation user changed during refresh',
+    });
+    expect(retrieve).toHaveBeenCalledTimes(2);
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('throws a bounded conflict after three fresh retrieves', async () => {
+    const retrieve = vi.fn(async () => ({ sequence: 1, userId }));
+    const readVersion = vi.fn(async () => 2);
+    const persist = vi.fn(async () => versionConflict());
+
+    await expect(
+      persistSubscriptionObservation<Observation>({
+        userId,
+        readVersion,
+        retrieve,
+        getUserId: (observation) => observation.userId,
+        persist,
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: `Subscription observation version conflicted after ${SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS} attempts`,
+    });
+    expect(readVersion).toHaveBeenCalledTimes(
+      SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS,
+    );
+    expect(retrieve).toHaveBeenCalledTimes(
+      SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS,
+    );
+    expect(persist).toHaveBeenCalledTimes(
+      SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS,
+    );
+  });
+});

--- a/src/application/shared/persist-subscription-observation.ts
+++ b/src/application/shared/persist-subscription-observation.ts
@@ -1,0 +1,83 @@
+import { ApplicationError } from '@/src/application/errors';
+import type { SubscriptionUpsertResult } from '@/src/application/ports/repositories';
+
+export const SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS = 3;
+
+type CompletedSubscriptionWrite = Exclude<
+  SubscriptionUpsertResult,
+  { persisted: false; reason: 'version_conflict' }
+>;
+
+export type PersistSubscriptionObservationInput<TObservation> = {
+  userId: string | null;
+  initialExpectedVersion?: number | null;
+  readVersion(userId: string): Promise<number | null>;
+  retrieve(): Promise<TObservation>;
+  getUserId(observation: TObservation): string;
+  persist(
+    observation: TObservation,
+    expectedVersion: number | null,
+  ): Promise<SubscriptionUpsertResult>;
+};
+
+export type PersistSubscriptionObservationResult<TObservation> = {
+  observation: TObservation;
+  write: CompletedSubscriptionWrite;
+};
+
+function isVersionConflict(
+  result: SubscriptionUpsertResult,
+): result is { persisted: false; reason: 'version_conflict' } {
+  return !result.persisted && result.reason === 'version_conflict';
+}
+
+export async function persistSubscriptionObservation<TObservation>(
+  input: PersistSubscriptionObservationInput<TObservation>,
+): Promise<PersistSubscriptionObservationResult<TObservation>> {
+  let expectedUserId = input.userId;
+
+  if (expectedUserId === null) {
+    // This retrieve is discovery-only. The observation written below must be
+    // re-retrieved after the local version is known, so do not reuse it.
+    const discovery = await input.retrieve();
+    expectedUserId = input.getUserId(discovery);
+  }
+
+  let expectedVersion =
+    input.initialExpectedVersion === undefined
+      ? await input.readVersion(expectedUserId)
+      : input.initialExpectedVersion;
+
+  for (
+    let attempt = 1;
+    attempt <= SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS;
+    attempt += 1
+  ) {
+    const observation = await input.retrieve();
+    if (input.getUserId(observation) !== expectedUserId) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'Subscription observation user changed during refresh',
+      );
+    }
+
+    const write = await input.persist(observation, expectedVersion);
+    if (!isVersionConflict(write)) {
+      return { observation, write };
+    }
+
+    if (attempt === SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS) {
+      throw new ApplicationError(
+        'CONFLICT',
+        `Subscription observation version conflicted after ${SUBSCRIPTION_OBSERVATION_MAX_ATTEMPTS} attempts`,
+      );
+    }
+
+    expectedVersion = await input.readVersion(expectedUserId);
+  }
+
+  throw new ApplicationError(
+    'INTERNAL_ERROR',
+    'Subscription observation retry loop exited unexpectedly',
+  );
+}

--- a/src/application/test-helpers/fakes/fake-subscription-repository-contract.test.ts
+++ b/src/application/test-helpers/fakes/fake-subscription-repository-contract.test.ts
@@ -1,0 +1,11 @@
+import { runSubscriptionObservationVersionContract } from '@/tests/shared/subscription-observation-version-contract';
+import { FakeSubscriptionRepository } from './fake-subscription-repository';
+
+runSubscriptionObservationVersionContract(
+  'FakeSubscriptionRepository',
+  async () => ({
+    repository: new FakeSubscriptionRepository(),
+    userId: crypto.randomUUID(),
+    externalSubscriptionId: (label) => `sub_${label}_${crypto.randomUUID()}`,
+  }),
+);

--- a/src/application/test-helpers/fakes/fake-subscription-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-subscription-repository.test.ts
@@ -12,6 +12,7 @@ function makeUpsertInput(
     status: 'active',
     currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
     cancelAtPeriodEnd: false,
+    expectedVersion: null,
     ...overrides,
   };
 }
@@ -48,6 +49,7 @@ describe('FakeSubscriptionRepository', () => {
       await repo.upsert(makeUpsertInput());
       await repo.upsert(
         makeUpsertInput({
+          expectedVersion: 1,
           externalSubscriptionId: 'sub_456',
           plan: 'annual',
           status: 'active',
@@ -79,6 +81,7 @@ describe('FakeSubscriptionRepository', () => {
       );
       const write = await repo.upsert(
         makeUpsertInput({
+          expectedVersion: 1,
           externalSubscriptionId: 'sub_superseded',
           status: 'canceled',
           currentPeriodEnd: new Date('2026-01-31T00:00:00.000Z'),
@@ -116,6 +119,7 @@ describe('FakeSubscriptionRepository', () => {
       );
       const write = await repo.upsert(
         makeUpsertInput({
+          expectedVersion: 1,
           externalSubscriptionId: 'sub_current',
           status: 'canceled',
           currentPeriodEnd: new Date('2026-01-31T00:00:00.000Z'),
@@ -144,6 +148,7 @@ describe('FakeSubscriptionRepository', () => {
       );
       const write = await repo.upsert(
         makeUpsertInput({
+          expectedVersion: 1,
           externalSubscriptionId: 'sub_superseded',
           status: 'canceled',
           currentPeriodEnd: new Date('2026-06-01T00:00:00.000Z'),
@@ -186,6 +191,7 @@ describe('FakeSubscriptionRepository', () => {
 
       const write = await repo.upsert(
         makeUpsertInput({
+          expectedVersion: 0,
           externalSubscriptionId: 'sub_superseded',
           status: 'canceled',
           currentPeriodEnd: new Date('2026-06-01T00:00:00.000Z'),
@@ -250,6 +256,7 @@ describe('FakeSubscriptionRepository', () => {
 
     await repo.upsert(
       makeUpsertInput({
+        expectedVersion: 1,
         externalSubscriptionId: 'sub_456',
         plan: 'annual',
         status: 'canceled',

--- a/src/application/test-helpers/fakes/fake-subscription-repository.ts
+++ b/src/application/test-helpers/fakes/fake-subscription-repository.ts
@@ -11,6 +11,7 @@ type SubscriptionSnapshot = {
   byUserId: ReadonlyArray<readonly [string, Subscription]>;
   externalSubscriptionIdByUserId: ReadonlyArray<readonly [string, string]>;
   userIdByExternalSubscriptionId: ReadonlyArray<readonly [string, string]>;
+  observationVersionByUserId: ReadonlyArray<readonly [string, number]>;
 };
 
 type FakeSubscriptionSeed =
@@ -18,6 +19,7 @@ type FakeSubscriptionSeed =
   | {
       subscription: Subscription;
       externalSubscriptionId: string;
+      version?: number;
     };
 
 function cloneSubscription(subscription: Subscription): Subscription {
@@ -39,6 +41,7 @@ export class FakeSubscriptionRepository implements SubscriptionRepository {
   private readonly byUserId = new Map<string, Subscription>();
   private readonly externalSubscriptionIdByUserId = new Map<string, string>();
   private readonly userIdByExternalSubscriptionId = new Map<string, string>();
+  private readonly observationVersionByUserId = new Map<string, number>();
 
   constructor(
     subscriptions: readonly FakeSubscriptionSeed[] = [],
@@ -47,6 +50,10 @@ export class FakeSubscriptionRepository implements SubscriptionRepository {
     for (const seed of subscriptions) {
       const subscription = isMappedSeed(seed) ? seed.subscription : seed;
       this.byUserId.set(subscription.userId, cloneSubscription(subscription));
+      this.observationVersionByUserId.set(
+        subscription.userId,
+        isMappedSeed(seed) ? (seed.version ?? 0) : 0,
+      );
 
       if (isMappedSeed(seed)) {
         this.externalSubscriptionIdByUserId.set(
@@ -65,6 +72,10 @@ export class FakeSubscriptionRepository implements SubscriptionRepository {
     return this.byUserId.get(userId) ?? null;
   }
 
+  async findObservationVersionByUserId(userId: string): Promise<number | null> {
+    return this.observationVersionByUserId.get(userId) ?? null;
+  }
+
   async findByExternalSubscriptionId(
     externalSubscriptionId: string,
   ): Promise<Subscription | null> {
@@ -78,19 +89,15 @@ export class FakeSubscriptionRepository implements SubscriptionRepository {
   async upsert(
     input: SubscriptionUpsertInput,
   ): Promise<SubscriptionUpsertResult> {
-    const mappedUserId = this.userIdByExternalSubscriptionId.get(
-      input.externalSubscriptionId,
-    );
-
-    if (mappedUserId && mappedUserId !== input.userId) {
-      throw new ApplicationError(
-        'CONFLICT',
-        'External subscription id is already mapped to a different user',
-      );
-    }
-
     const now = this.now();
     const existing = this.byUserId.get(input.userId);
+    const storedVersion = existing
+      ? (this.observationVersionByUserId.get(input.userId) ?? 0)
+      : null;
+    if (storedVersion !== input.expectedVersion) {
+      return { persisted: false, reason: 'version_conflict' };
+    }
+
     const existingExternalSubscriptionId =
       this.externalSubscriptionIdByUserId.get(input.userId);
     if (
@@ -110,7 +117,21 @@ export class FakeSubscriptionRepository implements SubscriptionRepository {
         now,
       })
     ) {
-      return { persisted: false, current: cloneSubscription(existing) };
+      return {
+        persisted: false,
+        reason: 'write_guard_rejected',
+        current: cloneSubscription(existing),
+      };
+    }
+
+    const mappedUserId = this.userIdByExternalSubscriptionId.get(
+      input.externalSubscriptionId,
+    );
+    if (mappedUserId && mappedUserId !== input.userId) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'External subscription id is already mapped to a different user',
+      );
     }
 
     const subscription: Subscription = {
@@ -144,6 +165,7 @@ export class FakeSubscriptionRepository implements SubscriptionRepository {
       input.externalSubscriptionId,
       input.userId,
     );
+    this.observationVersionByUserId.set(input.userId, (storedVersion ?? 0) + 1);
     return { persisted: true };
   }
 
@@ -158,6 +180,9 @@ export class FakeSubscriptionRepository implements SubscriptionRepository {
       ],
       userIdByExternalSubscriptionId: [
         ...this.userIdByExternalSubscriptionId.entries(),
+      ],
+      observationVersionByUserId: [
+        ...this.observationVersionByUserId.entries(),
       ],
     };
   }
@@ -182,6 +207,11 @@ export class FakeSubscriptionRepository implements SubscriptionRepository {
       userId,
     ] of snapshot.userIdByExternalSubscriptionId) {
       this.userIdByExternalSubscriptionId.set(externalSubscriptionId, userId);
+    }
+
+    this.observationVersionByUserId.clear();
+    for (const [userId, version] of snapshot.observationVersionByUserId) {
+      this.observationVersionByUserId.set(userId, version);
     }
   }
 }

--- a/tests/integration/bug-regression-subscription-observation-version-fence.integration.test.ts
+++ b/tests/integration/bug-regression-subscription-observation-version-fence.integration.test.ts
@@ -1,0 +1,399 @@
+import { randomUUID } from 'node:crypto';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { processStripeWebhook } from '@/src/adapters/controllers/stripe-webhook-controller';
+import { reconcileStripeSubscriptions } from '@/src/adapters/jobs/reconcile-stripe-subscriptions';
+import type { ReconcileStripeSubscriptionsDeps } from '@/src/adapters/jobs/reconcile-stripe-subscriptions-types';
+import { DrizzleStripeCustomerRepository } from '@/src/adapters/repositories/drizzle-stripe-customer-repository';
+import { DrizzleStripeEventRepository } from '@/src/adapters/repositories/drizzle-stripe-event-repository';
+import { DrizzleSubscriptionRepository } from '@/src/adapters/repositories/drizzle-subscription-repository';
+import type { WebhookEventResult } from '@/src/application/ports/gateways';
+import {
+  FakeLogger,
+  FakePaymentGateway,
+} from '@/src/application/test-helpers/fakes';
+import { runSubscriptionObservationVersionContract } from '@/tests/shared/subscription-observation-version-contract';
+import { createDeferred } from '@/tests/test-helpers/create-deferred';
+import {
+  cleanupAfterEach,
+  closeConnection,
+  createCleanupState,
+  createIntegrationDb,
+  createUser,
+} from './helpers';
+
+const { db, sql } = createIntegrationDb();
+const writerA = createIntegrationDb();
+const writerB = createIntegrationDb();
+const cleanup = createCleanupState();
+const priceIds = {
+  monthly: 'price_test_monthly',
+  annual: 'price_test_annual',
+} as const;
+
+afterEach(async () => {
+  await cleanupAfterEach(db, cleanup);
+});
+
+afterAll(async () => {
+  await Promise.all([
+    closeConnection(sql),
+    closeConnection(writerA.sql),
+    closeConnection(writerB.sql),
+  ]);
+});
+
+runSubscriptionObservationVersionContract(
+  'DrizzleSubscriptionRepository',
+  async () => {
+    const user = await createUser(db, cleanup);
+
+    return {
+      repository: new DrizzleSubscriptionRepository(db, priceIds),
+      userId: user.id,
+      externalSubscriptionId: (label: string) =>
+        `sub_${label}_${randomUUID().replaceAll('-', '')}`,
+    };
+  },
+);
+
+function stripeSubscription(input: {
+  userId: string;
+  externalCustomerId: string;
+  externalSubscriptionId: string;
+  status: 'active' | 'canceled';
+  currentPeriodEnd: number;
+}) {
+  return {
+    id: input.externalSubscriptionId,
+    customer: input.externalCustomerId,
+    status: input.status,
+    cancel_at_period_end: false,
+    metadata: { user_id: input.userId },
+    items: {
+      data: [
+        {
+          current_period_end: input.currentPeriodEnd,
+          price: { id: priceIds.monthly },
+        },
+      ],
+    },
+  };
+}
+
+class ControlledWebhookGateway extends FakePaymentGateway {
+  private callCount = 0;
+
+  constructor(
+    private readonly handler: (
+      call: number,
+    ) => Promise<WebhookEventResult> | WebhookEventResult,
+  ) {
+    super({
+      externalCustomerId: 'cus_unused',
+      checkoutUrl: 'https://stripe.test/checkout',
+      portalUrl: 'https://stripe.test/portal',
+      webhookResult: { eventId: 'evt_unused', type: 'unused' },
+    });
+  }
+
+  override async processWebhookEvent(
+    rawBody: string,
+    signature: string,
+  ): Promise<WebhookEventResult> {
+    this.webhookInputs.push({ rawBody, signature });
+    this.callCount += 1;
+    return this.handler(this.callCount);
+  }
+}
+
+function normalizedWebhookResult(input: {
+  eventId: string;
+  userId: string;
+  externalCustomerId: string;
+  externalSubscriptionId: string;
+  status: 'active' | 'canceled';
+  currentPeriodEnd: Date;
+}): WebhookEventResult {
+  return {
+    eventId: input.eventId,
+    type: 'customer.subscription.updated',
+    subscriptionUpdate: {
+      userId: input.userId,
+      externalCustomerId: input.externalCustomerId,
+      externalSubscriptionId: input.externalSubscriptionId,
+      plan: 'monthly',
+      status: input.status,
+      currentPeriodEnd: input.currentPeriodEnd,
+      cancelAtPeriodEnd: false,
+    },
+  };
+}
+
+async function runWebhook(input: {
+  gateway: FakePaymentGateway;
+  writer: typeof writerA.db;
+  eventId: string;
+}): Promise<void> {
+  cleanup.stripeEventIds.push(input.eventId);
+  const subscriptionVersions = new DrizzleSubscriptionRepository(
+    input.writer,
+    priceIds,
+  );
+
+  await processStripeWebhook(
+    {
+      paymentGateway: input.gateway,
+      subscriptionVersions,
+      logger: new FakeLogger(),
+      now: () => new Date('2026-07-11T00:00:00.000Z'),
+      transaction: (fn) =>
+        input.writer.transaction((tx) =>
+          fn({
+            stripeEvents: new DrizzleStripeEventRepository(tx),
+            subscriptions: new DrizzleSubscriptionRepository(tx, priceIds),
+            stripeCustomers: new DrizzleStripeCustomerRepository(tx),
+          }),
+        ),
+    },
+    { rawBody: input.eventId, signature: 'sig_test' },
+  );
+}
+
+describe('BUG-287 real PostgreSQL interleavings', () => {
+  it('rejects a stale reconcile Phase-4 write and re-retrieves to convergence', async () => {
+    const user = await createUser(db, cleanup);
+    const externalCustomerId = `cus_${randomUUID().replaceAll('-', '')}`;
+    const externalSubscriptionId = `sub_${randomUUID().replaceAll('-', '')}`;
+    const eventId = `evt_${randomUUID().replaceAll('-', '')}`;
+    const repository = new DrizzleSubscriptionRepository(db, priceIds);
+    await repository.upsert({
+      userId: user.id,
+      externalSubscriptionId,
+      plan: 'monthly',
+      status: 'active',
+      currentPeriodEnd: new Date('2030-01-01T00:00:00.000Z'),
+      cancelAtPeriodEnd: false,
+      expectedVersion: null,
+    });
+
+    const phaseOneVersion = await repository.findObservationVersionByUserId(
+      user.id,
+    );
+    if (phaseOneVersion === null) throw new Error('Missing seeded version');
+
+    const reconcileWindowOpen = createDeferred<void>();
+    const releaseReconcile = createDeferred<void>();
+    let retrieveCount = 0;
+    let listCount = 0;
+    const staleSubscription = stripeSubscription({
+      userId: user.id,
+      externalCustomerId,
+      externalSubscriptionId,
+      status: 'active',
+      currentPeriodEnd: 1_893_456_000,
+    });
+    const freshSubscription = stripeSubscription({
+      userId: user.id,
+      externalCustomerId,
+      externalSubscriptionId,
+      status: 'canceled',
+      currentPeriodEnd: 1_767_139_200,
+    });
+    const stripe: ReconcileStripeSubscriptionsDeps['stripe'] = {
+      customers: {
+        create: async () => {
+          throw new Error('Unexpected customers.create');
+        },
+      },
+      checkout: {
+        sessions: {
+          create: async () => {
+            throw new Error('Unexpected checkout.sessions.create');
+          },
+          list: async () => {
+            throw new Error('Unexpected checkout.sessions.list');
+          },
+          retrieve: async () => {
+            throw new Error('Unexpected checkout.sessions.retrieve');
+          },
+          expire: async () => {
+            throw new Error('Unexpected checkout.sessions.expire');
+          },
+        },
+      },
+      subscriptions: {
+        retrieve: async () => {
+          retrieveCount += 1;
+          return retrieveCount === 1 ? staleSubscription : freshSubscription;
+        },
+        list: async () => {
+          listCount += 1;
+          if (listCount === 1) {
+            reconcileWindowOpen.resolve();
+            await releaseReconcile.promise;
+          }
+          return { data: [] };
+        },
+        cancel: async () => freshSubscription,
+      },
+      billingPortal: {
+        sessions: {
+          create: async () => {
+            throw new Error('Unexpected billingPortal.sessions.create');
+          },
+        },
+      },
+      webhooks: {
+        constructEvent: () => {
+          throw new Error('Unexpected webhooks.constructEvent');
+        },
+      },
+    };
+
+    const reconcilePromise = reconcileStripeSubscriptions(
+      { limit: 1, offset: 0, dryRun: true, concurrency: 1 },
+      {
+        stripe,
+        priceIds,
+        logger: new FakeLogger(),
+        listLocalSubscriptions: async () => [
+          {
+            userId: user.id,
+            stripeSubscriptionId: externalSubscriptionId,
+            version: phaseOneVersion,
+          },
+        ],
+        transaction: (fn) =>
+          writerA.db.transaction((tx) =>
+            fn({
+              subscriptions: new DrizzleSubscriptionRepository(tx, priceIds),
+              stripeCustomers: new DrizzleStripeCustomerRepository(tx),
+            }),
+          ),
+      },
+    );
+
+    await reconcileWindowOpen.promise;
+    try {
+      const webhookGateway = new ControlledWebhookGateway(() =>
+        normalizedWebhookResult({
+          eventId,
+          userId: user.id,
+          externalCustomerId,
+          externalSubscriptionId,
+          status: 'canceled',
+          currentPeriodEnd: new Date('2025-12-31T00:00:00.000Z'),
+        }),
+      );
+      await runWebhook({
+        gateway: webhookGateway,
+        writer: writerB.db,
+        eventId,
+      });
+    } finally {
+      releaseReconcile.resolve();
+    }
+
+    await expect(reconcilePromise).resolves.toMatchObject({
+      updated: 1,
+      failed: 0,
+    });
+    await expect(repository.findByUserId(user.id)).resolves.toMatchObject({
+      status: 'canceled',
+      currentPeriodEnd: new Date('2025-12-31T00:00:00.000Z'),
+    });
+    await expect(
+      repository.findObservationVersionByUserId(user.id),
+    ).resolves.toBe(3);
+    expect(retrieveCount).toBe(2);
+    expect(listCount).toBe(2);
+  });
+
+  it('rejects the reverse-commit webhook observation and retries with current state', async () => {
+    const user = await createUser(db, cleanup);
+    const externalCustomerId = `cus_${randomUUID().replaceAll('-', '')}`;
+    const externalSubscriptionId = `sub_${randomUUID().replaceAll('-', '')}`;
+    const eventAId = `evt_${randomUUID().replaceAll('-', '')}`;
+    const eventBId = `evt_${randomUUID().replaceAll('-', '')}`;
+    const repository = new DrizzleSubscriptionRepository(db, priceIds);
+    await repository.upsert({
+      userId: user.id,
+      externalSubscriptionId,
+      plan: 'monthly',
+      status: 'active',
+      currentPeriodEnd: new Date('2030-01-01T00:00:00.000Z'),
+      cancelAtPeriodEnd: false,
+      expectedVersion: null,
+    });
+
+    const writerARetrieved = createDeferred<void>();
+    const releaseWriterA = createDeferred<void>();
+    const staleResult = normalizedWebhookResult({
+      eventId: eventAId,
+      userId: user.id,
+      externalCustomerId,
+      externalSubscriptionId,
+      status: 'active',
+      currentPeriodEnd: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    const freshAResult = normalizedWebhookResult({
+      eventId: eventAId,
+      userId: user.id,
+      externalCustomerId,
+      externalSubscriptionId,
+      status: 'canceled',
+      currentPeriodEnd: new Date('2025-12-31T00:00:00.000Z'),
+    });
+    const freshBResult = normalizedWebhookResult({
+      eventId: eventBId,
+      userId: user.id,
+      externalCustomerId,
+      externalSubscriptionId,
+      status: 'canceled',
+      currentPeriodEnd: new Date('2025-12-31T00:00:00.000Z'),
+    });
+    const gatewayA = new ControlledWebhookGateway(async (call) => {
+      if (call === 1) return staleResult;
+      if (call === 2) {
+        writerARetrieved.resolve();
+        await releaseWriterA.promise;
+        return staleResult;
+      }
+      return freshAResult;
+    });
+    const gatewayB = new ControlledWebhookGateway(() => freshBResult);
+
+    const writerAPromise = runWebhook({
+      gateway: gatewayA,
+      writer: writerA.db,
+      eventId: eventAId,
+    });
+    await writerARetrieved.promise;
+    try {
+      await runWebhook({
+        gateway: gatewayB,
+        writer: writerB.db,
+        eventId: eventBId,
+      });
+    } finally {
+      releaseWriterA.resolve();
+    }
+    await writerAPromise;
+
+    await expect(repository.findByUserId(user.id)).resolves.toMatchObject({
+      status: 'canceled',
+      currentPeriodEnd: new Date('2025-12-31T00:00:00.000Z'),
+    });
+    await expect(
+      repository.findObservationVersionByUserId(user.id),
+    ).resolves.toBe(3);
+    expect(gatewayA.webhookInputs).toHaveLength(3);
+    expect(gatewayB.webhookInputs).toHaveLength(2);
+    await expect(
+      new DrizzleStripeEventRepository(db).lock(eventAId),
+    ).resolves.toMatchObject({ processedAt: expect.any(Date), error: null });
+    await expect(
+      new DrizzleStripeEventRepository(db).lock(eventBId),
+    ).resolves.toMatchObject({ processedAt: expect.any(Date), error: null });
+  });
+});

--- a/tests/integration/controllers.integration.test.ts
+++ b/tests/integration/controllers.integration.test.ts
@@ -1031,6 +1031,7 @@ describe('stripe webhook controller (integration)', () => {
     await processStripeWebhook(
       {
         paymentGateway,
+        subscriptionVersions: new DrizzleSubscriptionRepository(db, priceIds),
         logger: new FakeLogger(),
         now: () => new Date(),
         transaction: async (fn) =>

--- a/tests/integration/stripe-repositories.integration.test.ts
+++ b/tests/integration/stripe-repositories.integration.test.ts
@@ -197,6 +197,7 @@ describe('Stripe repositories', () => {
     await repo.upsert({
       userId: user.id,
       externalSubscriptionId: stripeSubscriptionId1,
+      expectedVersion: null,
       status: 'active',
       plan: 'monthly',
       currentPeriodEnd: periodEnd1,
@@ -223,6 +224,7 @@ describe('Stripe repositories', () => {
     await repo.upsert({
       userId: user.id,
       externalSubscriptionId: stripeSubscriptionId2,
+      expectedVersion: 1,
       status: 'active',
       plan: 'annual',
       currentPeriodEnd: periodEnd2,
@@ -267,6 +269,7 @@ describe('Stripe repositories', () => {
     await repo.upsert({
       userId: user.id,
       externalSubscriptionId: currentSubscriptionId,
+      expectedVersion: null,
       status: 'active',
       plan: 'annual',
       currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
@@ -276,6 +279,7 @@ describe('Stripe repositories', () => {
     await repo.upsert({
       userId: user.id,
       externalSubscriptionId: supersededSubscriptionId,
+      expectedVersion: 1,
       status: 'canceled',
       plan: 'monthly',
       currentPeriodEnd: new Date('2026-05-31T00:00:00.000Z'),
@@ -317,6 +321,7 @@ describe('Stripe repositories', () => {
     await repo.upsert({
       userId: user.id,
       externalSubscriptionId: stripeSubscriptionId,
+      expectedVersion: null,
       status: 'active',
       plan: 'monthly',
       currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
@@ -326,6 +331,7 @@ describe('Stripe repositories', () => {
     await repo.upsert({
       userId: user.id,
       externalSubscriptionId: stripeSubscriptionId,
+      expectedVersion: 1,
       status: 'canceled',
       plan: 'monthly',
       currentPeriodEnd: new Date('2026-05-31T00:00:00.000Z'),
@@ -356,6 +362,7 @@ describe('Stripe repositories', () => {
     await repo.upsert({
       userId: userA.id,
       externalSubscriptionId: stripeSubscriptionId,
+      expectedVersion: null,
       status: 'active',
       plan: 'monthly',
       currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),
@@ -366,6 +373,7 @@ describe('Stripe repositories', () => {
       repo.upsert({
         userId: userB.id,
         externalSubscriptionId: stripeSubscriptionId,
+        expectedVersion: null,
         status: 'active',
         plan: 'monthly',
         currentPeriodEnd: new Date('2026-12-31T00:00:00.000Z'),

--- a/tests/integration/stripe-subscription-writer-lock-order.integration.test.ts
+++ b/tests/integration/stripe-subscription-writer-lock-order.integration.test.ts
@@ -219,6 +219,10 @@ async function runWebhookWriter(input: {
   await processStripeWebhook(
     {
       paymentGateway,
+      subscriptionVersions: new DrizzleSubscriptionRepository(
+        subscriptionWriter.db,
+        priceIds,
+      ),
       logger: new FakeLogger(),
       now: () => new Date(),
       transaction: async (fn) =>
@@ -256,6 +260,10 @@ async function runCheckoutSuccessWriter(input: {
   });
   const deps: CheckoutSuccessDeps = {
     authGateway,
+    subscriptionVersions: new DrizzleSubscriptionRepository(
+      subscriptionWriter.db,
+      priceIds,
+    ),
     getClerkAuth: async () => ({
       userId: input.userId,
       redirectToSignIn: () => {
@@ -364,7 +372,11 @@ describe('Stripe subscription writer lock order', () => {
         priceIds,
         logger: new FakeLogger(),
         listLocalSubscriptions: async () => [
-          { userId: user.id, stripeSubscriptionId: externalSubscriptionId },
+          {
+            userId: user.id,
+            stripeSubscriptionId: externalSubscriptionId,
+            version: null,
+          },
         ],
         transaction: async (fn) => {
           try {

--- a/tests/integration/stripe-webhook-failure-boundary.integration.test.ts
+++ b/tests/integration/stripe-webhook-failure-boundary.integration.test.ts
@@ -71,6 +71,7 @@ describe('Stripe webhook failure boundary', () => {
       await processStripeWebhook(
         {
           paymentGateway,
+          subscriptionVersions: new DrizzleSubscriptionRepository(db, priceIds),
           logger: new FakeLogger(),
           now: () => new Date(),
           transaction: async (fn) =>

--- a/tests/shared/fixture-uuid-integrity.test.ts
+++ b/tests/shared/fixture-uuid-integrity.test.ts
@@ -105,6 +105,7 @@ describe('fixture UUID integrity', () => {
       status: 'active',
       currentPeriodEnd: new Date(),
       cancelAtPeriodEnd: false,
+      expectedVersion: null,
     });
     const subscription =
       await subscriptionRepository.findByUserId(subscriptionUserId);

--- a/tests/shared/subscription-observation-version-contract.ts
+++ b/tests/shared/subscription-observation-version-contract.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  SubscriptionUpsertInput,
+  SubscriptionUpsertResult,
+} from '@/src/application/ports/repositories';
+import type { Subscription } from '@/src/domain/entities';
+
+export type SubscriptionObservationVersionContractRepository = {
+  findByUserId(userId: string): Promise<Subscription | null>;
+  findObservationVersionByUserId(userId: string): Promise<number | null>;
+  upsert(input: SubscriptionUpsertInput): Promise<SubscriptionUpsertResult>;
+};
+
+export type SubscriptionObservationVersionContractHarness = {
+  repository: SubscriptionObservationVersionContractRepository;
+  userId: string;
+  externalSubscriptionId(label: string): string;
+};
+
+type ContractScenario = {
+  name: string;
+  run(harness: SubscriptionObservationVersionContractHarness): Promise<void>;
+};
+
+function createUpsertInput(
+  harness: SubscriptionObservationVersionContractHarness,
+  externalSubscriptionId: string,
+  expectedVersion: number | null,
+  overrides: Partial<SubscriptionUpsertInput> = {},
+): SubscriptionUpsertInput {
+  return {
+    userId: harness.userId,
+    externalSubscriptionId,
+    plan: 'monthly',
+    status: 'active',
+    currentPeriodEnd: new Date('2030-01-01T00:00:00.000Z'),
+    cancelAtPeriodEnd: false,
+    expectedVersion,
+    ...overrides,
+  };
+}
+
+export const subscriptionObservationVersionContractScenarios: readonly ContractScenario[] =
+  [
+    {
+      name: 'starts a first persisted observation at version 1',
+      async run(harness) {
+        const externalSubscriptionId = harness.externalSubscriptionId('insert');
+
+        await expect(
+          harness.repository.findObservationVersionByUserId(harness.userId),
+        ).resolves.toBeNull();
+        await expect(
+          harness.repository.upsert(
+            createUpsertInput(harness, externalSubscriptionId, null),
+          ),
+        ).resolves.toEqual({ persisted: true });
+        await expect(
+          harness.repository.findObservationVersionByUserId(harness.userId),
+        ).resolves.toBe(1);
+      },
+    },
+    {
+      name: 'increments the observation version on update',
+      async run(harness) {
+        const externalSubscriptionId = harness.externalSubscriptionId('update');
+        await harness.repository.upsert(
+          createUpsertInput(harness, externalSubscriptionId, null),
+        );
+
+        await expect(
+          harness.repository.upsert(
+            createUpsertInput(harness, externalSubscriptionId, 1, {
+              plan: 'annual',
+              status: 'pastDue',
+              currentPeriodEnd: new Date('2031-01-01T00:00:00.000Z'),
+              cancelAtPeriodEnd: true,
+            }),
+          ),
+        ).resolves.toEqual({ persisted: true });
+        await expect(
+          harness.repository.findObservationVersionByUserId(harness.userId),
+        ).resolves.toBe(2);
+        await expect(
+          harness.repository.findByUserId(harness.userId),
+        ).resolves.toMatchObject({
+          plan: 'annual',
+          status: 'pastDue',
+          currentPeriodEnd: new Date('2031-01-01T00:00:00.000Z'),
+          cancelAtPeriodEnd: true,
+        });
+      },
+    },
+    {
+      name: 'increments the observation version on a successful no-op write',
+      async run(harness) {
+        const externalSubscriptionId = harness.externalSubscriptionId('no_op');
+        const input = createUpsertInput(harness, externalSubscriptionId, null);
+        await harness.repository.upsert(input);
+
+        await expect(
+          harness.repository.upsert({ ...input, expectedVersion: 1 }),
+        ).resolves.toEqual({ persisted: true });
+        await expect(
+          harness.repository.findObservationVersionByUserId(harness.userId),
+        ).resolves.toBe(2);
+      },
+    },
+    {
+      name: 'keeps the version unchanged when the write guard rejects',
+      async run(harness) {
+        const currentSubscriptionId =
+          harness.externalSubscriptionId('guard_current');
+        await harness.repository.upsert(
+          createUpsertInput(harness, currentSubscriptionId, null),
+        );
+
+        const supersededSubscriptionId =
+          harness.externalSubscriptionId('guard_superseded');
+        await expect(
+          harness.repository.upsert(
+            createUpsertInput(harness, supersededSubscriptionId, 1, {
+              status: 'canceled',
+              currentPeriodEnd: new Date('2025-01-01T00:00:00.000Z'),
+            }),
+          ),
+        ).resolves.toMatchObject({
+          persisted: false,
+          reason: 'write_guard_rejected',
+          current: {
+            userId: harness.userId,
+            status: 'active',
+          },
+        });
+        await expect(
+          harness.repository.findObservationVersionByUserId(harness.userId),
+        ).resolves.toBe(1);
+      },
+    },
+    {
+      name: 'rejects a stale expected version without mutating state',
+      async run(harness) {
+        const externalSubscriptionId = harness.externalSubscriptionId('stale');
+        await harness.repository.upsert(
+          createUpsertInput(harness, externalSubscriptionId, null),
+        );
+        await harness.repository.upsert(
+          createUpsertInput(harness, externalSubscriptionId, 1, {
+            currentPeriodEnd: new Date('2031-01-01T00:00:00.000Z'),
+          }),
+        );
+
+        await expect(
+          harness.repository.upsert(
+            createUpsertInput(harness, externalSubscriptionId, 1, {
+              status: 'canceled',
+              currentPeriodEnd: new Date('2025-01-01T00:00:00.000Z'),
+            }),
+          ),
+        ).resolves.toEqual({
+          persisted: false,
+          reason: 'version_conflict',
+        });
+        await expect(
+          harness.repository.findObservationVersionByUserId(harness.userId),
+        ).resolves.toBe(2);
+        await expect(
+          harness.repository.findByUserId(harness.userId),
+        ).resolves.toMatchObject({
+          status: 'active',
+          currentPeriodEnd: new Date('2031-01-01T00:00:00.000Z'),
+        });
+      },
+    },
+    {
+      name: 'reports a version conflict before consulting the write guard',
+      async run(harness) {
+        const currentSubscriptionId =
+          harness.externalSubscriptionId('ordering_current');
+        await harness.repository.upsert(
+          createUpsertInput(harness, currentSubscriptionId, null),
+        );
+
+        await expect(
+          harness.repository.upsert(
+            createUpsertInput(
+              harness,
+              harness.externalSubscriptionId('ordering_superseded'),
+              0,
+              {
+                status: 'canceled',
+                currentPeriodEnd: new Date('2025-01-01T00:00:00.000Z'),
+              },
+            ),
+          ),
+        ).resolves.toEqual({
+          persisted: false,
+          reason: 'version_conflict',
+        });
+        await expect(
+          harness.repository.findObservationVersionByUserId(harness.userId),
+        ).resolves.toBe(1);
+      },
+    },
+  ];
+
+export function runSubscriptionObservationVersionContract(
+  adapterName: string,
+  createHarness: () => Promise<SubscriptionObservationVersionContractHarness>,
+): void {
+  describe(`${adapterName} subscription observation-version contract`, () => {
+    it.each(
+      subscriptionObservationVersionContractScenarios,
+    )('$name', async (scenario) => {
+      await scenario.run(await createHarness());
+    });
+  });
+}


### PR DESCRIPTION
Promotes dev (e2e20f6b) to main.

Contains PR #635 — Fix BUG-287: optimistic observation-version fence for subscription writes (squash e2e20f6b):
- Migration 0029: additive `stripe_subscriptions.version integer NOT NULL DEFAULT 0`
- Repository CAS inside the existing advisory-locked transaction; version-conflict checked before the write guard; distinct `version_conflict` / `write_guard_rejected` / persisted outcomes
- `persistSubscriptionObservation` whole-operation retry (local version read → fresh Stripe retrieval → CAS), 3-attempt bound, typed CONFLICT exhaustion; no DB transaction spans Stripe I/O
- All three explicit writers fenced (Stripe webhook, reconcile Phase 4, checkout-success sync); canonical lock order advisory(user) → stripe_subscriptions → stripe_customers preserved
- FakeSubscriptionRepository mirrors adapter CAS ordering; paired fake/Drizzle contract tests; real-Postgres interleaving regressions for both stale-write orderings

CodeRabbit approved on exact head bbfe0293 (zero unresolved threads); full local gate + CI green on the fix PR. Bug doc remains Status: Open pending post-deploy production proof.

https://claude.ai/code/session_01AND8DhkyKL44snLEXW2wq1