### PR TITLE
Refactor BUG-298 feedback key rotation through shared helper

### DIFF
--- a/app/(app)/app/shared/question-feedback-actions.ts
+++ b/app/(app)/app/shared/question-feedback-actions.ts
@@ -177,7 +177,7 @@ export async function rateQuestionForQuestion(input: {
 
     input.setRating(result.data.rating);
     if (setToken && input.createIdempotencyKey) {
-      setToken({ key: input.createIdempotencyKey(), fingerprint });
+      mintRequestKey(input.createIdempotencyKey, fingerprint, setToken);
     }
     input.setFeedbackStatus('saved');
     return;
@@ -282,7 +282,7 @@ export async function submitReportForQuestion(input: {
     if (!isMounted()) return false;
 
     if (setToken && input.createIdempotencyKey) {
-      setToken({ key: input.createIdempotencyKey(), fingerprint });
+      mintRequestKey(input.createIdempotencyKey, fingerprint, setToken);
     }
     return true;
   }

--- a/docs/bugs/bug-298-preserved-keys-unbound-on-submit-mark-bookmark-surfaces.md
+++ b/docs/bugs/bug-298-preserved-keys-unbound-on-submit-mark-bookmark-surfaces.md
@@ -48,7 +48,7 @@ Silent wrong-outcome presentation on core practice surfaces: a grade shown for t
 
 ## Resolution State (2026-07-14)
 
-Implementation merged to `dev` through PR #647 (`b665d7ce`) and is awaiting production promotion after a final review follow-up on branch `fix/bug-298-request-identity-binding`. `Status` remains **Open** until production proof exists.
+Implementation merged to `dev` through PR #647 (`b665d7ce`). Follow-up PR #650 on branch `fix/bug-298-request-identity-binding` applies the promotion-review helper reuse and awaits exact-head CodeRabbit approval before merging; production promotion remains held in PR #649. `Status` remains **Open** until production proof exists.
 
 - Extracted BUG-295's fingerprint-bound key type and `resolveRequestKey`/`mintRequestKey` lifecycle into the neutral shared client module `app/(app)/app/shared/idempotency-request-key.ts`; feedback consumes the shared primitive with its existing fingerprints and behavior unchanged.
 - Bound submit tokens to question, selected choice, active practice-session identity, and (for standalone reattempts) retry provenance; bound mark tokens to session, question, and desired mark state; bound bookmark tokens to question and desired state. Same-identity indeterminate failures preserve their key, changed intent mints fresh, and a consumed success retires the token.

--- a/docs/bugs/bug-298-preserved-keys-unbound-on-submit-mark-bookmark-surfaces.md
+++ b/docs/bugs/bug-298-preserved-keys-unbound-on-submit-mark-bookmark-surfaces.md
@@ -48,12 +48,13 @@ Silent wrong-outcome presentation on core practice surfaces: a grade shown for t
 
 ## Resolution State (2026-07-14)
 
-Implementation is complete on branch `fix/bug-298-request-identity-binding` and is awaiting review, merge, and production proof. `Status` remains **Open** until that proof exists.
+Implementation merged to `dev` through PR #647 (`b665d7ce`) and is awaiting production promotion after a final review follow-up on branch `fix/bug-298-request-identity-binding`. `Status` remains **Open** until production proof exists.
 
 - Extracted BUG-295's fingerprint-bound key type and `resolveRequestKey`/`mintRequestKey` lifecycle into the neutral shared client module `app/(app)/app/shared/idempotency-request-key.ts`; feedback consumes the shared primitive with its existing fingerprints and behavior unchanged.
 - Bound submit tokens to question, selected choice, active practice-session identity, and (for standalone reattempts) retry provenance; bound mark tokens to session, question, and desired mark state; bound bookmark tokens to question and desired state. Same-identity indeterminate failures preserve their key, changed intent mints fresh, and a consumed success retires the token.
 - Added a standalone-submit in-flight fence after a browser red test exposed a lazy-mint double-submit race during self-review.
 - Added per-question in-flight fences to both bookmark owners after review exposed that two synchronous toggles could launch the same claim before React committed the saving state; the guard precedes hydration-version mutation and releases when the request settles.
+- Reused the neutral `mintRequestKey` primitive for both feedback success rotations after promotion review found the equivalent token construction had remained duplicated. A separate promotion-review claim that attempt reset needed another stale-submit fence was refuted by an unchanged browser reproduction: both reset paths already suppress the late transition result, while the existing owner fence prevents concurrent re-execution.
 - Widened both the Drizzle feedback replay guard and its application fake to reject same-token replays whose nullable attempt or practice-session context differs.
 - TDD coverage includes real-`withIdempotency` wrapper-boundary tests for all submit surfaces and bookmark, browser tests for mark plus the submit/bookmark in-flight fences, fake-repository contract tests, and real-Postgres replay-guard tests for both context fields. Red baselines reproduced stale changed-intent replay with one execution, duplicate launches before state commit, and the missing feedback conflicts before the implementation turned them green.
 


### PR DESCRIPTION
## Context

Promotion review on #649 produced two outside-diff findings after #647 had merged to dev. Each was revalidated before any change.

## Decision

- Accepted: both feedback success paths manually reconstructed the exact token produced by the neutral mintRequestKey helper. This PR replaces those two equivalent constructions with the shared primitive; behavior is unchanged and the existing success-rotation tests remain the contract.
- Refuted: attempt reset did not require another stale-submit fence. A browser reproduction invoked both onReattempt and onAnswerAsNew while submit was pending; the unchanged React 19 transition discarded the late result, and the existing synchronous owner fence prevented a second request. The proposed submitInFlightRef reset would instead permit overlapping writes, so no production change was made.

The BUG-298 Resolution State records both outcomes. No schema migration and no bugs-index change.

## Verification

- pnpm typecheck
- pnpm lint (existing advisory warnings only)
- pnpm test --run — 3,380 passed
- pnpm test:browser — 373 passed
- pnpm test:integration — 200 passed, 2 skipped
- pnpm build
- pnpm test:e2e — 36 passed

Promotion #649 remains open and must not merge until this follow-up lands and its checks rerun against the updated dev head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for question ratings, reports, submissions, and bookmarks by correctly associating retry protection with each request.
  - Prevented stale request tokens from being reused after user intent changes or successful actions.
  - Strengthened handling of concurrent actions to reduce duplicate or incorrectly applied updates.

- **Documentation**
  - Updated the BUG-298 status and resolution notes to reflect current request-handling behavior and remaining production verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->