### PR TITLE
Refine FW-4 corruption test seams

### DIFF
--- a/src/adapters/repositories/drizzle-practice-session-repository-history-summary.test.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository-history-summary.test.ts
@@ -160,4 +160,49 @@ describe('DrizzlePracticeSessionRepository history summaries', () => {
       }),
     ]);
   });
+
+  it.each([
+    {
+      name: 'extra normalized state rows',
+      orderedQuestionIds: [
+        firstQuestionId,
+        secondQuestionId,
+        crypto.randomUUID(),
+      ],
+      orderedPositions: [0, 1, 2],
+      message: `Practice session ${sessionId} has inconsistent normalized question state`,
+    },
+    {
+      name: 'missing normalized state rows',
+      orderedQuestionIds: [firstQuestionId],
+      orderedPositions: [0],
+      message: `Practice session ${sessionId} is missing normalized question state`,
+    },
+  ])('skips and logs $name', async (input) => {
+    const { db } = createDb([
+      createSummaryRow(input.orderedQuestionIds, input.orderedPositions),
+    ]);
+    const logger = new FakeLogger();
+    const repo = new DrizzlePracticeSessionRepository(
+      db,
+      () => new Date(),
+      logger,
+    );
+
+    await expect(
+      repo.findCompletedHistorySummariesByUserId(userId, 10, 0),
+    ).resolves.toEqual({ rows: [], total: 1 });
+    expect(logger.warnCalls).toEqual([
+      expect.objectContaining({
+        context: expect.objectContaining({
+          sessionId,
+          error: expect.objectContaining({
+            code: 'INTERNAL_ERROR',
+            message: input.message,
+          }),
+        }),
+        msg: 'Skipping corrupt completed practice session row',
+      }),
+    ]);
+  });
 });

--- a/src/adapters/repositories/drizzle-practice-session-repository-history-summary.test.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository-history-summary.test.ts
@@ -205,4 +205,30 @@ describe('DrizzlePracticeSessionRepository history summaries', () => {
       }),
     ]);
   });
+
+  it('skips and logs a completed summary missing ended_at', async () => {
+    const { db } = createDb([{ ...createSummaryRow(), endedAt: null }]);
+    const logger = new FakeLogger();
+    const repo = new DrizzlePracticeSessionRepository(
+      db,
+      () => new Date(),
+      logger,
+    );
+
+    await expect(
+      repo.findCompletedHistorySummariesByUserId(userId, 10, 0),
+    ).resolves.toEqual({ rows: [], total: 1 });
+    expect(logger.warnCalls).toEqual([
+      expect.objectContaining({
+        context: expect.objectContaining({
+          sessionId,
+          error: expect.objectContaining({
+            code: 'INTERNAL_ERROR',
+            message: `Completed practice session ${sessionId} is missing ended_at`,
+          }),
+        }),
+        msg: 'Skipping corrupt completed practice session row',
+      }),
+    ]);
+  });
 });

--- a/src/adapters/repositories/drizzle-practice-session-repository.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository.ts
@@ -92,19 +92,15 @@ export class DrizzlePracticeSessionRepository
     rows: readonly PracticeSessionQuestionStateRow[],
   ): PracticeSessionQuestionState[] {
     if (rows.length > params.questionIds.length) {
-      throw new CorruptPracticeSessionRowError(
-        new ApplicationError(
-          'INTERNAL_ERROR',
-          `Practice session ${sessionId} has inconsistent normalized question state`,
-        ),
+      this.corruptRow(
+        sessionId,
+        `Practice session ${sessionId} has inconsistent normalized question state`,
       );
     }
     if (rows.length < params.questionIds.length) {
-      throw new CorruptPracticeSessionRowError(
-        new ApplicationError(
-          'INTERNAL_ERROR',
-          `Practice session ${sessionId} is missing normalized question state`,
-        ),
+      this.corruptRow(
+        sessionId,
+        `Practice session ${sessionId} is missing normalized question state`,
       );
     }
 
@@ -112,11 +108,9 @@ export class DrizzlePracticeSessionRepository
     return params.questionIds.map((questionId, position) => {
       const row = rowsByQuestionId.get(questionId);
       if (!row || row.position !== position) {
-        throw new CorruptPracticeSessionRowError(
-          new ApplicationError(
-            'INTERNAL_ERROR',
-            `Practice session ${sessionId} is missing normalized question state`,
-          ),
+        this.corruptRow(
+          sessionId,
+          `Practice session ${sessionId} is missing normalized question state`,
         );
       }
       return toDomainQuestionState(row);
@@ -130,19 +124,15 @@ export class DrizzlePracticeSessionRepository
     actualPositions: readonly number[];
   }): void {
     if (input.actualQuestionIds.length > input.expectedQuestionIds.length) {
-      throw new CorruptPracticeSessionRowError(
-        new ApplicationError(
-          'INTERNAL_ERROR',
-          `Practice session ${input.sessionId} has inconsistent normalized question state`,
-        ),
+      this.corruptRow(
+        input.sessionId,
+        `Practice session ${input.sessionId} has inconsistent normalized question state`,
       );
     }
     if (input.actualQuestionIds.length < input.expectedQuestionIds.length) {
-      throw new CorruptPracticeSessionRowError(
-        new ApplicationError(
-          'INTERNAL_ERROR',
-          `Practice session ${input.sessionId} is missing normalized question state`,
-        ),
+      this.corruptRow(
+        input.sessionId,
+        `Practice session ${input.sessionId} is missing normalized question state`,
       );
     }
     if (
@@ -152,13 +142,17 @@ export class DrizzlePracticeSessionRepository
           input.actualPositions[position] !== position,
       )
     ) {
-      throw new CorruptPracticeSessionRowError(
-        new ApplicationError(
-          'INTERNAL_ERROR',
-          `Practice session ${input.sessionId} is missing normalized question state`,
-        ),
+      this.corruptRow(
+        input.sessionId,
+        `Practice session ${input.sessionId} is missing normalized question state`,
       );
     }
+  }
+
+  private corruptRow(_sessionId: string, message: string): never {
+    throw new CorruptPracticeSessionRowError(
+      new ApplicationError('INTERNAL_ERROR', message),
+    );
   }
 
   private async loadQuestionStateRowsBySessionIds(
@@ -515,11 +509,9 @@ export class DrizzlePracticeSessionRepository
               actualPositions: row.orderedPositions,
             });
             if (row.endedAt === null) {
-              throw new CorruptPracticeSessionRowError(
-                new ApplicationError(
-                  'INTERNAL_ERROR',
-                  `Completed practice session ${row.id} is missing ended_at`,
-                ),
+              this.corruptRow(
+                row.id,
+                `Completed practice session ${row.id} is missing ended_at`,
               );
             }
             summaries.push({

--- a/src/adapters/repositories/drizzle-practice-session-repository.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository.ts
@@ -93,13 +93,11 @@ export class DrizzlePracticeSessionRepository
   ): PracticeSessionQuestionState[] {
     if (rows.length > params.questionIds.length) {
       this.corruptRow(
-        sessionId,
         `Practice session ${sessionId} has inconsistent normalized question state`,
       );
     }
     if (rows.length < params.questionIds.length) {
       this.corruptRow(
-        sessionId,
         `Practice session ${sessionId} is missing normalized question state`,
       );
     }
@@ -109,7 +107,6 @@ export class DrizzlePracticeSessionRepository
       const row = rowsByQuestionId.get(questionId);
       if (!row || row.position !== position) {
         this.corruptRow(
-          sessionId,
           `Practice session ${sessionId} is missing normalized question state`,
         );
       }
@@ -125,13 +122,11 @@ export class DrizzlePracticeSessionRepository
   }): void {
     if (input.actualQuestionIds.length > input.expectedQuestionIds.length) {
       this.corruptRow(
-        input.sessionId,
         `Practice session ${input.sessionId} has inconsistent normalized question state`,
       );
     }
     if (input.actualQuestionIds.length < input.expectedQuestionIds.length) {
       this.corruptRow(
-        input.sessionId,
         `Practice session ${input.sessionId} is missing normalized question state`,
       );
     }
@@ -143,13 +138,12 @@ export class DrizzlePracticeSessionRepository
       )
     ) {
       this.corruptRow(
-        input.sessionId,
         `Practice session ${input.sessionId} is missing normalized question state`,
       );
     }
   }
 
-  private corruptRow(_sessionId: string, message: string): never {
+  private corruptRow(message: string): never {
     throw new CorruptPracticeSessionRowError(
       new ApplicationError('INTERNAL_ERROR', message),
     );
@@ -510,7 +504,6 @@ export class DrizzlePracticeSessionRepository
             });
             if (row.endedAt === null) {
               this.corruptRow(
-                row.id,
                 `Completed practice session ${row.id} is missing ended_at`,
               );
             }

--- a/src/application/use-cases/get-bookmarks.test.ts
+++ b/src/application/use-cases/get-bookmarks.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 import { ApplicationError } from '@/src/application/errors';
 import { FakeBookmarkRepository, FakeLogger } from '../test-helpers/fakes';


### PR DESCRIPTION
Addresses the final CodeRabbit findings from promotion review `4758502560`:

- runs the plain `GetBookmarksUseCase` unit test in Vitest's default environment
- centralizes behavior-identical corrupt practice-session row construction without changing codes, messages, or skip/log behavior

Verification:
- `pnpm typecheck`
- `pnpm lint` (24 existing warnings)
- `pnpm test --run` (3,568)
- `pnpm test:browser` (398)
- resolver-backed integration (218 passed, 2 skipped)
- `pnpm build`
- `pnpm test:e2e` (36)
- `pnpm db:test:down`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized construction of corruption errors/warnings for practice-session history, including normalized question-state and ordered question consistency checks, while preserving existing thrown errors and logged warning behavior/messages.
* **Tests**
  * Added failure-mode coverage to skip corrupted completed-session history rows with inconsistent or missing normalized question state, verifying empty results and scenario-specific internal warning logs.
  * Added coverage for completed sessions missing `endedAt`, verifying empty results and an internal warning.
  * Removed the jsdom environment directive from the bookmarks use-case test without changing assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->