### PR TITLE
Promote BUG-301 feedback token ownership fix

### DIFF
--- a/app/(app)/app/practice/hooks/use-practice-question-feedback.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-question-feedback.browser.spec.tsx
@@ -22,7 +22,10 @@ const reportClientError = vi.mocked(clientError.reportClientError);
 
 const questionId = '11111111-1111-4111-8111-111111111111';
 const attemptId = '22222222-2222-4222-8222-222222222222';
+const reattemptId = '44444444-4444-4444-8444-444444444444';
 const practiceSessionId = '33333333-3333-4333-8333-333333333333';
+const initialReportComment = 'Needs a clearer stem.';
+const editedReportComment = 'The revised stem is still ambiguous.';
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
@@ -40,10 +43,12 @@ function Probe({
   isMounted?: () => boolean;
 }) {
   const [isReviewMode, setIsReviewMode] = useState(initialReviewMode);
+  const [currentAttemptId, setCurrentAttemptId] = useState(attemptId);
+  const [reportComment, setReportComment] = useState(initialReportComment);
   const output = usePracticeQuestionFeedback({
     question: {
       questionId,
-      attemptId,
+      attemptId: currentAttemptId,
       practiceSessionId,
     },
     isReviewMode,
@@ -57,6 +62,8 @@ function Probe({
       <div data-testid="is-report-open">
         {output.isReportOpen ? 'true' : 'false'}
       </div>
+      <div data-testid="attempt-id">{currentAttemptId}</div>
+      <div data-testid="report-comment">{reportComment}</div>
       <button type="button" onClick={() => output.onRate('helpful')}>
         rate-helpful
       </button>
@@ -74,7 +81,7 @@ function Probe({
         onClick={() => {
           void output.submitReport({
             category: 'ambiguous_wording',
-            comment: 'Needs a clearer stem.',
+            comment: reportComment,
           });
         }}
       >
@@ -83,8 +90,33 @@ function Probe({
       <button type="button" onClick={() => setIsReviewMode(false)}>
         leave-review
       </button>
+      <button type="button" onClick={() => setCurrentAttemptId(reattemptId)}>
+        reattempt
+      </button>
+      <button
+        type="button"
+        onClick={() => setReportComment(editedReportComment)}
+      >
+        edit-report
+      </button>
     </>
   );
+}
+
+function requestKeyAt(
+  calls: readonly (readonly unknown[])[],
+  index: number,
+): string | undefined {
+  const request = calls[index]?.[0];
+  if (!request || typeof request !== 'object') return undefined;
+  if (!('idempotencyKey' in request)) return undefined;
+  return typeof request.idempotencyKey === 'string'
+    ? request.idempotencyKey
+    : undefined;
+}
+
+async function waitForAsyncContinuation(): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
 describe('usePracticeQuestionFeedback (browser)', () => {
@@ -193,6 +225,49 @@ describe('usePracticeQuestionFeedback (browser)', () => {
     });
   });
 
+  it('preserves a newer reattempt rating key after the stale request completes', async () => {
+    const staleResponse =
+      createDeferred<Awaited<ReturnType<typeof rateQuestion>>>();
+    rateQuestion
+      .mockReturnValueOnce(staleResponse.promise)
+      .mockRejectedValueOnce(new Error('newer response lost after commit'))
+      .mockResolvedValueOnce(ok({ rating: 'helpful' }));
+
+    const screen = await render(<Probe />);
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'rate-helpful' }).click();
+    await expect.poll(() => rateQuestion.mock.calls.length).toBe(1);
+    const firstKey = requestKeyAt(rateQuestion.mock.calls, 0);
+
+    await screen.getByRole('button', { name: 'reattempt' }).click();
+    await expect
+      .element(screen.getByTestId('attempt-id'))
+      .toHaveTextContent(reattemptId);
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'rate-helpful' }).click();
+    await expect.poll(() => rateQuestion.mock.calls.length).toBe(2);
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('error');
+    const newerKey = requestKeyAt(rateQuestion.mock.calls, 1);
+    expect(newerKey).toEqual(expect.any(String));
+    expect(newerKey).not.toBe(firstKey);
+
+    staleResponse.resolve(ok({ rating: 'helpful' }));
+    await waitForAsyncContinuation();
+
+    await screen.getByRole('button', { name: 'rate-helpful' }).click();
+    await expect.poll(() => rateQuestion.mock.calls.length).toBe(3);
+
+    expect(requestKeyAt(rateQuestion.mock.calls, 2)).toBe(newerKey);
+  });
+
   it('rolls back a retraction when the write fails', async () => {
     getQuestionRating.mockResolvedValue(ok({ rating: 'not_helpful' }));
     rateQuestion.mockResolvedValue({
@@ -240,7 +315,7 @@ describe('usePracticeQuestionFeedback (browser)', () => {
       attemptId,
       practiceSessionId,
       category: 'ambiguous_wording',
-      comment: 'Needs a clearer stem.',
+      comment: initialReportComment,
       idempotencyKey: expect.any(String),
     });
 
@@ -248,6 +323,83 @@ describe('usePracticeQuestionFeedback (browser)', () => {
     await expect
       .element(screen.getByTestId('is-report-open'))
       .toHaveTextContent('false');
+  });
+
+  it('preserves a newer edited-report key after the stale dialog request completes', async () => {
+    const staleResponse =
+      createDeferred<Awaited<ReturnType<typeof submitQuestionReport>>>();
+    submitQuestionReport
+      .mockReturnValueOnce(staleResponse.promise)
+      .mockRejectedValueOnce(new Error('newer response lost after commit'))
+      .mockResolvedValueOnce(ok({ feedbackId: crypto.randomUUID() }));
+
+    const screen = await render(<Probe />);
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'open-report' }).click();
+    await screen.getByRole('button', { name: 'submit-report' }).click();
+    await expect.poll(() => submitQuestionReport.mock.calls.length).toBe(1);
+    const firstKey = requestKeyAt(submitQuestionReport.mock.calls, 0);
+
+    await screen.getByRole('button', { name: 'close-report' }).click();
+    await screen.getByRole('button', { name: 'edit-report' }).click();
+    await expect
+      .element(screen.getByTestId('report-comment'))
+      .toHaveTextContent(editedReportComment);
+    await screen.getByRole('button', { name: 'open-report' }).click();
+    await screen.getByRole('button', { name: 'submit-report' }).click();
+    await expect.poll(() => submitQuestionReport.mock.calls.length).toBe(2);
+    await expect.poll(() => reportClientError.mock.calls.length).toBe(1);
+    const newerKey = requestKeyAt(submitQuestionReport.mock.calls, 1);
+    expect(newerKey).toEqual(expect.any(String));
+    expect(newerKey).not.toBe(firstKey);
+
+    staleResponse.resolve(ok({ feedbackId: crypto.randomUUID() }));
+    await waitForAsyncContinuation();
+
+    await screen.getByRole('button', { name: 'submit-report' }).click();
+    await expect.poll(() => submitQuestionReport.mock.calls.length).toBe(3);
+
+    expect(requestKeyAt(submitQuestionReport.mock.calls, 2)).toBe(newerKey);
+  });
+
+  it('commits reused-token retry and success rotations for one owner generation', async () => {
+    rateQuestion
+      .mockResolvedValueOnce({
+        ok: false,
+        error: {
+          code: 'CONFLICT',
+          message: 'Feedback request token was reused with a different request',
+          details: { reason: 'feedback_request_token_reused' },
+        },
+      })
+      .mockResolvedValueOnce(ok({ rating: 'helpful' }))
+      .mockResolvedValueOnce(ok({ rating: 'helpful' }));
+
+    const screen = await render(<Probe />);
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'rate-helpful' }).click();
+    await expect.poll(() => rateQuestion.mock.calls.length).toBe(2);
+    await expect
+      .element(screen.getByTestId('feedback-status'))
+      .toHaveTextContent('saved');
+
+    const initialKey = requestKeyAt(rateQuestion.mock.calls, 0);
+    const retryKey = requestKeyAt(rateQuestion.mock.calls, 1);
+    expect(retryKey).toEqual(expect.any(String));
+    expect(retryKey).not.toBe(initialKey);
+
+    await screen.getByRole('button', { name: 'rate-helpful' }).click();
+    await expect.poll(() => rateQuestion.mock.calls.length).toBe(3);
+
+    const retiredKey = requestKeyAt(rateQuestion.mock.calls, 2);
+    expect(retiredKey).toEqual(expect.any(String));
+    expect(retiredKey).not.toBe(retryKey);
   });
 
   it('reports submit-report failures through the client error reporter', async () => {

--- a/app/(app)/app/practice/hooks/use-practice-question-feedback.ts
+++ b/app/(app)/app/practice/hooks/use-practice-question-feedback.ts
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  claimRequestKeySlot,
+  createRequestKeySlotStore,
+} from '@/app/(app)/app/shared/idempotency-request-key';
+import {
   type FeedbackQuestionContext,
-  type FeedbackRequestToken,
   rateQuestionForQuestion,
   submitReportForQuestion,
 } from '@/app/(app)/app/shared/question-feedback-actions';
@@ -57,12 +60,8 @@ export function usePracticeQuestionFeedback(
   const [isReportOpen, setIsReportOpen] = useState(false);
   const latestRatingLookupRequestId = useRef(0);
   const feedbackStateVersionRef = useRef(0);
-  const ratingRequestTokensRef = useRef<Map<string, FeedbackRequestToken>>(
-    new Map(),
-  );
-  const reportRequestTokensRef = useRef<Map<string, FeedbackRequestToken>>(
-    new Map(),
-  );
+  const ratingRequestKeySlotsRef = useRef(createRequestKeySlotStore());
+  const reportRequestKeySlotsRef = useRef(createRequestKeySlotStore());
   const isMountedRef = useRef(input.isMounted);
   isMountedRef.current = input.isMounted;
   const questionId = input.question?.questionId ?? null;
@@ -143,17 +142,18 @@ export function usePracticeQuestionFeedback(
       feedbackStateVersionRef.current += 1;
       const stateVersion = feedbackStateVersionRef.current;
       const questionId = questionContext.questionId;
+      const requestKeyOwner = claimRequestKeySlot(
+        ratingRequestKeySlotsRef.current,
+        questionId,
+      );
 
       void rateQuestionForQuestion({
         question: questionContext,
         currentRating: rating,
         nextRating,
-        ratingRequestToken:
-          ratingRequestTokensRef.current.get(questionId) ?? null,
+        ratingRequestToken: requestKeyOwner.token,
         createIdempotencyKey: () => crypto.randomUUID(),
-        setRatingRequestToken: (token) => {
-          ratingRequestTokensRef.current.set(questionId, token);
-        },
+        setRatingRequestToken: requestKeyOwner.setToken,
         rateQuestionFn: rateQuestion,
         setRating: (nextRatingState) => {
           if (!isMountedRef.current()) return;
@@ -189,16 +189,17 @@ export function usePracticeQuestionFeedback(
       if (!questionContext) return false;
 
       const questionId = questionContext.questionId;
+      const requestKeyOwner = claimRequestKeySlot(
+        reportRequestKeySlotsRef.current,
+        questionId,
+      );
       return submitReportForQuestion({
         question: questionContext,
         category: report.category,
         comment: report.comment,
-        reportRequestToken:
-          reportRequestTokensRef.current.get(questionId) ?? null,
+        reportRequestToken: requestKeyOwner.token,
         createIdempotencyKey: () => crypto.randomUUID(),
-        setReportRequestToken: (token) => {
-          reportRequestTokensRef.current.set(questionId, token);
-        },
+        setReportRequestToken: requestKeyOwner.setToken,
         submitQuestionReportFn: submitQuestionReport,
         logError: (_message, context) => {
           reportClientError(context, {

--- a/app/(app)/app/shared/idempotency-request-key.test.ts
+++ b/app/(app)/app/shared/idempotency-request-key.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  claimRequestKeySlot,
   createRequestFingerprint,
+  createRequestKeySlotStore,
   mintRequestKey,
   resolveRequestKey,
 } from './idempotency-request-key';
@@ -55,6 +57,37 @@ describe('fingerprint-bound idempotency request keys', () => {
     expect(setToken).toHaveBeenCalledWith({
       key: 'replacement-key',
       fingerprint,
+    });
+  });
+
+  it('rejects token writes from a superseded owner generation', () => {
+    const slots = createRequestKeySlotStore();
+    const firstOwner = claimRequestKeySlot(slots, 'question-1');
+    firstOwner.setToken({ key: 'first-key', fingerprint: 'first-request' });
+
+    const secondOwner = claimRequestKeySlot(slots, 'question-1');
+    secondOwner.setToken({ key: 'second-key', fingerprint: 'second-request' });
+    firstOwner.setToken({ key: 'stale-key', fingerprint: 'first-request' });
+
+    const nextOwner = claimRequestKeySlot(slots, 'question-1');
+    expect(nextOwner.token).toEqual({
+      key: 'second-key',
+      fingerprint: 'second-request',
+    });
+  });
+
+  it('allows every token transition made by the current owner generation', () => {
+    const slots = createRequestKeySlotStore();
+    const owner = claimRequestKeySlot(slots, 'question-1');
+
+    owner.setToken({ key: 'initial-key', fingerprint: 'request' });
+    owner.setToken({ key: 'retry-key', fingerprint: 'request' });
+    owner.setToken({ key: 'retired-key', fingerprint: 'request' });
+
+    const nextOwner = claimRequestKeySlot(slots, 'question-1');
+    expect(nextOwner.token).toEqual({
+      key: 'retired-key',
+      fingerprint: 'request',
     });
   });
 });

--- a/app/(app)/app/shared/idempotency-request-key.ts
+++ b/app/(app)/app/shared/idempotency-request-key.ts
@@ -10,12 +10,53 @@ export type FingerprintBoundIdempotencyKey = Readonly<{
   fingerprint: string;
 }>;
 
+type RequestKeySlotState = Readonly<{
+  generation: number;
+  token: FingerprintBoundIdempotencyKey | null;
+}>;
+
+export type RequestKeySlotStore = Map<string, RequestKeySlotState>;
+
+export type RequestKeySlotClaim = Readonly<{
+  token: FingerprintBoundIdempotencyKey | null;
+  setToken: (token: FingerprintBoundIdempotencyKey) => void;
+}>;
+
 type RequestFingerprintPart =
   | string
   | number
   | boolean
   | null
   | readonly RequestFingerprintPart[];
+
+export function createRequestKeySlotStore(): RequestKeySlotStore {
+  return new Map();
+}
+
+/**
+ * Give one invocation ownership of a persisted request-key slot.
+ *
+ * A later invocation supersedes this claim. Token transitions made by the
+ * current invocation remain writable across its internal retry loop, while
+ * any completion from an older invocation is ignored.
+ */
+export function claimRequestKeySlot(
+  slots: RequestKeySlotStore,
+  slotId: string,
+): RequestKeySlotClaim {
+  const previous = slots.get(slotId);
+  const generation = (previous?.generation ?? 0) + 1;
+  const token = previous?.token ?? null;
+  slots.set(slotId, { generation, token });
+
+  return {
+    token,
+    setToken: (nextToken) => {
+      if (slots.get(slotId)?.generation !== generation) return;
+      slots.set(slotId, { generation, token: nextToken });
+    },
+  };
+}
 
 export function createRequestFingerprint(
   parts: readonly RequestFingerprintPart[],

--- a/app/(app)/app/shared/question-feedback-token-ownership.test.ts
+++ b/app/(app)/app/shared/question-feedback-token-ownership.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RateQuestionOutput } from '@/src/adapters/controllers/question-feedback-controller';
+import {
+  IdempotentActionNames,
+  shouldCacheQuestionRatingError,
+} from '@/src/adapters/controllers/shared/idempotency-error-policy';
+import { withIdempotency } from '@/src/adapters/shared/with-idempotency';
+import {
+  FakeAttemptRepository,
+  FakeIdempotencyKeyRepository,
+  FakeLogger,
+  FakePracticeSessionRepository,
+  FakeQuestionFeedbackRepository,
+  FakeQuestionRepository,
+} from '@/src/application/test-helpers/fakes';
+import { RateQuestionUseCase } from '@/src/application/use-cases/rate-question';
+import { createAttempt, createQuestion } from '@/src/domain/test-helpers';
+import type { QuestionFeedbackRating } from '@/src/domain/value-objects';
+import { ok } from '@/tests/test-helpers/ok';
+import {
+  claimRequestKeySlot,
+  createRequestKeySlotStore,
+} from './idempotency-request-key';
+import { rateQuestionForQuestion } from './question-feedback-actions';
+
+const userId = 'user-1';
+const questionId = '11111111-1111-4111-8111-111111111111';
+const firstAttemptId = '22222222-2222-4222-8222-222222222222';
+const secondAttemptId = '33333333-3333-4333-8333-333333333333';
+const firstRequestKey = '44444444-4444-4444-8444-444444444444';
+const secondRequestKey = '55555555-5555-4555-8555-555555555555';
+const firstRetiredKey = '66666666-6666-4666-8666-666666666666';
+const secondRetiredKey = '77777777-7777-4777-8777-777777777777';
+
+type RatingRequest = {
+  questionId: string;
+  attemptId: string | null;
+  practiceSessionId: string | null;
+  rating: QuestionFeedbackRating | null;
+  idempotencyKey: string;
+};
+
+function createDeferred<T>() {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve(value: T) {
+      if (!resolvePromise) throw new Error('Deferred promise is not ready');
+      resolvePromise(value);
+    },
+  };
+}
+
+function createRatingServer() {
+  const feedback = new FakeQuestionFeedbackRepository();
+  const idempotencyKeys = new FakeIdempotencyKeyRepository();
+  const rateQuestion = new RateQuestionUseCase(
+    feedback,
+    new FakeQuestionRepository([
+      createQuestion({ id: questionId, status: 'published' }),
+    ]),
+    new FakeAttemptRepository([
+      createAttempt({
+        id: firstAttemptId,
+        userId,
+        questionId,
+        practiceSessionId: null,
+      }),
+      createAttempt({
+        id: secondAttemptId,
+        userId,
+        questionId,
+        practiceSessionId: null,
+      }),
+    ]),
+    new FakePracticeSessionRepository(),
+  );
+  const executions: string[] = [];
+
+  return {
+    executions,
+    feedback,
+    handle(request: RatingRequest): Promise<RateQuestionOutput> {
+      return withIdempotency({
+        repo: idempotencyKeys,
+        logger: new FakeLogger(),
+        userId,
+        action: IdempotentActionNames.QuestionRating,
+        key: request.idempotencyKey,
+        now: () => new Date('2026-07-15T00:00:00.000Z'),
+        shouldCacheError: shouldCacheQuestionRatingError,
+        execute: async () => {
+          executions.push(request.idempotencyKey);
+          return rateQuestion.execute({ userId, ...request });
+        },
+      });
+    },
+  };
+}
+
+describe('question feedback token ownership', () => {
+  it('preserves the newer possibly-committed key after a stale completion and replays it once', async () => {
+    const server = createRatingServer();
+    const slots = createRequestKeySlotStore();
+    const releaseFirstResponse = createDeferred<void>();
+    const generatedKeys = [
+      firstRequestKey,
+      secondRequestKey,
+      firstRetiredKey,
+      secondRetiredKey,
+    ];
+    const createIdempotencyKey = vi.fn(() => {
+      const key = generatedKeys.shift();
+      if (!key) throw new Error('No generated request key remains');
+      return key;
+    });
+    const clientRequestKeys: string[] = [];
+
+    const firstOwner = claimRequestKeySlot(slots, questionId);
+    const firstRequest = rateQuestionForQuestion({
+      question: {
+        questionId,
+        attemptId: firstAttemptId,
+        practiceSessionId: null,
+      },
+      currentRating: null,
+      nextRating: 'helpful',
+      ratingRequestToken: firstOwner.token,
+      createIdempotencyKey,
+      setRatingRequestToken: firstOwner.setToken,
+      rateQuestionFn: async (input) => {
+        const request = input as RatingRequest;
+        clientRequestKeys.push(request.idempotencyKey);
+        await releaseFirstResponse.promise;
+        return ok(await server.handle(request));
+      },
+      setRating: vi.fn(),
+      setFeedbackStatus: vi.fn(),
+    });
+
+    const secondOwner = claimRequestKeySlot(slots, questionId);
+    await rateQuestionForQuestion({
+      question: {
+        questionId,
+        attemptId: secondAttemptId,
+        practiceSessionId: null,
+      },
+      currentRating: null,
+      nextRating: 'not_helpful',
+      ratingRequestToken: secondOwner.token,
+      createIdempotencyKey,
+      setRatingRequestToken: secondOwner.setToken,
+      rateQuestionFn: async (input) => {
+        const request = input as RatingRequest;
+        clientRequestKeys.push(request.idempotencyKey);
+        await server.handle(request);
+        throw new Error('response lost after commit');
+      },
+      setRating: vi.fn(),
+      setFeedbackStatus: vi.fn(),
+    });
+
+    releaseFirstResponse.resolve();
+    await firstRequest;
+
+    const retryOwner = claimRequestKeySlot(slots, questionId);
+    await rateQuestionForQuestion({
+      question: {
+        questionId,
+        attemptId: secondAttemptId,
+        practiceSessionId: null,
+      },
+      currentRating: null,
+      nextRating: 'not_helpful',
+      ratingRequestToken: retryOwner.token,
+      createIdempotencyKey,
+      setRatingRequestToken: retryOwner.setToken,
+      rateQuestionFn: async (input) => {
+        const request = input as RatingRequest;
+        clientRequestKeys.push(request.idempotencyKey);
+        return ok(await server.handle(request));
+      },
+      setRating: vi.fn(),
+      setFeedbackStatus: vi.fn(),
+    });
+
+    expect(clientRequestKeys).toEqual([
+      firstRequestKey,
+      secondRequestKey,
+      secondRequestKey,
+    ]);
+    expect(server.executions).toEqual([secondRequestKey, firstRequestKey]);
+    expect(server.feedback.getAll()).toHaveLength(2);
+  });
+});

--- a/docs/bugs/bug-301-stale-feedback-completion-clobbers-newer-request-key.md
+++ b/docs/bugs/bug-301-stale-feedback-completion-clobbers-newer-request-key.md
@@ -53,6 +53,12 @@ Identity binding answers “does this token describe this request?” It does no
 2. Preserve K-B after B's indeterminate failure. Do not solve the race by rotating on thrown/timeout outcomes or by disabling navigation indefinitely; both would violate the determinacy rule or couple unrelated UI ownership.
 3. Cover rating and report with browser tests using deferred A/B responses across reattempt/navigation/dialog close. Add a real-`withIdempotency` + fake-repository boundary test proving B executes once when its original key is preserved and twice under the pre-fix clobber sequence.
 
+## Resolution State
+
+Implementation completed on `fix/bug-301-feedback-token-ownership` on 2026-07-15; PR review, promotion, and production proof remain pending. The neutral `idempotency-request-key.ts` module now owns a reusable generation-fenced request-key slot: each invocation claims the slot, current-generation retry/success/error transitions remain writable, and a superseded invocation's token writes are ignored. `usePracticeQuestionFeedback` applies that owner claim to both rating and report before launching the shared helpers, covering the practice question flow, practice-session page model, and standalone question page through their existing shared hook.
+
+Red-first coverage reproduces both stale-completion failures in Chromium (reattempted rating and edited report after dialog close), pins the slot's compare-and-set contract, and exercises the lost-response interleaving through real `withIdempotency`, `RateQuestionUseCase`, and `FakeQuestionFeedbackRepository`; the newer key replays without a duplicate append-only write. Existing control tests continue to pin consumed-success rotation, determinate-error rotation, and the helper's same-generation reused-token retry. No server or schema changes are part of this fix. Status remains **Open** until wave-close archival after production proof.
+
 ## Related
 
 - [BUG-295 (archived)](../_archive/bugs/bug-295-preserved-idempotency-keys-replay-across-changed-intent.md) — established fingerprint-bound preservation and retirement for feedback tokens.


### PR DESCRIPTION
## Summary

Promotes the exact approved BUG-301 fix from `dev` to `main`.

- Fix PR: #656
- Squash commit: `da3cdfc6de50fae66a3bb785e372bbeb86ef9b75`
- Adds generation-owned/CAS-fenced rating and report request-key slots.
- Preserves the newer request key across stale completions and indeterminate outcomes.
- Leaves server/schema behavior and BUG-300 untouched.

## Verification

The fix head passed the complete local gate before push: typecheck, lint, 3,391 unit tests, 381 browser tests, 200 integration tests (2 skipped), build, and 36/36 hermetic E2E tests. Fix PR CI and exact-head CodeRabbit review are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of question ratings and report submissions when multiple requests overlap.
  * Prevented delayed responses from overwriting newer feedback actions.
  * Ensured retries reuse the correct request key and avoid duplicate submissions.

* **Documentation**
  * Updated the BUG-301 record with resolution details and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->