### PR TITLE
Correct BUG-303 browser-spec size evidence

### DIFF
--- a/docs/bugs/bug-303-concurrent-start-abandon-retires-still-running-key.md
+++ b/docs/bugs/bug-303-concurrent-start-abandon-retires-still-running-key.md
@@ -90,9 +90,10 @@ proof.
   uncertainty, and zero controller/UI effects from a stale render's handler.
   Existing controls remain green for ordinary abandon retirement, second-tab
   proven-absence retirement, BUG-300's immediate-refresh guard, and BUG-291's
-  thrown-outcome preservation. The claim-order scenarios now live in a focused
-  446-line browser spec; the original recovery spec is 698 lines, so neither
-  triggers the repository's 800-line test-file warning.
+  thrown-outcome preservation. The claim-order scenarios live in a focused
+  browser spec, and both browser specs remain below the repository's 800-line
+  test-file warning after the completion-barrier hardening in PR
+  [#671](https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/671).
 - A use-case orchestration test inserts and ends another tab's session during
   candidate selection—after the initial incomplete-session precheck and before
   the original `sessions.create`—then proves the original request can create its


### PR DESCRIPTION
## Problem

CodeRabbit’s exact-head review of promo PR #665 correctly found that BUG-303’s Resolution State retained pre-hardening browser-spec line counts. On the reviewed head, the claim-order spec is 476 lines and the recovery spec is 723 lines, not 446 and 698.

## Solution

Remove the brittle exact counts and preserve the load-bearing evidence: both focused browser specs remain below the repository’s 800-line warning after PR #671’s completion-barrier hardening. Link #671 so the source of the size change is explicit.

This is documentation-only. BUG-303 remains Open pending production proof, and the bug index is unchanged.

## Verification

Full local gate passed before push:
- typecheck
- lint (24 existing warning-level oversized-test diagnostics only)
- unit: 3,395/3,395
- browser: 397/397
- integration: 200 passed, 2 skipped
- production build
- hermetic E2E: 36/36

Follow-up to the actionable exact-head finding on #665: https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/665#discussion_r3608533391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified where claim-order scenarios are covered.
  * Updated test-file size guidance following completion-barrier improvements.
  * Confirmed both relevant browser specifications remain below the 800-line warning threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->