### PR TITLE
Address final FW-4 promotion review

### DIFF
--- a/src/adapters/controllers/action-result.test.ts
+++ b/src/adapters/controllers/action-result.test.ts
@@ -90,14 +90,15 @@ describe('action-result', () => {
     });
   });
 
-  it('handleError maps ZodError to VALIDATION_ERROR with fieldErrors', async () => {
+  it('handleError maps ZodError to VALIDATION_ERROR without logging routine validation', async () => {
     const { handleError } = await import('./action-result');
+    const fakeLogger = new FakeLogger();
     const schema = z.object({ email: z.string().email() }).strict();
     const parsed = schema.safeParse({ email: 'not-an-email' });
     expect(parsed.success).toBe(false);
     if (parsed.success) throw new Error('Expected schema to reject');
 
-    expect(handleError(parsed.error)).toMatchObject({
+    expect(handleError(parsed.error, { logger: fakeLogger })).toMatchObject({
       ok: false,
       error: {
         code: 'VALIDATION_ERROR',
@@ -105,6 +106,7 @@ describe('action-result', () => {
         fieldErrors: { email: expect.any(Array) },
       },
     });
+    expect(fakeLogger.errorCalls).toHaveLength(0);
   });
 
   it('handleError maps unknown errors to INTERNAL_ERROR, logs them, and does not leak details', async () => {

--- a/src/adapters/controllers/action-result.ts
+++ b/src/adapters/controllers/action-result.ts
@@ -1,3 +1,4 @@
+import { ZodError } from 'zod';
 import { logger } from '@/lib/logger';
 import { projectSafeErrorDiagnostics } from '@/src/adapters/shared/safe-error-diagnostics';
 import { toIdempotencyPublicError } from '@/src/adapters/shared/to-idempotency-public-error';
@@ -51,6 +52,7 @@ export function handleError(
 
   if (
     !isApplicationError(error) &&
+    !(error instanceof ZodError) &&
     !(
       typeof error === 'object' &&
       error !== null &&

--- a/src/adapters/repositories/drizzle-practice-session-repository-history-summary.test.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository-history-summary.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { practiceSessions } from '@/db/schema';
 import { FakeLogger } from '@/src/application/test-helpers/fakes';
 import { DrizzlePracticeSessionRepository } from './drizzle-practice-session-repository';
 
@@ -36,6 +37,7 @@ function createDb(summaryRows: readonly Record<string, unknown>[]) {
   return {
     db: { transaction } as unknown as RepoDb,
     select,
+    summaryGroupBy,
     transaction,
   };
 }
@@ -66,7 +68,9 @@ function createSummaryRow(
 
 describe('DrizzlePracticeSessionRepository history summaries', () => {
   it('returns one consumer-shaped summary row for an aggregated session', async () => {
-    const { db, select, transaction } = createDb([createSummaryRow()]);
+    const { db, select, summaryGroupBy, transaction } = createDb([
+      createSummaryRow(),
+    ]);
     const repo = new DrizzlePracticeSessionRepository(db);
 
     await expect(
@@ -101,6 +105,7 @@ describe('DrizzlePracticeSessionRepository history summaries', () => {
       'startedAt',
       'userId',
     ]);
+    expect(summaryGroupBy).toHaveBeenCalledWith(practiceSessions.id);
     expect(transaction).toHaveBeenCalledWith(expect.any(Function), {
       isolationLevel: 'repeatable read',
     });

--- a/src/adapters/repositories/drizzle-practice-session-repository.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository.ts
@@ -496,14 +496,7 @@ export class DrizzlePracticeSessionRepository
             ),
           )
           .where(this.completedSessionCondition(userId, mode))
-          .groupBy(
-            practiceSessions.id,
-            practiceSessions.userId,
-            practiceSessions.mode,
-            practiceSessions.paramsJson,
-            practiceSessions.startedAt,
-            practiceSessions.endedAt,
-          )
+          .groupBy(practiceSessions.id)
           .orderBy(
             desc(practiceSessions.endedAt),
             desc(practiceSessions.startedAt),

--- a/src/application/use-cases/get-bookmarks.test.ts
+++ b/src/application/use-cases/get-bookmarks.test.ts
@@ -88,7 +88,7 @@ describe('GetBookmarksUseCase', () => {
     expect(logger.warnCalls).toEqual([
       {
         context: { questionId: orphanedQuestionId },
-        msg: 'Bookmark references missing question',
+        msg: 'Bookmark references unavailable or unpublished question',
       },
     ]);
   });

--- a/src/application/use-cases/get-bookmarks.ts
+++ b/src/application/use-cases/get-bookmarks.ts
@@ -26,7 +26,7 @@ export class GetBookmarksUseCase {
       if (!summary.isAvailable) {
         this.logger.warn(
           { questionId: summary.questionId },
-          'Bookmark references missing question',
+          'Bookmark references unavailable or unpublished question',
         );
       }
     }


### PR DESCRIPTION
Addresses all three actionable findings from CodeRabbit's exact-head full review on promo #707:

- exclude routine `ZodError` validation from unhandled-controller error logging while preserving its public mapping;
- describe unavailable/unpublished bookmark rows accurately;
- group the history aggregate only by the `practice_sessions` primary key.

TDD red proof: the three focused regressions failed together before implementation, then passed (3 files / 16 tests).

Full local gate: typecheck; lint (24 existing warnings); 3,568 unit; 398 browser; 218 integration + 2 skipped; build; 36 E2E; resolver database down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of completed practice-session history summaries.
  * Validation errors are now handled as expected without being incorrectly reported as unhandled errors.
  * Clarified warnings when bookmarks reference unavailable or unpublished questions.
* **Tests**
  * Expanded coverage for validation handling, history aggregation, and bookmark warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->