### PR TITLE
Promote dev to main after BUG-300

### DIFF
--- a/app/(app)/app/practice/hooks/use-practice-session-start.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-start.browser.spec.tsx
@@ -1,15 +1,19 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import * as reportClientError from '@/lib/report-client-error';
 import { TimeoutError } from '@/lib/with-timeout';
 import type { ActionResult } from '@/src/adapters/controllers/action-result';
+import { err } from '@/src/adapters/controllers/action-result';
 import type { StartPracticeSessionOutput } from '@/src/adapters/controllers/practice-controller';
 import * as practiceController from '@/src/adapters/controllers/practice-controller';
+import { ApplicationConflictReasons } from '@/src/application/errors';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
 import { installReportClientErrorMocks } from '@/tests/test-helpers/report-client-error-mocks';
 import * as clientNavigation from '../client-navigation';
+import { IncompleteSessionCard } from '../components/incomplete-session-card';
+import { usePracticeIncompleteSession } from './use-practice-incomplete-session';
 import { usePracticeSessionStart } from './use-practice-session-start';
 
 const fixtureSession1Id = crypto.randomUUID();
@@ -19,6 +23,9 @@ vi.mock('@/lib/report-client-error', { spy: true });
 vi.mock('../client-navigation', { spy: true });
 
 const startPracticeSession = vi.mocked(practiceController.startPracticeSession);
+const getIncompletePracticeSession = vi.mocked(
+  practiceController.getIncompletePracticeSession,
+);
 const reportClientErrorSpy = vi.mocked(reportClientError.reportClientError);
 const navigateToSpy = vi.mocked(clientNavigation.navigateTo);
 const refreshIncompleteSession = async () => ({
@@ -42,8 +49,9 @@ function getIdempotencyKey(input: unknown): string {
 }
 
 function Probe() {
+  const isMounted = useCallback(() => true, []);
   const output = usePracticeSessionStart({
-    isMounted: () => true,
+    isMounted,
     refreshIncompleteSession,
   });
   const [settledStarts, setSettledStarts] = useState(0);
@@ -70,6 +78,43 @@ function Probe() {
         data-testid="start"
         onClick={() => {
           void output.onStartSession().finally(() => {
+            setSettledStarts((count) => count + 1);
+          });
+        }}
+      >
+        Start
+      </button>
+    </>
+  );
+}
+
+function RecoveryProbe() {
+  const isMounted = useCallback(() => true, []);
+  const incomplete = usePracticeIncompleteSession({ isMounted });
+  const sessionStart = usePracticeSessionStart({
+    isMounted,
+    refreshIncompleteSession: incomplete.refreshIncompleteSession,
+  });
+  const [settledStarts, setSettledStarts] = useState(0);
+
+  if (incomplete.incompleteSession) {
+    return (
+      <IncompleteSessionCard
+        session={incomplete.incompleteSession}
+        isPending={incomplete.incompleteSessionStatus === 'loading'}
+        onAbandon={() => undefined}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div data-testid="recovery-settled-starts">{settledStarts}</div>
+      <button
+        type="button"
+        data-testid="recovery-start"
+        onClick={() => {
+          void sessionStart.onStartSession().finally(() => {
             setSettledStarts((count) => count + 1);
           });
         }}
@@ -155,6 +200,66 @@ test('reuses the session start key after a timeout and reaches the recorded succ
   expect(navigateToSpy).toHaveBeenCalledWith(
     `/app/practice/${fixtureSession1Id}`,
   );
+});
+
+test('recovers a late concurrent start with the preserved key and renders the session panel', async () => {
+  const committedSession = {
+    sessionId: fixtureSession1Id,
+    mode: 'tutor' as const,
+    answeredCount: 0,
+    totalCount: 20,
+    startedAt: '2026-07-15T00:00:00.000Z',
+  };
+  let originalRequestCommitted = false;
+
+  getIncompletePracticeSession.mockImplementation(async () =>
+    ok(originalRequestCommitted ? committedSession : null),
+  );
+  startPracticeSession
+    .mockRejectedValueOnce(new TimeoutError(15_000))
+    .mockResolvedValue(
+      err('CONFLICT', 'Request is still running', undefined, {
+        reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
+      }),
+    );
+
+  const screen = await render(<RecoveryProbe />);
+  await expect
+    .poll(() => getIncompletePracticeSession.mock.calls.length)
+    .toBe(1);
+
+  await screen.getByTestId('recovery-start').click();
+  await expect
+    .element(screen.getByTestId('recovery-settled-starts'))
+    .toHaveTextContent('1');
+  const firstKey = getIdempotencyKey(startPracticeSession.mock.calls[0]?.[0]);
+
+  await screen.getByTestId('recovery-start').click();
+  await expect
+    .element(screen.getByTestId('recovery-settled-starts'))
+    .toHaveTextContent('2');
+  const concurrentRetryKey = getIdempotencyKey(
+    startPracticeSession.mock.calls[1]?.[0],
+  );
+  expect(concurrentRetryKey).toBe(firstKey);
+  await expect
+    .poll(() => getIncompletePracticeSession.mock.calls.length)
+    .toBe(2);
+
+  originalRequestCommitted = true;
+
+  await screen.getByTestId('recovery-start').click();
+  await expect.poll(() => startPracticeSession.mock.calls.length).toBe(3);
+  const recoveryRetryKey = getIdempotencyKey(
+    startPracticeSession.mock.calls[2]?.[0],
+  );
+  expect(recoveryRetryKey).toBe(firstKey);
+  await expect
+    .element(screen.getByRole('link', { name: 'Resume session' }))
+    .toHaveAttribute('href', `/app/practice/${fixtureSession1Id}`);
+  await expect
+    .element(screen.getByRole('button', { name: 'Abandon session' }))
+    .toBeVisible();
 });
 
 test('ignores stale successful session starts after config changes mid-flight', async () => {

--- a/app/(app)/app/practice/practice-page-logic-session-start.test.ts
+++ b/app/(app)/app/practice/practice-page-logic-session-start.test.ts
@@ -3,6 +3,7 @@ import { startSession } from '@/app/(app)/app/practice/practice-page-logic';
 import { toPracticeSessionRoute } from '@/lib/routes';
 import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import { err, ok } from '@/src/adapters/controllers/action-result';
+import { ApplicationConflictReasons } from '@/src/application/errors';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 
 const { fixtureSession1Id } = vi.hoisted(() => ({
@@ -213,6 +214,10 @@ describe('practice-page-logic session start', () => {
 
     it('preserves the key when a concurrent same-key request may still finish', async () => {
       const setIdempotencyKey = vi.fn();
+      const refreshIncompleteSession = vi.fn(async () => ({
+        kind: 'loaded' as const,
+        session: null,
+      }));
 
       await startSession({
         sessionMode: 'tutor',
@@ -223,13 +228,43 @@ describe('practice-page-logic session start', () => {
         setIdempotencyKey,
         startPracticeSessionFn: async () =>
           err('CONFLICT', 'Request is still running', undefined, {
-            reason: 'concurrent_request_in_progress',
+            reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
           }),
+        refreshIncompleteSession,
         setSessionStartStatus: vi.fn(),
         setSessionStartError: vi.fn(),
         navigateTo: vi.fn(),
       });
 
+      expect(refreshIncompleteSession).toHaveBeenCalledTimes(1);
+      expect(setIdempotencyKey).not.toHaveBeenCalled();
+    });
+
+    it('preserves the key and refreshes the panel when a concurrent request already committed', async () => {
+      const setIdempotencyKey = vi.fn();
+      const refreshIncompleteSession = vi.fn(async () => ({
+        kind: 'loaded' as const,
+        session: { sessionId: fixtureSession1Id },
+      }));
+
+      await startSession({
+        sessionMode: 'tutor',
+        sessionCount: 20,
+        filters: { tagSlugs: [], difficulty: null, status: 'unanswered' },
+        idempotencyKey: 'idem_1',
+        createIdempotencyKey: () => 'idem_2',
+        setIdempotencyKey,
+        startPracticeSessionFn: async () =>
+          err('CONFLICT', 'Request is still running', undefined, {
+            reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
+          }),
+        refreshIncompleteSession,
+        setSessionStartStatus: vi.fn(),
+        setSessionStartError: vi.fn(),
+        navigateTo: vi.fn(),
+      });
+
+      expect(refreshIncompleteSession).toHaveBeenCalledTimes(1);
       expect(setIdempotencyKey).not.toHaveBeenCalled();
     });
 

--- a/app/(app)/app/practice/practice-page-session-start.ts
+++ b/app/(app)/app/practice/practice-page-session-start.ts
@@ -10,6 +10,7 @@ import type { ActionResult } from '@/src/adapters/controllers/action-result';
 import type { StartPracticeSessionOutput } from '@/src/adapters/controllers/practice-controller';
 import {
   IdempotentActionNames,
+  isConcurrentRequestInProgressError,
   rotateIdempotencyKeyAfterDeterminateError,
 } from '@/src/adapters/controllers/shared/idempotency-error-policy';
 import {
@@ -136,6 +137,9 @@ export async function startSession(input: {
   if (!res.ok) {
     input.setSessionStartStatus('error');
     input.setSessionStartError(getActionResultErrorMessage(res));
+    const concurrentRequestMayStillFinish = isConcurrentRequestInProgressError(
+      res.error,
+    );
     const rotatedAfterDeterminateError =
       rotateIdempotencyKeyAfterDeterminateError(
         IdempotentActionNames.StartPracticeSession,
@@ -150,12 +154,13 @@ export async function startSession(input: {
       const refreshOutcome = await input.refreshIncompleteSession?.();
       if (
         !rotatedAfterDeterminateError &&
+        !concurrentRequestMayStillFinish &&
         isMounted() &&
         isLatestRequest() &&
         refreshProvesNoIncompleteSession(refreshOutcome)
       ) {
-        // The key's possibly committed session has been resolved elsewhere;
-        // no same-key replay can recover a live session now.
+        // The key's possibly committed session has been resolved elsewhere,
+        // and no same-key request remains known to be running.
         input.setIdempotencyKey(input.createIdempotencyKey());
       }
     } catch (error) {

--- a/app/(app)/app/practice/shared/question-flow-actions.ts
+++ b/app/(app)/app/practice/shared/question-flow-actions.ts
@@ -16,11 +16,11 @@ import type {
 import type { SaveExamDraftAnswerOutput } from '@/src/adapters/controllers/practice-controller';
 import {
   IdempotentActionNames,
+  isConcurrentRequestInProgressError,
   rotateIdempotencyKeyAfterDeterminateError,
 } from '@/src/adapters/controllers/shared/idempotency-error-policy';
 import {
   type ApplicationConflictReason,
-  ApplicationConflictReasons,
   isApplicationConflictReason,
   isPracticeSessionConflictReason,
   type PracticeSessionConflictReason,
@@ -248,10 +248,7 @@ export function isPracticeSessionAlreadyEndedActionConflict(
 export function isConcurrentRequestInProgressActionConflict(
   result: ActionResult<unknown>,
 ): boolean {
-  return (
-    getActionResultConflictReason(result) ===
-    ApplicationConflictReasons.ConcurrentRequestInProgress
-  );
+  return !result.ok && isConcurrentRequestInProgressError(result.error);
 }
 
 export async function maybeSaveDraftBeforeNavigation<

--- a/docs/bugs/bug-300-concurrent-start-refresh-retires-pending-key.md
+++ b/docs/bugs/bug-300-concurrent-start-refresh-retires-pending-key.md
@@ -54,6 +54,14 @@ The refresh outcome models authoritative state **at the read snapshot**, but key
 2. Preserve the existing loaded-null retirement for completed outcomes whose possibly committed session has since been resolved elsewhere; do not regress BUG-299's second-tab recovery.
 3. Add a production-shaped unit test that supplies the refresh callback to the concurrent-result case and asserts K1 is preserved, plus a browser sequence covering client timeout → same-key concurrent result → pre-commit null refresh → late original completion → same-key recovery.
 
+## Resolution State
+
+- **Approach:** Added a shared controller-boundary predicate that recognizes only `CONFLICT` plus `ApplicationConflictReasons.ConcurrentRequestInProgress`. The practice start flow still performs its authoritative refresh after every failed result, but a loaded-null refresh can retire the key only when that exact concurrent outcome is absent. Determinate rotation and every other loaded-null retirement path remain unchanged; the server idempotency wrapper is untouched.
+- **Tests:** Upgraded the production-shaped session-start unit case to cover typed concurrent failure plus loaded-null refresh, retained controls for determinate single rotation and non-concurrent loaded-null retirement, added concurrent live-session convergence coverage, asserted the shared predicate against correct and wrong shapes, and added a Vitest Browser sequence covering timeout → same-key concurrent retry → pre-commit null refresh → late commit → same-key recovery into the Resume/Abandon panel.
+- **Branch:** `fix/bug-300-concurrent-start-retirement-guard`
+
+Status remains **Open** pending wave-close archival with production proof.
+
 ## Related
 
 - [BUG-291 (archived)](../_archive/bugs/bug-291-session-start-key-rotation-on-timeout-conflict-dead-end.md) — established that `ConcurrentRequestInProgress` is indeterminate and must preserve the start key.

--- a/src/adapters/controllers/shared/idempotency-error-policy.test.ts
+++ b/src/adapters/controllers/shared/idempotency-error-policy.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@/src/application/errors';
 import {
   IdempotentActionNames,
+  isConcurrentRequestInProgressError,
   rotateGeneratedIdempotencyKeyAfterDeterminateError,
   rotateIdempotencyKeyAfterDeterminateError,
   shouldCacheBookmarkError,
@@ -225,6 +226,39 @@ describe('question-mark idempotency error policy', () => {
 });
 
 describe('client idempotency-key rotation policy', () => {
+  it('identifies only the typed concurrent-request conflict', () => {
+    expect(
+      isConcurrentRequestInProgressError({
+        code: 'CONFLICT',
+        details: {
+          reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      isConcurrentRequestInProgressError({
+        code: 'INTERNAL_ERROR',
+        details: {
+          reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isConcurrentRequestInProgressError({
+        code: 'CONFLICT',
+        details: {
+          reason: ApplicationConflictReasons.IncompleteSessionExists,
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isConcurrentRequestInProgressError({
+        code: 'CONFLICT',
+      }),
+    ).toBe(false);
+  });
+
   it('generates and stores a replacement key only when both collaborators are available', () => {
     let generatedKeys = 0;
     let storedKey: string | null = null;

--- a/src/adapters/controllers/shared/idempotency-error-policy.ts
+++ b/src/adapters/controllers/shared/idempotency-error-policy.ts
@@ -30,6 +30,16 @@ type PublicActionError = {
   details?: { reason?: string } | undefined;
 };
 
+export function isConcurrentRequestInProgressError(
+  error: PublicActionError,
+): boolean {
+  return (
+    error.code === 'CONFLICT' &&
+    error.details?.reason ===
+      ApplicationConflictReasons.ConcurrentRequestInProgress
+  );
+}
+
 const determinateCodesByAction: Record<
   IdempotentActionName,
   ReadonlySet<ApplicationErrorCode>


### PR DESCRIPTION
## Summary

- Promote the squash-merged BUG-300 fix from dev to main.
- Preserve the pending session-start idempotency key for typed concurrent requests while retaining authoritative refresh and BUG-299 retirement behavior.
- Include unit and browser regression coverage plus the bug document resolution state.

## Source

- Feature PR: #657
- Dev commit: d393f11ae8b5ed2f88a29b8aca6957e58c8851c2

## Verification

- typecheck, lint, 3,393 unit tests, 382 browser tests, 200 integration tests, production build
- 36 hermetic authenticated E2E flows
- CodeRabbit formally approved the exact final feature head

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when practice-session requests overlap or experience a timeout.
  - Preserved the original session request key during concurrent-request recovery.
  - Prevented premature refreshes or retries while another session request may still complete.
  - Ensured completed sessions can recover and display the “Resume session” and “Abandon session” options.

- **Tests**
  - Added coverage for delayed concurrent starts, late session completion, and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->