### PR TITLE
Address DEBT-462 promotion review boundaries

### DIFF
--- a/docs/_archive/debt/debt-462-observability-instrument-gap-parked-triggers.md
+++ b/docs/_archive/debt/debt-462-observability-instrument-gap-parked-triggers.md
@@ -69,6 +69,11 @@ nonzero rate was committed:
   `action.getAttemptedQuestions`, and Stripe
   (`stripe.webhook.process` parent plus
   `stripe.api.subscriptions.retrieve` children).
+- The binding requirement to place `Sentry.startSpan` at those exact adapter
+  seams is an intentional, bounded exception to the ordinary adapter dependency
+  rule. The production source scan permits only the six calls in these five
+  families, so this does not authorize other adapter modules to import or call
+  infrastructure SDKs directly.
 - [`server-tracing.ts`](../../../src/adapters/shared/server-tracing.ts) permits
   only the pinned action/route/operation values, nonnegative finite durations,
   nonnegative integer counts, and typed application error codes. Its

--- a/docs/dev/sanitized-explain-capture.md
+++ b/docs/dev/sanitized-explain-capture.md
@@ -92,11 +92,12 @@ names, node types, actual/planned row counts, loop counts, execution time,
 shared/local/temp buffer counts, sort method/memory, and the UTC observation
 date plus human-readable environment label.
 
-For DEBT-450 Part 5, explicitly state whether the duplicate window
-ranking/sort nodes dominate execution time or buffer work; the plan is required
-even if the Sentry/Neon threshold already fired. For Part 4, no index is
-authorized unless this procedure shows that the measured query shape and plan
-justify it.
+For DEBT-450 Part 5, capture separate sanitized plans for
+`listAttemptedQuestionsByUserId` and `countAttemptedQuestionsByUserId`, then
+state for each whether the duplicate latest-attempt window ranking/sort nodes
+dominate execution time or buffer work. Both plans are required even if the
+Sentry/Neon threshold already fired. For Part 4, no index is authorized unless
+this procedure shows that the measured query shape and plan justify it.
 
 After the sanitized artifact passes the denylist checks, remove the raw plan
 and clear the trap without leaving the current shell:

--- a/tests/server-span-family-boundary.test.ts
+++ b/tests/server-span-family-boundary.test.ts
@@ -46,6 +46,18 @@ const EXPECTED_START_SPAN_SITES = [
   },
 ] as const;
 
+interface SourceAnalysis {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+}
+
+const SOURCE_ANALYSIS_OPTIONS: ts.CompilerOptions = {
+  module: ts.ModuleKind.ESNext,
+  noLib: true,
+  noResolve: true,
+  target: ts.ScriptTarget.Latest,
+};
+
 function collectCallExpressions(
   root: ts.Node,
   predicate: (call: ts.CallExpression) => boolean,
@@ -59,15 +71,84 @@ function collectCallExpressions(
   return calls;
 }
 
-function isMethodCall(
-  call: ts.CallExpression,
-  receiver: string,
-  method: string,
+function findImportDeclaration(
+  node: ts.Node,
+): ts.ImportDeclaration | undefined {
+  let current: ts.Node | undefined = node;
+  while (current) {
+    if (ts.isImportDeclaration(current)) return current;
+    current = current.parent;
+  }
+  return undefined;
+}
+
+function isNamespaceImportFrom(
+  identifier: ts.Identifier,
+  checker: ts.TypeChecker,
+  moduleName: string,
 ): boolean {
+  const declarations = checker.getSymbolAtLocation(identifier)?.declarations;
+  return Boolean(
+    declarations?.some((declaration) => {
+      if (!ts.isNamespaceImport(declaration)) return false;
+      const importDeclaration = findImportDeclaration(declaration);
+      return (
+        importDeclaration !== undefined &&
+        ts.isStringLiteral(importDeclaration.moduleSpecifier) &&
+        importDeclaration.moduleSpecifier.text === moduleName
+      );
+    }),
+  );
+}
+
+function isNamedImportFrom(
+  identifier: ts.Identifier,
+  checker: ts.TypeChecker,
+  moduleName: string,
+  importedName: string,
+): boolean {
+  const declarations = checker.getSymbolAtLocation(identifier)?.declarations;
+  return Boolean(
+    declarations?.some((declaration) => {
+      if (!ts.isImportSpecifier(declaration)) return false;
+      const importDeclaration = findImportDeclaration(declaration);
+      return (
+        (declaration.propertyName ?? declaration.name).text === importedName &&
+        importDeclaration !== undefined &&
+        ts.isStringLiteral(importDeclaration.moduleSpecifier) &&
+        importDeclaration.moduleSpecifier.text === moduleName
+      );
+    }),
+  );
+}
+
+function isApprovedStartSpanCall(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  if (
+    ts.isPropertyAccessExpression(call.expression) &&
+    call.expression.name.text === 'startSpan' &&
+    ts.isIdentifier(call.expression.expression)
+  ) {
+    return isNamespaceImportFrom(
+      call.expression.expression,
+      checker,
+      '@sentry/nextjs',
+    );
+  }
+
+  return (
+    ts.isIdentifier(call.expression) &&
+    isNamedImportFrom(call.expression, checker, '@sentry/nextjs', 'startSpan')
+  );
+}
+
+function isSpanAttributeWrite(call: ts.CallExpression): boolean {
   return (
     ts.isPropertyAccessExpression(call.expression) &&
-    call.expression.expression.getText() === receiver &&
-    call.expression.name.text === method
+    call.expression.expression.getText() === 'span' &&
+    call.expression.name.text === 'setAttributes'
   );
 }
 
@@ -81,13 +162,69 @@ function getProperty(
   );
 }
 
-function isSafeAttributeProjection(node: ts.Node | undefined): boolean {
+function isSafeAttributeProjection(
+  node: ts.Node | undefined,
+  checker: ts.TypeChecker,
+): boolean {
   return (
     node !== undefined &&
     ts.isCallExpression(node) &&
     ts.isIdentifier(node.expression) &&
-    node.expression.text === 'projectSafeSpanAttributes'
+    isNamedImportFrom(
+      node.expression,
+      checker,
+      '@/src/adapters/shared/server-tracing',
+      'projectSafeSpanAttributes',
+    )
   );
+}
+
+function findApprovedStartSpanCalls(
+  analysis: SourceAnalysis,
+): ts.CallExpression[] {
+  return collectCallExpressions(analysis.sourceFile, (call) =>
+    isApprovedStartSpanCall(call, analysis.checker),
+  );
+}
+
+function findSafeAttributeProjectionCalls(
+  analysis: SourceAnalysis,
+): ts.CallExpression[] {
+  return collectCallExpressions(analysis.sourceFile, (call) =>
+    isSafeAttributeProjection(call, analysis.checker),
+  );
+}
+
+function analyzeSourceText(source: string): SourceAnalysis {
+  const fileName = '/virtual/server-span-family-boundary-fixture.ts';
+  const host = ts.createCompilerHost(SOURCE_ANALYSIS_OPTIONS);
+  host.fileExists = (candidate) => candidate === fileName;
+  host.readFile = (candidate) => (candidate === fileName ? source : undefined);
+  host.getSourceFile = (candidate, languageVersion) =>
+    candidate === fileName
+      ? ts.createSourceFile(candidate, source, languageVersion, true)
+      : undefined;
+
+  const program = ts.createProgram([fileName], SOURCE_ANALYSIS_OPTIONS, host);
+  const sourceFile = program.getSourceFile(fileName);
+  if (!sourceFile) {
+    throw new Error('Failed to parse server span boundary fixture');
+  }
+
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function analyzeSourcePaths(filePaths: readonly string[]): SourceAnalysis[] {
+  const absolutePaths = filePaths.map((filePath) =>
+    resolve(process.cwd(), filePath),
+  );
+  const program = ts.createProgram(absolutePaths, SOURCE_ANALYSIS_OPTIONS);
+  const checker = program.getTypeChecker();
+
+  return absolutePaths.flatMap((absolutePath) => {
+    const sourceFile = program.getSourceFile(absolutePath);
+    return sourceFile ? [{ sourceFile, checker }] : [];
+  });
 }
 
 function findContainingBlock(node: ts.Node): ts.Block | undefined {
@@ -121,6 +258,56 @@ function hasPinnedFamilyDeclaration(
 }
 
 describe('server span family boundary', () => {
+  it('accepts tracing calls only when identifiers resolve to approved imports', () => {
+    const approved = analyzeSourceText(`
+      import * as Telemetry from '@sentry/nextjs';
+      import { startSpan as beginSpan } from '@sentry/nextjs';
+      import {
+        projectSafeSpanAttributes as safeAttributes,
+      } from '@/src/adapters/shared/server-tracing';
+
+      Telemetry.startSpan(
+        { attributes: safeAttributes({ 'app.count': 1 }) },
+        () => undefined,
+      );
+      beginSpan(
+        { attributes: safeAttributes({ 'app.count': 1 }) },
+        () => undefined,
+      );
+    `);
+    const wrongModule = analyzeSourceText(`
+      import * as Sentry from 'unrelated-telemetry';
+      import { projectSafeSpanAttributes } from 'unrelated-projector';
+
+      Sentry.startSpan(
+        { attributes: projectSafeSpanAttributes({ 'app.count': 1 }) },
+        () => undefined,
+      );
+    `);
+    const shadowed = analyzeSourceText(`
+      import * as Sentry from '@sentry/nextjs';
+      import {
+        projectSafeSpanAttributes,
+      } from '@/src/adapters/shared/server-tracing';
+
+      function run(
+        Sentry: { startSpan: (config: unknown) => unknown },
+        projectSafeSpanAttributes: (input: unknown) => unknown,
+      ) {
+        return Sentry.startSpan({
+          attributes: projectSafeSpanAttributes({ 'app.count': 1 }),
+        });
+      }
+    `);
+
+    expect(findApprovedStartSpanCalls(approved)).toHaveLength(2);
+    expect(findSafeAttributeProjectionCalls(approved)).toHaveLength(2);
+    expect(findApprovedStartSpanCalls(wrongModule)).toHaveLength(0);
+    expect(findSafeAttributeProjectionCalls(wrongModule)).toHaveLength(0);
+    expect(findApprovedStartSpanCalls(shadowed)).toHaveLength(0);
+    expect(findSafeAttributeProjectionCalls(shadowed)).toHaveLength(0);
+  });
+
   it('allows only the six pinned startSpan sites within five families', () => {
     expect(Object.keys(SERVER_SPAN_FAMILIES)).toEqual([
       'finalizeExamAnswers',
@@ -130,26 +317,28 @@ describe('server span family boundary', () => {
       'stripe',
     ]);
 
-    const actualSites = fg
+    const candidatePaths = fg
       .sync(PRODUCTION_SOURCE_GLOBS, {
         cwd: process.cwd(),
         ignore: PRODUCTION_SOURCE_IGNORE_GLOBS,
         onlyFiles: true,
       })
       .sort()
-      .flatMap((filePath) => {
+      .filter((filePath) => {
         const source = readFileSync(resolve(process.cwd(), filePath), 'utf8');
-        const sourceFile = ts.createSourceFile(
-          filePath,
-          source,
-          ts.ScriptTarget.Latest,
-          true,
-        );
-        const calls = collectCallExpressions(sourceFile, (call) =>
-          isMethodCall(call, 'Sentry', 'startSpan'),
-        );
-        return calls.length > 0 ? [{ filePath, calls }] : [];
+        return source.includes('startSpan');
       });
+    const actualSites = analyzeSourcePaths(candidatePaths).flatMap(
+      (analysis) => {
+        const calls = findApprovedStartSpanCalls(analysis);
+        const filePath = candidatePaths.find((candidate) =>
+          analysis.sourceFile.fileName.endsWith(candidate),
+        );
+        return filePath && calls.length > 0
+          ? [{ filePath, calls, checker: analysis.checker }]
+          : [];
+      },
+    );
 
     expect(
       actualSites.map(({ filePath, calls }) => ({
@@ -170,6 +359,7 @@ describe('server span family boundary', () => {
       expect(actual?.calls).toHaveLength(1);
       const startSpanCall = actual?.calls[0];
       if (!startSpanCall) continue;
+      const checker = actual.checker;
 
       expect(
         hasPinnedFamilyDeclaration(startSpanCall, expected.familyReference),
@@ -188,6 +378,7 @@ describe('server span family boundary', () => {
       expect(
         isSafeAttributeProjection(
           getProperty(config, 'attributes')?.initializer,
+          checker,
         ),
       ).toBe(true);
 
@@ -205,11 +396,13 @@ describe('server span family boundary', () => {
 
       const manualAttributeWrites = collectCallExpressions(
         callback.body,
-        (call) => isMethodCall(call, 'span', 'setAttributes'),
+        isSpanAttributeWrite,
       );
       for (const write of manualAttributeWrites) {
         expect(write.arguments).toHaveLength(1);
-        expect(isSafeAttributeProjection(write.arguments[0])).toBe(true);
+        expect(isSafeAttributeProjection(write.arguments[0], checker)).toBe(
+          true,
+        );
       }
     }
   });

--- a/tests/server-span-family-boundary.test.ts
+++ b/tests/server-span-family-boundary.test.ts
@@ -51,6 +51,10 @@ interface SourceAnalysis {
   checker: ts.TypeChecker;
 }
 
+interface SourcePathAnalysis extends SourceAnalysis {
+  filePath: string;
+}
+
 const SOURCE_ANALYSIS_OPTIONS: ts.CompilerOptions = {
   module: ts.ModuleKind.ESNext,
   noLib: true,
@@ -144,11 +148,24 @@ function isApprovedStartSpanCall(
   );
 }
 
-function isSpanAttributeWrite(call: ts.CallExpression): boolean {
+function isSpanAttributeWrite(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+  callback: ts.ArrowFunction | ts.FunctionExpression,
+): boolean {
+  const callbackParameter = callback.parameters[0]?.name;
+  const receiver = ts.isPropertyAccessExpression(call.expression)
+    ? call.expression.expression
+    : undefined;
   return (
     ts.isPropertyAccessExpression(call.expression) &&
-    call.expression.expression.getText() === 'span' &&
-    call.expression.name.text === 'setAttributes'
+    call.expression.name.text === 'setAttributes' &&
+    receiver !== undefined &&
+    ts.isIdentifier(receiver) &&
+    callbackParameter !== undefined &&
+    ts.isIdentifier(callbackParameter) &&
+    checker.getSymbolAtLocation(receiver) ===
+      checker.getSymbolAtLocation(callbackParameter)
   );
 }
 
@@ -214,16 +231,22 @@ function analyzeSourceText(source: string): SourceAnalysis {
   return { sourceFile, checker: program.getTypeChecker() };
 }
 
-function analyzeSourcePaths(filePaths: readonly string[]): SourceAnalysis[] {
-  const absolutePaths = filePaths.map((filePath) =>
-    resolve(process.cwd(), filePath),
+function analyzeSourcePaths(
+  filePaths: readonly string[],
+): SourcePathAnalysis[] {
+  const pathEntries = filePaths.map((filePath) => ({
+    filePath,
+    absolutePath: resolve(process.cwd(), filePath),
+  }));
+  const program = ts.createProgram(
+    pathEntries.map(({ absolutePath }) => absolutePath),
+    SOURCE_ANALYSIS_OPTIONS,
   );
-  const program = ts.createProgram(absolutePaths, SOURCE_ANALYSIS_OPTIONS);
   const checker = program.getTypeChecker();
 
-  return absolutePaths.flatMap((absolutePath) => {
+  return pathEntries.flatMap(({ filePath, absolutePath }) => {
     const sourceFile = program.getSourceFile(absolutePath);
-    return sourceFile ? [{ sourceFile, checker }] : [];
+    return sourceFile ? [{ filePath, sourceFile, checker }] : [];
   });
 }
 
@@ -308,6 +331,40 @@ describe('server span family boundary', () => {
     expect(findSafeAttributeProjectionCalls(shadowed)).toHaveLength(0);
   });
 
+  it('recognizes attribute writes only on the approved callback parameter symbol', () => {
+    const analysis = analyzeSourceText(`
+      import * as Telemetry from '@sentry/nextjs';
+
+      Telemetry.startSpan({}, (activeSpan) => {
+        activeSpan.setAttributes({});
+        const unrelatedSpan = { setAttributes: (_input: unknown) => undefined };
+        unrelatedSpan.setAttributes({});
+        {
+          const activeSpan = unrelatedSpan;
+          activeSpan.setAttributes({});
+        }
+      });
+    `);
+    const startSpanCall = findApprovedStartSpanCalls(analysis)[0];
+    expect(startSpanCall).toBeDefined();
+    const callback = startSpanCall?.arguments[1];
+    expect(callback && ts.isArrowFunction(callback)).toBe(true);
+    if (!callback || !ts.isArrowFunction(callback)) return;
+
+    const attributeWrites = collectCallExpressions(
+      callback.body,
+      (call) =>
+        ts.isPropertyAccessExpression(call.expression) &&
+        call.expression.name.text === 'setAttributes',
+    );
+
+    expect(
+      attributeWrites.map((call) =>
+        isSpanAttributeWrite(call, analysis.checker, callback),
+      ),
+    ).toEqual([true, false, false]);
+  });
+
   it('allows only the six pinned startSpan sites within five families', () => {
     expect(Object.keys(SERVER_SPAN_FAMILIES)).toEqual([
       'finalizeExamAnswers',
@@ -331,11 +388,14 @@ describe('server span family boundary', () => {
     const actualSites = analyzeSourcePaths(candidatePaths).flatMap(
       (analysis) => {
         const calls = findApprovedStartSpanCalls(analysis);
-        const filePath = candidatePaths.find((candidate) =>
-          analysis.sourceFile.fileName.endsWith(candidate),
-        );
-        return filePath && calls.length > 0
-          ? [{ filePath, calls, checker: analysis.checker }]
+        return calls.length > 0
+          ? [
+              {
+                filePath: analysis.filePath,
+                calls,
+                checker: analysis.checker,
+              },
+            ]
           : [];
       },
     );
@@ -396,7 +456,7 @@ describe('server span family boundary', () => {
 
       const manualAttributeWrites = collectCallExpressions(
         callback.body,
-        isSpanAttributeWrite,
+        (call) => isSpanAttributeWrite(call, checker, callback),
       );
       for (const write of manualAttributeWrites) {
         expect(write.arguments).toHaveLength(1);


### PR DESCRIPTION
## Summary

Addresses the valid review findings from promotion PR #712 without changing tracing behavior or the five-family boundary:

- adds a red-first compiler-symbol test proving approved renamed imports are accepted while wrong-module and shadowed Sentry/projector identifiers are rejected
- makes the production no-sprawl scan resolve `startSpan` and `projectSafeSpanAttributes` through their approved imports
- requires separate sanitized plans for both DEBT-450 Part 5 rank statements
- records the exact five direct Sentry seams as the bounded exception mandated by DEBT-462's binding Direction

The remaining promo comments conflict with the pinned direction or safety law and will be dispositioned in #712: DEBT-462 must be resolved before post-deploy proof; the exact prescribed stats response and owner-provided 14-day 5% session envelope must remain as observed; and auto-derived attribute allowlists would weaken deliberate review of new family values.

## TDD

Red: `pnpm test --run tests/server-span-family-boundary.test.ts` failed because the approved-import analysis did not exist.

Green: focused tracing/config suite passes 15 tests.

## Full gate

- typecheck: pass
- lint: pass, 24 warnings (no growth)
- unit: 3,576 pass
- browser: 398 pass
- integration: 218 pass / 2 skipped via isolated resolver DB; DB removed
- build: pass
- E2E: 36 pass; DB removed

Exact head: `dfc01416a55865d1a1e3a3e6006e654ccb1d204c`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified approved observability instrumentation exceptions and production tracing boundaries.
  * Updated database troubleshooting guidance to capture separate sanitized query plans and assess execution time and buffer usage.

* **Tests**
  * Improved validation of tracing instrumentation by verifying resolved imports and safe attribute projections.
  * Added coverage for namespace imports, aliased imports, incorrect modules, and shadowed identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->