### PR TITLE
Address FW-4 promotion review findings

### DIFF
--- a/src/adapters/controllers/practice-controller.ts
+++ b/src/adapters/controllers/practice-controller.ts
@@ -467,18 +467,15 @@ export const setPracticeSessionQuestionMark = createAction({
     const userId = await requireEntitledUserId(d, meta);
 
     const { sessionId, questionId, markedForReview, idempotencyKey } = input;
+    const action = IdempotentActionNames.QuestionMark;
 
     return executeIdempotent({
       d,
       userId,
-      action: IdempotentActionNames.QuestionMark,
+      action,
       idempotencyKey,
       outputSchema: SetPracticeSessionQuestionMarkOutputSchema,
-      beforeExecute: mutationBeforeExecute(
-        'practice:setPracticeSessionQuestionMark',
-        userId,
-        d,
-      ),
+      beforeExecute: mutationBeforeExecute(action, userId, d),
       shouldCacheError: shouldCacheQuestionMarkError,
       execute: () =>
         d.setPracticeSessionQuestionMarkUseCase.execute({

--- a/src/adapters/controllers/practice-controller.ts
+++ b/src/adapters/controllers/practice-controller.ts
@@ -199,6 +199,21 @@ async function enforceRateLimit(input: {
   }
 }
 
+function mutationBeforeExecute(
+  action: string,
+  userId: string,
+  deps: Pick<PracticeControllerDeps, 'rateLimiter'>,
+): () => Promise<void> {
+  return () =>
+    enforceRateLimit({
+      rateLimiter: deps.rateLimiter,
+      key: `${action}:${userId}`,
+      policy: PRACTICE_SESSION_MUTATION_RATE_LIMIT,
+      message: (retryAfterSeconds) =>
+        `Too many session mutations. Try again in ${retryAfterSeconds}s.`,
+    });
+}
+
 export const startPracticeSession = createAction({
   schema: StartPracticeSessionInputSchema,
   getDeps,
@@ -298,14 +313,11 @@ export const endPracticeSession = createAction({
       action: 'practice:endPracticeSession',
       idempotencyKey,
       outputSchema: EndPracticeSessionOutputSchema,
-      beforeExecute: () =>
-        enforceRateLimit({
-          rateLimiter: d.rateLimiter,
-          key: `practice:endPracticeSession:${userId}`,
-          policy: PRACTICE_SESSION_MUTATION_RATE_LIMIT,
-          message: (retryAfterSeconds) =>
-            `Too many session mutations. Try again in ${retryAfterSeconds}s.`,
-        }),
+      beforeExecute: mutationBeforeExecute(
+        'practice:endPracticeSession',
+        userId,
+        d,
+      ),
       shouldCacheError: shouldCachePracticeSessionLifecycleError,
       execute: () =>
         d.endPracticeSessionUseCase.execute({
@@ -330,14 +342,11 @@ export const discardPracticeSession = createAction({
       action: 'practice:discardPracticeSession',
       idempotencyKey,
       outputSchema: DiscardPracticeSessionOutputSchema,
-      beforeExecute: () =>
-        enforceRateLimit({
-          rateLimiter: d.rateLimiter,
-          key: `practice:discardPracticeSession:${userId}`,
-          policy: PRACTICE_SESSION_MUTATION_RATE_LIMIT,
-          message: (retryAfterSeconds) =>
-            `Too many session mutations. Try again in ${retryAfterSeconds}s.`,
-        }),
+      beforeExecute: mutationBeforeExecute(
+        'practice:discardPracticeSession',
+        userId,
+        d,
+      ),
       shouldCacheError: shouldCachePracticeSessionLifecycleError,
       execute: () =>
         d.discardPracticeSessionUseCase.execute({
@@ -372,14 +381,11 @@ export const finalizeExamAnswers = createAction({
       action: 'practice:finalizeExamAnswers',
       idempotencyKey,
       outputSchema: FinalizeExamAnswersOutputSchema,
-      beforeExecute: () =>
-        enforceRateLimit({
-          rateLimiter: d.rateLimiter,
-          key: `practice:finalizeExamAnswers:${userId}`,
-          policy: PRACTICE_SESSION_MUTATION_RATE_LIMIT,
-          message: (retryAfterSeconds) =>
-            `Too many session mutations. Try again in ${retryAfterSeconds}s.`,
-        }),
+      beforeExecute: mutationBeforeExecute(
+        'practice:finalizeExamAnswers',
+        userId,
+        d,
+      ),
       shouldCacheError: shouldCachePracticeSessionStateWriteError,
       execute: finalizeExam,
     });
@@ -468,14 +474,11 @@ export const setPracticeSessionQuestionMark = createAction({
       action: IdempotentActionNames.QuestionMark,
       idempotencyKey,
       outputSchema: SetPracticeSessionQuestionMarkOutputSchema,
-      beforeExecute: () =>
-        enforceRateLimit({
-          rateLimiter: d.rateLimiter,
-          key: `practice:setPracticeSessionQuestionMark:${userId}`,
-          policy: PRACTICE_SESSION_MUTATION_RATE_LIMIT,
-          message: (retryAfterSeconds) =>
-            `Too many session mutations. Try again in ${retryAfterSeconds}s.`,
-        }),
+      beforeExecute: mutationBeforeExecute(
+        'practice:setPracticeSessionQuestionMark',
+        userId,
+        d,
+      ),
       shouldCacheError: shouldCacheQuestionMarkError,
       execute: () =>
         d.setPracticeSessionQuestionMarkUseCase.execute({

--- a/src/adapters/repositories/drizzle-idempotency-key-repository.test.ts
+++ b/src/adapters/repositories/drizzle-idempotency-key-repository.test.ts
@@ -356,6 +356,42 @@ describe('DrizzleIdempotencyKeyRepository', () => {
       });
     });
 
+    it('fails loudly with a cause when a cached error code is empty', async () => {
+      const expiresAt = new Date('2026-02-08T01:00:00.000Z');
+      const completedAt = new Date('2026-02-08T00:00:00.000Z');
+      const selectWhere = vi.fn(async () => [
+        {
+          resultJson: null,
+          errorCode: '',
+          errorMessage: 'corrupt error',
+          expiresAt,
+          completedAt,
+        },
+      ]);
+      const selectFrom = vi.fn(() => ({ where: selectWhere }));
+      const select = vi.fn(() => ({ from: selectFrom }));
+
+      const db = {
+        select,
+      } as unknown as RepoDb;
+
+      const repo = new DrizzleIdempotencyKeyRepository(
+        db,
+        () => new Date('2026-02-08T00:00:00.000Z'),
+      );
+
+      await expect(
+        repo.find(
+          '11111111-1111-1111-1111-111111111111',
+          'question:submitAnswer',
+          'idem-1',
+        ),
+      ).rejects.toMatchObject({
+        code: 'INTERNAL_ERROR',
+        cause: expect.any(Error),
+      });
+    });
+
     it('returns completed records even when resultJson is null', async () => {
       const expiresAt = new Date('2026-02-08T01:00:00.000Z');
       const completedAt = new Date('2026-02-08T00:00:00.000Z');

--- a/src/adapters/repositories/drizzle-idempotency-key-repository.ts
+++ b/src/adapters/repositories/drizzle-idempotency-key-repository.ts
@@ -127,19 +127,20 @@ export class DrizzleIdempotencyKeyRepository
 
     return {
       resultJson: row.resultJson ?? null,
-      error: row.errorCode
-        ? decodeIdempotencyPublicError({
-            code: row.errorCode,
-            message: row.errorMessage,
-            ...(row.errorFieldErrors !== null &&
-            row.errorFieldErrors !== undefined
-              ? { fieldErrors: row.errorFieldErrors }
-              : {}),
-            ...(row.errorDetails !== null && row.errorDetails !== undefined
-              ? { details: row.errorDetails }
-              : {}),
-          })
-        : null,
+      error:
+        row.errorCode !== null && row.errorCode !== undefined
+          ? decodeIdempotencyPublicError({
+              code: row.errorCode,
+              message: row.errorMessage,
+              ...(row.errorFieldErrors !== null &&
+              row.errorFieldErrors !== undefined
+                ? { fieldErrors: row.errorFieldErrors }
+                : {}),
+              ...(row.errorDetails !== null && row.errorDetails !== undefined
+                ? { details: row.errorDetails }
+                : {}),
+            })
+          : null,
       completedAt: row.completedAt,
       expiresAt: row.expiresAt,
     };

--- a/src/adapters/shared/to-idempotency-public-error.test.ts
+++ b/src/adapters/shared/to-idempotency-public-error.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { toIdempotencyPublicError } from './to-idempotency-public-error';
+
+describe('toIdempotencyPublicError', () => {
+  it('preserves root-level Zod validation messages under _root', () => {
+    const parsed = z.object({}).strict().safeParse({ unexpected: true });
+    expect(parsed.success).toBe(false);
+    if (parsed.success) throw new Error('Expected schema to reject');
+
+    expect(toIdempotencyPublicError(parsed.error)).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'Invalid input',
+      fieldErrors: {
+        _root: ['Unrecognized key: "unexpected"'],
+      },
+    });
+  });
+});

--- a/src/adapters/shared/to-idempotency-public-error.ts
+++ b/src/adapters/shared/to-idempotency-public-error.ts
@@ -23,10 +23,16 @@ export function toIdempotencyPublicError(
   }
 
   if (error instanceof ZodError) {
-    const flattened = z.flattenError(error).fieldErrors;
+    const flattened = z.flattenError(error);
     const fieldErrors: Record<string, string[]> = {};
-    for (const [field, messages] of Object.entries(flattened)) {
+    for (const [field, messages] of Object.entries(flattened.fieldErrors)) {
       if (Array.isArray(messages)) fieldErrors[field] = messages;
+    }
+    if (flattened.formErrors.length > 0) {
+      fieldErrors._root = [
+        ...(fieldErrors._root ?? []),
+        ...flattened.formErrors,
+      ];
     }
 
     return {

--- a/src/adapters/shared/with-idempotency.ts
+++ b/src/adapters/shared/with-idempotency.ts
@@ -1,5 +1,4 @@
 import { delay } from '@/src/adapters/shared/delay';
-import { toIdempotencyPublicError } from '@/src/adapters/shared/to-idempotency-public-error';
 import {
   ApplicationConflictReasons,
   ApplicationError,
@@ -12,6 +11,7 @@ import {
 } from '@/src/application/ports/repositories';
 import { DAY_MS } from '@/src/domain/services';
 import { PRUNE_BATCH_LIMIT } from './prune-constants';
+import { toIdempotencyPublicError } from './to-idempotency-public-error';
 
 const DEFAULT_TTL_MS = DAY_MS;
 const DEFAULT_MAX_WAIT_MS = 2_000;


### PR DESCRIPTION
## Summary
- fail loudly when durable idempotency error codes are empty rather than treating them as absent
- preserve root-level Zod validation messages under `fieldErrors._root`
- consolidate practice-session mutation admission configuration and align the sibling import

## TDD
Red first:
- `fails loudly with a cause when a cached error code is empty`
- `preserves root-level Zod validation messages under _root`

## Verification
- `pnpm typecheck`
- `pnpm lint` (24 existing warnings, 1 schema notice)
- `pnpm test --run` — 3,568 passed
- `pnpm test:browser` — 398 passed
- resolver-backed `pnpm test:integration` — 218 passed, 2 skipped
- `pnpm build`
- `pnpm test:e2e` — 36 passed
- `pnpm db:test:down`

Follow-up to promo review #4756529964 on #707.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error responses by preserving messages for invalid top-level input.
  * Improved handling of cached idempotency errors, including clearer internal error reporting for incomplete records.
  * Maintained consistent rate limiting across practice-session actions.

* **Tests**
  * Added coverage for root-level validation messages and incomplete cached idempotency error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->