### PR TITLE
Stabilize BUG-303 recovery test completion

### DIFF
--- a/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
@@ -558,6 +558,10 @@ describe('usePracticeSessionControls recovery convergence (browser)', () => {
       createDeferred<
         Awaited<ReturnType<typeof practiceController.startPracticeSession>>
       >();
+    const thirdSettledResult =
+      createDeferred<
+        Awaited<ReturnType<typeof practiceController.startPracticeSession>>
+      >();
     const incompleteSession = {
       sessionId,
       mode: 'tutor' as const,
@@ -573,7 +577,7 @@ describe('usePracticeSessionControls recovery convergence (browser)', () => {
     startPracticeSession
       .mockImplementationOnce(() => firstSettledResult.promise)
       .mockImplementationOnce(() => laterUnsettledResult.promise)
-      .mockResolvedValue(err('INTERNAL_ERROR', 'Recorded start failed'));
+      .mockImplementationOnce(() => thirdSettledResult.promise);
     endPracticeSession.mockResolvedValue(
       ok({
         sessionId,
@@ -631,12 +635,29 @@ describe('usePracticeSessionControls recovery convergence (browser)', () => {
     expect(firstStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
     expect(thirdStartKey).toBe(firstStartKey);
 
+    const refreshCountBeforeLaterSettlement =
+      getIncompletePracticeSession.mock.calls.length;
     laterUnsettledResult.resolve(
       err('CONFLICT', 'Request is still running', undefined, {
         reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
       }),
     );
     await laterUnsettledResult.promise;
+    await vi.waitFor(() =>
+      expect(getIncompletePracticeSession).toHaveBeenCalledTimes(
+        refreshCountBeforeLaterSettlement + 1,
+      ),
+    );
+
+    const refreshCountBeforeThirdSettlement =
+      getIncompletePracticeSession.mock.calls.length;
+    thirdSettledResult.resolve(err('INTERNAL_ERROR', 'Recorded start failed'));
+    await thirdSettledResult.promise;
+    await vi.waitFor(() =>
+      expect(getIncompletePracticeSession).toHaveBeenCalledTimes(
+        refreshCountBeforeThirdSettlement + 1,
+      ),
+    );
   });
 
   it('does not let a stale concurrent observation override a later settled result', async () => {


### PR DESCRIPTION
## Problem

The exact-head promotion review on #665 correctly found that the BUG-303 browser regression awaited only the deferred controller result. It did not prove that the hook's post-await recovery continuation (authoritative refresh and state reconciliation) had settled before test teardown, so the test could pass while leaving asynchronous work in flight.

## Solution

This test-only follow-up adds behavior-scoped completion barriers to the production-hook regression:

- capture the authoritative-refresh call count immediately before each deferred start result settles;
- wait for exactly one additional refresh after settlement;
- keep all production code and BUG-303 semantics unchanged.

The barriers are relative rather than hard-coded, so they pin the observed continuation without coupling the test to unrelated refresh history.

## TDD evidence

- Red: the first draft assumed absolute refresh counts and failed because successful abandon clears the locally tracked incomplete session without another refresh. That exposed the assumption as incorrect.
- Green: relative `before + 1` barriers pass and prove each later start continuation reaches its production refresh callback before teardown.
- Focused recovery browser file: 11/11 passed.

## Full gate on `618b299cd638e1702e7282157e756b4a9635fdf0`

- typecheck: passed
- lint: passed (existing advisory-size warnings only)
- unit: 3,394 passed
- browser: 394 passed
- integration: 200 passed, 2 skipped
- build: passed
- hermetic E2E: 36 scenarios completed; 35 direct passes plus one configured retry after an external Clerk sign-in redirect, final exit 0

## Review context

This resolves CodeRabbit thread `PRRT_kwDORFuvf86R9D_U` on promotion PR #665. The promotion remains blocked until this PR is exact-head approved, merged to dev, the updated promo head passes the full local gate, and CodeRabbit formally approves that exact head after any rate-limit cooldown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated browser coverage for practice-session recovery when repeated attempts share the same key.
  * Added verification that session status checks occur exactly once after each recovery outcome.
  * Covered recovery behavior when a later attempt remains pending and subsequently fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->