### PR TITLE
Fix DEBT-414 promo review findings

### DIFF
--- a/app/(marketing)/privacy/page.test.tsx
+++ b/app/(marketing)/privacy/page.test.tsx
@@ -11,12 +11,16 @@ vi.mock('next/link', () => ({
 }));
 
 let PrivacyPage: typeof import('./page').default;
-let renderPrivacyPage: typeof import('./page').renderPrivacyPage;
+let renderPrivacyPage: typeof import('./privacy-page-renderer').renderPrivacyPage;
 let privacyContent: typeof import('./privacy-content').privacyContent;
 
 beforeAll(async () => {
-  [{ default: PrivacyPage, renderPrivacyPage }, { privacyContent }] =
-    await Promise.all([import('./page'), import('./privacy-content')]);
+  [{ default: PrivacyPage }, { renderPrivacyPage }, { privacyContent }] =
+    await Promise.all([
+      import('./page'),
+      import('./privacy-page-renderer'),
+      import('./privacy-content'),
+    ]);
 });
 
 function publicPrivacyMarkdown(): string {

--- a/app/(marketing)/privacy/page.tsx
+++ b/app/(marketing)/privacy/page.tsx
@@ -1,25 +1,9 @@
 import type { Metadata } from 'next';
-import type { ReactNode } from 'react';
-import { privacyContent } from '@/app/(marketing)/privacy/privacy-content';
-import { LegalDocument } from '@/components/legal/legal-document';
-import { MarketingLayout } from '@/components/marketing/marketing-layout';
-import { ROUTES } from '@/lib/routes';
+import { renderPrivacyPage } from '@/app/(marketing)/privacy/privacy-page-renderer';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy - Addiction Boards',
 };
-
-export async function renderPrivacyPage({
-  authNavSlot,
-}: {
-  authNavSlot?: ReactNode;
-} = {}) {
-  return MarketingLayout({
-    ...(authNavSlot === undefined ? {} : { authNavSlot }),
-    featuresHref: `${ROUTES.HOME}#features`,
-    children: <LegalDocument content={privacyContent} />,
-  });
-}
 
 export default function PrivacyPage() {
   return renderPrivacyPage();

--- a/app/(marketing)/privacy/privacy-page-renderer.tsx
+++ b/app/(marketing)/privacy/privacy-page-renderer.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+import { privacyContent } from '@/app/(marketing)/privacy/privacy-content';
+import { LegalDocument } from '@/components/legal/legal-document';
+import { MarketingLayout } from '@/components/marketing/marketing-layout';
+import { ROUTES } from '@/lib/routes';
+
+export async function renderPrivacyPage({
+  authNavSlot,
+}: {
+  authNavSlot?: ReactNode;
+} = {}) {
+  return MarketingLayout({
+    ...(authNavSlot === undefined ? {} : { authNavSlot }),
+    featuresHref: `${ROUTES.HOME}#features`,
+    children: <LegalDocument content={privacyContent} />,
+  });
+}

--- a/app/(marketing)/terms/page.test.tsx
+++ b/app/(marketing)/terms/page.test.tsx
@@ -11,12 +11,16 @@ vi.mock('next/link', () => ({
 }));
 
 let TermsPage: typeof import('./page').default;
-let renderTermsPage: typeof import('./page').renderTermsPage;
+let renderTermsPage: typeof import('./terms-page-renderer').renderTermsPage;
 let termsContent: typeof import('./terms-content').termsContent;
 
 beforeAll(async () => {
-  [{ default: TermsPage, renderTermsPage }, { termsContent }] =
-    await Promise.all([import('./page'), import('./terms-content')]);
+  [{ default: TermsPage }, { renderTermsPage }, { termsContent }] =
+    await Promise.all([
+      import('./page'),
+      import('./terms-page-renderer'),
+      import('./terms-content'),
+    ]);
 });
 
 function publicTermsMarkdown(): string {

--- a/app/(marketing)/terms/page.tsx
+++ b/app/(marketing)/terms/page.tsx
@@ -1,25 +1,9 @@
 import type { Metadata } from 'next';
-import type { ReactNode } from 'react';
-import { termsContent } from '@/app/(marketing)/terms/terms-content';
-import { LegalDocument } from '@/components/legal/legal-document';
-import { MarketingLayout } from '@/components/marketing/marketing-layout';
-import { ROUTES } from '@/lib/routes';
+import { renderTermsPage } from '@/app/(marketing)/terms/terms-page-renderer';
 
 export const metadata: Metadata = {
   title: 'Terms of Service - Addiction Boards',
 };
-
-export async function renderTermsPage({
-  authNavSlot,
-}: {
-  authNavSlot?: ReactNode;
-} = {}) {
-  return MarketingLayout({
-    ...(authNavSlot === undefined ? {} : { authNavSlot }),
-    featuresHref: `${ROUTES.HOME}#features`,
-    children: <LegalDocument content={termsContent} />,
-  });
-}
 
 export default function TermsPage() {
   return renderTermsPage();

--- a/app/(marketing)/terms/terms-content.ts
+++ b/app/(marketing)/terms/terms-content.ts
@@ -1,4 +1,5 @@
 import type { LegalDocumentContent } from '@/components/legal/legal-document';
+import { ROUTES } from '@/lib/routes';
 
 export const termsContent = {
   title: 'Terms of Service',
@@ -11,7 +12,7 @@ The rest of this page is the detail behind those sentences, and the detail contr
 
 ### 1. Who we are and what you're agreeing to
 
-Addiction Boards (the "Service", at \`addictionboards.com\`) is operated by **John H. Jung, MD, MS**, a sole proprietor based in New York ("we", "us", "our"). Creating an account alone does not accept these Terms. These Terms govern access to and use of the Service. The pricing page presents links to these Terms and the [Privacy Policy](/privacy) before subscription and free-trial actions. If you do not agree to these Terms, do not start a trial, subscribe, or use protected Service content.
+Addiction Boards (the "Service", at \`addictionboards.com\`) is operated by **John H. Jung, MD, MS**, a sole proprietor based in New York ("we", "us", "our"). Creating an account alone does not accept these Terms. These Terms govern access to and use of the Service. The pricing page presents links to these Terms and the [Privacy Policy](${ROUTES.PRIVACY}) before subscription and free-trial actions. If you do not agree to these Terms, do not start a trial, subscribe, or use protected Service content.
 
 Contact: **support@addictionboards.com**
 

--- a/app/(marketing)/terms/terms-page-renderer.tsx
+++ b/app/(marketing)/terms/terms-page-renderer.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+import { termsContent } from '@/app/(marketing)/terms/terms-content';
+import { LegalDocument } from '@/components/legal/legal-document';
+import { MarketingLayout } from '@/components/marketing/marketing-layout';
+import { ROUTES } from '@/lib/routes';
+
+export async function renderTermsPage({
+  authNavSlot,
+}: {
+  authNavSlot?: ReactNode;
+} = {}) {
+  return MarketingLayout({
+    ...(authNavSlot === undefined ? {} : { authNavSlot }),
+    featuresHref: `${ROUTES.HOME}#features`,
+    children: <LegalDocument content={termsContent} />,
+  });
+}

--- a/components/legal/legal-document.test.tsx
+++ b/components/legal/legal-document.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   findAnchorByHref,
+  findElementByText,
   findHeadingByText,
   parseHtml,
 } from '@/tests/shared/dom-helpers';
@@ -87,8 +88,7 @@ describe('LegalDocument', () => {
     );
     const doc = parseHtml(html);
 
-    expect(doc.querySelector('a')?.getAttribute('href') ?? '').not.toMatch(
-      /^javascript:/i,
-    );
+    const unsafeLink = findElementByText<HTMLAnchorElement>(doc, 'a', 'Unsafe');
+    expect(unsafeLink?.getAttribute('href') ?? '').not.toMatch(/^javascript:/i);
   });
 });

--- a/components/legal/legal-document.test.tsx
+++ b/components/legal/legal-document.test.tsx
@@ -85,7 +85,10 @@ describe('LegalDocument', () => {
         }}
       />,
     );
+    const doc = parseHtml(html);
 
-    expect(html.toLowerCase()).not.toContain('javascript:');
+    expect(doc.querySelector('a')?.getAttribute('href') ?? '').not.toMatch(
+      /^javascript:/i,
+    );
   });
 });

--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -2,7 +2,7 @@
 
 > **STATUS: PUBLICATION COPY — first published 2026-08-04.** This is the committed source for [DEBT-414](../debt/debt-414-public-legal-pages-privacy-terms.md).
 > It was independently re-audited against the repository on 2026-07-29. The audit corrected unsupported absolute claims about retention, deletion, analytics, Sentry, payment information, cookies, security, and United States-only processing. See *Provenance and adversarial verification* below.
-> Owner decision on record: draft in house while the product is pre-revenue with no active users, and obtain focused legal review before paid user acquisition.
+> Owner decision on record: draft in-house while the product is pre-revenue with no active users, and obtain focused legal review before paid user acquisition.
 > The public-policy portion of this file is mirrored verbatim in `app/(marketing)/privacy/privacy-content.ts` per the DEBT-414 implementation spec. The provenance appendix remains an internal repository record.
 
 ---

--- a/docs/legal/terms-of-service.md
+++ b/docs/legal/terms-of-service.md
@@ -1,7 +1,7 @@
 # Terms of Service — publication copy
 
-> **STATUS: PUBLICATION COPY — first published 2026-08-04.** Working copy for [DEBT-414](../debt/debt-414-public-legal-pages-privacy-terms.md), drafted 2026-08-03 in house from primary sources and the codebase at `5773a148`. Companion to the [Privacy Policy](./privacy-policy.md); the two documents publish together.
-> Owner decision on record: draft in house while pre-revenue with no active users; obtain focused legal review before paid user acquisition. The *Decisions on record* and *Provenance* appendices at the end are internal and do not publish.
+> **STATUS: PUBLICATION COPY — first published 2026-08-04.** Working copy for [DEBT-414](../debt/debt-414-public-legal-pages-privacy-terms.md), drafted 2026-08-03 in-house from primary sources and the codebase at `5773a148`. Companion to the [Privacy Policy](./privacy-policy.md); the two documents publish together.
+> Owner decision on record: draft in-house while pre-revenue with no active users; obtain focused legal review before paid user acquisition. The *Decisions on record* and *Provenance* appendices at the end are internal and do not publish.
 > The public portion is mirrored verbatim in `app/(marketing)/terms/terms-content.ts` per the DEBT-414 implementation spec.
 
 ---


### PR DESCRIPTION
## Summary\n\n- move legal-page render helpers out of Next.js route modules while preserving route metadata/default-export boundaries\n- use ROUTES.PRIVACY in committed Terms content\n- parse rendered DOM before asserting sanitized link hrefs\n- normalize “in-house” in internal publication headers\n\n## Review disposition\n\nFour valid findings from Promo 1 CodeRabbit review 4857756858 are fixed here. The proposed Stage-2 dependency on Resend activation is intentionally not applied: the binding DEBT-414 sequence is PR-B consent/ledger, then PR-C Resend/outbox delivery, then Promo 2. Missing RESEND_API_KEY fails closed by retaining undelivered outbox rows; it must not reorder the approved implementation wave.\n\n## Verification\n\n- pnpm typecheck\n- pnpm lint (pass; 24 existing oversized-file warnings)\n- pnpm test --run: 409 files / 3,599 tests\n- pnpm test:browser: 64 files / 398 tests\n- pnpm test:integration: 34 files / 220 tests (218 passed, 2 skipped)\n- pnpm build: 22/22 static pages\n- pnpm test:e2e: 38/38\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the Privacy Policy and Terms of Service pages for more consistent rendering within the marketing site.
  - Terms of Service now uses the configured Privacy Policy link.
  - Legal pages continue to support authentication navigation where applicable.

- **Documentation**
  - Corrected “in-house” wording in the Privacy Policy and Terms of Service publication notes.

- **Bug Fixes**
  - Improved validation of legal-document links to help prevent unsafe link protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->