### PR TITLE
Fence BUG-303 null-refresh key retirement

### DIFF
--- a/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
+++ b/app/(app)/app/practice/hooks/use-practice-session-controls-recovery.browser.spec.tsx
@@ -660,6 +660,91 @@ describe('usePracticeSessionControls recovery convergence (browser)', () => {
     );
   });
 
+  it('preserves the key when a settled failure proves absence while a later same-key invocation remains unsettled', async () => {
+    const firstSettledResult =
+      createDeferred<
+        Awaited<ReturnType<typeof practiceController.startPracticeSession>>
+      >();
+    const laterUnsettledResult =
+      createDeferred<
+        Awaited<ReturnType<typeof practiceController.startPracticeSession>>
+      >();
+    const thirdSettledResult =
+      createDeferred<
+        Awaited<ReturnType<typeof practiceController.startPracticeSession>>
+      >();
+    arrangeControlDependencies();
+    getIncompletePracticeSession.mockResolvedValue(ok(null));
+    startPracticeSession
+      .mockImplementationOnce(() => firstSettledResult.promise)
+      .mockImplementationOnce(() => laterUnsettledResult.promise)
+      .mockImplementationOnce(() => thirdSettledResult.promise);
+
+    const screen = await render(<RecoveryHookProbe />);
+    await expect
+      .element(screen.getByTestId('incomplete-load-status'))
+      .toHaveTextContent('idle');
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await vi.waitFor(() =>
+      expect(startPracticeSession).toHaveBeenCalledTimes(2),
+    );
+    const firstStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      0,
+    );
+    expect(getCallIdempotencyKey(startPracticeSession.mock.calls, 1)).toBe(
+      firstStartKey,
+    );
+
+    const refreshCountBeforeFirstSettlement =
+      getIncompletePracticeSession.mock.calls.length;
+    firstSettledResult.resolve(err('INTERNAL_ERROR', 'Recorded start failed'));
+    await firstSettledResult.promise;
+    await vi.waitFor(() =>
+      expect(getIncompletePracticeSession).toHaveBeenCalledTimes(
+        refreshCountBeforeFirstSettlement + 1,
+      ),
+    );
+
+    await screen.getByRole('button', { name: 'start-session' }).click();
+    await vi.waitFor(() =>
+      expect(startPracticeSession).toHaveBeenCalledTimes(3),
+    );
+    const thirdStartKey = getCallIdempotencyKey(
+      startPracticeSession.mock.calls,
+      2,
+    );
+
+    expect(firstStartKey).toEqual(expect.stringMatching(UUID_PATTERN));
+    expect(thirdStartKey).toBe(firstStartKey);
+
+    const refreshCountBeforeLaterSettlement =
+      getIncompletePracticeSession.mock.calls.length;
+    laterUnsettledResult.resolve(
+      err('CONFLICT', 'Request is still running', undefined, {
+        reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
+      }),
+    );
+    await laterUnsettledResult.promise;
+    await vi.waitFor(() =>
+      expect(getIncompletePracticeSession).toHaveBeenCalledTimes(
+        refreshCountBeforeLaterSettlement + 1,
+      ),
+    );
+
+    const refreshCountBeforeThirdSettlement =
+      getIncompletePracticeSession.mock.calls.length;
+    thirdSettledResult.resolve(err('INTERNAL_ERROR', 'Recorded start failed'));
+    await thirdSettledResult.promise;
+    await vi.waitFor(() =>
+      expect(getIncompletePracticeSession).toHaveBeenCalledTimes(
+        refreshCountBeforeThirdSettlement + 1,
+      ),
+    );
+  });
+
   it('does not let a stale concurrent observation override a later settled result', async () => {
     const sessionId = '11111111-1111-4111-8111-111111111127';
     const settledResult =

--- a/app/(app)/app/practice/hooks/use-practice-session-start.ts
+++ b/app/(app)/app/practice/hooks/use-practice-session-start.ts
@@ -248,6 +248,8 @@ export function usePracticeSessionStart(
     if (!setConcurrentExecutionUncertainty) {
       return Promise.resolve();
     }
+    const tryRetireIdempotencyKeyAfterProvenAbsence =
+      captureIdempotencyKeyRetirement();
 
     return startSession({
       sessionMode,
@@ -257,6 +259,7 @@ export function usePracticeSessionStart(
       getLatestIdempotencyKey: () => startSessionIdempotencyKeyRef.current,
       createIdempotencyKey: () => crypto.randomUUID(),
       setIdempotencyKey: setStartSessionIdempotencyKey,
+      tryRetireIdempotencyKeyAfterProvenAbsence,
       setConcurrentExecutionUncertainty,
       startPracticeSessionFn: startPracticeSession,
       reportError: (error, context) => {
@@ -272,6 +275,7 @@ export function usePracticeSessionStart(
       isMounted: input.isMounted,
     });
   }, [
+    captureIdempotencyKeyRetirement,
     claimStartExecutionUncertainty,
     filters,
     sessionMode,

--- a/app/(app)/app/practice/practice-page-logic-session-start.test.ts
+++ b/app/(app)/app/practice/practice-page-logic-session-start.test.ts
@@ -10,6 +10,8 @@ const { fixtureSession1Id } = vi.hoisted(() => ({
   fixtureSession1Id: crypto.randomUUID(),
 }));
 
+const refuseStartKeyRetirement = () => false;
+
 describe('practice-page-logic session start', () => {
   describe('startSession', () => {
     it('sets error state when controller fails', async () => {
@@ -28,6 +30,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
         startPracticeSessionFn: async () => err('NOT_FOUND', 'No questions'),
         setSessionStartStatus,
         setSessionStartError,
@@ -61,6 +64,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
         startPracticeSessionFn,
         setSessionStartStatus: vi.fn(),
         setSessionStartError: vi.fn(),
@@ -98,6 +102,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey: vi.fn(),
+        tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
         startPracticeSessionFn,
         setSessionStartStatus: vi.fn(),
         setSessionStartError: vi.fn(),
@@ -126,6 +131,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
         setConcurrentExecutionUncertainty,
         startPracticeSessionFn: async () => {
           throw new Error('Boom');
@@ -159,6 +165,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
         startPracticeSessionFn: async () => {
           throw error;
         },
@@ -197,6 +204,7 @@ describe('practice-page-logic session start', () => {
           idempotencyKey: 'idem_1',
           createIdempotencyKey: () => 'idem_2',
           setIdempotencyKey,
+          tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
           startPracticeSessionFn: async () => {
             throw error;
           },
@@ -218,6 +226,7 @@ describe('practice-page-logic session start', () => {
     it('preserves the key when a concurrent same-key request may still finish', async () => {
       const setIdempotencyKey = vi.fn();
       const setConcurrentExecutionUncertainty = vi.fn();
+      const tryRetireIdempotencyKeyAfterProvenAbsence = vi.fn(() => false);
       const refreshIncompleteSession = vi.fn(async () => ({
         kind: 'loaded' as const,
         session: null,
@@ -230,6 +239,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        tryRetireIdempotencyKeyAfterProvenAbsence,
         setConcurrentExecutionUncertainty,
         startPracticeSessionFn: async () =>
           err('CONFLICT', 'Request is still running', undefined, {
@@ -243,6 +253,9 @@ describe('practice-page-logic session start', () => {
 
       expect(refreshIncompleteSession).toHaveBeenCalledTimes(1);
       expect(setIdempotencyKey).not.toHaveBeenCalled();
+      expect(tryRetireIdempotencyKeyAfterProvenAbsence).toHaveBeenCalledTimes(
+        1,
+      );
       expect(setConcurrentExecutionUncertainty).toHaveBeenCalledExactlyOnceWith(
         true,
       );
@@ -262,6 +275,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
         startPracticeSessionFn: async () =>
           err('CONFLICT', 'Request is still running', undefined, {
             reason: ApplicationConflictReasons.ConcurrentRequestInProgress,
@@ -290,6 +304,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
         startPracticeSessionFn: async () =>
           err('CONFLICT', 'Incomplete session exists', undefined, {
             reason: 'incomplete_practice_session_exists',
@@ -322,6 +337,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
         setConcurrentExecutionUncertainty,
         // The cache-error-and-throw arm replays INTERNAL_ERROR after a
         // committed session; only the refetch can render Resume/Abandon.
@@ -342,6 +358,10 @@ describe('practice-page-logic session start', () => {
 
     it('retires a preserved start key when refresh proves no incomplete session remains', async () => {
       const setIdempotencyKey = vi.fn();
+      const tryRetireIdempotencyKeyAfterProvenAbsence = vi.fn(() => {
+        setIdempotencyKey('idem_2');
+        return true;
+      });
       const refreshIncompleteSession = vi.fn(async () => ({
         kind: 'loaded' as const,
         session: null,
@@ -354,6 +374,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        tryRetireIdempotencyKeyAfterProvenAbsence,
         // The preserved key replays the post-commit outcome-store failure.
         // Authoritative absence means the referred-to session was resolved
         // elsewhere, so replay can no longer recover anything useful.
@@ -366,8 +387,40 @@ describe('practice-page-logic session start', () => {
       });
 
       expect(refreshIncompleteSession).toHaveBeenCalledTimes(1);
+      expect(tryRetireIdempotencyKeyAfterProvenAbsence).toHaveBeenCalledTimes(
+        1,
+      );
       expect(setIdempotencyKey).toHaveBeenCalledTimes(1);
       expect(setIdempotencyKey).toHaveBeenCalledWith('idem_2');
+    });
+
+    it('does not bypass the owner when proven-absence retirement is refused', async () => {
+      const setIdempotencyKey = vi.fn();
+      const tryRetireIdempotencyKeyAfterProvenAbsence = vi.fn(() => false);
+
+      await startSession({
+        sessionMode: 'tutor',
+        sessionCount: 20,
+        filters: { tagSlugs: [], difficulty: null, status: 'unanswered' },
+        idempotencyKey: 'idem_1',
+        createIdempotencyKey: () => 'idem_2',
+        setIdempotencyKey,
+        tryRetireIdempotencyKeyAfterProvenAbsence,
+        startPracticeSessionFn: async () =>
+          err('INTERNAL_ERROR', 'Failed to record committed start outcome'),
+        refreshIncompleteSession: async () => ({
+          kind: 'loaded' as const,
+          session: null,
+        }),
+        setSessionStartStatus: vi.fn(),
+        setSessionStartError: vi.fn(),
+        navigateTo: vi.fn(),
+      });
+
+      expect(tryRetireIdempotencyKeyAfterProvenAbsence).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(setIdempotencyKey).not.toHaveBeenCalled();
     });
 
     it('preserves a start key when the incomplete-session refresh fails', async () => {
@@ -380,6 +433,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
         startPracticeSessionFn: async () =>
           err('INTERNAL_ERROR', 'Failed to record committed start outcome'),
         refreshIncompleteSession: async () => ({ kind: 'failed' as const }),
@@ -408,6 +462,7 @@ describe('practice-page-logic session start', () => {
         getLatestIdempotencyKey: () => latestKey,
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
         startPracticeSessionFn: async () =>
           err('INTERNAL_ERROR', 'Failed to record committed start outcome'),
         refreshIncompleteSession: async () => {
@@ -441,6 +496,7 @@ describe('practice-page-logic session start', () => {
           idempotencyKey: 'idem_1',
           createIdempotencyKey: () => 'idem_2',
           setIdempotencyKey: vi.fn(),
+          tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
           startPracticeSessionFn: async () =>
             err('CONFLICT', 'Incomplete session exists', undefined, {
               reason: 'incomplete_practice_session_exists',
@@ -475,6 +531,7 @@ describe('practice-page-logic session start', () => {
           idempotencyKey: 'idem_1',
           createIdempotencyKey: () => 'idem_2',
           setIdempotencyKey: vi.fn(),
+          tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
           startPracticeSessionFn: async () =>
             err('CONFLICT', 'Incomplete session exists', undefined, {
               reason: 'incomplete_practice_session_exists',
@@ -516,6 +573,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey: vi.fn(),
+        tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
         startPracticeSessionFn: async () => deferred.promise,
         setSessionStartStatus: vi.fn(),
         setSessionStartError: vi.fn(),
@@ -564,6 +622,7 @@ describe('practice-page-logic session start', () => {
         idempotencyKey: 'idem_1',
         createIdempotencyKey: () => 'idem_2',
         setIdempotencyKey,
+        tryRetireIdempotencyKeyAfterProvenAbsence: refuseStartKeyRetirement,
         startPracticeSessionFn: async () => deferred.promise,
         reportError,
         setSessionStartStatus,

--- a/app/(app)/app/practice/practice-page-session-start.ts
+++ b/app/(app)/app/practice/practice-page-session-start.ts
@@ -88,6 +88,7 @@ export async function startSession(input: {
   getLatestIdempotencyKey?: () => string;
   createIdempotencyKey: () => string;
   setIdempotencyKey: (key: string) => void;
+  tryRetireIdempotencyKeyAfterProvenAbsence: () => boolean;
   setConcurrentExecutionUncertainty?: (mayStillFinish: boolean) => void;
   startPracticeSessionFn: (
     input: unknown,
@@ -160,14 +161,15 @@ export async function startSession(input: {
       const refreshOutcome = await input.refreshIncompleteSession?.();
       if (
         !rotatedAfterDeterminateError &&
-        !concurrentRequestMayStillFinish &&
         isMounted() &&
         isLatestRequest() &&
         refreshProvesNoIncompleteSession(refreshOutcome)
       ) {
-        // The key's possibly committed session has been resolved elsewhere,
-        // and no same-key request remains known to be running.
-        input.setIdempotencyKey(input.createIdempotencyKey());
+        // Authoritative absence can consume this recovery outcome, but only
+        // the key owner can prove that no other same-key claim may still
+        // commit. Keep that key-wide policy out of this invocation-local
+        // helper.
+        input.tryRetireIdempotencyKeyAfterProvenAbsence();
       }
     } catch (error) {
       reportSessionStartError(

--- a/docs/bugs/bug-303-concurrent-start-abandon-retires-still-running-key.md
+++ b/docs/bugs/bug-303-concurrent-start-abandon-retires-still-running-key.md
@@ -42,9 +42,9 @@ The lifecycle owner models “this captured key has not changed” but not “th
 
 ## Resolution State
 
-Implementation is complete on
-`fix/bug-303-abandon-retires-running-start-key` as of 2026-07-17; Status
-remains Open until wave-5 archival records production proof.
+Implementation began on `fix/bug-303-abandon-retires-running-start-key` on
+2026-07-17 and received two promotion-review hardening follow-ups on 2026-07-18.
+Status remains Open until wave-5 archival records production proof.
 
 - `usePracticeSessionStart` now owns per-key concurrent-execution uncertainty.
   Each accepted Start invocation receives an ordered claim identity and enters
@@ -61,12 +61,23 @@ remains Open until wave-5 archival records production proof.
   now also rejects a captured key whose same-key execution may still commit.
   Authoritative incomplete-session refresh continues to own panel convergence,
   but the per-user session it returns is never treated as request identity.
+- The first promotion follow-up replaced key-wide settlement with ordered
+  per-invocation claims. A later full review then exposed the remaining inline
+  bypass: an earlier `INTERNAL_ERROR` followed by authoritative absence could
+  still rotate directly inside `startSession` while a later same-key claim was
+  unsettled. On `fix/bug-303-null-refresh-claim-fence`, proven-absence
+  retirement now goes through a required owner-issued retirement gate captured
+  after the invocation claims the key. The helper retains request-local error
+  classification, while the hook remains the sole owner of key-wide retirement
+  eligibility.
 - Red-first Chromium proof reproduced the defect through the production
   `usePracticeSessionControls` hook: typed concurrent result → refresh renders
   session S → successful abandon S → next Start carried a fresh UUID instead of
   the preserved key. The green suite proves same-key reuse, thrown/timeout
   preservation across unrelated-session abandon, claim-scoped settlement,
   preservation while a later same-key invocation remains unresolved,
+  preservation when an earlier `INTERNAL_ERROR` refresh proves absence while a
+  later same-key invocation remains unresolved,
   stale-observation generation ordering, and zero controller/UI effects from a
   stale render's handler. Existing controls remain green for ordinary abandon
   retirement, second-tab proven-absence retirement, BUG-300's immediate-refresh


### PR DESCRIPTION
## Problem

The fresh exact-head promotion review on #665 found one remaining BUG-303 bypass. Ordered same-key claims correctly left later request B unsettled when earlier request A returned `INTERNAL_ERROR`, but A's null-refresh branch in `startSession` still rotated K directly from its request-local `concurrentRequestMayStillFinish === false`. That reset the hook's key-wide uncertainty state even though B could still commit under K.

This was independently confirmed at source and reproduced through the production `usePracticeSessionControls` hook.

## Solution

- Make proven-absence retirement a required `startSession` contract.
- Capture the existing owner-issued `captureIdempotencyKeyRetirement()` gate immediately after each invocation claims K.
- Route null-refresh retirement through that gate; `startSession` retains request-local error classification but can no longer decide key-wide eligibility.
- Preserve determinate-error rotation and all BUG-291/299/300/303 controls.
- Correct BUG-303's Resolution State to record the promotion-review hardening; Status remains Open pending production proof and wave-close archival.

No server, schema, database, or idempotency-wrapper changes are included.

## TDD evidence

Red first, through the production hook:

1. A and later B launched under the same K.
2. A returned `INTERNAL_ERROR`.
3. Authoritative refresh proved no incomplete session while B remained deferred.
4. The next Start used a fresh UUID instead of K.

The pre-fix failure was exact: expected the third key to equal K, received a different UUID. Green coverage now proves the third Start reuses K, then explicitly settles B and the third invocation and waits for both post-await refresh continuations.

Additional unit coverage pins that proven absence delegates to the owner gate and cannot bypass an owner refusal.

## Full local gate on `eb32f0c59cb75ec377bb943b4621624d3f6da164`

- typecheck: passed
- lint: passed (existing advisory warnings only)
- unit: 3,395 passed
- browser: 395 passed
- integration: 200 passed, 2 skipped on the per-clone local Postgres target
- production build: passed
- hermetic E2E: 36/36 passed, no retry (non-failing Clerk teardown warnings only)

## Review context

Resolves promotion thread `PRRT_kwDORFuvf86R9n2J` on #665 if exact-head review confirms the owner-gate design. The promo remains blocked until this PR is approved and merged, the combined final dev head passes the full gate again, and a fresh non-rate-limited CodeRabbit review formally approves that exact promo head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when multiple practice-session starts occur concurrently.
  * Ensured idempotency keys are retired only after authoritative confirmation that no active session exists.
  * Prevented stale or failed requests from incorrectly replacing or preserving keys.
  * Added safeguards for refresh failures, outdated actions, reporting errors, and unmount scenarios.

* **Tests**
  * Expanded coverage for concurrent starts, recovery ordering, key preservation, and fresh-key generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->