### PR TITLE
Fix BUG-303: preserve still-running start keys

### DIFF
--- a/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { Button } from '@/components/ui/button';
@@ -32,6 +33,7 @@ installReportClientErrorMocks(reportClientError);
 
 function RecoveryHookProbe() {
   const output = usePracticeSessionControls();
+  const originalOnStartSessionRef = useRef(output.onStartSession);
 
   return (
     <>
@@ -49,6 +51,14 @@ function RecoveryHookProbe() {
         }}
       >
         start-session
+      </Button>
+      <Button
+        type="button"
+        onClick={() => {
+          void originalOnStartSessionRef.current();
+        }}
+      >
+        start-original-handler
       </Button>
       <Button
         type="button"
@@ -555,6 +565,87 @@ describe('usePracticeSessionControls recovery convergence (browser)', () => {
     expect(firstStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
     expect(thirdStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
     expect(thirdStartKey).not.toBe(firstStartKey);
+  });
+
+  it('does not let a stale start handler erase uncertainty owned by a newer key', async () => {
+    const sessionId = '11111111-1111-4111-8111-111111111128';
+    const incompleteSession = {
+      sessionId,
+      mode: 'tutor' as const,
+      answeredCount: 0,
+      totalCount: 20,
+      startedAt: '2026-07-17T00:00:00.000Z',
+    };
+    arrangeControlDependencies();
+    getIncompletePracticeSession
+      .mockResolvedValueOnce(ok(null))
+      .mockResolvedValueOnce(ok(incompleteSession))
+      .mockResolvedValue(ok(null));
+    startPracticeSession.mockResolvedValue(
+      err('CONFLICT', 'Request is still running', undefined, {
+        reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
+      }),
+    );
+    endPracticeSession.mockResolvedValue(
+      ok({
+        sessionId,
+        mode: 'tutor',
+        questionCount: 20,
+        endedAt: '2026-07-17T01:00:00.000Z',
+        totals: {
+          answered: 0,
+          correct: 0,
+          accuracy: 0,
+          durationSeconds: 60,
+        },
+      }),
+    );
+
+    const screen = await render(<RecoveryHookProbe />);
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'change-start-intent' }).click();
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await expect
+      .element(screen.getByTestId('incomplete-session-id'))
+      .toHaveTextContent(sessionId);
+    const currentStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      0,
+    );
+
+    await screen
+      .getByRole('button', { name: 'start-original-handler' })
+      .click();
+    await vi.waitFor(() =>
+      expect(startPracticeSession).toHaveBeenCalledTimes(2),
+    );
+    const staleStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      1,
+    );
+    expect(staleStartKey).not.toBe(currentStartKey);
+
+    await screen
+      .getByRole('button', { name: 'abandon-incomplete-session' })
+      .click();
+    await expect
+      .element(screen.getByTestId('incomplete-session-id'))
+      .toHaveTextContent(/^$/);
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await vi.waitFor(() =>
+      expect(startPracticeSession).toHaveBeenCalledTimes(3),
+    );
+    const nextStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      2,
+    );
+
+    expect(currentStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
+    expect(nextStartKey).toBe(currentStartKey);
   });
 
   it('does not retire a newer in-flight start intent when abandon recovery resolves', async () => {

--- a/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
@@ -392,6 +392,82 @@ describe('usePracticeSessionControls recovery convergence (browser)', () => {
     expect(secondStartKey).toBe(firstStartKey);
   });
 
+  it('preserves a timed-out start key when abandoning an unrelated refreshed session', async () => {
+    const sessionId = '11111111-1111-4111-8111-111111111129';
+    const initialRefresh =
+      createDeferred<
+        Awaited<
+          ReturnType<typeof practiceController.getIncompletePracticeSession>
+        >
+      >();
+    const incompleteSession = {
+      sessionId,
+      mode: 'tutor' as const,
+      answeredCount: 0,
+      totalCount: 20,
+      startedAt: '2026-07-17T00:00:00.000Z',
+    };
+    arrangeControlDependencies();
+    getIncompletePracticeSession
+      .mockImplementationOnce(() => initialRefresh.promise)
+      .mockResolvedValue(ok(null));
+    startPracticeSession
+      .mockRejectedValueOnce(new TimeoutError(15_000))
+      .mockResolvedValue(err('INTERNAL_ERROR', 'Recorded start failed'));
+    endPracticeSession.mockResolvedValue(
+      ok({
+        sessionId,
+        mode: 'tutor',
+        questionCount: 20,
+        endedAt: '2026-07-17T01:00:00.000Z',
+        totals: {
+          answered: 0,
+          correct: 0,
+          accuracy: 0,
+          durationSeconds: 60,
+        },
+      }),
+    );
+
+    const screen = await render(<RecoveryHookProbe />);
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('loading');
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await expect
+      .element(screen.getByTestId('session-start-status'))
+      .toHaveTextContent('error');
+    const timedOutStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      0,
+    );
+
+    initialRefresh.resolve(ok(incompleteSession));
+    await expect
+      .element(screen.getByTestId('incomplete-session-id'))
+      .toHaveTextContent(sessionId);
+
+    await screen
+      .getByRole('button', { name: 'abandon-incomplete-session' })
+      .click();
+    await expect
+      .element(screen.getByTestId('incomplete-session-id'))
+      .toHaveTextContent(/^$/);
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await vi.waitFor(() =>
+      expect(startPracticeSession).toHaveBeenCalledTimes(2),
+    );
+    const retriedStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      1,
+    );
+
+    expect(timedOutStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
+    expect(retriedStartKey).toBe(timedOutStartKey);
+  });
+
   it('allows retirement after a same-key result consumes concurrent uncertainty', async () => {
     const sessionId = '11111111-1111-4111-8111-111111111126';
     const incompleteSession = {

--- a/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
@@ -643,7 +643,7 @@ describe('usePracticeSessionControls recovery convergence (browser)', () => {
     expect(thirdStartKey).not.toBe(firstStartKey);
   });
 
-  it('does not let a stale start handler erase uncertainty owned by a newer key', async () => {
+  it('rejects a stale start handler without changing the newer request state', async () => {
     const sessionId = '11111111-1111-4111-8111-111111111128';
     const incompleteSession = {
       sessionId,
@@ -687,6 +687,9 @@ describe('usePracticeSessionControls recovery convergence (browser)', () => {
     await expect
       .element(screen.getByTestId('incomplete-session-id'))
       .toHaveTextContent(sessionId);
+    await expect
+      .element(screen.getByTestId('session-start-status'))
+      .toHaveTextContent('error');
     const currentStartKey = getCallIdempotencyKey(
       startPracticeSession.mock.calls,
       0,
@@ -695,14 +698,10 @@ describe('usePracticeSessionControls recovery convergence (browser)', () => {
     await screen
       .getByRole('button', { name: 'start-original-handler' })
       .click();
-    await vi.waitFor(() =>
-      expect(startPracticeSession).toHaveBeenCalledTimes(2),
-    );
-    const staleStartKey = getCallIdempotencyKey(
-      startPracticeSession.mock.calls,
-      1,
-    );
-    expect(staleStartKey).not.toBe(currentStartKey);
+    expect(startPracticeSession).toHaveBeenCalledTimes(1);
+    await expect
+      .element(screen.getByTestId('session-start-status'))
+      .toHaveTextContent('error');
 
     await screen
       .getByRole('button', { name: 'abandon-incomplete-session' })
@@ -713,11 +712,11 @@ describe('usePracticeSessionControls recovery convergence (browser)', () => {
 
     await screen.getByRole('button', { name: 'start-session' }).click();
     await vi.waitFor(() =>
-      expect(startPracticeSession).toHaveBeenCalledTimes(3),
+      expect(startPracticeSession).toHaveBeenCalledTimes(2),
     );
     const nextStartKey = getCallIdempotencyKey(
       startPracticeSession.mock.calls,
-      2,
+      1,
     );
 
     expect(currentStartKey).toEqual(expect.stringMatching(UUID_PATTERN));

--- a/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
@@ -6,6 +6,7 @@ import { TimeoutError } from '@/lib/with-timeout';
 import { err } from '@/src/adapters/controllers/action-result';
 import * as practiceController from '@/src/adapters/controllers/practice-controller';
 import * as tagController from '@/src/adapters/controllers/tag-controller';
+import { ApplicationConflictReasons } from '@/src/application/errors';
 import { createDeferred } from '@/tests/test-helpers/create-deferred';
 import { ok } from '@/tests/test-helpers/ok';
 import { installReportClientErrorMocks } from '@/tests/test-helpers/report-client-error-mocks';
@@ -311,6 +312,249 @@ describe('usePracticeSessionControls recovery convergence (browser)', () => {
     expect(firstStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
     expect(secondStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
     expect(secondStartKey).not.toBe(firstStartKey);
+  });
+
+  it('preserves a still-running start key when abandoning an unrelated refreshed session', async () => {
+    const sessionId = '11111111-1111-4111-8111-111111111125';
+    const incompleteSession = {
+      sessionId,
+      mode: 'tutor' as const,
+      answeredCount: 0,
+      totalCount: 20,
+      startedAt: '2026-07-17T00:00:00.000Z',
+    };
+    arrangeControlDependencies();
+    getIncompletePracticeSession
+      .mockResolvedValueOnce(ok(null))
+      .mockResolvedValueOnce(ok(incompleteSession))
+      .mockResolvedValue(ok(null));
+    startPracticeSession.mockResolvedValue(
+      err('CONFLICT', 'Request is still running', undefined, {
+        reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
+      }),
+    );
+    endPracticeSession.mockResolvedValue(
+      ok({
+        sessionId,
+        mode: 'tutor',
+        questionCount: 20,
+        endedAt: '2026-07-17T01:00:00.000Z',
+        totals: {
+          answered: 0,
+          correct: 0,
+          accuracy: 0,
+          durationSeconds: 60,
+        },
+      }),
+    );
+
+    const screen = await render(<RecoveryHookProbe />);
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await expect
+      .element(screen.getByTestId('incomplete-session-id'))
+      .toHaveTextContent(sessionId);
+    const firstStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      0,
+    );
+
+    await screen
+      .getByRole('button', { name: 'abandon-incomplete-session' })
+      .click();
+    await expect
+      .element(screen.getByTestId('incomplete-session-id'))
+      .toHaveTextContent(/^$/);
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await vi.waitFor(() =>
+      expect(startPracticeSession).toHaveBeenCalledTimes(2),
+    );
+    const secondStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      1,
+    );
+
+    expect(firstStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
+    expect(secondStartKey).toBe(firstStartKey);
+  });
+
+  it('allows retirement after a same-key result consumes concurrent uncertainty', async () => {
+    const sessionId = '11111111-1111-4111-8111-111111111126';
+    const incompleteSession = {
+      sessionId,
+      mode: 'tutor' as const,
+      answeredCount: 0,
+      totalCount: 20,
+      startedAt: '2026-07-17T00:00:00.000Z',
+    };
+    arrangeControlDependencies();
+    getIncompletePracticeSession
+      .mockResolvedValueOnce(ok(null))
+      .mockResolvedValueOnce(ok(incompleteSession))
+      .mockResolvedValueOnce(ok(incompleteSession))
+      .mockResolvedValue(ok(null));
+    startPracticeSession
+      .mockResolvedValueOnce(
+        err('CONFLICT', 'Request is still running', undefined, {
+          reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
+        }),
+      )
+      .mockResolvedValue(err('INTERNAL_ERROR', 'Recorded start failed'));
+    endPracticeSession.mockResolvedValue(
+      ok({
+        sessionId,
+        mode: 'tutor',
+        questionCount: 20,
+        endedAt: '2026-07-17T01:00:00.000Z',
+        totals: {
+          answered: 0,
+          correct: 0,
+          accuracy: 0,
+          durationSeconds: 60,
+        },
+      }),
+    );
+
+    const screen = await render(<RecoveryHookProbe />);
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await expect
+      .element(screen.getByTestId('incomplete-session-id'))
+      .toHaveTextContent(sessionId);
+    const firstStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      0,
+    );
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await vi.waitFor(() =>
+      expect(getIncompletePracticeSession).toHaveBeenCalledTimes(3),
+    );
+    expect(getCallIdempotencyKey(startPracticeSession.mock.calls, 1)).toBe(
+      firstStartKey,
+    );
+
+    await screen
+      .getByRole('button', { name: 'abandon-incomplete-session' })
+      .click();
+    await expect
+      .element(screen.getByTestId('incomplete-session-id'))
+      .toHaveTextContent(/^$/);
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await vi.waitFor(() =>
+      expect(startPracticeSession).toHaveBeenCalledTimes(3),
+    );
+    const thirdStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      2,
+    );
+
+    expect(firstStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
+    expect(thirdStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
+    expect(thirdStartKey).not.toBe(firstStartKey);
+  });
+
+  it('does not let a stale concurrent observation override a later settled result', async () => {
+    const sessionId = '11111111-1111-4111-8111-111111111127';
+    const settledResult =
+      createDeferred<
+        Awaited<ReturnType<typeof practiceController.startPracticeSession>>
+      >();
+    const staleConcurrentResult =
+      createDeferred<
+        Awaited<ReturnType<typeof practiceController.startPracticeSession>>
+      >();
+    const incompleteSession = {
+      sessionId,
+      mode: 'tutor' as const,
+      answeredCount: 0,
+      totalCount: 20,
+      startedAt: '2026-07-17T00:00:00.000Z',
+    };
+    arrangeControlDependencies();
+    getIncompletePracticeSession
+      .mockResolvedValueOnce(ok(null))
+      .mockResolvedValueOnce(ok(incompleteSession))
+      .mockResolvedValueOnce(ok(incompleteSession))
+      .mockResolvedValue(ok(null));
+    startPracticeSession
+      .mockImplementationOnce(() => settledResult.promise)
+      .mockImplementationOnce(() => staleConcurrentResult.promise)
+      .mockResolvedValue(err('INTERNAL_ERROR', 'Recorded start failed'));
+    endPracticeSession.mockResolvedValue(
+      ok({
+        sessionId,
+        mode: 'tutor',
+        questionCount: 20,
+        endedAt: '2026-07-17T01:00:00.000Z',
+        totals: {
+          answered: 0,
+          correct: 0,
+          accuracy: 0,
+          durationSeconds: 60,
+        },
+      }),
+    );
+
+    const screen = await render(<RecoveryHookProbe />);
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await vi.waitFor(() =>
+      expect(startPracticeSession).toHaveBeenCalledTimes(2),
+    );
+    const firstStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      0,
+    );
+    expect(getCallIdempotencyKey(startPracticeSession.mock.calls, 1)).toBe(
+      firstStartKey,
+    );
+
+    settledResult.resolve(err('INTERNAL_ERROR', 'Recorded start failed'));
+    await expect
+      .element(screen.getByTestId('incomplete-session-id'))
+      .toHaveTextContent(sessionId);
+
+    staleConcurrentResult.resolve(
+      err('CONFLICT', 'Request is still running', undefined, {
+        reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(getIncompletePracticeSession).toHaveBeenCalledTimes(3),
+    );
+
+    await screen
+      .getByRole('button', { name: 'abandon-incomplete-session' })
+      .click();
+    await expect
+      .element(screen.getByTestId('incomplete-session-id'))
+      .toHaveTextContent(/^$/);
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await vi.waitFor(() =>
+      expect(startPracticeSession).toHaveBeenCalledTimes(3),
+    );
+    const thirdStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      2,
+    );
+
+    expect(firstStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
+    expect(thirdStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
+    expect(thirdStartKey).not.toBe(firstStartKey);
   });
 
   it('does not retire a newer in-flight start intent when abandon recovery resolves', async () => {

--- a/app/(app)/app/practice/hooks/use-practice-session-start.ts
+++ b/app/(app)/app/practice/hooks/use-practice-session-start.ts
@@ -48,6 +48,8 @@ type StartExecutionUncertainty = {
   mayStillFinish: boolean;
 };
 
+type StartExecutionUncertaintyObservation = (mayStillFinish: boolean) => void;
+
 export function usePracticeSessionStart(
   input: UsePracticeSessionStartInput,
 ): UsePracticeSessionStartOutput {
@@ -88,13 +90,14 @@ export function usePracticeSessionStart(
   }, []);
 
   const claimStartExecutionUncertainty = useCallback(
-    (idempotencyKey: string) => {
+    (idempotencyKey: string): StartExecutionUncertaintyObservation | null => {
       if (
         startExecutionUncertaintyRef.current.idempotencyKey !== idempotencyKey
       ) {
         // A stale render may still invoke an old handler after a newer intent
-        // owns the slot. It must not replace the newer key's uncertainty.
-        return () => {};
+        // owns the slot. Reject it before it can submit obsolete intent or
+        // mutate the newer request's UI state.
+        return null;
       }
       const claimedSettledVersion =
         startExecutionUncertaintyRef.current.settledVersion;
@@ -208,6 +211,9 @@ export function usePracticeSessionStart(
     const setConcurrentExecutionUncertainty = claimStartExecutionUncertainty(
       startSessionIdempotencyKey,
     );
+    if (!setConcurrentExecutionUncertainty) {
+      return Promise.resolve();
+    }
 
     return startSession({
       sessionMode,

--- a/app/(app)/app/practice/hooks/use-practice-session-start.ts
+++ b/app/(app)/app/practice/hooks/use-practice-session-start.ts
@@ -87,7 +87,7 @@ export function usePracticeSessionStart(
     setStartSessionIdempotencyKeyState(key);
   }, []);
 
-  const claimConcurrentExecutionUncertainty = useCallback(
+  const claimStartExecutionUncertainty = useCallback(
     (idempotencyKey: string) => {
       if (
         startExecutionUncertaintyRef.current.idempotencyKey !== idempotencyKey
@@ -98,6 +98,10 @@ export function usePracticeSessionStart(
       }
       const claimedSettledVersion =
         startExecutionUncertaintyRef.current.settledVersion;
+      startExecutionUncertaintyRef.current = {
+        ...startExecutionUncertaintyRef.current,
+        mayStillFinish: true,
+      };
 
       return (mayStillFinish: boolean) => {
         const current = startExecutionUncertaintyRef.current;
@@ -201,8 +205,9 @@ export function usePracticeSessionStart(
   );
 
   const onStartSession = useCallback(() => {
-    const setConcurrentExecutionUncertainty =
-      claimConcurrentExecutionUncertainty(startSessionIdempotencyKey);
+    const setConcurrentExecutionUncertainty = claimStartExecutionUncertainty(
+      startSessionIdempotencyKey,
+    );
 
     return startSession({
       sessionMode,
@@ -227,7 +232,7 @@ export function usePracticeSessionStart(
       isMounted: input.isMounted,
     });
   }, [
-    claimConcurrentExecutionUncertainty,
+    claimStartExecutionUncertainty,
     filters,
     sessionMode,
     sessionCount,

--- a/app/(app)/app/practice/hooks/use-practice-session-start.ts
+++ b/app/(app)/app/practice/hooks/use-practice-session-start.ts
@@ -42,6 +42,12 @@ export type UsePracticeSessionStartOutput = {
   captureIdempotencyKeyRetirement: () => () => boolean;
 };
 
+type StartExecutionUncertainty = {
+  idempotencyKey: string;
+  settledVersion: number;
+  mayStillFinish: boolean;
+};
+
 export function usePracticeSessionStart(
   input: UsePracticeSessionStartInput,
 ): UsePracticeSessionStartOutput {
@@ -58,6 +64,11 @@ export function usePracticeSessionStart(
   const [startSessionIdempotencyKey, setStartSessionIdempotencyKeyState] =
     useState(() => crypto.randomUUID());
   const startSessionIdempotencyKeyRef = useRef(startSessionIdempotencyKey);
+  const startExecutionUncertaintyRef = useRef<StartExecutionUncertainty>({
+    idempotencyKey: startSessionIdempotencyKey,
+    settledVersion: 0,
+    mayStillFinish: false,
+  });
   const [sessionStartStatus, setSessionStartStatus] = useState<
     'idle' | 'loading' | 'error'
   >('idle');
@@ -66,17 +77,64 @@ export function usePracticeSessionStart(
   );
   const setStartSessionIdempotencyKey = useCallback((key: string) => {
     startSessionIdempotencyKeyRef.current = key;
+    if (startExecutionUncertaintyRef.current.idempotencyKey !== key) {
+      startExecutionUncertaintyRef.current = {
+        idempotencyKey: key,
+        settledVersion: 0,
+        mayStillFinish: false,
+      };
+    }
     setStartSessionIdempotencyKeyState(key);
   }, []);
 
+  const claimConcurrentExecutionUncertainty = useCallback(
+    (idempotencyKey: string) => {
+      if (
+        startExecutionUncertaintyRef.current.idempotencyKey !== idempotencyKey
+      ) {
+        // A stale render may still invoke an old handler after a newer intent
+        // owns the slot. It must not replace the newer key's uncertainty.
+        return () => {};
+      }
+      const claimedSettledVersion =
+        startExecutionUncertaintyRef.current.settledVersion;
+
+      return (mayStillFinish: boolean) => {
+        const current = startExecutionUncertaintyRef.current;
+        if (
+          current.idempotencyKey !== idempotencyKey ||
+          current.settledVersion !== claimedSettledVersion
+        ) {
+          return;
+        }
+
+        startExecutionUncertaintyRef.current = mayStillFinish
+          ? { ...current, mayStillFinish: true }
+          : {
+              ...current,
+              settledVersion: current.settledVersion + 1,
+              mayStillFinish: false,
+            };
+      };
+    },
+    [],
+  );
+
   // Capture the key whose recovery lifecycle is being resolved. The returned
-  // fence refuses to retire a newer intent that arrived while recovery was
-  // awaiting an external result.
+  // fence refuses to retire either a newer intent or a captured key whose
+  // same-key execution may still commit.
   const captureIdempotencyKeyRetirement = useCallback(() => {
     const capturedKey = startSessionIdempotencyKeyRef.current;
 
     return () => {
       if (startSessionIdempotencyKeyRef.current !== capturedKey) return false;
+      const uncertainty = startExecutionUncertaintyRef.current;
+      if (
+        uncertainty.idempotencyKey === capturedKey &&
+        uncertainty.mayStillFinish
+      ) {
+        return false;
+      }
       setStartSessionIdempotencyKey(crypto.randomUUID());
       return true;
     };
@@ -142,39 +200,42 @@ export function usePracticeSessionStart(
     [setStartSessionIdempotencyKey],
   );
 
-  const onStartSession = useMemo(
-    () =>
-      startSession.bind(null, {
-        sessionMode,
-        sessionCount,
-        filters,
-        idempotencyKey: startSessionIdempotencyKey,
-        getLatestIdempotencyKey: () => startSessionIdempotencyKeyRef.current,
-        createIdempotencyKey: () => crypto.randomUUID(),
-        setIdempotencyKey: setStartSessionIdempotencyKey,
-        startPracticeSessionFn: startPracticeSession,
-        reportError: (error, context) => {
-          reportClientError(error, {
-            component: 'UsePracticeSessionStart',
-            action: context.action,
-          });
-        },
-        refreshIncompleteSession: input.refreshIncompleteSession,
-        setSessionStartStatus,
-        setSessionStartError,
-        navigateTo,
-        isMounted: input.isMounted,
-      }),
-    [
-      filters,
+  const onStartSession = useCallback(() => {
+    const setConcurrentExecutionUncertainty =
+      claimConcurrentExecutionUncertainty(startSessionIdempotencyKey);
+
+    return startSession({
       sessionMode,
       sessionCount,
-      startSessionIdempotencyKey,
-      input.isMounted,
-      input.refreshIncompleteSession,
-      setStartSessionIdempotencyKey,
-    ],
-  );
+      filters,
+      idempotencyKey: startSessionIdempotencyKey,
+      getLatestIdempotencyKey: () => startSessionIdempotencyKeyRef.current,
+      createIdempotencyKey: () => crypto.randomUUID(),
+      setIdempotencyKey: setStartSessionIdempotencyKey,
+      setConcurrentExecutionUncertainty,
+      startPracticeSessionFn: startPracticeSession,
+      reportError: (error, context) => {
+        reportClientError(error, {
+          component: 'UsePracticeSessionStart',
+          action: context.action,
+        });
+      },
+      refreshIncompleteSession: input.refreshIncompleteSession,
+      setSessionStartStatus,
+      setSessionStartError,
+      navigateTo,
+      isMounted: input.isMounted,
+    });
+  }, [
+    claimConcurrentExecutionUncertainty,
+    filters,
+    sessionMode,
+    sessionCount,
+    startSessionIdempotencyKey,
+    input.isMounted,
+    input.refreshIncompleteSession,
+    setStartSessionIdempotencyKey,
+  ]);
 
   return {
     filters,

--- a/app/(app)/app/practice/practice-page-logic-session-start.test.ts
+++ b/app/(app)/app/practice/practice-page-logic-session-start.test.ts
@@ -113,6 +113,7 @@ describe('practice-page-logic session start', () => {
       const setSessionStartStatus = vi.fn();
       const setSessionStartError = vi.fn();
       const setIdempotencyKey = vi.fn();
+      const setConcurrentExecutionUncertainty = vi.fn();
 
       await startSession({
         sessionMode: 'tutor',
@@ -125,6 +126,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        setConcurrentExecutionUncertainty,
         startPracticeSessionFn: async () => {
           throw new Error('Boom');
         },
@@ -136,6 +138,7 @@ describe('practice-page-logic session start', () => {
       expect(setSessionStartStatus).toHaveBeenCalledWith('error');
       expect(setSessionStartError).toHaveBeenCalledWith('Boom');
       expect(setIdempotencyKey).not.toHaveBeenCalled();
+      expect(setConcurrentExecutionUncertainty).not.toHaveBeenCalled();
     });
 
     it('reports thrown session start errors while preserving error UI state', async () => {
@@ -214,6 +217,7 @@ describe('practice-page-logic session start', () => {
 
     it('preserves the key when a concurrent same-key request may still finish', async () => {
       const setIdempotencyKey = vi.fn();
+      const setConcurrentExecutionUncertainty = vi.fn();
       const refreshIncompleteSession = vi.fn(async () => ({
         kind: 'loaded' as const,
         session: null,
@@ -226,6 +230,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        setConcurrentExecutionUncertainty,
         startPracticeSessionFn: async () =>
           err('CONFLICT', 'Request is still running', undefined, {
             reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
@@ -238,6 +243,9 @@ describe('practice-page-logic session start', () => {
 
       expect(refreshIncompleteSession).toHaveBeenCalledTimes(1);
       expect(setIdempotencyKey).not.toHaveBeenCalled();
+      expect(setConcurrentExecutionUncertainty).toHaveBeenCalledExactlyOnceWith(
+        true,
+      );
     });
 
     it('preserves the key and refreshes the panel when a concurrent request already committed', async () => {
@@ -301,6 +309,7 @@ describe('practice-page-logic session start', () => {
 
     it('refreshes recovery state after a non-conflict failure so a committed session can surface', async () => {
       const setIdempotencyKey = vi.fn();
+      const setConcurrentExecutionUncertainty = vi.fn();
       const refreshIncompleteSession = vi.fn(async () => ({
         kind: 'loaded' as const,
         session: { sessionId: fixtureSession1Id },
@@ -313,6 +322,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        setConcurrentExecutionUncertainty,
         // The cache-error-and-throw arm replays INTERNAL_ERROR after a
         // committed session; only the refetch can render Resume/Abandon.
         startPracticeSessionFn: async () =>
@@ -325,6 +335,9 @@ describe('practice-page-logic session start', () => {
 
       expect(refreshIncompleteSession).toHaveBeenCalledTimes(1);
       expect(setIdempotencyKey).not.toHaveBeenCalled();
+      expect(setConcurrentExecutionUncertainty).toHaveBeenCalledExactlyOnceWith(
+        false,
+      );
     });
 
     it('retires a preserved start key when refresh proves no incomplete session remains', async () => {

--- a/app/(app)/app/practice/practice-page-session-start.ts
+++ b/app/(app)/app/practice/practice-page-session-start.ts
@@ -88,6 +88,7 @@ export async function startSession(input: {
   getLatestIdempotencyKey?: () => string;
   createIdempotencyKey: () => string;
   setIdempotencyKey: (key: string) => void;
+  setConcurrentExecutionUncertainty?: (mayStillFinish: boolean) => void;
   startPracticeSessionFn: (
     input: unknown,
   ) => Promise<ActionResult<StartPracticeSessionOutput>>;
@@ -134,12 +135,17 @@ export async function startSession(input: {
   if (!isMounted()) return;
   if (!isLatestRequest()) return;
 
+  const concurrentRequestMayStillFinish =
+    !res.ok && isConcurrentRequestInProgressError(res.error);
+  // A returned same-key result is authoritative about the wrapper execution:
+  // only the typed concurrent result leaves another execution able to commit.
+  // Thrown transport outcomes never reach this observation and remain
+  // indeterminate.
+  input.setConcurrentExecutionUncertainty?.(concurrentRequestMayStillFinish);
+
   if (!res.ok) {
     input.setSessionStartStatus('error');
     input.setSessionStartError(getActionResultErrorMessage(res));
-    const concurrentRequestMayStillFinish = isConcurrentRequestInProgressError(
-      res.error,
-    );
     const rotatedAfterDeterminateError =
       rotateIdempotencyKeyAfterDeterminateError(
         IdempotentActionNames.StartPracticeSession,

--- a/docs/bugs/bug-303-concurrent-start-abandon-retires-still-running-key.md
+++ b/docs/bugs/bug-303-concurrent-start-abandon-retires-still-running-key.md
@@ -40,6 +40,38 @@ The lifecycle owner models “this captured key has not changed” but not “th
 3. Make the capture-then-retire callback refuse retirement while its captured key remains uncertain, while preserving BUG-299 retirement for ordinary post-commit error recovery and external resolution.
 4. Add a production-hook Chromium sequence matching the interleaving above and a server/use-case orchestration test proving S can be ended between A's precheck and create.
 
+## Resolution State
+
+Implementation is complete on
+`fix/bug-303-abandon-retires-running-start-key` as of 2026-07-17; Status
+remains Open until wave-5 archival records production proof.
+
+- `usePracticeSessionStart` now owns per-key concurrent-execution uncertainty.
+  Each Start invocation claims the key's current settled version. The typed
+  `concurrent_request_in_progress` result marks that key uncertain; a returned
+  same-key settled result clears it. Compare-and-set versioning prevents a
+  delayed concurrent observation from overwriting a newer settled observation.
+  Thrown transport and timeout outcomes publish no settled observation, so
+  their key remains preserved.
+- `captureIdempotencyKeyRetirement` still rejects a superseded captured key and
+  now also rejects a captured key whose same-key execution may still commit.
+  Authoritative incomplete-session refresh continues to own panel convergence,
+  but the per-user session it returns is never treated as request identity.
+- Red-first Chromium proof reproduced the defect through the production
+  `usePracticeSessionControls` hook: typed concurrent result → refresh renders
+  session S → successful abandon S → next Start carried a fresh UUID instead of
+  the preserved key. The green suite proves same-key reuse, settlement clearing,
+  and stale-observation compare-and-set ordering. Existing controls remain green
+  for ordinary abandon retirement, second-tab proven-absence retirement,
+  BUG-300's immediate-refresh guard, and BUG-291's thrown-outcome preservation.
+- A use-case orchestration test inserts and ends another tab's session during
+  candidate selection—after the initial incomplete-session precheck and before
+  the original `sessions.create`—then proves the original request can create its
+  distinct session. This pins why session S cannot identify request A.
+- PR number, exact approved head, squash SHA, full-gate evidence, and promotion
+  proof are delivery facts recorded after their respective steps; the wave-5
+  close will replace this implementation-state note with the immutable chain.
+
 ## Related
 
 - [BUG-300 (archived)](../_archive/bugs/bug-300-concurrent-start-refresh-retires-pending-key.md) — fixes immediate refresh retirement but does not propagate uncertainty to the later abandon owner.

--- a/docs/bugs/bug-303-concurrent-start-abandon-retires-still-running-key.md
+++ b/docs/bugs/bug-303-concurrent-start-abandon-retires-still-running-key.md
@@ -47,12 +47,13 @@ Implementation is complete on
 remains Open until wave-5 archival records production proof.
 
 - `usePracticeSessionStart` now owns per-key concurrent-execution uncertainty.
-  Each Start invocation claims the key's current settled version. The typed
-  `concurrent_request_in_progress` result marks that key uncertain; a returned
-  same-key settled result clears it. Compare-and-set versioning prevents a
-  delayed concurrent observation from overwriting a newer settled observation.
-  Thrown transport and timeout outcomes publish no settled observation, so
-  their key remains preserved.
+  Each Start invocation claims the key's current settled version and marks the
+  execution uncertain before awaiting the controller. A returned same-key
+  settled result clears that uncertainty; the typed
+  `concurrent_request_in_progress` result preserves it. Compare-and-set
+  versioning prevents a delayed concurrent observation from overwriting a newer
+  settled observation. Thrown transport and timeout outcomes publish no settled
+  observation, so their key remains preserved.
 - `captureIdempotencyKeyRetirement` still rejects a superseded captured key and
   now also rejects a captured key whose same-key execution may still commit.
   Authoritative incomplete-session refresh continues to own panel convergence,
@@ -60,10 +61,11 @@ remains Open until wave-5 archival records production proof.
 - Red-first Chromium proof reproduced the defect through the production
   `usePracticeSessionControls` hook: typed concurrent result → refresh renders
   session S → successful abandon S → next Start carried a fresh UUID instead of
-  the preserved key. The green suite proves same-key reuse, settlement clearing,
-  and stale-observation compare-and-set ordering. Existing controls remain green
-  for ordinary abandon retirement, second-tab proven-absence retirement,
-  BUG-300's immediate-refresh guard, and BUG-291's thrown-outcome preservation.
+  the preserved key. The green suite proves same-key reuse, thrown/timeout
+  preservation across unrelated-session abandon, settlement clearing, and
+  stale-observation compare-and-set ordering. Existing controls remain green for
+  ordinary abandon retirement, second-tab proven-absence retirement, BUG-300's
+  immediate-refresh guard, and BUG-291's thrown-outcome preservation.
 - A use-case orchestration test inserts and ends another tab's session during
   candidate selection—after the initial incomplete-session precheck and before
   the original `sessions.create`—then proves the original request can create its

--- a/docs/bugs/bug-303-concurrent-start-abandon-retires-still-running-key.md
+++ b/docs/bugs/bug-303-concurrent-start-abandon-retires-still-running-key.md
@@ -52,8 +52,10 @@ remains Open until wave-5 archival records production proof.
   settled result clears that uncertainty; the typed
   `concurrent_request_in_progress` result preserves it. Compare-and-set
   versioning prevents a delayed concurrent observation from overwriting a newer
-  settled observation. Thrown transport and timeout outcomes publish no settled
-  observation, so their key remains preserved.
+  settled observation. A handler captured by an obsolete render is rejected
+  before it can submit stale intent or mutate the current request state. Thrown
+  transport and timeout outcomes publish no settled observation, so their key
+  remains preserved.
 - `captureIdempotencyKeyRetirement` still rejects a superseded captured key and
   now also rejects a captured key whose same-key execution may still commit.
   Authoritative incomplete-session refresh continues to own panel convergence,
@@ -62,9 +64,10 @@ remains Open until wave-5 archival records production proof.
   `usePracticeSessionControls` hook: typed concurrent result → refresh renders
   session S → successful abandon S → next Start carried a fresh UUID instead of
   the preserved key. The green suite proves same-key reuse, thrown/timeout
-  preservation across unrelated-session abandon, settlement clearing, and
-  stale-observation compare-and-set ordering. Existing controls remain green for
-  ordinary abandon retirement, second-tab proven-absence retirement, BUG-300's
+  preservation across unrelated-session abandon, settlement clearing,
+  stale-observation compare-and-set ordering, and zero controller/UI effects
+  from a stale render's handler. Existing controls remain green for ordinary
+  abandon retirement, second-tab proven-absence retirement, BUG-300's
   immediate-refresh guard, and BUG-291's thrown-outcome preservation.
 - A use-case orchestration test inserts and ends another tab's session during
   candidate selection—after the initial incomplete-session precheck and before

--- a/src/application/use-cases/start-practice-session.test.ts
+++ b/src/application/use-cases/start-practice-session.test.ts
@@ -286,4 +286,66 @@ describe('StartPracticeSessionUseCase', () => {
       },
     });
   });
+
+  it('can create after another session starts and ends between the incomplete check and create', async () => {
+    const userId = 'user-1';
+    const questions = [
+      createQuestion({
+        id: 'q1',
+        difficulty: 'easy',
+        tags: [],
+      }),
+    ];
+    const sessions = new FakePracticeSessionRepository();
+
+    class InterleavingQuestionRepository extends FakeQuestionRepository {
+      interleavedSessionId: string | null = null;
+
+      override async listPublishedCandidateIds(
+        filters: Parameters<
+          FakeQuestionRepository['listPublishedCandidateIds']
+        >[0],
+      ): Promise<readonly string[]> {
+        const interleaved = await sessions.create({
+          userId,
+          mode: 'tutor',
+          paramsJson: {
+            questionIds: ['q1'],
+            tagSlugs: [],
+            difficulties: [],
+          },
+        });
+        this.interleavedSessionId = interleaved.id;
+        await sessions.end(interleaved.id, userId);
+        return super.listPublishedCandidateIds(filters);
+      }
+    }
+
+    const questionRepository = new InterleavingQuestionRepository(questions);
+    const useCase = new StartPracticeSessionUseCase(
+      questionRepository,
+      sessions,
+    );
+
+    const result = await useCase.execute({
+      userId,
+      mode: 'tutor',
+      count: 1,
+      tagSlugs: [],
+      difficulties: [],
+    });
+
+    expect(questionRepository.interleavedSessionId).not.toBeNull();
+    expect(result.sessionId).not.toBe(questionRepository.interleavedSessionId);
+    await expect(
+      sessions.findByIdAndUserId(
+        questionRepository.interleavedSessionId ?? '',
+        userId,
+      ),
+    ).resolves.toMatchObject({ endedAt: expect.any(Date) });
+    await expect(
+      sessions.findByIdAndUserId(result.sessionId, userId),
+    ).resolves.toMatchObject({ endedAt: null });
+    expect(sessions.createInputs).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
## Problem

BUG-300 preserves a Start key inside the immediate `ConcurrentRequestInProgress` refresh, but that uncertainty was local to one helper call. BUG-299's later recovery-panel abandon captured only the unchanged key. A refreshed per-user session can belong to another tab, so successfully abandoning it could rotate the only replay handle for a different same-key request that was still able to create a session.

The final review exposed the sibling transport arm: every accepted Start is indeterminate until a same-key result is consumed. Marking uncertainty only after a typed concurrent result left a thrown/timeout request vulnerable to the same later-abandon rotation.

## Solution

- Persist per-key execution uncertainty at `usePracticeSessionStart`, the lifecycle owner.
- Claim the current key's settled version and mark it uncertain before awaiting the controller.
- Treat only a returned, version-matched same-key result as a settlement observation: typed `concurrent_request_in_progress` preserves uncertainty; every other returned result clears it. Thrown/timeout outcomes publish no settlement and therefore remain fenced.
- Fence observations by key and settled version. A stale render handler is rejected before it can call the controller or mutate the newer request's UI state, and a delayed concurrent observation cannot overwrite a later settled observation.
- Extend `captureIdempotencyKeyRetirement` to refuse retirement while its captured key remains able to commit. The existing key-unchanged fence remains intact.
- Keep authoritative refresh responsible only for panel state. No per-user incomplete session is treated as request identity.
- Leave server/session semantics, the idempotency wrapper, and BUG-291/299/300 policies unchanged.

## TDD and proof

Initial red production-hook sequence:

1. Start returned typed `concurrent_request_in_progress` under K.
2. Refresh rendered another tab's session S.
3. Abandon S succeeded.
4. The next Start carried a fresh UUID instead of K.

Final-review red production-hook sequence:

1. Start under K timed out while an unrelated initial refresh remained pending.
2. That authoritative refresh rendered another tab's session S.
3. Abandon S succeeded.
4. The next Start carried a fresh UUID instead of K.

Green coverage now proves:

- both sequences reuse K;
- a returned same-key result clears uncertainty so ordinary retirement remains possible;
- a delayed concurrent observation cannot re-poison a key after a newer settled result;
- a stale handler for an older intent makes no controller call, leaves the newer UI state unchanged, and cannot erase uncertainty owned by the newer key;
- a thrown/timeout outcome cannot be falsely settled by later unrelated-session recovery;
- existing ordinary-abandon and second-tab proven-absence retirement controls remain green;
- BUG-300's immediate loaded-null guard remains green.

The stale-handler test was added after Codecov identified the guard as the sole uncovered new line. It is behavior-scoped rather than percentage-driven: mutating the guard back to the unsafe stale-key reset made the production-hook Chromium sequence fail; restoring the guard made it green.

A `StartPracticeSessionUseCase` orchestration test creates and ends session S during candidate selection—after the initial incomplete-session precheck and before the original `sessions.create`—then proves the original request creates distinct session T. This pins why refresh result S cannot establish request identity.

## Review record

- Initial head `f774d15a` received CodeRabbit formal APPROVED with zero review threads after the first full cooldown.
- Codecov's uncovered concurrency-guard line was independently adjudicated and addressed with a non-vacuous stale-handler behavior test on `2493dd11`.
- A fresh full review on `2493dd11`, requested only after the stated 45-minute cooldown, correctly found that claim-time uncertainty was missing for thrown/timeout outcomes. The finding was reproduced red, fixed at the lifecycle owner, documented, and covered on `bbd04d38`.
- The next exact-head full review correctly found that an obsolete render handler still entered `startSession`, submitting stale intent and potentially stranding the current UI in `loading`. The existing browser test failed red with controller call #2; `5bb9fcc9` rejects the stale owner claim before any controller or UI effect and pins current-key reuse after recovery.
- The push-triggered incremental review on `5bb9fcc9` reached the shared rate limit. The head is frozen for the full stated 45-minute cooldown.
- Merge remains blocked until a fresh CodeRabbit review gives formal APPROVED on this exact head.

## Verification

Full gate passed before each push. Latest evidence on `5bb9fcc9`:

- typecheck
- lint (pre-existing advisory warnings only)
- unit: 3,394 passed
- browser: 392 passed
- integration against the per-clone local Postgres target: 200 passed, 2 skipped
- production build
- hermetic E2E: clean rerun, 36/36 passed

## Register

- Updates the [BUG-303 SSOT](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/blob/fix/bug-303-abandon-retires-running-start-key/docs/bugs/bug-303-concurrent-start-abandon-retires-still-running-key.md) with Resolution State while leaving Status Open.
- `docs/bugs/index.md` is intentionally untouched; archival waits for production proof at the wave-5 close.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved practice-session recovery when concurrent start requests are in progress.
  * Prevented session recovery from incorrectly reusing/retiring the wrong in-progress start attempt.
  * Ensured delayed or stale observations can’t overwrite newer recovery outcomes, and added idempotency-aware uncertainty handling.
  * Improved reliability when sessions change between validation and creation.
* **Tests**
  * Added coverage for concurrent-start edge cases, stale recovery results, idempotency-key rotation, and cross-session recovery/interleaving.
* **Documentation**
  * Expanded BUG-303 resolution state and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->