### PR TITLE
Record shipped DEBT-414 legal links

### DIFF
--- a/docs/debt/debt-414-public-legal-pages-privacy-terms.md
+++ b/docs/debt/debt-414-public-legal-pages-privacy-terms.md
@@ -187,7 +187,7 @@ For a no-card trial, state accurately: without a payment method, Stripe is confi
 - `app/(app)/app/layout-shell.test.tsx`;
 - `app/pricing/pricing-view.test.tsx`.
 
-**Stage-1 page work:** add the Terms/Privacy links after those routes exist. **Still required before billing-consent closure:** replace the trial banner's generic portal action with the dedicated consent-bearing setup flow below and persist the consent/acknowledgment. The new visible copy narrows the current risk but is not represented as complete ARL/ROSCA compliance.
+**Stage-1 page work:** the Terms/Privacy links are implemented in the marketing footer and both pricing disclosure blocks, and the routes pass the committed signed-out E2E guard; production verification remains pending until Promo 1 deploys. **Still required before billing-consent closure:** replace the trial banner's generic portal action with the dedicated consent-bearing setup flow below and persist the consent/acknowledgment. The new visible copy narrows the current risk but is not represented as complete ARL/ROSCA compliance.
 
 ### 5. Stripe consent
 
@@ -331,8 +331,9 @@ Only after the deployed pages return signed-out 200:
 - [ ] Retainable acknowledgment, annual/renewal, and change notices exist.
 - [ ] An increased recurring price cannot be charged without a matching affirmative price-increase consent record.
 - [ ] Cancellation is online, simple, and accurately described.
-- [ ] `/privacy` and `/terms` are derived public patterns and pass signed-out 200 E2E checks.
-- [ ] Footer and pre-billing links exist.
+- [x] `/privacy` and `/terms` are derived public patterns and pass signed-out 200 E2E checks.
+- [x] Footer and pre-billing links exist in committed code.
+- [ ] Production signed-out requests return 200 for both legal routes with mandatory copy present, and production pricing renders both legal links.
 - [ ] SHIELD security and incident programs are adopted and evidence-backed.
 - [ ] Stripe legal links are set only after deployment; existing descriptor reverified, not recreated.
 - [ ] Full quality gate passes before push.


### PR DESCRIPTION
## Summary
- mark the committed `/privacy` and `/terms` public-route E2E guard complete
- mark marketing-footer and pricing-disclosure legal links complete in code
- keep production signed-out and pricing verification as a distinct pending acceptance criterion

## Review context
Fixes the still-valid CodeRabbit finding on Promo #728 without changing the settled two-stage promotion sequence.

## Validation
- `pnpm typecheck`
- `pnpm lint` (passes with 24 existing oversized-file warnings and one Biome schema-version info)
- `pnpm test --run`: 409 files, 3599 tests
- `pnpm test:browser`: 64 files, 398 tests
- `pnpm test:integration`: 34 files, 218 passed, 2 skipped
- `pnpm build`: 22/22 static pages
- `pnpm test:e2e`: 38/38


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated legal-page documentation to reflect completed links for Privacy and Terms pages.
  * Recorded that signed-out navigation checks for public legal routes are complete.
  * Clarified that production verification and billing-consent updates remain outstanding.
  * Added tracking for production route validation and pricing-link verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->