### PR TITLE
Fix wave 5 promotion review races

### DIFF
--- a/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
@@ -548,6 +548,97 @@ describe('usePracticeSessionControls recovery convergence (browser)', () => {
     expect(thirdStartKey).not.toBe(firstStartKey);
   });
 
+  it('preserves the key while a later same-key invocation remains unsettled', async () => {
+    const sessionId = '11111111-1111-4111-8111-111111111129';
+    const firstSettledResult =
+      createDeferred<
+        Awaited<ReturnType<typeof practiceController.startPracticeSession>>
+      >();
+    const laterUnsettledResult =
+      createDeferred<
+        Awaited<ReturnType<typeof practiceController.startPracticeSession>>
+      >();
+    const incompleteSession = {
+      sessionId,
+      mode: 'tutor' as const,
+      answeredCount: 0,
+      totalCount: 20,
+      startedAt: '2026-07-17T00:00:00.000Z',
+    };
+    arrangeControlDependencies();
+    getIncompletePracticeSession
+      .mockResolvedValueOnce(ok(null))
+      .mockResolvedValueOnce(ok(incompleteSession))
+      .mockResolvedValue(ok(null));
+    startPracticeSession
+      .mockImplementationOnce(() => firstSettledResult.promise)
+      .mockImplementationOnce(() => laterUnsettledResult.promise)
+      .mockResolvedValue(err('INTERNAL_ERROR', 'Recorded start failed'));
+    endPracticeSession.mockResolvedValue(
+      ok({
+        sessionId,
+        mode: 'tutor',
+        questionCount: 20,
+        endedAt: '2026-07-17T01:00:00.000Z',
+        totals: {
+          answered: 0,
+          correct: 0,
+          accuracy: 0,
+          durationSeconds: 60,
+        },
+      }),
+    );
+
+    const screen = await render(<RecoveryHookProbe />);
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await vi.waitFor(() =>
+      expect(startPracticeSession).toHaveBeenCalledTimes(2),
+    );
+    const firstStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      0,
+    );
+    expect(getCallIdempotencyKey(startPracticeSession.mock.calls, 1)).toBe(
+      firstStartKey,
+    );
+
+    firstSettledResult.resolve(err('INTERNAL_ERROR', 'Recorded start failed'));
+    await expect
+      .element(screen.getByTestId('incomplete-session-id'))
+      .toHaveTextContent(sessionId);
+
+    await screen
+      .getByRole('button', { name: 'abandon-incomplete-session' })
+      .click();
+    await expect
+      .element(screen.getByTestId('incomplete-session-id'))
+      .toHaveTextContent(/^$/);
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await vi.waitFor(() =>
+      expect(startPracticeSession).toHaveBeenCalledTimes(3),
+    );
+    const thirdStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      2,
+    );
+
+    expect(firstStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
+    expect(thirdStartKey).toBe(firstStartKey);
+
+    laterUnsettledResult.resolve(
+      err('CONFLICT', 'Request is still running', undefined, {
+        reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
+      }),
+    );
+    await laterUnsettledResult.promise;
+  });
+
   it('does not let a stale concurrent observation override a later settled result', async () => {
     const sessionId = '11111111-1111-4111-8111-111111111127';
     const settledResult =

--- a/app/(app)/app/practice/hooks/use-practice-session-start.ts
+++ b/app/(app)/app/practice/hooks/use-practice-session-start.ts
@@ -44,8 +44,10 @@ export type UsePracticeSessionStartOutput = {
 
 type StartExecutionUncertainty = {
   idempotencyKey: string;
+  nextClaimId: number;
+  unsettledClaimIds: ReadonlySet<number>;
   settledVersion: number;
-  mayStillFinish: boolean;
+  concurrentExecutionMayStillFinish: boolean;
 };
 
 type StartExecutionUncertaintyObservation = (mayStillFinish: boolean) => void;
@@ -68,8 +70,10 @@ export function usePracticeSessionStart(
   const startSessionIdempotencyKeyRef = useRef(startSessionIdempotencyKey);
   const startExecutionUncertaintyRef = useRef<StartExecutionUncertainty>({
     idempotencyKey: startSessionIdempotencyKey,
+    nextClaimId: 1,
+    unsettledClaimIds: new Set(),
     settledVersion: 0,
-    mayStillFinish: false,
+    concurrentExecutionMayStillFinish: false,
   });
   const [sessionStartStatus, setSessionStartStatus] = useState<
     'idle' | 'loading' | 'error'
@@ -82,8 +86,10 @@ export function usePracticeSessionStart(
     if (startExecutionUncertaintyRef.current.idempotencyKey !== key) {
       startExecutionUncertaintyRef.current = {
         idempotencyKey: key,
+        nextClaimId: 1,
+        unsettledClaimIds: new Set(),
         settledVersion: 0,
-        mayStillFinish: false,
+        concurrentExecutionMayStillFinish: false,
       };
     }
     setStartSessionIdempotencyKeyState(key);
@@ -99,29 +105,56 @@ export function usePracticeSessionStart(
         // mutate the newer request's UI state.
         return null;
       }
+      const claimId = startExecutionUncertaintyRef.current.nextClaimId;
       const claimedSettledVersion =
         startExecutionUncertaintyRef.current.settledVersion;
+      const unsettledClaimIds = new Set(
+        startExecutionUncertaintyRef.current.unsettledClaimIds,
+      );
+      unsettledClaimIds.add(claimId);
       startExecutionUncertaintyRef.current = {
         ...startExecutionUncertaintyRef.current,
-        mayStillFinish: true,
+        nextClaimId: claimId + 1,
+        unsettledClaimIds,
       };
 
       return (mayStillFinish: boolean) => {
         const current = startExecutionUncertaintyRef.current;
         if (
           current.idempotencyKey !== idempotencyKey ||
-          current.settledVersion !== claimedSettledVersion
+          !current.unsettledClaimIds.has(claimId)
         ) {
           return;
         }
 
-        startExecutionUncertaintyRef.current = mayStillFinish
-          ? { ...current, mayStillFinish: true }
-          : {
-              ...current,
-              settledVersion: current.settledVersion + 1,
-              mayStillFinish: false,
-            };
+        const remainingClaimIds = new Set(current.unsettledClaimIds);
+        remainingClaimIds.delete(claimId);
+
+        if (mayStillFinish) {
+          startExecutionUncertaintyRef.current = {
+            ...current,
+            unsettledClaimIds: remainingClaimIds,
+            concurrentExecutionMayStillFinish:
+              current.concurrentExecutionMayStillFinish ||
+              current.settledVersion === claimedSettledVersion,
+          };
+          return;
+        }
+
+        // A settled same-key result consumes indeterminate claims launched no
+        // later than itself. Claims launched after it may still acquire a
+        // released transient wrapper claim and must keep fencing retirement.
+        for (const remainingClaimId of remainingClaimIds) {
+          if (remainingClaimId <= claimId) {
+            remainingClaimIds.delete(remainingClaimId);
+          }
+        }
+        startExecutionUncertaintyRef.current = {
+          ...current,
+          unsettledClaimIds: remainingClaimIds,
+          settledVersion: current.settledVersion + 1,
+          concurrentExecutionMayStillFinish: false,
+        };
       };
     },
     [],
@@ -138,7 +171,8 @@ export function usePracticeSessionStart(
       const uncertainty = startExecutionUncertaintyRef.current;
       if (
         uncertainty.idempotencyKey === capturedKey &&
-        uncertainty.mayStillFinish
+        (uncertainty.unsettledClaimIds.size > 0 ||
+          uncertainty.concurrentExecutionMayStillFinish)
       ) {
         return false;
       }

--- a/app/(app)/app/practice/practice-page-session-start.ts
+++ b/app/(app)/app/practice/practice-page-session-start.ts
@@ -137,10 +137,10 @@ export async function startSession(input: {
 
   const concurrentRequestMayStillFinish =
     !res.ok && isConcurrentRequestInProgressError(res.error);
-  // A returned same-key result is authoritative about the wrapper execution:
-  // only the typed concurrent result leaves another execution able to commit.
-  // Thrown transport outcomes never reach this observation and remain
-  // indeterminate.
+  // Each invocation publishes through its owner-issued claim observer. A
+  // returned non-concurrent result settles that claim; the typed concurrent
+  // result retains uncertainty about another execution. Thrown transport
+  // outcomes never reach this observation and remain indeterminate.
   input.setConcurrentExecutionUncertainty?.(concurrentRequestMayStillFinish);
 
   if (!res.ok) {

--- a/components/question/question-report-dialog.browser.spec.tsx
+++ b/components/question/question-report-dialog.browser.spec.tsx
@@ -67,6 +67,41 @@ test('validates category, submits selected feedback, closes, and returns focus',
   await expect.element(trigger).toHaveFocus();
 });
 
+test('unmounting supersedes an in-flight report submission', async () => {
+  const submission = createDeferred<boolean>();
+  const submitReport = vi.fn().mockReturnValue(submission.promise);
+  const onOpenChange = vi.fn();
+  const screen = await render(
+    <NotificationProvider>
+      <QuestionReportDialog
+        open
+        onOpenChange={onOpenChange}
+        submitReport={submitReport}
+      />
+    </NotificationProvider>,
+  );
+
+  await screen.getByRole('radio', { name: 'Ambiguous wording' }).click();
+  await screen.getByRole('button', { name: 'Submit feedback' }).click();
+  await expect.poll(() => submitReport.mock.calls.length).toBe(1);
+
+  await screen.rerender(
+    <NotificationProvider>
+      <div>Report dialog removed</div>
+    </NotificationProvider>,
+  );
+  await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
+  const openChangeCountAfterUnmount = onOpenChange.mock.calls.length;
+
+  submission.resolve(true);
+  await submission.promise;
+
+  expect(onOpenChange).toHaveBeenCalledTimes(openChangeCountAfterUnmount);
+  await expect
+    .element(screen.getByText(REPORT_SUCCESS_MESSAGE))
+    .not.toBeInTheDocument();
+});
+
 test('stale success cannot close or reset a newer report submission', async () => {
   const firstSubmission = createDeferred<boolean>();
   const secondSubmission = createDeferred<boolean>();

--- a/components/question/question-report-dialog.tsx
+++ b/components/question/question-report-dialog.tsx
@@ -211,6 +211,12 @@ export function QuestionReportDialog({
     if (wasOpen && !open) resetDialogLifecycle();
   }, [open, resetDialogLifecycle]);
 
+  useLayoutEffect(() => {
+    return () => {
+      submissionGenerationRef.current += 1;
+    };
+  }, []);
+
   function handleOpenChange(nextOpen: boolean) {
     if (!nextOpen) {
       previousOpenRef.current = false;

--- a/docs/bugs/bug-302-stale-report-completion-closes-newer-dialog.md
+++ b/docs/bugs/bug-302-stale-report-completion-closes-newer-dialog.md
@@ -85,6 +85,12 @@ Open until wave-5 archival records production proof.
   transition fence now invalidates and resets before paint, and the green test
   proves B survives A's later completion. Stale-toast checks await the settled
   request and use exact retryable Browser Mode message locators.
+- The combined promotion review exposed the remaining component-removal seam:
+  unmounting did not advance the owner generation, so the removed dialog's
+  continuation could still notify through the surviving provider and call the
+  parent `onOpenChange`. A red Chromium test observed that stale callback; an
+  unmount-only layout-effect cleanup now invalidates ownership without changing
+  the feedback hook or idempotency-key lifecycle.
 - PR number, exact approved head, squash SHA, full-gate evidence, and promotion
   proof are delivery facts recorded after their respective steps; the wave-5
   close will replace this implementation-state note with the complete immutable

--- a/docs/bugs/bug-303-concurrent-start-abandon-retires-still-running-key.md
+++ b/docs/bugs/bug-303-concurrent-start-abandon-retires-still-running-key.md
@@ -47,15 +47,16 @@ Implementation is complete on
 remains Open until wave-5 archival records production proof.
 
 - `usePracticeSessionStart` now owns per-key concurrent-execution uncertainty.
-  Each Start invocation claims the key's current settled version and marks the
-  execution uncertain before awaiting the controller. A returned same-key
-  settled result clears that uncertainty; the typed
-  `concurrent_request_in_progress` result preserves it. Compare-and-set
-  versioning prevents a delayed concurrent observation from overwriting a newer
-  settled observation. A handler captured by an obsolete render is rejected
-  before it can submit stale intent or mutate the current request state. Thrown
-  transport and timeout outcomes publish no settled observation, so their key
-  remains preserved.
+  Each accepted Start invocation receives an ordered claim identity and enters
+  the key's unsettled-claim set before awaiting the controller. A returned
+  non-concurrent result consumes its own and older same-key claims, but never a
+  later outstanding claim that could still acquire the released transient
+  wrapper claim. A typed `concurrent_request_in_progress` result releases its
+  local claim while preserving generation-fenced uncertainty about the other
+  execution. A handler captured by an obsolete render is rejected before it can
+  submit stale intent or mutate the current request state. Thrown transport and
+  timeout outcomes publish no settled observation, so their claim remains
+  preserved.
 - `captureIdempotencyKeyRetirement` still rejects a superseded captured key and
   now also rejects a captured key whose same-key execution may still commit.
   Authoritative incomplete-session refresh continues to own panel convergence,
@@ -64,11 +65,12 @@ remains Open until wave-5 archival records production proof.
   `usePracticeSessionControls` hook: typed concurrent result → refresh renders
   session S → successful abandon S → next Start carried a fresh UUID instead of
   the preserved key. The green suite proves same-key reuse, thrown/timeout
-  preservation across unrelated-session abandon, settlement clearing,
-  stale-observation compare-and-set ordering, and zero controller/UI effects
-  from a stale render's handler. Existing controls remain green for ordinary
-  abandon retirement, second-tab proven-absence retirement, BUG-300's
-  immediate-refresh guard, and BUG-291's thrown-outcome preservation.
+  preservation across unrelated-session abandon, claim-scoped settlement,
+  preservation while a later same-key invocation remains unresolved,
+  stale-observation generation ordering, and zero controller/UI effects from a
+  stale render's handler. Existing controls remain green for ordinary abandon
+  retirement, second-tab proven-absence retirement, BUG-300's immediate-refresh
+  guard, and BUG-291's thrown-outcome preservation.
 - A use-case orchestration test inserts and ends another tab's session during
   candidate selection—after the initial incomplete-session precheck and before
   the original `sessions.create`—then proves the original request can create its


### PR DESCRIPTION
## Problem

The full combined-diff review on promo #665 found two real lifecycle gaps that the individually approved fix PRs did not cover:

1. BUG-303 still represented uncertainty as one key-wide settled version. With two same-key invocations A then B, A could return a settled result and clear the key while later B remained unresolved and could still acquire a released transient wrapper claim. Recovery abandonment could then retire K prematurely.
2. BUG-302 invalidated dialog ownership on close/reopen but not component removal. An in-flight continuation from an unmounted dialog could still notify through the surviving provider and call the parent `onOpenChange`.

## Solution

- Give every accepted Start an ordered owner claim. Retirement is fenced while any local claim remains unsettled or generation-current server concurrency remains possible. A returned non-concurrent result consumes only its own and older claims; later claims remain fenced. Typed concurrent observations remain generation-checked, so delayed stale conflicts cannot re-poison a settled key.
- Keep the helper callback claim-scoped through the owner-issued closure; server/session/idempotency-wrapper semantics are unchanged.
- Advance the report-dialog submission generation in an unmount-only layout-effect cleanup. Existing true→false reset behavior remains unchanged; feedback token and idempotency-key ownership remain untouched.
- Update the BUG-302/303 Resolution State notes while leaving both Status values Open.

## Red-first proof

- Start race: A and B launch under K; A settles and renders recovery session S; S is abandoned while B remains deferred; a third Start carried a fresh UUID before the fix. It now reuses K. Existing delayed-concurrent, sequential settlement, timeout, ordinary-abandon, external-resolution, and stale-handler controls remain green.
- Dialog removal: submit A, unmount the dialog while its result is deferred, then resolve success. Before the fix the stale continuation called `onOpenChange(false)` and emitted a success notification. It now produces neither external effect. All close/reopen and controlled-close controls remain green.

## Verification

Full local gate on final head:

- typecheck
- lint (existing advisory warnings only)
- unit: 3,394 passed
- browser: 394 passed
- integration on per-clone local Postgres: 200 passed, 2 skipped
- production build
- hermetic E2E: 36/36 passed

## Delivery

This is the narrowly scoped follow-up required by promo #665 review threads. Promo #665 remains blocked. This PR must receive formal CodeRabbit APPROVED on its exact final head, be squash-merged to dev, and then the updated promo head must pass the full gate and a fresh formal review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved practice session recovery when multiple starts share an idempotency key, preventing active requests from being retired prematurely.
  * Prevented stale report submissions from updating or closing a dialog after it has been removed.
* **Tests**
  * Added coverage for concurrent practice-session recovery and unmounted report-dialog submissions.
* **Documentation**
  * Updated bug records to reflect the implemented fixes and verification coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->