### PR TITLE
Fix BUG-302: fence report dialog continuations

### DIFF
--- a/components/question/question-report-dialog.browser.spec.tsx
+++ b/components/question/question-report-dialog.browser.spec.tsx
@@ -6,12 +6,18 @@ import { QuestionReportDialog } from '@/components/question/question-report-dial
 import { NotificationProvider } from '@/components/ui/notification-provider';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 
+const REPORT_SUCCESS_MESSAGE = 'Thanks — our editors will take a look.';
+const REPORT_FAILURE_MESSAGE =
+  "Couldn't send your feedback. Check your connection.";
+
 function DialogProbe({
   submitReport = async () => true,
   onOpenChangeObserved,
+  openOverride,
 }: {
   submitReport?: Parameters<typeof QuestionReportDialog>[0]['submitReport'];
   onOpenChangeObserved?: (open: boolean) => void;
+  openOverride?: boolean;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -23,22 +29,11 @@ function DialogProbe({
   return (
     <NotificationProvider>
       <QuestionReportDialog
-        open={open}
+        open={openOverride ?? open}
         onOpenChange={handleOpenChange}
         submitReport={submitReport}
       />
     </NotificationProvider>
-  );
-}
-
-async function waitForUiCommit(): Promise<void> {
-  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-}
-
-function visibleNotificationMessages(): string[] {
-  return Array.from(
-    document.querySelectorAll('[data-testid="app-toast"]'),
-    (toast) => toast.textContent?.trim() ?? '',
   );
 }
 
@@ -67,9 +62,7 @@ test('validates category, submits selected feedback, closes, and returns focus',
     category: 'ambiguous_wording',
     comment: 'Needs a clearer stem.',
   });
-  await expect
-    .element(screen.getByText('Thanks — our editors will take a look.'))
-    .toBeVisible();
+  await expect.element(screen.getByText(REPORT_SUCCESS_MESSAGE)).toBeVisible();
   await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
   await expect.element(trigger).toHaveFocus();
 });
@@ -104,7 +97,7 @@ test('stale success cannot close or reset a newer report submission', async () =
   await expect.poll(() => submitReport.mock.calls.length).toBe(2);
 
   firstSubmission.resolve(true);
-  await waitForUiCommit();
+  await firstSubmission.promise;
 
   await expect.element(screen.getByRole('dialog')).toBeVisible();
   await expect
@@ -116,12 +109,12 @@ test('stale success cannot close or reset a newer report submission', async () =
   await expect
     .element(screen.getByRole('button', { name: 'Submit feedback' }))
     .toBeDisabled();
-  expect(visibleNotificationMessages()).toEqual([]);
+  await expect
+    .element(screen.getByText(REPORT_SUCCESS_MESSAGE))
+    .not.toBeInTheDocument();
 
   secondSubmission.resolve(true);
-  await expect
-    .element(screen.getByText('Thanks — our editors will take a look.'))
-    .toBeVisible();
+  await expect.element(screen.getByText(REPORT_SUCCESS_MESSAGE)).toBeVisible();
   await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
 });
 
@@ -151,11 +144,13 @@ test('closing the dialog alone supersedes its in-flight submission', async () =>
   const openChangeCountAfterClose = onOpenChangeObserved.mock.calls.length;
 
   firstSubmission.resolve(true);
-  await waitForUiCommit();
+  await firstSubmission.promise;
 
   expect(onOpenChangeObserved).toHaveBeenCalledTimes(openChangeCountAfterClose);
-  expect(visibleNotificationMessages()).toEqual([]);
   await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
+  await expect
+    .element(screen.getByText(REPORT_SUCCESS_MESSAGE))
+    .not.toBeInTheDocument();
 
   await trigger.click();
   await screen.getByRole('radio', { name: 'Other' }).click();
@@ -163,10 +158,79 @@ test('closing the dialog alone supersedes its in-flight submission', async () =>
   await expect.poll(() => submitReport.mock.calls.length).toBe(2);
 
   secondSubmission.resolve(true);
-  await expect
-    .element(screen.getByText('Thanks — our editors will take a look.'))
-    .toBeVisible();
+  await expect.element(screen.getByText(REPORT_SUCCESS_MESSAGE)).toBeVisible();
   await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
+});
+
+test('a controlled close supersedes the in-flight submission before reopening', async () => {
+  const firstSubmission = createDeferred<boolean>();
+  const secondSubmission = createDeferred<boolean>();
+  const submitReport = vi
+    .fn()
+    .mockReturnValueOnce(firstSubmission.promise)
+    .mockReturnValueOnce(secondSubmission.promise);
+  const onOpenChangeObserved = vi.fn();
+  const screen = await render(
+    <DialogProbe
+      openOverride
+      submitReport={submitReport}
+      onOpenChangeObserved={onOpenChangeObserved}
+    />,
+  );
+
+  await screen.getByRole('radio', { name: 'Ambiguous wording' }).click();
+  await screen
+    .getByRole('textbox', { name: 'Add details (optional)' })
+    .fill('Externally closed report A');
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+  await expect.poll(() => submitReport.mock.calls.length).toBe(1);
+
+  await screen.rerender(
+    <DialogProbe
+      openOverride={false}
+      submitReport={submitReport}
+      onOpenChangeObserved={onOpenChangeObserved}
+    />,
+  );
+  await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
+
+  await screen.rerender(
+    <DialogProbe
+      openOverride
+      submitReport={submitReport}
+      onOpenChangeObserved={onOpenChangeObserved}
+    />,
+  );
+  await expect
+    .element(screen.getByRole('button', { name: 'Submit feedback' }))
+    .toBeEnabled();
+  await expect
+    .element(screen.getByRole('textbox', { name: 'Add details (optional)' }))
+    .toHaveValue('');
+
+  await screen.getByRole('radio', { name: 'Other' }).click();
+  await screen
+    .getByRole('textbox', { name: 'Add details (optional)' })
+    .fill('Current report B');
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+  await expect.poll(() => submitReport.mock.calls.length).toBe(2);
+
+  firstSubmission.resolve(true);
+  await firstSubmission.promise;
+
+  await expect.element(screen.getByRole('dialog')).toBeVisible();
+  await expect
+    .element(screen.getByRole('textbox', { name: 'Add details (optional)' }))
+    .toHaveValue('Current report B');
+  await expect
+    .element(screen.getByRole('button', { name: 'Submit feedback' }))
+    .toBeDisabled();
+  await expect
+    .element(screen.getByText(REPORT_SUCCESS_MESSAGE))
+    .not.toBeInTheDocument();
+
+  secondSubmission.resolve(true);
+  await expect.element(screen.getByText(REPORT_SUCCESS_MESSAGE)).toBeVisible();
 });
 
 test('stale failed result cannot notify or re-enable a newer report submission', async () => {
@@ -195,7 +259,7 @@ test('stale failed result cannot notify or re-enable a newer report submission',
   await expect.poll(() => submitReport.mock.calls.length).toBe(2);
 
   firstSubmission.resolve(false);
-  await waitForUiCommit();
+  await firstSubmission.promise;
 
   await expect.element(screen.getByRole('dialog')).toBeVisible();
   await expect
@@ -204,14 +268,12 @@ test('stale failed result cannot notify or re-enable a newer report submission',
   await expect
     .element(screen.getByRole('button', { name: 'Submit feedback' }))
     .toBeDisabled();
-  expect(visibleNotificationMessages()).toEqual([]);
+  await expect
+    .element(screen.getByText(REPORT_FAILURE_MESSAGE))
+    .not.toBeInTheDocument();
 
   secondSubmission.resolve(false);
-  await expect
-    .element(
-      screen.getByText("Couldn't send your feedback. Check your connection."),
-    )
-    .toBeVisible();
+  await expect.element(screen.getByText(REPORT_FAILURE_MESSAGE)).toBeVisible();
   await expect
     .element(screen.getByRole('button', { name: 'Submit feedback' }))
     .toBeEnabled();
@@ -242,8 +304,12 @@ test('stale thrown failure cannot notify or re-enable a newer report submission'
   await screen.getByRole('button', { name: 'Submit feedback' }).click();
   await expect.poll(() => submitReport.mock.calls.length).toBe(2);
 
-  firstSubmission.reject(new Error('Obsolete network failure'));
-  await waitForUiCommit();
+  const obsoleteFailure = new Error('Obsolete network failure');
+  const rejectedSubmission = expect(firstSubmission.promise).rejects.toThrow(
+    obsoleteFailure.message,
+  );
+  firstSubmission.reject(obsoleteFailure);
+  await rejectedSubmission;
 
   await expect.element(screen.getByRole('dialog')).toBeVisible();
   await expect
@@ -252,12 +318,12 @@ test('stale thrown failure cannot notify or re-enable a newer report submission'
   await expect
     .element(screen.getByRole('button', { name: 'Submit feedback' }))
     .toBeDisabled();
-  expect(visibleNotificationMessages()).toEqual([]);
+  await expect
+    .element(screen.getByText(REPORT_FAILURE_MESSAGE))
+    .not.toBeInTheDocument();
 
   secondSubmission.resolve(true);
-  await expect
-    .element(screen.getByText('Thanks — our editors will take a look.'))
-    .toBeVisible();
+  await expect.element(screen.getByText(REPORT_SUCCESS_MESSAGE)).toBeVisible();
   await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
 });
 
@@ -271,11 +337,7 @@ test('keeps the dialog open on submit failure and closes on Escape with focus re
   await screen.getByRole('button', { name: 'Submit feedback' }).click();
 
   await expect.poll(() => submitReport.mock.calls.length).toBe(1);
-  await expect
-    .element(
-      screen.getByText("Couldn't send your feedback. Check your connection."),
-    )
-    .toBeVisible();
+  await expect.element(screen.getByText(REPORT_FAILURE_MESSAGE)).toBeVisible();
   await expect.element(screen.getByRole('dialog')).toBeVisible();
   await expect
     .element(screen.getByRole('heading', { name: 'Give feedback' }))
@@ -319,10 +381,6 @@ test('keeps the dialog open when submit throws', async () => {
   await screen.getByRole('button', { name: 'Submit feedback' }).click();
 
   await expect.poll(() => submitReport.mock.calls.length).toBe(1);
-  await expect
-    .element(
-      screen.getByText("Couldn't send your feedback. Check your connection."),
-    )
-    .toBeVisible();
+  await expect.element(screen.getByText(REPORT_FAILURE_MESSAGE)).toBeVisible();
   await expect.element(screen.getByRole('dialog')).toBeVisible();
 });

--- a/components/question/question-report-dialog.browser.spec.tsx
+++ b/components/question/question-report-dialog.browser.spec.tsx
@@ -8,16 +8,23 @@ import { createDeferred } from '@/tests/test-helpers/create-deferred';
 
 function DialogProbe({
   submitReport = async () => true,
+  onOpenChangeObserved,
 }: {
   submitReport?: Parameters<typeof QuestionReportDialog>[0]['submitReport'];
+  onOpenChangeObserved?: (open: boolean) => void;
 }) {
   const [open, setOpen] = useState(false);
+
+  function handleOpenChange(nextOpen: boolean) {
+    onOpenChangeObserved?.(nextOpen);
+    setOpen(nextOpen);
+  }
 
   return (
     <NotificationProvider>
       <QuestionReportDialog
         open={open}
-        onOpenChange={setOpen}
+        onOpenChange={handleOpenChange}
         submitReport={submitReport}
       />
     </NotificationProvider>
@@ -63,7 +70,7 @@ test('validates category, submits selected feedback, closes, and returns focus',
   await expect
     .element(screen.getByText('Thanks — our editors will take a look.'))
     .toBeVisible();
-  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+  await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
   await expect.element(trigger).toHaveFocus();
 });
 
@@ -86,7 +93,7 @@ test('stale success cannot close or reset a newer report submission', async () =
   await expect.poll(() => submitReport.mock.calls.length).toBe(1);
 
   await userEvent.keyboard('{Escape}');
-  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+  await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
 
   await trigger.click();
   await screen.getByRole('radio', { name: 'Other' }).click();
@@ -115,7 +122,51 @@ test('stale success cannot close or reset a newer report submission', async () =
   await expect
     .element(screen.getByText('Thanks — our editors will take a look.'))
     .toBeVisible();
-  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+  await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
+});
+
+test('closing the dialog alone supersedes its in-flight submission', async () => {
+  const firstSubmission = createDeferred<boolean>();
+  const secondSubmission = createDeferred<boolean>();
+  const submitReport = vi
+    .fn()
+    .mockReturnValueOnce(firstSubmission.promise)
+    .mockReturnValueOnce(secondSubmission.promise);
+  const onOpenChangeObserved = vi.fn();
+  const screen = await render(
+    <DialogProbe
+      submitReport={submitReport}
+      onOpenChangeObserved={onOpenChangeObserved}
+    />,
+  );
+  const trigger = screen.getByRole('button', { name: 'Give feedback' });
+
+  await trigger.click();
+  await screen.getByRole('radio', { name: 'Ambiguous wording' }).click();
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+  await expect.poll(() => submitReport.mock.calls.length).toBe(1);
+
+  await userEvent.keyboard('{Escape}');
+  await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
+  const openChangeCountAfterClose = onOpenChangeObserved.mock.calls.length;
+
+  firstSubmission.resolve(true);
+  await waitForUiCommit();
+
+  expect(onOpenChangeObserved).toHaveBeenCalledTimes(openChangeCountAfterClose);
+  expect(visibleNotificationMessages()).toEqual([]);
+  await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
+
+  await trigger.click();
+  await screen.getByRole('radio', { name: 'Other' }).click();
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+  await expect.poll(() => submitReport.mock.calls.length).toBe(2);
+
+  secondSubmission.resolve(true);
+  await expect
+    .element(screen.getByText('Thanks — our editors will take a look.'))
+    .toBeVisible();
+  await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
 });
 
 test('stale failed result cannot notify or re-enable a newer report submission', async () => {
@@ -133,7 +184,7 @@ test('stale failed result cannot notify or re-enable a newer report submission',
   await screen.getByRole('button', { name: 'Submit feedback' }).click();
   await expect.poll(() => submitReport.mock.calls.length).toBe(1);
   await userEvent.keyboard('{Escape}');
-  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+  await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
 
   await trigger.click();
   await screen.getByRole('radio', { name: 'Other' }).click();
@@ -181,7 +232,7 @@ test('stale thrown failure cannot notify or re-enable a newer report submission'
   await screen.getByRole('button', { name: 'Submit feedback' }).click();
   await expect.poll(() => submitReport.mock.calls.length).toBe(1);
   await userEvent.keyboard('{Escape}');
-  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+  await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
 
   await trigger.click();
   await screen.getByRole('radio', { name: 'Typo or formatting' }).click();
@@ -207,7 +258,7 @@ test('stale thrown failure cannot notify or re-enable a newer report submission'
   await expect
     .element(screen.getByText('Thanks — our editors will take a look.'))
     .toBeVisible();
-  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+  await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
 });
 
 test('keeps the dialog open on submit failure and closes on Escape with focus return', async () => {
@@ -232,7 +283,7 @@ test('keeps the dialog open on submit failure and closes on Escape with focus re
 
   await userEvent.keyboard('{Escape}');
 
-  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+  await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
   await expect.element(trigger).toHaveFocus();
 });
 
@@ -246,7 +297,7 @@ test('cancels, resets the form, and returns focus to the trigger', async () => {
   await userEvent.keyboard('Temporary note');
   await screen.getByRole('button', { name: 'Cancel' }).click();
 
-  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+  await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
   await expect.element(trigger).toHaveFocus();
 
   await trigger.click();

--- a/components/question/question-report-dialog.browser.spec.tsx
+++ b/components/question/question-report-dialog.browser.spec.tsx
@@ -4,6 +4,7 @@ import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
 import { QuestionReportDialog } from '@/components/question/question-report-dialog';
 import { NotificationProvider } from '@/components/ui/notification-provider';
+import { createDeferred } from '@/tests/test-helpers/create-deferred';
 
 function DialogProbe({
   submitReport = async () => true,
@@ -20,6 +21,17 @@ function DialogProbe({
         submitReport={submitReport}
       />
     </NotificationProvider>
+  );
+}
+
+async function waitForUiCommit(): Promise<void> {
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function visibleNotificationMessages(): string[] {
+  return Array.from(
+    document.querySelectorAll('[data-testid="app-toast"]'),
+    (toast) => toast.textContent?.trim() ?? '',
   );
 }
 
@@ -53,6 +65,149 @@ test('validates category, submits selected feedback, closes, and returns focus',
     .toBeVisible();
   await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
   await expect.element(trigger).toHaveFocus();
+});
+
+test('stale success cannot close or reset a newer report submission', async () => {
+  const firstSubmission = createDeferred<boolean>();
+  const secondSubmission = createDeferred<boolean>();
+  const submitReport = vi
+    .fn()
+    .mockReturnValueOnce(firstSubmission.promise)
+    .mockReturnValueOnce(secondSubmission.promise);
+  const screen = await render(<DialogProbe submitReport={submitReport} />);
+  const trigger = screen.getByRole('button', { name: 'Give feedback' });
+
+  await trigger.click();
+  await screen.getByRole('radio', { name: 'Ambiguous wording' }).click();
+  await screen
+    .getByRole('textbox', { name: 'Add details (optional)' })
+    .fill('Report A');
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+  await expect.poll(() => submitReport.mock.calls.length).toBe(1);
+
+  await userEvent.keyboard('{Escape}');
+  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+
+  await trigger.click();
+  await screen.getByRole('radio', { name: 'Other' }).click();
+  await screen
+    .getByRole('textbox', { name: 'Add details (optional)' })
+    .fill('Report B must survive');
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+  await expect.poll(() => submitReport.mock.calls.length).toBe(2);
+
+  firstSubmission.resolve(true);
+  await waitForUiCommit();
+
+  await expect.element(screen.getByRole('dialog')).toBeVisible();
+  await expect
+    .element(screen.getByRole('radio', { name: 'Other' }))
+    .toBeChecked();
+  await expect
+    .element(screen.getByRole('textbox', { name: 'Add details (optional)' }))
+    .toHaveValue('Report B must survive');
+  await expect
+    .element(screen.getByRole('button', { name: 'Submit feedback' }))
+    .toBeDisabled();
+  expect(visibleNotificationMessages()).toEqual([]);
+
+  secondSubmission.resolve(true);
+  await expect
+    .element(screen.getByText('Thanks — our editors will take a look.'))
+    .toBeVisible();
+  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+});
+
+test('stale failed result cannot notify or re-enable a newer report submission', async () => {
+  const firstSubmission = createDeferred<boolean>();
+  const secondSubmission = createDeferred<boolean>();
+  const submitReport = vi
+    .fn()
+    .mockReturnValueOnce(firstSubmission.promise)
+    .mockReturnValueOnce(secondSubmission.promise);
+  const screen = await render(<DialogProbe submitReport={submitReport} />);
+  const trigger = screen.getByRole('button', { name: 'Give feedback' });
+
+  await trigger.click();
+  await screen.getByRole('radio', { name: 'Incorrect answer' }).click();
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+  await expect.poll(() => submitReport.mock.calls.length).toBe(1);
+  await userEvent.keyboard('{Escape}');
+  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+
+  await trigger.click();
+  await screen.getByRole('radio', { name: 'Other' }).click();
+  await screen
+    .getByRole('textbox', { name: 'Add details (optional)' })
+    .fill('Current report');
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+  await expect.poll(() => submitReport.mock.calls.length).toBe(2);
+
+  firstSubmission.resolve(false);
+  await waitForUiCommit();
+
+  await expect.element(screen.getByRole('dialog')).toBeVisible();
+  await expect
+    .element(screen.getByRole('textbox', { name: 'Add details (optional)' }))
+    .toHaveValue('Current report');
+  await expect
+    .element(screen.getByRole('button', { name: 'Submit feedback' }))
+    .toBeDisabled();
+  expect(visibleNotificationMessages()).toEqual([]);
+
+  secondSubmission.resolve(false);
+  await expect
+    .element(
+      screen.getByText("Couldn't send your feedback. Check your connection."),
+    )
+    .toBeVisible();
+  await expect
+    .element(screen.getByRole('button', { name: 'Submit feedback' }))
+    .toBeEnabled();
+});
+
+test('stale thrown failure cannot notify or re-enable a newer report submission', async () => {
+  const firstSubmission = createDeferred<boolean>();
+  const secondSubmission = createDeferred<boolean>();
+  const submitReport = vi
+    .fn()
+    .mockReturnValueOnce(firstSubmission.promise)
+    .mockReturnValueOnce(secondSubmission.promise);
+  const screen = await render(<DialogProbe submitReport={submitReport} />);
+  const trigger = screen.getByRole('button', { name: 'Give feedback' });
+
+  await trigger.click();
+  await screen.getByRole('radio', { name: 'Outdated reference' }).click();
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+  await expect.poll(() => submitReport.mock.calls.length).toBe(1);
+  await userEvent.keyboard('{Escape}');
+  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
+
+  await trigger.click();
+  await screen.getByRole('radio', { name: 'Typo or formatting' }).click();
+  await screen
+    .getByRole('textbox', { name: 'Add details (optional)' })
+    .fill('Newer typo report');
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+  await expect.poll(() => submitReport.mock.calls.length).toBe(2);
+
+  firstSubmission.reject(new Error('Obsolete network failure'));
+  await waitForUiCommit();
+
+  await expect.element(screen.getByRole('dialog')).toBeVisible();
+  await expect
+    .element(screen.getByRole('textbox', { name: 'Add details (optional)' }))
+    .toHaveValue('Newer typo report');
+  await expect
+    .element(screen.getByRole('button', { name: 'Submit feedback' }))
+    .toBeDisabled();
+  expect(visibleNotificationMessages()).toEqual([]);
+
+  secondSubmission.resolve(true);
+  await expect
+    .element(screen.getByText('Thanks — our editors will take a look.'))
+    .toBeVisible();
+  await expect.poll(() => document.querySelector('[role="dialog"]')).toBeNull();
 });
 
 test('keeps the dialog open on submit failure and closes on Escape with focus return', async () => {

--- a/components/question/question-report-dialog.tsx
+++ b/components/question/question-report-dialog.tsx
@@ -193,8 +193,10 @@ export function QuestionReportDialog({
   const [validationError, setValidationError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const firstCategoryInputRef = useRef<HTMLInputElement>(null);
+  const submissionGenerationRef = useRef(0);
 
-  function resetForm() {
+  function resetDialogLifecycle() {
+    submissionGenerationRef.current += 1;
     setCategory(null);
     setComment('');
     setValidationError(null);
@@ -202,7 +204,7 @@ export function QuestionReportDialog({
   }
 
   function handleOpenChange(nextOpen: boolean) {
-    if (!nextOpen) resetForm();
+    if (!nextOpen) resetDialogLifecycle();
     onOpenChange(nextOpen);
   }
 
@@ -217,6 +219,8 @@ export function QuestionReportDialog({
 
     setValidationError(null);
     setIsSubmitting(true);
+    const submissionGeneration = submissionGenerationRef.current + 1;
+    submissionGenerationRef.current = submissionGeneration;
 
     const trimmedComment = comment.trim();
     try {
@@ -224,6 +228,8 @@ export function QuestionReportDialog({
         category,
         comment: trimmedComment.length > 0 ? trimmedComment : null,
       });
+
+      if (submissionGenerationRef.current !== submissionGeneration) return;
 
       if (!didSubmit) {
         notify({
@@ -238,9 +244,11 @@ export function QuestionReportDialog({
         message: 'Thanks — our editors will take a look.',
         tone: 'success',
       });
-      resetForm();
+      resetDialogLifecycle();
       onOpenChange(false);
     } catch {
+      if (submissionGenerationRef.current !== submissionGeneration) return;
+
       notify({
         message: "Couldn't send your feedback. Check your connection.",
         tone: 'error',

--- a/components/question/question-report-dialog.tsx
+++ b/components/question/question-report-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type * as React from 'react';
-import { useId, useRef, useState } from 'react';
+import { useCallback, useId, useLayoutEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -194,17 +194,28 @@ export function QuestionReportDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const firstCategoryInputRef = useRef<HTMLInputElement>(null);
   const submissionGenerationRef = useRef(0);
+  const previousOpenRef = useRef(open);
 
-  function resetDialogLifecycle() {
+  const resetDialogLifecycle = useCallback(() => {
     submissionGenerationRef.current += 1;
     setCategory(null);
     setComment('');
     setValidationError(null);
     setIsSubmitting(false);
-  }
+  }, []);
+
+  useLayoutEffect(() => {
+    const wasOpen = previousOpenRef.current;
+    previousOpenRef.current = open;
+
+    if (wasOpen && !open) resetDialogLifecycle();
+  }, [open, resetDialogLifecycle]);
 
   function handleOpenChange(nextOpen: boolean) {
-    if (!nextOpen) resetDialogLifecycle();
+    if (!nextOpen) {
+      previousOpenRef.current = false;
+      resetDialogLifecycle();
+    }
     onOpenChange(nextOpen);
   }
 
@@ -244,8 +255,7 @@ export function QuestionReportDialog({
         message: 'Thanks — our editors will take a look.',
         tone: 'success',
       });
-      resetDialogLifecycle();
-      onOpenChange(false);
+      handleOpenChange(false);
     } catch {
       if (submissionGenerationRef.current !== submissionGeneration) return;
 

--- a/docs/bugs/bug-302-stale-report-completion-closes-newer-dialog.md
+++ b/docs/bugs/bug-302-stale-report-completion-closes-newer-dialog.md
@@ -53,6 +53,31 @@ The first owner was fixed without propagating equivalent stale-completion author
 3. Do not cancel or rotate the hook's preserved idempotency key when the dialog closes; BUG-291/301 determinacy remains authoritative.
 4. Add Chromium sequences for stale success and stale failure across close/reopen, plus an ordinary single-submit control.
 
+## Resolution State
+
+Implementation is complete on
+`fix/bug-302-report-dialog-stale-completion` as of 2026-07-17; Status remains
+Open until wave-5 archival records production proof.
+
+- `QuestionReportDialog` now owns a monotonically increasing submission
+  generation. Starting a submission claims the current generation; closing or
+  resetting the dialog advances it. Every post-`await` success, returned
+  failure, and thrown-failure continuation verifies ownership before it may
+  notify, change `isSubmitting`, reset form state, or close the dialog.
+- The feedback hook, token-slot generation CAS, fingerprints, and idempotency
+  key determinacy behavior are unchanged. The rating surface was audited and
+  has no equivalent presentation continuation: it delegates synchronously to
+  the already generation-fenced hook.
+- Red-first Chromium proof reproduced three failures on the pre-fix component:
+  stale success closed the reopened dialog, while stale returned and thrown
+  failures re-enabled the newer submission. The same focused suite is green
+  after the owner-generation fence, including the existing ordinary
+  single-submit close/success-toast control.
+- PR number, exact approved head, squash SHA, full-gate evidence, and promotion
+  proof are delivery facts recorded after their respective steps; the wave-5
+  close will replace this implementation-state note with the complete immutable
+  chain.
+
 ## Related
 
 - [BUG-301 (archived)](../_archive/bugs/bug-301-stale-feedback-completion-clobbers-newer-request-key.md) — correctly fences the token slot but does not own dialog presentation state.

--- a/docs/bugs/bug-302-stale-report-completion-closes-newer-dialog.md
+++ b/docs/bugs/bug-302-stale-report-completion-closes-newer-dialog.md
@@ -60,10 +60,11 @@ Implementation is complete on
 Open until wave-5 archival records production proof.
 
 - `QuestionReportDialog` now owns a monotonically increasing submission
-  generation. Starting a submission claims the current generation; closing or
-  resetting the dialog advances it. Every post-`await` success, returned
-  failure, and thrown-failure continuation verifies ownership before it may
-  notify, change `isSubmitting`, reset form state, or close the dialog.
+  generation. Starting a submission claims the current generation; both
+  dialog-originated closes and externally controlled `open: true -> false`
+  transitions advance it and reset the form. Every post-`await` success,
+  returned failure, and thrown-failure continuation verifies ownership before
+  it may notify, change `isSubmitting`, reset form state, or close the dialog.
 - The feedback hook, token-slot generation CAS, fingerprints, and idempotency
   key determinacy behavior are unchanged. The rating surface was audited and
   has no equivalent presentation continuation: it delegates synchronously to
@@ -79,6 +80,11 @@ Open until wave-5 archival records production proof.
   obsolete third `onOpenChange` call; the restored fence passes the added
   close-only Chromium sequence. Dialog-removal assertions now use Browser Mode
   retryable locators rather than manual DOM polling.
+- A post-cooldown full review then exposed the controlled-prop close seam. Its
+  red Chromium sequence reopened with A's Submit state still disabled. A layout
+  transition fence now invalidates and resets before paint, and the green test
+  proves B survives A's later completion. Stale-toast checks await the settled
+  request and use exact retryable Browser Mode message locators.
 - PR number, exact approved head, squash SHA, full-gate evidence, and promotion
   proof are delivery facts recorded after their respective steps; the wave-5
   close will replace this implementation-state note with the complete immutable

--- a/docs/bugs/bug-302-stale-report-completion-closes-newer-dialog.md
+++ b/docs/bugs/bug-302-stale-report-completion-closes-newer-dialog.md
@@ -73,6 +73,12 @@ Open until wave-5 archival records production proof.
   failures re-enabled the newer submission. The same focused suite is green
   after the owner-generation fence, including the existing ordinary
   single-submit close/success-toast control.
+- Exact-head review identified that the initial race matrix did not isolate
+  close-only invalidation from a newer submission's generation claim. A
+  mutation check with the close-generation increment removed failed on an
+  obsolete third `onOpenChange` call; the restored fence passes the added
+  close-only Chromium sequence. Dialog-removal assertions now use Browser Mode
+  retryable locators rather than manual DOM polling.
 - PR number, exact approved head, squash SHA, full-gate evidence, and promotion
   proof are delivery facts recorded after their respective steps; the wave-5
   close will replace this implementation-state note with the complete immutable


### PR DESCRIPTION
## Problem

A report submission could finish after the user closed and reopened the dialog. Its stale post-`await` continuation still owned presentation state, so it could close/reset the newer dialog, emit an obsolete toast, or clear the newer submission's loading state. A controlled parent-driven `open: true → false` transition was part of the same ownership boundary.

## Solution

- Give `QuestionReportDialog` a monotonic submission-owner generation.
- Supersede the owner when the dialog closes/resets, including committed controlled `open: true → false` transitions, or a newer submission begins.
- Gate every post-`await` branch—success, returned failure, and thrown failure—before notification, loading-state mutation, form reset, or dialog close.
- Observe externally controlled closure in a layout transition so ownership is retired and form state is reset before paint.
- Leave the feedback hook and its BUG-291/295/301 idempotency-key lifecycle unchanged.
- Audit the rating surface: it has no analogous presentation continuation; it synchronously delegates to the hook whose async state writes are already generation-fenced.

## Red → green evidence

Initial pre-fix Chromium failures:

- stale success closed the reopened dialog;
- stale returned failure re-enabled the newer in-flight submission;
- stale thrown failure re-enabled the newer in-flight submission.

Review-driven red proofs:

- removing the close-generation increment caused the isolated close-only test to observe an obsolete third `onOpenChange` call;
- controlled `open: true → false → true` reopened with A's Submit state still disabled before the controlled-transition fence.

Post-fix:

- focused report-dialog browser suite: 9/9;
- repeated focused Chromium suite: 10 consecutive green runs on the final behavior;
- ordinary single-submit success still toasts, closes, and returns focus;
- stale toast checks await request settlement and use exact retryable Browser Mode locators.

## CodeRabbit review dispositions

- First exact-head review requested two stronger test contracts: isolate close-only invalidation and replace manual dialog-removal polling. Both were validated, implemented, mutation-proven, and auto-resolved.
- The post-cooldown review identified a temporally weak toast assertion and the externally controlled close seam. Both were valid. The assertions now use exact retryable locators, and the component owner handles committed controlled closure.
- Final exact head `f40ce2ce6b4a673809928a6dbdd4e7aa911f8e96` has a formal APPROVED review object. After the required cooldown, a fresh full review completed with no new findings and zero unresolved threads.

## Full local gate on final behavior

- typecheck: passed
- lint: passed (pre-existing warnings only)
- unit: 3,393 passed
- browser: 387 passed
- integration: 200 passed, 2 skipped
- build: passed
- hermetic E2E: 36/36 passed

## Register

- [BUG-302](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/blob/dev/docs/bugs/bug-302-stale-report-completion-closes-newer-dialog.md)
- Status remains Open until wave-5 archival after production proof.
