### PR TITLE
Add trial payment consent setup flow

### DIFF
--- a/app/(app)/app/layout-shell.test.tsx
+++ b/app/(app)/app/layout-shell.test.tsx
@@ -249,14 +249,14 @@ describe('app/(app)/app/layout (shell)', () => {
       plan: 'annual' as const,
       trialEndsAt: new Date('2026-02-08T00:00:00Z'),
     }));
-    const manageBillingActionFn = vi.fn(async () => undefined);
+    const createTrialPaymentMethodActionFn = vi.fn(async () => undefined);
 
     const element = await renderAppLayout({
       children: <div>Child content</div>,
       enforceEntitledAppUserFn,
       authNavFn: vi.fn(async () => <div>AuthNav</div>),
       mobileNav: <div>MobileNav</div>,
-      manageBillingActionFn,
+      createTrialPaymentMethodActionFn,
       nowFn: () => new Date('2026-02-04T12:00:00Z'),
     });
 
@@ -274,15 +274,29 @@ describe('app/(app)/app/layout (shell)', () => {
     const actionButton = banner
       ? findButtonByText(banner, 'Add a card to keep access')
       : null;
+    const termsLink = banner ? findAnchorByHref(banner, ROUTES.TERMS) : null;
+    const privacyLink = banner
+      ? findAnchorByHref(banner, ROUTES.PRIVACY)
+      : null;
 
     expect(
       banner ? findElementByText(banner, 'span', '4 days left in trial') : null,
     ).not.toBeNull();
     expect(disclosure).not.toBeNull();
     expect(actionButton).not.toBeNull();
+    expect(termsLink).not.toBeNull();
+    expect(privacyLink).not.toBeNull();
     expect(
       disclosure && actionButton
         ? isNodeBefore(disclosure, actionButton)
+        : false,
+    ).toBe(true);
+    expect(
+      termsLink && actionButton ? isNodeBefore(termsLink, actionButton) : false,
+    ).toBe(true);
+    expect(
+      privacyLink && actionButton
+        ? isNodeBefore(privacyLink, actionButton)
         : false,
     ).toBe(true);
     expect(banner?.textContent).toContain('days left in trial');
@@ -304,7 +318,7 @@ describe('app/(app)/app/layout (shell)', () => {
       })),
       authNavFn: vi.fn(async () => <div>AuthNav</div>),
       mobileNav: <div>MobileNav</div>,
-      manageBillingActionFn: vi.fn(async () => undefined),
+      createTrialPaymentMethodActionFn: vi.fn(async () => undefined),
       nowFn: () => new Date('2026-02-07T21:00:00Z'),
     });
 

--- a/app/(app)/app/layout.tsx
+++ b/app/(app)/app/layout.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
-import { manageBillingAction } from '@/app/(app)/app/billing/manage-billing-actions';
+import { createTrialPaymentMethodAction } from '@/app/(app)/app/trial-payment-method-actions';
 import { AppDesktopNav } from '@/components/app-desktop-nav';
 import { AuthNav } from '@/components/auth-nav';
 import { IdempotencyKeyField } from '@/components/idempotency-key-field';
@@ -131,11 +131,11 @@ export function AppLayoutShell({
 export function TrialCountdownBanner({
   daysLeft,
   plan,
-  manageBillingActionFn,
+  createTrialPaymentMethodActionFn,
 }: {
   daysLeft: number;
   plan: SubscriptionPlan;
-  manageBillingActionFn: (formData: FormData) => Promise<void>;
+  createTrialPaymentMethodActionFn: (formData: FormData) => Promise<void>;
 }) {
   const countdown =
     daysLeft === 1 ? '1 day left in trial' : `${daysLeft} days left in trial`;
@@ -144,10 +144,27 @@ export function TrialCountdownBanner({
     <div className="block border-b border-border bg-card px-4 py-3 text-sm text-muted-foreground">
       <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-center gap-3">
         <span className="font-medium text-foreground">{countdown}</span>
-        <span className="max-w-3xl leading-relaxed text-foreground">
-          {PRICING_DATA[plan].trialPaymentDisclosure}
-        </span>
-        <form action={manageBillingActionFn}>
+        <div className="max-w-3xl leading-relaxed text-foreground">
+          <span>{PRICING_DATA[plan].trialPaymentDisclosure}</span>{' '}
+          <span className="text-muted-foreground">
+            Review the{' '}
+            <Link
+              href={ROUTES.TERMS}
+              className="rounded-sm font-medium text-foreground hover:underline ring-focus"
+            >
+              Terms of Service
+            </Link>{' '}
+            and{' '}
+            <Link
+              href={ROUTES.PRIVACY}
+              className="rounded-sm font-medium text-foreground hover:underline ring-focus"
+            >
+              Privacy Policy
+            </Link>
+            .
+          </span>
+        </div>
+        <form action={createTrialPaymentMethodActionFn}>
           <IdempotencyKeyField />
           <Button
             type="submit"
@@ -184,7 +201,7 @@ export async function renderAppLayout(input: {
   enforceEntitledAppUserFn?: () => Promise<EntitledAppUser>;
   authNavFn?: () => Promise<React.ReactNode>;
   mobileNav?: React.ReactNode;
-  manageBillingActionFn?: (formData: FormData) => Promise<void>;
+  createTrialPaymentMethodActionFn?: (formData: FormData) => Promise<void>;
   nowFn?: () => Date;
 }): Promise<React.ReactElement> {
   const enforceEntitledAppUserFn =
@@ -192,8 +209,8 @@ export async function renderAppLayout(input: {
   const authNavFn =
     input.authNavFn ?? (() => AuthNav({ showPrimaryLink: false }));
   const mobileNav = input.mobileNav ?? <MobileNav />;
-  const manageBillingActionFn =
-    input.manageBillingActionFn ?? manageBillingAction;
+  const createTrialPaymentMethodActionFn =
+    input.createTrialPaymentMethodActionFn ?? createTrialPaymentMethodAction;
   const nowFn = input.nowFn ?? (() => new Date());
 
   const [{ subscriptionStatus, plan, trialEndsAt }, authNav] =
@@ -205,7 +222,7 @@ export async function renderAppLayout(input: {
       <TrialCountdownBanner
         daysLeft={getTrialDaysLeft(trialEndsAt, nowFn())}
         plan={plan}
-        manageBillingActionFn={manageBillingActionFn}
+        createTrialPaymentMethodActionFn={createTrialPaymentMethodActionFn}
       />
     ) : undefined;
 

--- a/app/(app)/app/trial-payment-method-actions.test.ts
+++ b/app/(app)/app/trial-payment-method-actions.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTrialPaymentMethodAction } from '@/app/(app)/app/trial-payment-method-actions';
+import { ROUTES } from '@/lib/routes';
+import { err, ok } from '@/src/adapters/controllers/action-result';
+
+function createRedirectFn() {
+  return vi.fn((url: string): never => {
+    throw new Error(`redirect:${url}`);
+  });
+}
+
+describe('trial-payment-method-actions', () => {
+  it('redirects to the setup session and passes the form idempotency key', async () => {
+    const createSessionFn = vi.fn(async () =>
+      ok({ url: 'https://stripe.test/setup' }),
+    );
+    const formData = new FormData();
+    formData.set('idempotencyKey', '11111111-1111-1111-1111-111111111111');
+
+    await expect(
+      createTrialPaymentMethodAction(formData, {
+        createSessionFn,
+        redirectFn: createRedirectFn(),
+      }),
+    ).rejects.toThrow('redirect:https://stripe.test/setup');
+
+    expect(createSessionFn).toHaveBeenCalledWith({
+      idempotencyKey: '11111111-1111-1111-1111-111111111111',
+    });
+  });
+
+  it('redirects unauthenticated users to sign up', async () => {
+    const createSessionFn = vi.fn(async () =>
+      err('UNAUTHENTICATED', 'Not signed in'),
+    );
+
+    await expect(
+      createTrialPaymentMethodAction(new FormData(), {
+        createSessionFn,
+        redirectFn: createRedirectFn(),
+      }),
+    ).rejects.toThrow(`redirect:${ROUTES.SIGN_UP}`);
+  });
+
+  it('redirects setup failures to Billing without exposing error details', async () => {
+    const createSessionFn = vi.fn(async () =>
+      err('INTERNAL_ERROR', 'provider secret'),
+    );
+
+    await expect(
+      createTrialPaymentMethodAction(new FormData(), {
+        createSessionFn,
+        redirectFn: createRedirectFn(),
+      }),
+    ).rejects.toThrow(
+      `redirect:${ROUTES.APP_BILLING}?error=trial_payment_method_failed`,
+    );
+  });
+});

--- a/app/(app)/app/trial-payment-method-actions.ts
+++ b/app/(app)/app/trial-payment-method-actions.ts
@@ -1,0 +1,55 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { logger as appLogger } from '@/lib/logger';
+import { ROUTES } from '@/lib/routes';
+import type { ActionResult } from '@/src/adapters/controllers/action-result';
+import { createTrialPaymentMethodSetupSession } from '@/src/adapters/controllers/billing-controller';
+
+type CreateSessionFn = (input: {
+  idempotencyKey?: string;
+}) => Promise<ActionResult<{ url: string }>>;
+
+export type TrialPaymentMethodActionDeps = {
+  createSessionFn: CreateSessionFn;
+  redirectFn: (url: string) => never;
+};
+
+function getDeps(
+  deps?: Partial<TrialPaymentMethodActionDeps>,
+): TrialPaymentMethodActionDeps {
+  return {
+    createSessionFn:
+      deps?.createSessionFn ?? createTrialPaymentMethodSetupSession,
+    redirectFn: deps?.redirectFn ?? redirect,
+  };
+}
+
+export async function createTrialPaymentMethodAction(
+  formData: FormData,
+  deps?: Partial<TrialPaymentMethodActionDeps>,
+): Promise<void> {
+  const d = getDeps(deps);
+  const rawKey = formData.get('idempotencyKey');
+  const idempotencyKey = typeof rawKey === 'string' ? rawKey : undefined;
+  const result = await d.createSessionFn(
+    idempotencyKey ? { idempotencyKey } : {},
+  );
+
+  if (result.ok) return d.redirectFn(result.data.url);
+  if (result.error.code === 'UNAUTHENTICATED') {
+    return d.redirectFn(ROUTES.SIGN_UP);
+  }
+
+  try {
+    appLogger.error(
+      { errorCode: result.error.code },
+      'Trial payment-method setup failed',
+    );
+  } catch {
+    // Logging must not replace the safe redirect.
+  }
+  return d.redirectFn(
+    `${ROUTES.APP_BILLING}?error=trial_payment_method_failed`,
+  );
+}

--- a/app/api/stripe/webhook/route.test.ts
+++ b/app/api/stripe/webhook/route.test.ts
@@ -10,12 +10,21 @@ import type {
   PaymentGateway,
   RateLimiter,
 } from '@/src/application/ports/gateways';
-import { FakeLogger } from '@/src/application/test-helpers/fakes';
+import {
+  FakeLogger,
+  FakeTrialPaymentMethodSetupOperationRepository,
+} from '@/src/application/test-helpers/fakes';
 
 function createPaymentGatewayStub(): PaymentGateway {
   return {
     createCustomer: async () => ({ externalCustomerId: 'cus_123' }),
     createCheckoutSession: async () => ({ url: 'https://stripe/checkout' }),
+    createTrialPaymentMethodSetupSession: async () => ({
+      sessionId: 'cs_setup',
+      url: 'https://stripe/setup',
+    }),
+    attachTrialPaymentMethod: async () => undefined,
+    setTrialSubscriptionDefaultPaymentMethod: async () => undefined,
     createPortalSession: async () => ({ url: 'https://stripe/portal' }),
     processWebhookEvent: async () => ({ eventId: 'evt_1', type: 'test' }),
   };
@@ -45,6 +54,7 @@ function createTestDeps() {
     },
     subscriptions: {
       findByUserId: async () => null,
+      findExternalSubscriptionIdByUserId: async () => null,
       findObservationVersionByUserId: async () => null,
       findByExternalSubscriptionId: async () => null,
       upsert: async () => ({ persisted: true }) as const,
@@ -53,6 +63,8 @@ function createTestDeps() {
       findByUserId: async () => null,
       insert: async () => undefined,
     },
+    trialPaymentMethodSetupOperations:
+      new FakeTrialPaymentMethodSetupOperationRepository(),
   } satisfies StripeWebhookTransaction;
 
   const logger = new FakeLogger();

--- a/db/migrations/0032_bouncy_ben_grimm.sql
+++ b/db/migrations/0032_bouncy_ben_grimm.sql
@@ -1,0 +1,29 @@
+CREATE TYPE "public"."trial_payment_method_setup_operation_status" AS ENUM('pending', 'processing', 'completed');--> statement-breakpoint
+CREATE TABLE "trial_payment_method_setup_operations" (
+	"session_id" varchar(255) PRIMARY KEY NOT NULL,
+	"user_id" uuid NOT NULL,
+	"stripe_customer_id" varchar(255) NOT NULL,
+	"stripe_subscription_id" varchar(255) NOT NULL,
+	"plan" varchar(16) NOT NULL,
+	"amount_cents" integer NOT NULL,
+	"currency" varchar(3) NOT NULL,
+	"frequency" varchar(16) NOT NULL,
+	"trial_ends_at" timestamp with time zone NOT NULL,
+	"disclosure_snapshot" text NOT NULL,
+	"disclosure_version" varchar(64) NOT NULL,
+	"terms_version" varchar(64) NOT NULL,
+	"terms_hash" varchar(128) NOT NULL,
+	"status" "trial_payment_method_setup_operation_status" DEFAULT 'pending' NOT NULL,
+	"claim_id" varchar(255),
+	"claimed_at" timestamp with time zone,
+	"stripe_payment_method_id" varchar(255),
+	"payment_method_attached_at" timestamp with time zone,
+	"subscription_default_set_at" timestamp with time zone,
+	"completed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "trial_payment_method_setup_operations" ADD CONSTRAINT "trial_payment_method_setup_operations_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "trial_payment_method_setup_operations_user_id_idx" ON "trial_payment_method_setup_operations" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "trial_payment_method_setup_operations_status_claimed_at_idx" ON "trial_payment_method_setup_operations" USING btree ("status","claimed_at");

--- a/db/migrations/meta/0032_snapshot.json
+++ b/db/migrations/meta/0032_snapshot.json
@@ -1,0 +1,2713 @@
+{
+  "id": "f0245802-ad04-447e-9e7f-f369b01cec76",
+  "prevId": "159672c9-402c-4e94-8aea-1efbf46507df",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.attempts": {
+      "name": "attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_choice_id": {
+          "name": "selected_choice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_omitted": {
+          "name": "is_omitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_spent_seconds": {
+          "name": "time_spent_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_of_attempt_id": {
+          "name": "retry_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_origin": {
+          "name": "retry_origin",
+          "type": "attempt_retry_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_session_id": {
+          "name": "retry_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attempts_user_answered_at_idx": {
+          "name": "attempts_user_answered_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_user_question_answered_at_idx": {
+          "name": "attempts_user_question_answered_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_user_is_correct_answered_at_idx": {
+          "name": "attempts_user_is_correct_answered_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_correct",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_session_answered_at_idx": {
+          "name": "attempts_session_answered_at_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_session_user_answered_at_idx": {
+          "name": "attempts_session_user_answered_at_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"answered_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_question_id_idx": {
+          "name": "attempts_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_selected_choice_question_idx": {
+          "name": "attempts_selected_choice_question_idx",
+          "columns": [
+            {
+              "expression": "selected_choice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_retry_of_attempt_id_idx": {
+          "name": "attempts_retry_of_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "retry_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_session_question_uq": {
+          "name": "attempts_session_question_uq",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "practice_session_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attempts_user_id_users_id_fk": {
+          "name": "attempts_user_id_users_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_question_id_questions_id_fk": {
+          "name": "attempts_question_id_questions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_practice_session_id_practice_sessions_id_fk": {
+          "name": "attempts_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "practice_sessions",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "attempts_selected_choice_question_fk": {
+          "name": "attempts_selected_choice_question_fk",
+          "tableFrom": "attempts",
+          "tableTo": "choices",
+          "columnsFrom": [
+            "selected_choice_id",
+            "question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "question_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attempts_selected_choice_or_omitted_chk": {
+          "name": "attempts_selected_choice_or_omitted_chk",
+          "value": "(\"attempts\".\"selected_choice_id\" IS NOT NULL) <> \"attempts\".\"is_omitted\""
+        },
+        "attempts_omitted_incorrect_chk": {
+          "name": "attempts_omitted_incorrect_chk",
+          "value": "NOT \"attempts\".\"is_omitted\" OR \"attempts\".\"is_correct\" = false"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_created_at_idx": {
+          "name": "bookmarks_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_question_id_idx": {
+          "name": "bookmarks_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_question_id_questions_id_fk": {
+          "name": "bookmarks_question_id_questions_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bookmarks_user_id_question_id_pk": {
+          "name": "bookmarks_user_id_question_id_pk",
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.choices": {
+      "name": "choices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_md": {
+          "name": "text_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation_md": {
+          "name": "explanation_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "choices_id_question_id_uq": {
+          "name": "choices_id_question_id_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "choices_question_id_idx": {
+          "name": "choices_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "choices_question_id_label_uq": {
+          "name": "choices_question_id_label_uq",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "choices_question_id_sort_order_uq": {
+          "name": "choices_question_id_sort_order_uq",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "choices_question_id_questions_id_fk": {
+          "name": "choices_question_id_questions_id_fk",
+          "tableFrom": "choices",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clerk_events": {
+      "name": "clerk_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clerk_events_type_idx": {
+          "name": "clerk_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clerk_events_processed_at_idx": {
+          "name": "clerk_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deleted_clerk_users": {
+      "name": "deleted_clerk_users",
+      "schema": "",
+      "columns": {
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deleted_clerk_users_deleted_at_idx": {
+          "name": "deleted_clerk_users_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_field_errors": {
+          "name": "error_field_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idempotency_keys_expires_at_idx": {
+          "name": "idempotency_keys_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_user_id_users_id_fk": {
+          "name": "idempotency_keys_user_id_users_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotency_keys_user_id_action_key_pk": {
+          "name": "idempotency_keys_user_id_action_key_pk",
+          "columns": [
+            "user_id",
+            "action",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_stripe_cancellations": {
+      "name": "pending_stripe_cancellations",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_stripe_cancellations_created_at_idx": {
+          "name": "pending_stripe_cancellations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_stripe_cancellations_event_id_clerk_events_id_fk": {
+          "name": "pending_stripe_cancellations_event_id_clerk_events_id_fk",
+          "tableFrom": "pending_stripe_cancellations",
+          "tableTo": "clerk_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_session_question_states": {
+      "name": "practice_session_question_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marked_for_review": {
+          "name": "marked_for_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "latest_selected_choice_id": {
+          "name": "latest_selected_choice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_is_correct": {
+          "name": "latest_is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_answered_at": {
+          "name": "latest_answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_selected_choice_id": {
+          "name": "draft_selected_choice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_saved_at": {
+          "name": "draft_saved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_cumulative_ms": {
+          "name": "draft_cumulative_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "practice_session_question_states_session_question_uq": {
+          "name": "practice_session_question_states_session_question_uq",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_question_states_session_position_uq": {
+          "name": "practice_session_question_states_session_position_uq",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_question_states_question_id_idx": {
+          "name": "practice_session_question_states_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_question_states_latest_choice_question_idx": {
+          "name": "practice_session_question_states_latest_choice_question_idx",
+          "columns": [
+            {
+              "expression": "latest_selected_choice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_question_states_draft_choice_question_idx": {
+          "name": "practice_session_question_states_draft_choice_question_idx",
+          "columns": [
+            {
+              "expression": "draft_selected_choice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_session_question_states_practice_session_id_practice_sessions_id_fk": {
+          "name": "practice_session_question_states_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "practice_session_question_states",
+          "tableTo": "practice_sessions",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "practice_session_question_states_question_id_questions_id_fk": {
+          "name": "practice_session_question_states_question_id_questions_id_fk",
+          "tableFrom": "practice_session_question_states",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "practice_session_question_states_latest_choice_question_fk": {
+          "name": "practice_session_question_states_latest_choice_question_fk",
+          "tableFrom": "practice_session_question_states",
+          "tableTo": "choices",
+          "columnsFrom": [
+            "latest_selected_choice_id",
+            "question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "question_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "practice_session_question_states_draft_choice_question_fk": {
+          "name": "practice_session_question_states_draft_choice_question_fk",
+          "tableFrom": "practice_session_question_states",
+          "tableTo": "choices",
+          "columnsFrom": [
+            "draft_selected_choice_id",
+            "question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "question_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_session_question_states_draft_cumulative_ms_chk": {
+          "name": "practice_session_question_states_draft_cumulative_ms_chk",
+          "value": "\"practice_session_question_states\".\"draft_cumulative_ms\" BETWEEN 0 AND 86400000"
+        },
+        "practice_session_question_states_latest_answer_chk": {
+          "name": "practice_session_question_states_latest_answer_chk",
+          "value": "(\"practice_session_question_states\".\"latest_is_correct\" IS NULL) = (\"practice_session_question_states\".\"latest_answered_at\" IS NULL)\n          AND (\"practice_session_question_states\".\"latest_selected_choice_id\" IS NOT NULL OR \"practice_session_question_states\".\"latest_is_correct\" IS NOT TRUE)\n          AND (\"practice_session_question_states\".\"latest_selected_choice_id\" IS NULL OR (\"practice_session_question_states\".\"latest_is_correct\" IS NOT NULL AND \"practice_session_question_states\".\"latest_answered_at\" IS NOT NULL))"
+        },
+        "practice_session_question_states_draft_saved_chk": {
+          "name": "practice_session_question_states_draft_saved_chk",
+          "value": "(\"practice_session_question_states\".\"draft_selected_choice_id\" IS NULL AND \"practice_session_question_states\".\"draft_cumulative_ms\" = 0)\n          OR \"practice_session_question_states\".\"draft_saved_at\" IS NOT NULL"
+        },
+        "practice_session_question_states_position_chk": {
+          "name": "practice_session_question_states_position_chk",
+          "value": "\"practice_session_question_states\".\"position\" >= 0"
+        },
+        "practice_session_question_states_version_chk": {
+          "name": "practice_session_question_states_version_chk",
+          "value": "\"practice_session_question_states\".\"version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.practice_sessions": {
+      "name": "practice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "practice_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_json": {
+          "name": "params_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_sessions_user_started_at_idx": {
+          "name": "practice_sessions_user_started_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"started_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_sessions_user_ended_at_idx": {
+          "name": "practice_sessions_user_ended_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"ended_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_sessions_user_incomplete_uq": {
+          "name": "practice_sessions_user_incomplete_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "ended_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_sessions_user_id_users_id_fk": {
+          "name": "practice_sessions_user_id_users_id_fk",
+          "tableFrom": "practice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_sessions_params_json_object_chk": {
+          "name": "practice_sessions_params_json_object_chk",
+          "value": "jsonb_typeof(\"practice_sessions\".\"params_json\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.question_feedback": {
+      "name": "question_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "question_feedback_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "question_feedback_rating",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "question_feedback_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_feedback_user_created_at_idx": {
+          "name": "question_feedback_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_question_created_at_idx": {
+          "name": "question_feedback_question_created_at_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_attempt_created_at_idx": {
+          "name": "question_feedback_attempt_created_at_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_practice_session_created_at_idx": {
+          "name": "question_feedback_practice_session_created_at_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_rating_user_question_created_at_idx": {
+          "name": "question_feedback_rating_user_question_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"question_feedback\".\"kind\" = 'rating'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_kind_created_at_idx": {
+          "name": "question_feedback_kind_created_at_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_feedback_user_kind_idempotency_key_uq": {
+          "name": "question_feedback_user_kind_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_feedback_user_id_users_id_fk": {
+          "name": "question_feedback_user_id_users_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_feedback_question_id_questions_id_fk": {
+          "name": "question_feedback_question_id_questions_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_feedback_attempt_id_attempts_id_fk": {
+          "name": "question_feedback_attempt_id_attempts_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "question_feedback_practice_session_id_practice_sessions_id_fk": {
+          "name": "question_feedback_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "question_feedback",
+          "tableTo": "practice_sessions",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "question_feedback_kind_shape_chk": {
+          "name": "question_feedback_kind_shape_chk",
+          "value": "(\"question_feedback\".\"kind\" = 'rating' AND \"question_feedback\".\"category\" IS NULL AND \"question_feedback\".\"comment\" IS NULL)\n          OR (\"question_feedback\".\"kind\" = 'report' AND \"question_feedback\".\"category\" IS NOT NULL AND \"question_feedback\".\"rating\" IS NULL)"
+        },
+        "question_feedback_comment_len_chk": {
+          "name": "question_feedback_comment_len_chk",
+          "value": "\"question_feedback\".\"comment\" IS NULL OR char_length(\"question_feedback\".\"comment\") <= 2000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.question_tags": {
+      "name": "question_tags",
+      "schema": "",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "question_tags_tag_id_idx": {
+          "name": "question_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_tags_question_id_idx": {
+          "name": "question_tags_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_tags_question_id_questions_id_fk": {
+          "name": "question_tags_question_id_questions_id_fk",
+          "tableFrom": "question_tags",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_tags_tag_id_tags_id_fk": {
+          "name": "question_tags_tag_id_tags_id_fk",
+          "tableFrom": "question_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "question_tags_question_id_tag_id_pk": {
+          "name": "question_tags_question_id_tag_id_pk",
+          "columns": [
+            "question_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stem_md": {
+          "name": "stem_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation_md": {
+          "name": "explanation_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_md": {
+          "name": "reference_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_slug_uq": {
+          "name": "questions_slug_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_status_difficulty_idx": {
+          "name": "questions_status_difficulty_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_status_created_at_idx": {
+          "name": "questions_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limits_window_start_idx": {
+          "name": "rate_limits_window_start_idx",
+          "columns": [
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limits_key_window_start_pk": {
+          "name": "rate_limits_key_window_start_pk",
+          "columns": [
+            "key",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_customers": {
+      "name": "stripe_customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_customers_user_id_uq": {
+          "name": "stripe_customers_user_id_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_customers_stripe_customer_id_uq": {
+          "name": "stripe_customers_stripe_customer_id_uq",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_customers_user_id_users_id_fk": {
+          "name": "stripe_customers_user_id_users_id_fk",
+          "tableFrom": "stripe_customers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "stripe_events_type_idx": {
+          "name": "stripe_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_events_processed_at_idx": {
+          "name": "stripe_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_subscriptions": {
+      "name": "stripe_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_subscriptions_user_id_uq": {
+          "name": "stripe_subscriptions_user_id_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_subscriptions_stripe_subscription_id_uq": {
+          "name": "stripe_subscriptions_stripe_subscription_id_uq",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_subscriptions_user_status_idx": {
+          "name": "stripe_subscriptions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_subscriptions_user_id_users_id_fk": {
+          "name": "stripe_subscriptions_user_id_users_id_fk",
+          "tableFrom": "stripe_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "tag_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_slug_uq": {
+          "name": "tags_slug_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_kind_slug_idx": {
+          "name": "tags_kind_slug_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trial_payment_method_setup_operations": {
+      "name": "trial_payment_method_setup_operations",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_snapshot": {
+          "name": "disclosure_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_version": {
+          "name": "terms_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_hash": {
+          "name": "terms_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "trial_payment_method_setup_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_attached_at": {
+          "name": "payment_method_attached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_default_set_at": {
+          "name": "subscription_default_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trial_payment_method_setup_operations_user_id_idx": {
+          "name": "trial_payment_method_setup_operations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trial_payment_method_setup_operations_status_claimed_at_idx": {
+          "name": "trial_payment_method_setup_operations_status_claimed_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trial_payment_method_setup_operations_user_id_users_id_fk": {
+          "name": "trial_payment_method_setup_operations_user_id_users_id_fk",
+          "tableFrom": "trial_payment_method_setup_operations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_uq": {
+          "name": "users_clerk_user_id_uq",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_uq": {
+          "name": "users_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attempt_retry_origin": {
+      "name": "attempt_retry_origin",
+      "schema": "public",
+      "values": [
+        "history",
+        "dashboard",
+        "bookmarks",
+        "session_review",
+        "other"
+      ]
+    },
+    "public.practice_mode": {
+      "name": "practice_mode",
+      "schema": "public",
+      "values": [
+        "tutor",
+        "exam"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "easy",
+        "medium",
+        "hard"
+      ]
+    },
+    "public.question_feedback_category": {
+      "name": "question_feedback_category",
+      "schema": "public",
+      "values": [
+        "incorrect_answer",
+        "ambiguous_wording",
+        "typo_formatting",
+        "outdated_reference",
+        "other"
+      ]
+    },
+    "public.question_feedback_kind": {
+      "name": "question_feedback_kind",
+      "schema": "public",
+      "values": [
+        "rating",
+        "report"
+      ]
+    },
+    "public.question_feedback_rating": {
+      "name": "question_feedback_rating",
+      "schema": "public",
+      "values": [
+        "helpful",
+        "not_helpful"
+      ]
+    },
+    "public.question_status": {
+      "name": "question_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.stripe_subscription_status": {
+      "name": "stripe_subscription_status",
+      "schema": "public",
+      "values": [
+        "incomplete",
+        "incomplete_expired",
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid",
+        "paused"
+      ]
+    },
+    "public.tag_kind": {
+      "name": "tag_kind",
+      "schema": "public",
+      "values": [
+        "topic",
+        "substance",
+        "treatment",
+        "diagnosis"
+      ]
+    },
+    "public.trial_payment_method_setup_operation_status": {
+      "name": "trial_payment_method_setup_operation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1784730362410,
       "tag": "0031_crazy_toad",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1786045099420,
+      "tag": "0032_bouncy_ben_grimm",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -65,6 +65,11 @@ export const stripeSubscriptionStatusEnum = pgEnum(
   ],
 );
 
+export const trialPaymentMethodSetupOperationStatusEnum = pgEnum(
+  'trial_payment_method_setup_operation_status',
+  ['pending', 'processing', 'completed'],
+);
+
 export const attemptRetryOriginEnum = pgEnum('attempt_retry_origin', [
   'history',
   'dashboard',
@@ -104,6 +109,8 @@ export type TagKind = (typeof tagKindEnum.enumValues)[number];
 export type PracticeMode = (typeof practiceModeEnum.enumValues)[number];
 export type StripeSubscriptionStatus =
   (typeof stripeSubscriptionStatusEnum.enumValues)[number];
+export type TrialPaymentMethodSetupOperationStatus =
+  (typeof trialPaymentMethodSetupOperationStatusEnum.enumValues)[number];
 export type AttemptRetryOrigin =
   (typeof attemptRetryOriginEnum.enumValues)[number];
 export type QuestionFeedbackKind =
@@ -203,6 +210,63 @@ export const stripeSubscriptions = pgTable(
       t.userId,
       t.status,
     ),
+  }),
+);
+
+// trial_payment_method_setup_operations
+export const trialPaymentMethodSetupOperations = pgTable(
+  'trial_payment_method_setup_operations',
+  {
+    sessionId: varchar('session_id', { length: 255 }).primaryKey(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    stripeCustomerId: varchar('stripe_customer_id', {
+      length: 255,
+    }).notNull(),
+    stripeSubscriptionId: varchar('stripe_subscription_id', {
+      length: 255,
+    }).notNull(),
+    plan: varchar('plan', { length: 16 }).notNull(),
+    amountCents: integer('amount_cents').notNull(),
+    currency: varchar('currency', { length: 3 }).notNull(),
+    frequency: varchar('frequency', { length: 16 }).notNull(),
+    trialEndsAt: timestamp('trial_ends_at', { withTimezone: true }).notNull(),
+    disclosureSnapshot: text('disclosure_snapshot').notNull(),
+    disclosureVersion: varchar('disclosure_version', {
+      length: 64,
+    }).notNull(),
+    termsVersion: varchar('terms_version', { length: 64 }).notNull(),
+    termsHash: varchar('terms_hash', { length: 128 }).notNull(),
+    status: trialPaymentMethodSetupOperationStatusEnum('status')
+      .notNull()
+      .default('pending'),
+    claimId: varchar('claim_id', { length: 255 }),
+    claimedAt: timestamp('claimed_at', { withTimezone: true }),
+    stripePaymentMethodId: varchar('stripe_payment_method_id', {
+      length: 255,
+    }),
+    paymentMethodAttachedAt: timestamp('payment_method_attached_at', {
+      withTimezone: true,
+    }),
+    subscriptionDefaultSetAt: timestamp('subscription_default_set_at', {
+      withTimezone: true,
+    }),
+    completedAt: timestamp('completed_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    userIdIdx: index('trial_payment_method_setup_operations_user_id_idx').on(
+      t.userId,
+    ),
+    statusClaimedAtIdx: index(
+      'trial_payment_method_setup_operations_status_claimed_at_idx',
+    ).on(t.status, t.claimedAt),
   }),
 );
 

--- a/lib/container.test.ts
+++ b/lib/container.test.ts
@@ -19,6 +19,7 @@ import {
   DrizzleStripeEventRepository,
   DrizzleSubscriptionRepository,
   DrizzleTagRepository,
+  DrizzleTrialPaymentMethodSetupOperationRepository,
 } from '@/src/adapters/repositories';
 import { DrizzleUserRepository } from '@/src/adapters/repositories/drizzle-user-repository';
 import type { DrizzleDb } from '@/src/adapters/shared/database-types';
@@ -33,6 +34,7 @@ import {
   CountAvailableQuestionsUseCase,
   CreateCheckoutSessionUseCase,
   CreatePortalSessionUseCase,
+  CreateTrialPaymentMethodSetupSessionUseCase,
   DiscardPracticeSessionUseCase,
   EndPracticeSessionUseCase,
   FinalizeExamAnswersUseCase,
@@ -118,6 +120,9 @@ describe('container factories', () => {
     expect(typeof container.createQuestionFeedbackRepository).toBe('function');
     expect(typeof container.createQuestionRepository).toBe('function');
     expect(typeof container.createTagRepository).toBe('function');
+    expect(
+      container.createTrialPaymentMethodSetupOperationRepository(),
+    ).toBeInstanceOf(DrizzleTrialPaymentMethodSetupOperationRepository);
     expect(typeof container.createSubscriptionRepository).toBe('function');
     expect(typeof container.createStripeCustomerRepository).toBe('function');
     expect(typeof container.createStripeEventRepository).toBe('function');
@@ -281,6 +286,9 @@ describe('container factories', () => {
     expect(container.createPortalSessionUseCase()).toBeInstanceOf(
       CreatePortalSessionUseCase,
     );
+    expect(
+      container.createTrialPaymentMethodSetupSessionUseCase(),
+    ).toBeInstanceOf(CreateTrialPaymentMethodSetupSessionUseCase);
     expect(container.createFinalizeExamAnswersUseCase()).toBeInstanceOf(
       FinalizeExamAnswersUseCase,
     );
@@ -326,6 +334,9 @@ describe('container factories', () => {
     expect(billingDeps.createPortalSessionUseCase).toBeInstanceOf(
       CreatePortalSessionUseCase,
     );
+    expect(
+      billingDeps.createTrialPaymentMethodSetupSessionUseCase,
+    ).toBeInstanceOf(CreateTrialPaymentMethodSetupSessionUseCase);
     expect(billingDeps.idempotencyKeyRepository).toBeInstanceOf(
       DrizzleIdempotencyKeyRepository,
     );
@@ -548,6 +559,7 @@ describe('container factories', () => {
     }));
     const createSubscriptionRepository = vi.fn(() => ({
       findByUserId: async () => null,
+      findExternalSubscriptionIdByUserId: async () => null,
       findObservationVersionByUserId: async () => null,
       findByExternalSubscriptionId: async () => null,
       upsert: async () => ({ persisted: true }) as const,
@@ -560,6 +572,12 @@ describe('container factories', () => {
     const paymentGateway = {
       createCustomer: async () => ({ externalCustomerId: 'cus_123' }),
       createCheckoutSession: async () => ({ url: 'https://stripe/checkout' }),
+      createTrialPaymentMethodSetupSession: async () => ({
+        sessionId: 'cs_setup',
+        url: 'https://stripe/setup',
+      }),
+      attachTrialPaymentMethod: async () => undefined,
+      setTrialSubscriptionDefaultPaymentMethod: async () => undefined,
       createPortalSession: async () => ({ url: 'https://stripe/portal' }),
       processWebhookEvent: async () => ({ eventId: 'evt_1', type: 'test' }),
     };

--- a/lib/container/controllers.ts
+++ b/lib/container/controllers.ts
@@ -28,6 +28,8 @@ export function createControllerFactories(input: {
             stripeEvents: repositories.createStripeEventRepository(tx),
             subscriptions: repositories.createSubscriptionRepository(tx),
             stripeCustomers: repositories.createStripeCustomerRepository(tx),
+            trialPaymentMethodSetupOperations:
+              repositories.createTrialPaymentMethodSetupOperationRepository(tx),
           }),
         ),
     }),
@@ -53,6 +55,8 @@ export function createControllerFactories(input: {
       logger: primitives.logger,
       createCheckoutSessionUseCase: useCases.createCheckoutSessionUseCase(),
       createPortalSessionUseCase: useCases.createPortalSessionUseCase(),
+      createTrialPaymentMethodSetupSessionUseCase:
+        useCases.createTrialPaymentMethodSetupSessionUseCase(),
       idempotencyKeyRepository: repositories.createIdempotencyKeyRepository(),
       rateLimiter: gateways.createRateLimiter(),
       getClerkUserId: async () => (await getClerkUser())?.id ?? null,

--- a/lib/container/repositories.ts
+++ b/lib/container/repositories.ts
@@ -12,6 +12,7 @@ import {
   DrizzleStripeEventRepository,
   DrizzleSubscriptionRepository,
   DrizzleTagRepository,
+  DrizzleTrialPaymentMethodSetupOperationRepository,
   DrizzleUserRepository,
 } from '@/src/adapters/repositories';
 import type {
@@ -50,6 +51,13 @@ export function createRepositoryFactories(
       new DrizzleQuestionRepository(dbOverride),
     createTagRepository: (dbOverride = primitives.db) =>
       new DrizzleTagRepository(dbOverride),
+    createTrialPaymentMethodSetupOperationRepository: (
+      dbOverride = primitives.db,
+    ) =>
+      new DrizzleTrialPaymentMethodSetupOperationRepository(
+        dbOverride,
+        primitives.now,
+      ),
     createSubscriptionRepository: (dbOverride = primitives.db) =>
       new DrizzleSubscriptionRepository(
         dbOverride,

--- a/lib/container/types.ts
+++ b/lib/container/types.ts
@@ -28,6 +28,7 @@ import type {
   StripeEventRepository,
   SubscriptionRepository,
   TagRepository,
+  TrialPaymentMethodSetupOperationRepository,
   UserRepository,
 } from '@/src/application/ports/repositories';
 import type {
@@ -35,6 +36,7 @@ import type {
   CountAvailableQuestionsUseCase,
   CreateCheckoutSessionUseCase,
   CreatePortalSessionUseCase,
+  CreateTrialPaymentMethodSetupSessionUseCase,
   DiscardPracticeSessionUseCase,
   EndPracticeSessionUseCase,
   FinalizeExamAnswersUseCase,
@@ -97,6 +99,9 @@ export type RepositoryFactories = {
   ) => QuestionFeedbackRepository;
   createQuestionRepository: (dbOverride?: DrizzleDb) => QuestionRepository;
   createTagRepository: (dbOverride?: DrizzleDb) => TagRepository;
+  createTrialPaymentMethodSetupOperationRepository: (
+    dbOverride?: DrizzleDb,
+  ) => TrialPaymentMethodSetupOperationRepository;
   createSubscriptionRepository: (
     dbOverride?: DrizzleDb,
   ) => SubscriptionRepository;
@@ -119,6 +124,7 @@ export type UseCaseFactories = {
   createCheckEntitlementUseCase: () => CheckEntitlementUseCase;
   createCheckoutSessionUseCase: () => CreateCheckoutSessionUseCase;
   createPortalSessionUseCase: () => CreatePortalSessionUseCase;
+  createTrialPaymentMethodSetupSessionUseCase: () => CreateTrialPaymentMethodSetupSessionUseCase;
   createCountAvailableQuestionsUseCase: () => CountAvailableQuestionsUseCase;
   createDiscardPracticeSessionUseCase: () => DiscardPracticeSessionUseCase;
   createEndPracticeSessionUseCase: () => EndPracticeSessionUseCase;

--- a/lib/container/use-cases.ts
+++ b/lib/container/use-cases.ts
@@ -1,5 +1,10 @@
 import * as Sentry from '@sentry/nextjs';
 import {
+  PRICING_DATA,
+  TERMS_CONTENT_SHA256,
+  TERMS_VERSION,
+} from '@/lib/pricing-data';
+import {
   getPostgresErrorCode,
   toRollbackCertainPersistenceError,
 } from '@/src/adapters/repositories/postgres-errors';
@@ -18,6 +23,7 @@ import {
   CountAvailableQuestionsUseCase,
   CreateCheckoutSessionUseCase,
   CreatePortalSessionUseCase,
+  CreateTrialPaymentMethodSetupSessionUseCase,
   DiscardPracticeSessionUseCase,
   EndPracticeSessionUseCase,
   FinalizeExamAnswersUseCase,
@@ -216,6 +222,28 @@ export function createUseCaseFactories(input: {
       new CreatePortalSessionUseCase(
         repositories.createStripeCustomerRepository(),
         gateways.createPaymentGateway(),
+      ),
+    createTrialPaymentMethodSetupSessionUseCase: () =>
+      new CreateTrialPaymentMethodSetupSessionUseCase(
+        repositories.createSubscriptionRepository(),
+        repositories.createStripeCustomerRepository(),
+        repositories.createTrialPaymentMethodSetupOperationRepository(),
+        gateways.createPaymentGateway(),
+        (plan) => {
+          const pricing = PRICING_DATA[plan];
+          return {
+            plan,
+            amountCents: pricing.amountCents,
+            currency: pricing.currency,
+            frequency: pricing.frequency,
+            disclosureSnapshot: pricing.trialPaymentDisclosure,
+            disclosureVersion: pricing.disclosureVersion,
+            termsVersion: TERMS_VERSION,
+            termsHash: TERMS_CONTENT_SHA256,
+          };
+        },
+        primitives.logger,
+        primitives.now,
       ),
     createCountAvailableQuestionsUseCase: () =>
       new CountAvailableQuestionsUseCase(

--- a/lib/pricing-data.test.ts
+++ b/lib/pricing-data.test.ts
@@ -1,5 +1,11 @@
+import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
-import { PRICING_DATA } from '@/lib/pricing-data';
+import { termsContent } from '@/app/(marketing)/terms/terms-content';
+import {
+  PRICING_DATA,
+  TERMS_CONTENT_SHA256,
+  TERMS_VERSION,
+} from '@/lib/pricing-data';
 
 // ROSCA / NY GBL § 527-a: the renewal disclosure must accurately describe the
 // simple cancellation mechanism. The app's actual path is the "Billing" nav
@@ -33,5 +39,24 @@ describe('PRICING_DATA renewal disclosures', () => {
     disclosures,
   )('%s names the support contact as a cancellation fallback', (_name, disclosure) => {
     expect(disclosure).toContain('support@addictionboards.com');
+  });
+
+  it('pins machine-readable renewal terms to the rendered disclosure and Terms version', () => {
+    expect(PRICING_DATA.monthly).toMatchObject({
+      amountCents: 2900,
+      currency: 'usd',
+      frequency: 'month',
+      disclosureVersion: '2026-08-05',
+    });
+    expect(PRICING_DATA.annual).toMatchObject({
+      amountCents: 19900,
+      currency: 'usd',
+      frequency: 'year',
+      disclosureVersion: '2026-08-05',
+    });
+    expect(TERMS_VERSION).toBe('2026-08-05');
+    expect(TERMS_CONTENT_SHA256).toBe(
+      createHash('sha256').update(termsContent.bodyMarkdown).digest('hex'),
+    );
   });
 });

--- a/lib/pricing-data.ts
+++ b/lib/pricing-data.ts
@@ -9,11 +9,19 @@ export const ANNUAL_PLAN_FEATURES = [
   'Best value',
 ] as const;
 
+export const TERMS_VERSION = '2026-08-05';
+export const TERMS_CONTENT_SHA256 =
+  'e6914e723d963b5342dee652c342fb1f748fa5fcfa8067c8d5cf79248c732eb8';
+
 export const PRICING_DATA = {
   monthly: {
     name: 'Pro Monthly',
     price: '$29',
     period: '/mo',
+    amountCents: 2900,
+    currency: 'usd',
+    frequency: 'month',
+    disclosureVersion: '2026-08-05',
     features: MONTHLY_PLAN_FEATURES,
     trialCta: 'Start 7-day free trial',
     trialDisclosure:
@@ -27,6 +35,10 @@ export const PRICING_DATA = {
     name: 'Pro Annual',
     price: '$199',
     period: '/yr',
+    amountCents: 19900,
+    currency: 'usd',
+    frequency: 'year',
+    disclosureVersion: '2026-08-05',
     savings: 'Save $149 per year',
     features: ANNUAL_PLAN_FEATURES,
     trialCta: 'Start 7-day free trial',

--- a/src/adapters/controllers/billing-controller.test.ts
+++ b/src/adapters/controllers/billing-controller.test.ts
@@ -6,6 +6,7 @@ import {
   FakeAuthGateway,
   FakeCreateCheckoutSessionUseCase,
   FakeCreatePortalSessionUseCase,
+  FakeCreateTrialPaymentMethodSetupSessionUseCase,
   FakeIdempotencyKeyRepository,
   FakeLogger,
   FakeRateLimiter,
@@ -20,11 +21,13 @@ import {
   type BillingControllerDeps,
   createCheckoutSession,
   createPortalSession,
+  createTrialPaymentMethodSetupSession,
 } from './billing-controller';
 
 type BillingControllerTestDeps = BillingControllerDeps & {
   createCheckoutSessionUseCase: FakeCreateCheckoutSessionUseCase;
   createPortalSessionUseCase: FakeCreatePortalSessionUseCase;
+  createTrialPaymentMethodSetupSessionUseCase: FakeCreateTrialPaymentMethodSetupSessionUseCase;
   _calls: {
     clerkCalls: Array<undefined>;
   };
@@ -41,6 +44,7 @@ function createDeps(overrides?: {
   checkoutThrows?: unknown;
   portalOutput?: CreatePortalSessionOutput;
   portalThrows?: unknown;
+  setupThrows?: unknown;
   rateLimiter?: RateLimiter;
   now?: () => Date;
 }): BillingControllerTestDeps {
@@ -71,6 +75,13 @@ function createDeps(overrides?: {
     overrides?.portalOutput ?? { url: 'https://stripe/portal' },
     overrides?.portalThrows,
   );
+  const createTrialPaymentMethodSetupSessionUseCase =
+    new FakeCreateTrialPaymentMethodSetupSessionUseCase(
+      {
+        url: 'https://stripe/setup',
+      },
+      overrides?.setupThrows,
+    );
 
   const rateLimiter: RateLimiter =
     overrides?.rateLimiter ?? new FakeRateLimiter();
@@ -82,6 +93,7 @@ function createDeps(overrides?: {
     logger: new FakeLogger(),
     createCheckoutSessionUseCase,
     createPortalSessionUseCase,
+    createTrialPaymentMethodSetupSessionUseCase,
     idempotencyKeyRepository: new FakeIdempotencyKeyRepository(now),
     rateLimiter,
     getClerkUserId: async () => {
@@ -100,6 +112,84 @@ function createDeps(overrides?: {
 }
 
 describe('billing-controller', () => {
+  describe('createTrialPaymentMethodSetupSession', () => {
+    it('passes only the authenticated user and server-owned return URLs', async () => {
+      const deps = createDeps({ appUrl: 'https://app.example.com' });
+
+      const result = await createTrialPaymentMethodSetupSession({}, deps);
+
+      expect(result).toEqual({
+        ok: true,
+        data: { url: 'https://stripe/setup' },
+      });
+      expect(deps.createTrialPaymentMethodSetupSessionUseCase.inputs).toEqual([
+        {
+          userId: deps._fixtures.userId,
+          successUrl:
+            'https://app.example.com/app/billing?trial_payment_method=success&session_id={CHECKOUT_SESSION_ID}',
+          cancelUrl:
+            'https://app.example.com/app/billing?trial_payment_method=cancel',
+        },
+      ]);
+    });
+
+    it('returns UNAUTHENTICATED without creating a setup session', async () => {
+      const deps = createDeps({ user: null });
+
+      const result = await createTrialPaymentMethodSetupSession({}, deps);
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: 'UNAUTHENTICATED' },
+      });
+      expect(deps.createTrialPaymentMethodSetupSessionUseCase.inputs).toEqual(
+        [],
+      );
+    });
+
+    it('returns RATE_LIMITED without creating a setup session', async () => {
+      const deps = createDeps({
+        rateLimiter: new FakeRateLimiter({
+          success: false,
+          limit: 10,
+          remaining: 0,
+          retryAfterSeconds: 60,
+        }),
+      });
+
+      const result = await createTrialPaymentMethodSetupSession({}, deps);
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: 'RATE_LIMITED' },
+      });
+      expect(deps.createTrialPaymentMethodSetupSessionUseCase.inputs).toEqual(
+        [],
+      );
+    });
+
+    it('replays the cached setup URL for a reused idempotency key', async () => {
+      const deps = createDeps();
+      const input = {
+        idempotencyKey: '11111111-1111-1111-1111-111111111111',
+      };
+
+      const [first, second] = await Promise.all([
+        createTrialPaymentMethodSetupSession(input, deps),
+        createTrialPaymentMethodSetupSession(input, deps),
+      ]);
+
+      expect(first).toEqual({
+        ok: true,
+        data: { url: 'https://stripe/setup' },
+      });
+      expect(second).toEqual(first);
+      expect(
+        deps.createTrialPaymentMethodSetupSessionUseCase.inputs,
+      ).toHaveLength(1);
+    });
+  });
+
   describe('createCheckoutSession', () => {
     it('returns VALIDATION_ERROR when input is invalid', async () => {
       const deps = createDeps();

--- a/src/adapters/controllers/billing-controller.ts
+++ b/src/adapters/controllers/billing-controller.ts
@@ -20,6 +20,8 @@ import type {
   CreateCheckoutSessionOutput,
   CreatePortalSessionInput,
   CreatePortalSessionOutput,
+  CreateTrialPaymentMethodSetupSessionInput,
+  CreateTrialPaymentMethodSetupSessionOutput,
 } from '@/src/application/use-cases';
 import { createAction } from './create-action';
 import { executeIdempotent } from './shared/execute-idempotent';
@@ -27,6 +29,7 @@ import {
   IdempotentActionNames,
   shouldCacheCheckoutSessionError,
   shouldCachePortalSessionError,
+  shouldCacheTrialPaymentMethodSetupSessionError,
 } from './shared/idempotency-error-policy';
 
 const zSubscriptionPlan = z.enum(['monthly', 'annual']);
@@ -45,6 +48,12 @@ const CreatePortalSessionInputSchema = z
   })
   .strict();
 
+const CreateTrialPaymentMethodSetupSessionInputSchema = z
+  .object({
+    idempotencyKey: zIdempotencyKey.optional(),
+  })
+  .strict();
+
 const CreateCheckoutSessionOutputSchema = z
   .object({
     url: z.string().min(1),
@@ -57,9 +66,16 @@ const CreatePortalSessionOutputSchema = z
   })
   .strict();
 
+const CreateTrialPaymentMethodSetupSessionOutputSchema = z
+  .object({
+    url: z.string().min(1),
+  })
+  .strict();
+
 export type {
   CreateCheckoutSessionOutput,
   CreatePortalSessionOutput,
+  CreateTrialPaymentMethodSetupSessionOutput,
 } from '@/src/application/use-cases';
 
 export type BillingControllerDeps = {
@@ -74,6 +90,11 @@ export type BillingControllerDeps = {
     execute: (
       input: CreatePortalSessionInput,
     ) => Promise<CreatePortalSessionOutput>;
+  };
+  createTrialPaymentMethodSetupSessionUseCase: {
+    execute: (
+      input: CreateTrialPaymentMethodSetupSessionInput,
+    ) => Promise<CreateTrialPaymentMethodSetupSessionOutput>;
   };
   idempotencyKeyRepository: IdempotencyKeyRepository;
   rateLimiter: RateLimiter;
@@ -105,6 +126,61 @@ function toCancelUrl(appUrl: string): string {
 function toBillingReturnUrl(appUrl: string): string {
   return new URL(ROUTES.APP_BILLING, appUrl).toString();
 }
+
+function toTrialPaymentMethodReturnUrl(
+  appUrl: string,
+  outcome: 'success' | 'cancel',
+): string {
+  const url = new URL(ROUTES.APP_BILLING, appUrl);
+  url.searchParams.set('trial_payment_method', outcome);
+  if (outcome === 'success') {
+    return `${url.toString()}&session_id={CHECKOUT_SESSION_ID}`;
+  }
+  return url.toString();
+}
+
+export const createTrialPaymentMethodSetupSession = createAction({
+  schema: CreateTrialPaymentMethodSetupSessionInputSchema,
+  getDeps,
+  execute: async (input, d) => {
+    const user = await d.authGateway.requireUser();
+    const { idempotencyKey } = input;
+
+    async function createNewSession(): Promise<CreateTrialPaymentMethodSetupSessionOutput> {
+      const setupInput = {
+        userId: user.id,
+        successUrl: toTrialPaymentMethodReturnUrl(d.appUrl, 'success'),
+        cancelUrl: toTrialPaymentMethodReturnUrl(d.appUrl, 'cancel'),
+      } as const;
+
+      return d.createTrialPaymentMethodSetupSessionUseCase.execute(setupInput);
+    }
+
+    async function enforceSetupRateLimit(): Promise<void> {
+      const rateLimit = await d.rateLimiter.limit({
+        key: `${IdempotentActionNames.TrialPaymentMethodSetup}:${user.id}`,
+        ...CHECKOUT_SESSION_RATE_LIMIT,
+      });
+      if (!rateLimit.success) {
+        throw new ApplicationError(
+          'RATE_LIMITED',
+          `Too many payment-method setup attempts. Try again in ${rateLimit.retryAfterSeconds}s.`,
+        );
+      }
+    }
+
+    return executeIdempotent({
+      d,
+      userId: user.id,
+      action: IdempotentActionNames.TrialPaymentMethodSetup,
+      idempotencyKey,
+      outputSchema: CreateTrialPaymentMethodSetupSessionOutputSchema,
+      beforeExecute: enforceSetupRateLimit,
+      shouldCacheError: shouldCacheTrialPaymentMethodSetupSessionError,
+      execute: createNewSession,
+    });
+  },
+});
 
 export const createCheckoutSession = createAction({
   schema: CreateCheckoutSessionInputSchema,

--- a/src/adapters/controllers/shared/idempotency-error-policy.ts
+++ b/src/adapters/controllers/shared/idempotency-error-policy.ts
@@ -9,6 +9,7 @@ import {
 export const IdempotentActionNames = {
   Checkout: 'billing:createCheckoutSession',
   Portal: 'billing:createPortalSession',
+  TrialPaymentMethodSetup: 'billing:createTrialPaymentMethodSetupSession',
   Bookmark: 'bookmark:setBookmark',
   QuestionRating: 'question-feedback:rateQuestion',
   QuestionReport: 'question-feedback:submitQuestionReport',
@@ -50,6 +51,7 @@ const determinateCodesByAction: Record<
   // a later checkout can create. Nothing user-mutable is cacheable here.
   [IdempotentActionNames.Checkout]: new Set([]),
   [IdempotentActionNames.Portal]: new Set([]),
+  [IdempotentActionNames.TrialPaymentMethodSetup]: new Set([]),
   [IdempotentActionNames.Bookmark]: new Set(['NOT_FOUND']),
   [IdempotentActionNames.QuestionRating]: new Set([
     'VALIDATION_ERROR',
@@ -186,6 +188,10 @@ export const shouldCacheCheckoutSessionError = (error: unknown): boolean =>
 
 export const shouldCachePortalSessionError = (error: unknown): boolean =>
   shouldCache(IdempotentActionNames.Portal, error);
+
+export const shouldCacheTrialPaymentMethodSetupSessionError = (
+  error: unknown,
+): boolean => shouldCache(IdempotentActionNames.TrialPaymentMethodSetup, error);
 
 export const shouldCacheBookmarkError = (error: unknown): boolean =>
   shouldCache(IdempotentActionNames.Bookmark, error);

--- a/src/adapters/controllers/stripe-webhook-controller-failure-boundary.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller-failure-boundary.test.ts
@@ -6,6 +6,7 @@ import {
   FakeStripeCustomerRepository,
   FakeStripeEventRepository,
   FakeSubscriptionRepository,
+  FakeTrialPaymentMethodSetupOperationRepository,
 } from '@/src/application/test-helpers/fakes';
 import {
   processStripeWebhook,
@@ -75,6 +76,8 @@ function createMissingUserAcknowledgementHarness(input: {
           stripeEvents: new FakeStripeEventRepository(),
           subscriptions: missingSubscriptions,
           stripeCustomers: new FakeStripeCustomerRepository(),
+          trialPaymentMethodSetupOperations:
+            new FakeTrialPaymentMethodSetupOperationRepository(),
         });
       }
 
@@ -86,6 +89,8 @@ function createMissingUserAcknowledgementHarness(input: {
         stripeEvents,
         subscriptions: new FakeSubscriptionRepository(),
         stripeCustomers: new FakeStripeCustomerRepository(),
+        trialPaymentMethodSetupOperations:
+          new FakeTrialPaymentMethodSetupOperationRepository(),
       });
     },
   };
@@ -133,6 +138,8 @@ function createAbortedTransactionDeps(input: {
               stripeCustomers: new ThrowingStripeCustomerRepository(
                 input.processingError,
               ),
+              trialPaymentMethodSetupOperations:
+                new FakeTrialPaymentMethodSetupOperationRepository(),
             });
           } catch {
             // postgres.js can surface the scope's first statement error instead
@@ -150,6 +157,8 @@ function createAbortedTransactionDeps(input: {
           stripeEvents,
           subscriptions: new FakeSubscriptionRepository(),
           stripeCustomers: new FakeStripeCustomerRepository(),
+          trialPaymentMethodSetupOperations:
+            new FakeTrialPaymentMethodSetupOperationRepository(),
         });
       },
     },
@@ -233,6 +242,8 @@ describe('processStripeWebhook failure boundary', () => {
     const stripeEvents = new FakeStripeEventRepository();
     const subscriptions = new FakeSubscriptionRepository();
     const stripeCustomers = new FakeStripeCustomerRepository();
+    const trialPaymentMethodSetupOperations =
+      new FakeTrialPaymentMethodSetupOperationRepository();
     const logger = new FakeLogger();
     subscriptions.markUserMissing(userId);
     const insertCustomer = vi.spyOn(stripeCustomers, 'insert');
@@ -242,7 +253,12 @@ describe('processStripeWebhook failure boundary', () => {
       logger,
       now: () => new Date(),
       transaction: async (fn) =>
-        fn({ stripeEvents, subscriptions, stripeCustomers }),
+        fn({
+          stripeEvents,
+          subscriptions,
+          stripeCustomers,
+          trialPaymentMethodSetupOperations,
+        }),
     };
 
     await expect(
@@ -289,6 +305,8 @@ describe('processStripeWebhook failure boundary', () => {
               stripeEvents: new FakeStripeEventRepository(),
               subscriptions: missingSubscriptions,
               stripeCustomers: new FakeStripeCustomerRepository(),
+              trialPaymentMethodSetupOperations:
+                new FakeTrialPaymentMethodSetupOperationRepository(),
             });
           } catch (error) {
             await stripeEvents.claim(eventId, 'customer.subscription.updated');
@@ -301,6 +319,8 @@ describe('processStripeWebhook failure boundary', () => {
           stripeEvents,
           subscriptions: new FakeSubscriptionRepository(),
           stripeCustomers: new FakeStripeCustomerRepository(),
+          trialPaymentMethodSetupOperations:
+            new FakeTrialPaymentMethodSetupOperationRepository(),
         });
       },
     };
@@ -428,6 +448,8 @@ describe('processStripeWebhook failure boundary', () => {
           stripeEvents,
           subscriptions: new FakeSubscriptionRepository(),
           stripeCustomers: new FakeStripeCustomerRepository(),
+          trialPaymentMethodSetupOperations:
+            new FakeTrialPaymentMethodSetupOperationRepository(),
         });
       },
     };

--- a/src/adapters/controllers/stripe-webhook-controller-version-fence.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller-version-fence.test.ts
@@ -14,6 +14,7 @@ import {
   FakeStripeCustomerRepository,
   FakeStripeEventRepository,
   FakeSubscriptionRepository,
+  FakeTrialPaymentMethodSetupOperationRepository,
 } from '@/src/application/test-helpers/fakes';
 
 class AlwaysConflictingSubscriptionRepository extends FakeSubscriptionRepository {
@@ -56,13 +57,20 @@ describe('processStripeWebhook observation-version fence', () => {
     const stripeEvents = new FakeStripeEventRepository();
     const subscriptions = new AlwaysConflictingSubscriptionRepository();
     const stripeCustomers = new FakeStripeCustomerRepository();
+    const trialPaymentMethodSetupOperations =
+      new FakeTrialPaymentMethodSetupOperationRepository();
     const deps = {
       paymentGateway,
       subscriptionVersions: subscriptions,
       logger: new FakeLogger(),
       now: () => new Date('2026-01-01T00:00:00.000Z'),
       transaction: async (fn) =>
-        fn({ stripeEvents, subscriptions, stripeCustomers }),
+        fn({
+          stripeEvents,
+          subscriptions,
+          stripeCustomers,
+          trialPaymentMethodSetupOperations,
+        }),
     } as StripeWebhookDeps;
 
     await expect(

--- a/src/adapters/controllers/stripe-webhook-controller.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.test.ts
@@ -1,12 +1,15 @@
+// biome-ignore lint/style/noExcessiveLinesPerFile: Keep the Stripe webhook transaction, failure-ledger, and setup-operation concurrency cases in one controller contract suite.
 import { describe, expect, it, vi } from 'vitest';
 import { STRIPE_SUBSCRIPTION_METADATA_E2E_OWNER_FIELD } from '@/src/adapters/shared/stripe-subscription-errors';
 import { ApplicationError } from '@/src/application/errors';
+import type { WebhookEventResult } from '@/src/application/ports/gateways';
 import {
   FakeLogger,
   FakePaymentGateway,
   FakeStripeCustomerRepository,
   FakeStripeEventRepository,
   FakeSubscriptionRepository,
+  FakeTrialPaymentMethodSetupOperationRepository,
 } from '@/src/application/test-helpers/fakes';
 import {
   processStripeWebhook,
@@ -79,12 +82,14 @@ function createDeps(overrides: {
   subscriptions?: FakeSubscriptionRepository;
   stripeCustomers?: FakeStripeCustomerRepository;
   logger?: FakeLogger;
+  setupOperations?: FakeTrialPaymentMethodSetupOperationRepository;
 }): {
   deps: StripeWebhookDeps;
   stripeEvents: FakeStripeEventRepository;
   subscriptions: FakeSubscriptionRepository;
   stripeCustomers: FakeStripeCustomerRepository;
   logger: FakeLogger;
+  setupOperations: FakeTrialPaymentMethodSetupOperationRepository;
 } {
   const stripeEvents =
     overrides.stripeEvents ?? new FakeStripeEventRepository();
@@ -93,6 +98,9 @@ function createDeps(overrides: {
   const stripeCustomers =
     overrides.stripeCustomers ?? new FakeStripeCustomerRepository();
   const logger = overrides.logger ?? new FakeLogger();
+  const setupOperations =
+    overrides.setupOperations ??
+    new FakeTrialPaymentMethodSetupOperationRepository();
 
   return {
     deps: {
@@ -101,12 +109,18 @@ function createDeps(overrides: {
       logger,
       now: () => new Date(),
       transaction: async (fn) =>
-        fn({ stripeEvents, subscriptions, stripeCustomers }),
+        fn({
+          stripeEvents,
+          subscriptions,
+          stripeCustomers,
+          trialPaymentMethodSetupOperations: setupOperations,
+        }),
     },
     stripeEvents,
     subscriptions,
     stripeCustomers,
     logger,
+    setupOperations,
   };
 }
 
@@ -116,12 +130,14 @@ function createRollbackAwareDeps(overrides: {
   subscriptions?: FakeSubscriptionRepository;
   stripeCustomers?: FakeStripeCustomerRepository;
   logger?: FakeLogger;
+  setupOperations?: FakeTrialPaymentMethodSetupOperationRepository;
 }): {
   deps: StripeWebhookDeps;
   stripeEvents: FakeStripeEventRepository;
   subscriptions: FakeSubscriptionRepository;
   stripeCustomers: FakeStripeCustomerRepository;
   logger: FakeLogger;
+  setupOperations: FakeTrialPaymentMethodSetupOperationRepository;
 } {
   const base = createDeps(overrides);
 
@@ -140,20 +156,25 @@ function createRollbackAwareDeps(overrides: {
         const stagingEvents = new StripeEventsCtor();
         const stagingSubscriptions = new SubscriptionsCtor();
         const stagingStripeCustomers = new StripeCustomersCtor();
+        const stagingSetupOperations =
+          new FakeTrialPaymentMethodSetupOperationRepository();
 
         stagingEvents.restore(base.stripeEvents.snapshot());
         stagingSubscriptions.restore(base.subscriptions.snapshot());
         stagingStripeCustomers.restore(base.stripeCustomers.snapshot());
+        stagingSetupOperations.restore(base.setupOperations.snapshot());
 
         const result = await fn({
           stripeEvents: stagingEvents,
           subscriptions: stagingSubscriptions,
           stripeCustomers: stagingStripeCustomers,
+          trialPaymentMethodSetupOperations: stagingSetupOperations,
         });
 
         base.stripeEvents.restore(stagingEvents.snapshot());
         base.subscriptions.restore(stagingSubscriptions.snapshot());
         base.stripeCustomers.restore(stagingStripeCustomers.snapshot());
+        base.setupOperations.restore(stagingSetupOperations.snapshot());
 
         return result;
       },
@@ -183,6 +204,397 @@ function createSubscriptionUpdatePaymentGateway(eventId: string) {
 }
 
 describe('processStripeWebhook', () => {
+  it('attaches and selects a verified setup payment method after exact local matching', async () => {
+    const userId = crypto.randomUUID();
+    const completion = {
+      sessionId: 'cs_setup_123',
+      userId,
+      externalCustomerId: 'cus_123',
+      externalSubscriptionId: 'sub_123',
+      plan: 'monthly' as const,
+      amountCents: 2900,
+      currency: 'usd' as const,
+      frequency: 'month' as const,
+      trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+      disclosureVersion: '2026-08-05',
+      termsVersion: '2026-08-05',
+      termsHash: 'terms-hash',
+      stripePaymentMethodId: 'pm_123',
+    };
+    const paymentGateway = new FakePaymentGateway({
+      externalCustomerId: 'cus_123',
+      checkoutUrl: 'https://stripe/checkout',
+      portalUrl: 'https://stripe/portal',
+      webhookResult: {
+        eventId: 'evt_setup',
+        type: 'checkout.session.completed',
+        trialPaymentMethodSetupCompletion: completion,
+      },
+    });
+    const { deps, subscriptions, stripeCustomers, setupOperations } =
+      createDeps({ paymentGateway });
+    await subscriptions.upsert({
+      userId,
+      externalSubscriptionId: 'sub_123',
+      plan: 'monthly',
+      status: 'inTrial',
+      currentPeriodEnd: completion.trialEndsAt,
+      cancelAtPeriodEnd: false,
+      expectedVersion: null,
+    });
+    await stripeCustomers.insert(userId, 'cus_123');
+    await setupOperations.createPending({
+      sessionId: completion.sessionId,
+      userId,
+      stripeCustomerId: 'cus_123',
+      stripeSubscriptionId: 'sub_123',
+      plan: 'monthly',
+      amountCents: 2900,
+      currency: 'usd',
+      frequency: 'month',
+      trialEndsAt: completion.trialEndsAt,
+      disclosureSnapshot: 'Exact disclosure.',
+      disclosureVersion: '2026-08-05',
+      termsVersion: '2026-08-05',
+      termsHash: 'terms-hash',
+    });
+
+    await processStripeWebhook(deps, { rawBody: 'raw', signature: 'sig' });
+
+    expect(paymentGateway.trialPaymentMethodAttachInputs).toEqual([
+      {
+        sessionId: 'cs_setup_123',
+        externalPaymentMethodId: 'pm_123',
+        externalCustomerId: 'cus_123',
+      },
+    ]);
+    expect(paymentGateway.trialSubscriptionDefaultInputs).toEqual([
+      {
+        sessionId: 'cs_setup_123',
+        externalPaymentMethodId: 'pm_123',
+        externalSubscriptionId: 'sub_123',
+      },
+    ]);
+    await expect(
+      setupOperations.findBySessionId('cs_setup_123'),
+    ).resolves.toMatchObject({
+      status: 'completed',
+      stripePaymentMethodId: 'pm_123',
+      paymentMethodAttachedAt: expect.any(Date),
+      subscriptionDefaultSetAt: expect.any(Date),
+      completedAt: expect.any(Date),
+    });
+  });
+
+  it('fails closed when the accepted snapshot differs from the pending operation', async () => {
+    const userId = crypto.randomUUID();
+    const paymentGateway = new FakePaymentGateway({
+      externalCustomerId: 'cus_123',
+      checkoutUrl: 'https://stripe/checkout',
+      portalUrl: 'https://stripe/portal',
+      webhookResult: {
+        eventId: 'evt_setup_mismatch',
+        type: 'checkout.session.completed',
+        trialPaymentMethodSetupCompletion: {
+          sessionId: 'cs_setup_123',
+          userId,
+          externalCustomerId: 'cus_123',
+          externalSubscriptionId: 'sub_123',
+          plan: 'monthly',
+          amountCents: 9999,
+          currency: 'usd',
+          frequency: 'month',
+          trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+          disclosureVersion: '2026-08-05',
+          termsVersion: '2026-08-05',
+          termsHash: 'terms-hash',
+          stripePaymentMethodId: 'pm_123',
+        },
+      },
+    });
+    const { deps, subscriptions, stripeCustomers, setupOperations } =
+      createDeps({ paymentGateway });
+    await subscriptions.upsert({
+      userId,
+      externalSubscriptionId: 'sub_123',
+      plan: 'monthly',
+      status: 'inTrial',
+      currentPeriodEnd: new Date('2026-08-13T12:00:00Z'),
+      cancelAtPeriodEnd: false,
+      expectedVersion: null,
+    });
+    await stripeCustomers.insert(userId, 'cus_123');
+    await setupOperations.createPending({
+      sessionId: 'cs_setup_123',
+      userId,
+      stripeCustomerId: 'cus_123',
+      stripeSubscriptionId: 'sub_123',
+      plan: 'monthly',
+      amountCents: 2900,
+      currency: 'usd',
+      frequency: 'month',
+      trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+      disclosureSnapshot: 'Exact disclosure.',
+      disclosureVersion: '2026-08-05',
+      termsVersion: '2026-08-05',
+      termsHash: 'terms-hash',
+    });
+
+    await expect(
+      processStripeWebhook(deps, { rawBody: 'raw', signature: 'sig' }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+    expect(paymentGateway.trialPaymentMethodAttachInputs).toEqual([]);
+    expect(paymentGateway.trialSubscriptionDefaultInputs).toEqual([]);
+  });
+
+  it('fails closed when the signed customer does not match the local user mapping', async () => {
+    const userId = crypto.randomUUID();
+    const trialEndsAt = new Date('2026-08-13T12:00:00Z');
+    const paymentGateway = new FakePaymentGateway({
+      externalCustomerId: 'cus_signed',
+      checkoutUrl: 'https://stripe/checkout',
+      portalUrl: 'https://stripe/portal',
+      webhookResult: {
+        eventId: 'evt_setup_wrong_owner',
+        type: 'checkout.session.completed',
+        trialPaymentMethodSetupCompletion: {
+          sessionId: 'cs_setup_wrong_owner',
+          userId,
+          externalCustomerId: 'cus_signed',
+          externalSubscriptionId: 'sub_123',
+          plan: 'monthly',
+          amountCents: 2900,
+          currency: 'usd',
+          frequency: 'month',
+          trialEndsAt,
+          disclosureVersion: '2026-08-05',
+          termsVersion: '2026-08-05',
+          termsHash: 'terms-hash',
+          stripePaymentMethodId: 'pm_123',
+        },
+      },
+    });
+    const harness = createDeps({ paymentGateway });
+    await harness.subscriptions.upsert({
+      userId,
+      externalSubscriptionId: 'sub_123',
+      plan: 'monthly',
+      status: 'inTrial',
+      currentPeriodEnd: trialEndsAt,
+      cancelAtPeriodEnd: false,
+      expectedVersion: null,
+    });
+    await harness.stripeCustomers.insert(userId, 'cus_other');
+    await harness.setupOperations.createPending({
+      sessionId: 'cs_setup_wrong_owner',
+      userId,
+      stripeCustomerId: 'cus_signed',
+      stripeSubscriptionId: 'sub_123',
+      plan: 'monthly',
+      amountCents: 2900,
+      currency: 'usd',
+      frequency: 'month',
+      trialEndsAt,
+      disclosureSnapshot: 'Exact disclosure.',
+      disclosureVersion: '2026-08-05',
+      termsVersion: '2026-08-05',
+      termsHash: 'terms-hash',
+    });
+
+    await expect(
+      processStripeWebhook(harness.deps, {
+        rawBody: 'raw',
+        signature: 'sig',
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+    expect(paymentGateway.trialPaymentMethodAttachInputs).toEqual([]);
+    expect(paymentGateway.trialSubscriptionDefaultInputs).toEqual([]);
+  });
+
+  it('allows only one of two concurrent deliveries for the same Session to perform provider writes', async () => {
+    const userId = crypto.randomUUID();
+    let releaseAttach: () => void = () => undefined;
+    const attachBarrier = new Promise<void>((resolve) => {
+      releaseAttach = resolve;
+    });
+    let signalAttachStarted: () => void = () => undefined;
+    const attachStarted = new Promise<void>((resolve) => {
+      signalAttachStarted = resolve;
+    });
+    class ConcurrentGateway extends FakePaymentGateway {
+      private delivery = 0;
+
+      override async processWebhookEvent(): Promise<WebhookEventResult> {
+        this.delivery += 1;
+        return {
+          eventId: `evt_setup_${this.delivery}`,
+          type: 'checkout.session.completed',
+          trialPaymentMethodSetupCompletion: {
+            sessionId: 'cs_setup_concurrent',
+            userId,
+            externalCustomerId: 'cus_123',
+            externalSubscriptionId: 'sub_123',
+            plan: 'monthly',
+            amountCents: 2900,
+            currency: 'usd',
+            frequency: 'month',
+            trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+            disclosureVersion: '2026-08-05',
+            termsVersion: '2026-08-05',
+            termsHash: 'terms-hash',
+            stripePaymentMethodId: 'pm_123',
+          },
+        };
+      }
+
+      override async attachTrialPaymentMethod(
+        input: Parameters<FakePaymentGateway['attachTrialPaymentMethod']>[0],
+      ): Promise<void> {
+        await super.attachTrialPaymentMethod(input);
+        signalAttachStarted();
+        await attachBarrier;
+      }
+    }
+    const paymentGateway = new ConcurrentGateway({
+      externalCustomerId: 'cus_123',
+      checkoutUrl: 'https://stripe/checkout',
+      portalUrl: 'https://stripe/portal',
+      webhookResult: { eventId: 'unused', type: 'charge.refunded' },
+    });
+    const { deps, subscriptions, stripeCustomers, setupOperations } =
+      createDeps({ paymentGateway });
+    await subscriptions.upsert({
+      userId,
+      externalSubscriptionId: 'sub_123',
+      plan: 'monthly',
+      status: 'inTrial',
+      currentPeriodEnd: new Date('2026-08-13T12:00:00Z'),
+      cancelAtPeriodEnd: false,
+      expectedVersion: null,
+    });
+    await stripeCustomers.insert(userId, 'cus_123');
+    await setupOperations.createPending({
+      sessionId: 'cs_setup_concurrent',
+      userId,
+      stripeCustomerId: 'cus_123',
+      stripeSubscriptionId: 'sub_123',
+      plan: 'monthly',
+      amountCents: 2900,
+      currency: 'usd',
+      frequency: 'month',
+      trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+      disclosureSnapshot: 'Exact disclosure.',
+      disclosureVersion: '2026-08-05',
+      termsVersion: '2026-08-05',
+      termsHash: 'terms-hash',
+    });
+
+    const first = processStripeWebhook(deps, {
+      rawBody: 'raw-1',
+      signature: 'sig-1',
+    });
+    await attachStarted;
+    const second = processStripeWebhook(deps, {
+      rawBody: 'raw-2',
+      signature: 'sig-2',
+    });
+    await expect(second).rejects.toMatchObject({ code: 'CONFLICT' });
+    releaseAttach();
+    await expect(first).resolves.toBeUndefined();
+
+    expect(paymentGateway.trialPaymentMethodAttachInputs).toHaveLength(1);
+    expect(paymentGateway.trialSubscriptionDefaultInputs).toHaveLength(1);
+  });
+
+  it('resumes after the lease without repeating an already-recorded attach', async () => {
+    const userId = crypto.randomUUID();
+    let defaultAttempts = 0;
+    class OnceFailingDefaultGateway extends FakePaymentGateway {
+      override async setTrialSubscriptionDefaultPaymentMethod(
+        input: Parameters<
+          FakePaymentGateway['setTrialSubscriptionDefaultPaymentMethod']
+        >[0],
+      ): Promise<void> {
+        defaultAttempts += 1;
+        if (defaultAttempts === 1) throw new Error('transient');
+        await super.setTrialSubscriptionDefaultPaymentMethod(input);
+      }
+    }
+    const paymentGateway = new OnceFailingDefaultGateway({
+      externalCustomerId: 'cus_123',
+      checkoutUrl: 'https://stripe/checkout',
+      portalUrl: 'https://stripe/portal',
+      webhookResult: {
+        eventId: 'evt_setup_recovery',
+        type: 'checkout.session.completed',
+        trialPaymentMethodSetupCompletion: {
+          sessionId: 'cs_setup_recovery',
+          userId,
+          externalCustomerId: 'cus_123',
+          externalSubscriptionId: 'sub_123',
+          plan: 'monthly',
+          amountCents: 2900,
+          currency: 'usd',
+          frequency: 'month',
+          trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+          disclosureVersion: '2026-08-05',
+          termsVersion: '2026-08-05',
+          termsHash: 'terms-hash',
+          stripePaymentMethodId: 'pm_123',
+        },
+      },
+    });
+    const harness = createDeps({ paymentGateway });
+    let now = new Date('2026-08-06T12:00:00Z');
+    harness.deps.now = () => now;
+    await harness.subscriptions.upsert({
+      userId,
+      externalSubscriptionId: 'sub_123',
+      plan: 'monthly',
+      status: 'inTrial',
+      currentPeriodEnd: new Date('2026-08-13T12:00:00Z'),
+      cancelAtPeriodEnd: false,
+      expectedVersion: null,
+    });
+    await harness.stripeCustomers.insert(userId, 'cus_123');
+    await harness.setupOperations.createPending({
+      sessionId: 'cs_setup_recovery',
+      userId,
+      stripeCustomerId: 'cus_123',
+      stripeSubscriptionId: 'sub_123',
+      plan: 'monthly',
+      amountCents: 2900,
+      currency: 'usd',
+      frequency: 'month',
+      trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+      disclosureSnapshot: 'Exact disclosure.',
+      disclosureVersion: '2026-08-05',
+      termsVersion: '2026-08-05',
+      termsHash: 'terms-hash',
+    });
+
+    await expect(
+      processStripeWebhook(harness.deps, {
+        rawBody: 'raw',
+        signature: 'sig',
+      }),
+    ).rejects.toThrow('transient');
+    now = new Date('2026-08-06T12:06:00Z');
+    await expect(
+      processStripeWebhook(harness.deps, {
+        rawBody: 'raw',
+        signature: 'sig',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(paymentGateway.trialPaymentMethodAttachInputs).toHaveLength(1);
+    expect(defaultAttempts).toBe(2);
+    expect(paymentGateway.trialSubscriptionDefaultInputs).toHaveLength(1);
+    await expect(
+      harness.setupOperations.findBySessionId('cs_setup_recovery'),
+    ).resolves.toMatchObject({ status: 'completed' });
+  });
+
   it('skips subscription webhooks that are missing metadata.user_id', async () => {
     const paymentGateway = new ThrowingPaymentGateway(
       new ApplicationError(

--- a/src/adapters/controllers/stripe-webhook-controller.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.test.ts
@@ -58,6 +58,12 @@ class ConcurrentlyCompletingStripeEventRepository extends FakeStripeEventReposit
   }
 }
 
+class LookupFailingSetupOperationRepository extends FakeTrialPaymentMethodSetupOperationRepository {
+  override async findBySessionId(): Promise<never> {
+    throw new Error('setup operation lookup failed');
+  }
+}
+
 class ThrowingPaymentGateway extends FakePaymentGateway {
   constructor(private readonly error: unknown) {
     super({
@@ -152,12 +158,13 @@ function createRollbackAwareDeps(overrides: {
           .constructor as new () => FakeSubscriptionRepository;
         const StripeCustomersCtor = base.stripeCustomers
           .constructor as new () => FakeStripeCustomerRepository;
+        const SetupOperationsCtor = base.setupOperations
+          .constructor as new () => FakeTrialPaymentMethodSetupOperationRepository;
 
         const stagingEvents = new StripeEventsCtor();
         const stagingSubscriptions = new SubscriptionsCtor();
         const stagingStripeCustomers = new StripeCustomersCtor();
-        const stagingSetupOperations =
-          new FakeTrialPaymentMethodSetupOperationRepository();
+        const stagingSetupOperations = new SetupOperationsCtor();
 
         stagingEvents.restore(base.stripeEvents.snapshot());
         stagingSubscriptions.restore(base.subscriptions.snapshot());
@@ -345,6 +352,76 @@ describe('processStripeWebhook', () => {
     ).rejects.toMatchObject({ code: 'CONFLICT' });
     expect(paymentGateway.trialPaymentMethodAttachInputs).toEqual([]);
     expect(paymentGateway.trialSubscriptionDefaultInputs).toEqual([]);
+  });
+
+  it('reports a missing setup operation before evaluating its snapshot', async () => {
+    const paymentGateway = new FakePaymentGateway({
+      externalCustomerId: 'cus_123',
+      checkoutUrl: 'https://stripe/checkout',
+      portalUrl: 'https://stripe/portal',
+      webhookResult: {
+        eventId: 'evt_setup_missing',
+        type: 'checkout.session.completed',
+        trialPaymentMethodSetupCompletion: {
+          sessionId: 'cs_setup_missing',
+          userId: crypto.randomUUID(),
+          externalCustomerId: 'cus_123',
+          externalSubscriptionId: 'sub_123',
+          plan: 'monthly',
+          amountCents: 2900,
+          currency: 'usd',
+          frequency: 'month',
+          trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+          disclosureVersion: '2026-08-05',
+          termsVersion: '2026-08-05',
+          termsHash: 'terms-hash',
+          stripePaymentMethodId: 'pm_123',
+        },
+      },
+    });
+    const { deps } = createDeps({ paymentGateway });
+
+    await expect(
+      processStripeWebhook(deps, { rawBody: 'raw', signature: 'sig' }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Trial payment-method setup operation is missing',
+    });
+  });
+
+  it('preserves an injected setup-operation repository subclass inside staged transactions', async () => {
+    const paymentGateway = new FakePaymentGateway({
+      externalCustomerId: 'cus_123',
+      checkoutUrl: 'https://stripe/checkout',
+      portalUrl: 'https://stripe/portal',
+      webhookResult: {
+        eventId: 'evt_setup_lookup_failure',
+        type: 'checkout.session.completed',
+        trialPaymentMethodSetupCompletion: {
+          sessionId: 'cs_setup_lookup_failure',
+          userId: crypto.randomUUID(),
+          externalCustomerId: 'cus_123',
+          externalSubscriptionId: 'sub_123',
+          plan: 'monthly',
+          amountCents: 2900,
+          currency: 'usd',
+          frequency: 'month',
+          trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+          disclosureVersion: '2026-08-05',
+          termsVersion: '2026-08-05',
+          termsHash: 'terms-hash',
+          stripePaymentMethodId: 'pm_123',
+        },
+      },
+    });
+    const { deps } = createRollbackAwareDeps({
+      paymentGateway,
+      setupOperations: new LookupFailingSetupOperationRepository(),
+    });
+
+    await expect(
+      processStripeWebhook(deps, { rawBody: 'raw', signature: 'sig' }),
+    ).rejects.toThrow('setup operation lookup failed');
   });
 
   it('fails closed when the signed customer does not match the local user mapping', async () => {

--- a/src/adapters/controllers/stripe-webhook-controller.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.ts
@@ -20,6 +20,7 @@ import type {
   StripeCustomerRepository,
   StripeEventRepository,
   SubscriptionRepository,
+  TrialPaymentMethodSetupOperation,
   TrialPaymentMethodSetupOperationRepository,
 } from '@/src/application/ports/repositories';
 import { persistSubscriptionObservation } from '@/src/application/shared/persist-subscription-observation';
@@ -74,25 +75,22 @@ const PROCESSED_STRIPE_EVENTS_RETENTION_MS = 90 * DAY_MS;
 const TRIAL_PAYMENT_METHOD_SETUP_CLAIM_LEASE_MS = 5 * 60 * 1000;
 
 function setupSnapshotMatches(
-  operation: Awaited<
-    ReturnType<TrialPaymentMethodSetupOperationRepository['findBySessionId']>
-  >,
+  operation: TrialPaymentMethodSetupOperation,
   completion: TrialPaymentMethodSetupCompletion,
 ): boolean {
-  return Boolean(
-    operation &&
-      operation.sessionId === completion.sessionId &&
-      operation.userId === completion.userId &&
-      operation.stripeCustomerId === completion.externalCustomerId &&
-      operation.stripeSubscriptionId === completion.externalSubscriptionId &&
-      operation.plan === completion.plan &&
-      operation.amountCents === completion.amountCents &&
-      operation.currency === completion.currency &&
-      operation.frequency === completion.frequency &&
-      operation.trialEndsAt.getTime() === completion.trialEndsAt.getTime() &&
-      operation.disclosureVersion === completion.disclosureVersion &&
-      operation.termsVersion === completion.termsVersion &&
-      operation.termsHash === completion.termsHash,
+  return (
+    operation.sessionId === completion.sessionId &&
+    operation.userId === completion.userId &&
+    operation.stripeCustomerId === completion.externalCustomerId &&
+    operation.stripeSubscriptionId === completion.externalSubscriptionId &&
+    operation.plan === completion.plan &&
+    operation.amountCents === completion.amountCents &&
+    operation.currency === completion.currency &&
+    operation.frequency === completion.frequency &&
+    operation.trialEndsAt.getTime() === completion.trialEndsAt.getTime() &&
+    operation.disclosureVersion === completion.disclosureVersion &&
+    operation.termsVersion === completion.termsVersion &&
+    operation.termsHash === completion.termsHash
   );
 }
 
@@ -117,16 +115,16 @@ async function processTrialPaymentMethodSetupWebhook(
       const operation = await trialPaymentMethodSetupOperations.findBySessionId(
         completion.sessionId,
       );
-      if (!setupSnapshotMatches(operation, completion)) {
-        throw new ApplicationError(
-          'CONFLICT',
-          'Trial payment-method completion does not match its pending consent snapshot',
-        );
-      }
       if (!operation) {
         throw new ApplicationError(
           'CONFLICT',
           'Trial payment-method setup operation is missing',
+        );
+      }
+      if (!setupSnapshotMatches(operation, completion)) {
+        throw new ApplicationError(
+          'CONFLICT',
+          'Trial payment-method completion does not match its pending consent snapshot',
         );
       }
       if (operation.status === 'completed') {
@@ -162,14 +160,14 @@ async function processTrialPaymentMethodSetupWebhook(
         );
       }
 
-      const result = await trialPaymentMethodSetupOperations.claim(
-        completion.sessionId,
+      const result = await trialPaymentMethodSetupOperations.claim({
+        sessionId: completion.sessionId,
         claimId,
         claimedAt,
-        new Date(
+        staleBefore: new Date(
           claimedAt.getTime() - TRIAL_PAYMENT_METHOD_SETUP_CLAIM_LEASE_MS,
         ),
-      );
+      });
       if (!result) {
         throw new ApplicationError(
           'CONFLICT',
@@ -189,12 +187,12 @@ async function processTrialPaymentMethodSetupWebhook(
       externalCustomerId: completion.externalCustomerId,
     });
     await deps.transaction(async ({ trialPaymentMethodSetupOperations }) => {
-      await trialPaymentMethodSetupOperations.markPaymentMethodAttached(
-        completion.sessionId,
+      await trialPaymentMethodSetupOperations.markPaymentMethodAttached({
+        sessionId: completion.sessionId,
         claimId,
-        completion.stripePaymentMethodId,
-        deps.now(),
-      );
+        stripePaymentMethodId: completion.stripePaymentMethodId,
+        attachedAt: deps.now(),
+      });
     });
   } else if (
     claimed.stripePaymentMethodId !== completion.stripePaymentMethodId
@@ -212,21 +210,21 @@ async function processTrialPaymentMethodSetupWebhook(
       externalSubscriptionId: completion.externalSubscriptionId,
     });
     await deps.transaction(async ({ trialPaymentMethodSetupOperations }) => {
-      await trialPaymentMethodSetupOperations.markSubscriptionDefaultSet(
-        completion.sessionId,
+      await trialPaymentMethodSetupOperations.markSubscriptionDefaultSet({
+        sessionId: completion.sessionId,
         claimId,
-        deps.now(),
-      );
+        selectedAt: deps.now(),
+      });
     });
   }
 
   await deps.transaction(
     async ({ stripeEvents, trialPaymentMethodSetupOperations }) => {
-      await trialPaymentMethodSetupOperations.markCompleted(
-        completion.sessionId,
+      await trialPaymentMethodSetupOperations.markCompleted({
+        sessionId: completion.sessionId,
         claimId,
-        deps.now(),
-      );
+        completedAt: deps.now(),
+      });
       await stripeEvents.markProcessed(event.eventId);
     },
   );

--- a/src/adapters/controllers/stripe-webhook-controller.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.ts
@@ -20,6 +20,7 @@ import type {
   StripeCustomerRepository,
   StripeEventRepository,
   SubscriptionRepository,
+  TrialPaymentMethodSetupOperationRepository,
 } from '@/src/application/ports/repositories';
 import { persistSubscriptionObservation } from '@/src/application/shared/persist-subscription-observation';
 import { DAY_MS } from '@/src/domain/services';
@@ -33,6 +34,7 @@ export type StripeWebhookTransaction = {
   stripeEvents: StripeEventRepository;
   subscriptions: SubscriptionRepository;
   stripeCustomers: StripeCustomerRepository;
+  trialPaymentMethodSetupOperations: TrialPaymentMethodSetupOperationRepository;
 };
 
 export type StripeWebhookDeps = {
@@ -54,6 +56,9 @@ type StripeWebhookEvent = Awaited<
 type StripeSubscriptionUpdate = NonNullable<
   StripeWebhookEvent['subscriptionUpdate']
 >;
+type TrialPaymentMethodSetupCompletion = NonNullable<
+  StripeWebhookEvent['trialPaymentMethodSetupCompletion']
+>;
 
 class StripeWebhookAlreadyProcessed extends Error {}
 
@@ -66,6 +71,166 @@ class StripeWebhookAlreadyProcessed extends Error {}
 // - The inline user.deleted path owns immediate customer cleanup, while the
 //   daily drain owns retries and fallback.
 const PROCESSED_STRIPE_EVENTS_RETENTION_MS = 90 * DAY_MS;
+const TRIAL_PAYMENT_METHOD_SETUP_CLAIM_LEASE_MS = 5 * 60 * 1000;
+
+function setupSnapshotMatches(
+  operation: Awaited<
+    ReturnType<TrialPaymentMethodSetupOperationRepository['findBySessionId']>
+  >,
+  completion: TrialPaymentMethodSetupCompletion,
+): boolean {
+  return Boolean(
+    operation &&
+      operation.sessionId === completion.sessionId &&
+      operation.userId === completion.userId &&
+      operation.stripeCustomerId === completion.externalCustomerId &&
+      operation.stripeSubscriptionId === completion.externalSubscriptionId &&
+      operation.plan === completion.plan &&
+      operation.amountCents === completion.amountCents &&
+      operation.currency === completion.currency &&
+      operation.frequency === completion.frequency &&
+      operation.trialEndsAt.getTime() === completion.trialEndsAt.getTime() &&
+      operation.disclosureVersion === completion.disclosureVersion &&
+      operation.termsVersion === completion.termsVersion &&
+      operation.termsHash === completion.termsHash,
+  );
+}
+
+async function processTrialPaymentMethodSetupWebhook(
+  deps: StripeWebhookDeps,
+  event: StripeWebhookEvent,
+  completion: TrialPaymentMethodSetupCompletion,
+): Promise<void> {
+  const claimedAt = deps.now();
+  const claimId = crypto.randomUUID();
+  const claimed = await deps.transaction(
+    async ({
+      stripeEvents,
+      subscriptions,
+      stripeCustomers,
+      trialPaymentMethodSetupOperations,
+    }) => {
+      await stripeEvents.claim(event.eventId, event.type);
+      const eventState = await stripeEvents.lock(event.eventId);
+      if (isSuccessfullyProcessed(eventState)) return null;
+
+      const operation = await trialPaymentMethodSetupOperations.findBySessionId(
+        completion.sessionId,
+      );
+      if (!setupSnapshotMatches(operation, completion)) {
+        throw new ApplicationError(
+          'CONFLICT',
+          'Trial payment-method completion does not match its pending consent snapshot',
+        );
+      }
+      if (!operation) {
+        throw new ApplicationError(
+          'CONFLICT',
+          'Trial payment-method setup operation is missing',
+        );
+      }
+      if (operation.status === 'completed') {
+        if (
+          operation.stripePaymentMethodId !== completion.stripePaymentMethodId
+        ) {
+          throw new ApplicationError(
+            'CONFLICT',
+            'Completed trial payment-method setup changed payment method',
+          );
+        }
+        await stripeEvents.markProcessed(event.eventId);
+        return null;
+      }
+
+      const [subscription, externalSubscriptionId, customer] =
+        await Promise.all([
+          subscriptions.findByUserId(completion.userId),
+          subscriptions.findExternalSubscriptionIdByUserId(completion.userId),
+          stripeCustomers.findByUserId(completion.userId),
+        ]);
+      if (
+        subscription?.status !== 'inTrial' ||
+        subscription.plan !== completion.plan ||
+        subscription.currentPeriodEnd.getTime() !==
+          completion.trialEndsAt.getTime() ||
+        externalSubscriptionId !== completion.externalSubscriptionId ||
+        customer?.stripeCustomerId !== completion.externalCustomerId
+      ) {
+        throw new ApplicationError(
+          'CONFLICT',
+          'Trial payment-method completion does not match current local billing ownership',
+        );
+      }
+
+      const result = await trialPaymentMethodSetupOperations.claim(
+        completion.sessionId,
+        claimId,
+        claimedAt,
+        new Date(
+          claimedAt.getTime() - TRIAL_PAYMENT_METHOD_SETUP_CLAIM_LEASE_MS,
+        ),
+      );
+      if (!result) {
+        throw new ApplicationError(
+          'CONFLICT',
+          'Trial payment-method setup is already being processed',
+        );
+      }
+      return result;
+    },
+  );
+
+  if (!claimed) return;
+
+  if (!claimed.paymentMethodAttachedAt) {
+    await deps.paymentGateway.attachTrialPaymentMethod({
+      sessionId: completion.sessionId,
+      externalPaymentMethodId: completion.stripePaymentMethodId,
+      externalCustomerId: completion.externalCustomerId,
+    });
+    await deps.transaction(async ({ trialPaymentMethodSetupOperations }) => {
+      await trialPaymentMethodSetupOperations.markPaymentMethodAttached(
+        completion.sessionId,
+        claimId,
+        completion.stripePaymentMethodId,
+        deps.now(),
+      );
+    });
+  } else if (
+    claimed.stripePaymentMethodId !== completion.stripePaymentMethodId
+  ) {
+    throw new ApplicationError(
+      'CONFLICT',
+      'Recovered trial payment-method setup changed payment method',
+    );
+  }
+
+  if (!claimed.subscriptionDefaultSetAt) {
+    await deps.paymentGateway.setTrialSubscriptionDefaultPaymentMethod({
+      sessionId: completion.sessionId,
+      externalPaymentMethodId: completion.stripePaymentMethodId,
+      externalSubscriptionId: completion.externalSubscriptionId,
+    });
+    await deps.transaction(async ({ trialPaymentMethodSetupOperations }) => {
+      await trialPaymentMethodSetupOperations.markSubscriptionDefaultSet(
+        completion.sessionId,
+        claimId,
+        deps.now(),
+      );
+    });
+  }
+
+  await deps.transaction(
+    async ({ stripeEvents, trialPaymentMethodSetupOperations }) => {
+      await trialPaymentMethodSetupOperations.markCompleted(
+        completion.sessionId,
+        claimId,
+        deps.now(),
+      );
+      await stripeEvents.markProcessed(event.eventId);
+    },
+  );
+}
 
 function isSuccessfullyProcessed(event: {
   processedAt: Date | null;
@@ -276,7 +441,13 @@ async function processStripeWebhookWithinSpan(
   let hasProcessingError = false;
 
   try {
-    if (event.subscriptionUpdate) {
+    if (event.trialPaymentMethodSetupCompletion) {
+      await processTrialPaymentMethodSetupWebhook(
+        deps,
+        event,
+        event.trialPaymentMethodSetupCompletion,
+      );
+    } else if (event.subscriptionUpdate) {
       await processSubscriptionWebhook(
         deps,
         input,

--- a/src/adapters/gateways/stripe-payment-gateway.test.ts
+++ b/src/adapters/gateways/stripe-payment-gateway.test.ts
@@ -176,11 +176,15 @@ function createStripeMock({
 describe('StripePaymentGateway', () => {
   it('attaches a trial payment method and selects it with Session-derived idempotency keys', async () => {
     const base = createStripeMock({ withSubscriptions: true });
-    const attach = vi.fn(async () => ({ id: 'pm_123' }));
+    const retrieve = vi.fn(async () => ({ id: 'pm_123', customer: null }));
+    const attach = vi.fn(async () => ({
+      id: 'pm_123',
+      customer: 'cus_123',
+    }));
     const update = vi.fn(async () => ({}));
     const stripe: StripeClient = {
       ...base.stripe,
-      paymentMethods: { attach },
+      paymentMethods: { retrieve, attach },
       subscriptions: { ...base.stripe.subscriptions, update },
     };
     const gateway = createGateway(stripe);
@@ -201,11 +205,83 @@ describe('StripePaymentGateway', () => {
       { customer: 'cus_123' },
       { idempotencyKey: 'trial_setup:cs_setup_123:attach_payment_method' },
     );
+    expect(retrieve).toHaveBeenCalledWith('pm_123');
     expect(update).toHaveBeenCalledWith(
       'sub_123',
       { default_payment_method: 'pm_123' },
       { idempotencyKey: 'trial_setup:cs_setup_123:set_subscription_default' },
     );
+  });
+
+  it('reconciles an already-attached payment method without issuing a second attach', async () => {
+    const base = createStripeMock({ withSubscriptions: true });
+    const retrieve = vi.fn(async () => ({
+      id: 'pm_123',
+      customer: 'cus_123',
+    }));
+    const attach = vi.fn(async () => ({
+      id: 'pm_123',
+      customer: 'cus_123',
+    }));
+    const stripe: StripeClient = {
+      ...base.stripe,
+      paymentMethods: { retrieve, attach },
+    };
+
+    await createGateway(stripe).attachTrialPaymentMethod({
+      sessionId: 'cs_setup_123',
+      externalPaymentMethodId: 'pm_123',
+      externalCustomerId: 'cus_123',
+    });
+
+    expect(retrieve).toHaveBeenCalledWith('pm_123');
+    expect(attach).not.toHaveBeenCalled();
+  });
+
+  it('rejects an attachment response that is not bound to the verified customer', async () => {
+    const base = createStripeMock({ withSubscriptions: true });
+    const stripe: StripeClient = {
+      ...base.stripe,
+      paymentMethods: {
+        retrieve: vi.fn(async () => ({ id: 'pm_123', customer: null })),
+        attach: vi.fn(async () => ({ id: 'pm_123', customer: 'cus_other' })),
+      },
+    };
+
+    await expect(
+      createGateway(stripe).attachTrialPaymentMethod({
+        sessionId: 'cs_setup_123',
+        externalPaymentMethodId: 'pm_123',
+        externalCustomerId: 'cus_123',
+      }),
+    ).rejects.toMatchObject({ code: 'STRIPE_ERROR' });
+  });
+
+  it('rejects a payment method already attached to another customer', async () => {
+    const base = createStripeMock({ withSubscriptions: true });
+    const attach = vi.fn(async () => ({
+      id: 'pm_123',
+      customer: 'cus_123',
+    }));
+    const stripe: StripeClient = {
+      ...base.stripe,
+      paymentMethods: {
+        retrieve: vi.fn(async () => ({
+          id: 'pm_123',
+          customer: 'cus_other',
+        })),
+        attach,
+      },
+    };
+
+    await expect(
+      createGateway(stripe).attachTrialPaymentMethod({
+        sessionId: 'cs_setup_123',
+        externalPaymentMethodId: 'pm_123',
+        externalCustomerId: 'cus_123',
+      }),
+    ).rejects.toMatchObject({ code: 'STRIPE_ERROR' });
+    expect(attach).not.toHaveBeenCalled();
   });
 
   it('creates a Stripe customer with the correct Stripe parameters', async () => {

--- a/src/adapters/gateways/stripe-payment-gateway.test.ts
+++ b/src/adapters/gateways/stripe-payment-gateway.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type {
+  CheckoutSessionCreateParams,
   StripeBillingPortalSession,
   StripeCheckoutSession,
   StripeCheckoutSessionList,
@@ -7,6 +8,7 @@ import type {
   StripeClient,
   StripeCustomer,
   StripeCustomerSearchResult,
+  StripeRequestOptions,
   StripeSubscription,
   StripeSubscriptionListResult,
 } from '@/src/adapters/shared/stripe-types';
@@ -64,7 +66,10 @@ function createStripeMockBase() {
     async () => ({ data: [] }) as StripeCustomerSearchResult,
   );
   const sessionsCreate = vi.fn(
-    async () =>
+    async (
+      _params: CheckoutSessionCreateParams,
+      _options?: StripeRequestOptions,
+    ) =>
       ({
         id: 'cs_new',
         url: 'https://stripe/checkout',
@@ -169,6 +174,40 @@ function createStripeMock({
 }
 
 describe('StripePaymentGateway', () => {
+  it('attaches a trial payment method and selects it with Session-derived idempotency keys', async () => {
+    const base = createStripeMock({ withSubscriptions: true });
+    const attach = vi.fn(async () => ({ id: 'pm_123' }));
+    const update = vi.fn(async () => ({}));
+    const stripe: StripeClient = {
+      ...base.stripe,
+      paymentMethods: { attach },
+      subscriptions: { ...base.stripe.subscriptions, update },
+    };
+    const gateway = createGateway(stripe);
+
+    await gateway.attachTrialPaymentMethod({
+      sessionId: 'cs_setup_123',
+      externalPaymentMethodId: 'pm_123',
+      externalCustomerId: 'cus_123',
+    });
+    await gateway.setTrialSubscriptionDefaultPaymentMethod({
+      sessionId: 'cs_setup_123',
+      externalPaymentMethodId: 'pm_123',
+      externalSubscriptionId: 'sub_123',
+    });
+
+    expect(attach).toHaveBeenCalledWith(
+      'pm_123',
+      { customer: 'cus_123' },
+      { idempotencyKey: 'trial_setup:cs_setup_123:attach_payment_method' },
+    );
+    expect(update).toHaveBeenCalledWith(
+      'sub_123',
+      { default_payment_method: 'pm_123' },
+      { idempotencyKey: 'trial_setup:cs_setup_123:set_subscription_default' },
+    );
+  });
+
   it('creates a Stripe customer with the correct Stripe parameters', async () => {
     const { stripe, customersCreate, customersSearch } = createStripeMock();
     const gateway = createGateway(stripe);
@@ -289,6 +328,43 @@ describe('StripePaymentGateway', () => {
         idempotencyKey: `checkout_session:${appUserId}:monthly`,
       }),
     );
+  });
+
+  it('creates the trial payment-method setup Session through the customer-less setup seam', async () => {
+    const { stripe, sessionsCreate } = createStripeMock();
+    const gateway = createGateway(stripe);
+
+    await expect(
+      gateway.createTrialPaymentMethodSetupSession({
+        userId: appUserId,
+        externalCustomerId: 'cus_123',
+        externalSubscriptionId: 'sub_123',
+        plan: 'monthly',
+        amountCents: 2900,
+        currency: 'usd',
+        frequency: 'month',
+        trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+        disclosureVersion: '2026-08-05',
+        termsVersion: '2026-08-05',
+        termsHash: 'terms-hash',
+        disclosureSnapshot: 'Exact disclosure.',
+        successUrl: 'https://app/success',
+        cancelUrl: 'https://app/cancel',
+      }),
+    ).resolves.toEqual({
+      sessionId: 'cs_new',
+      url: 'https://stripe/checkout',
+    });
+
+    expect(sessionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'setup',
+        currency: 'usd',
+        consent_collection: { terms_of_service: 'required' },
+      }),
+      expect.any(Object),
+    );
+    expect(sessionsCreate.mock.calls[0]?.[0]).not.toHaveProperty('customer');
   });
 
   it.each([

--- a/src/adapters/gateways/stripe-payment-gateway.ts
+++ b/src/adapters/gateways/stripe-payment-gateway.ts
@@ -84,7 +84,24 @@ export class StripePaymentGateway implements PaymentGateway {
         'Stripe PaymentMethod API is unavailable',
       );
     }
-    await callStripeWithRetry({
+    const current = await callStripeWithRetry({
+      operation: 'payment_methods.retrieve_trial_setup',
+      fn: () => paymentMethods.retrieve(input.externalPaymentMethodId),
+      logger: this.deps.logger,
+    });
+    const currentCustomerId =
+      typeof current.customer === 'string'
+        ? current.customer
+        : current.customer?.id;
+    if (currentCustomerId === input.externalCustomerId) return;
+    if (currentCustomerId) {
+      throw new ApplicationError(
+        'STRIPE_ERROR',
+        'Trial PaymentMethod is attached to a different customer',
+      );
+    }
+
+    const attached = await callStripeWithRetry({
       operation: 'payment_methods.attach_trial_setup',
       fn: () =>
         paymentMethods.attach(
@@ -96,6 +113,16 @@ export class StripePaymentGateway implements PaymentGateway {
         ),
       logger: this.deps.logger,
     });
+    const attachedCustomerId =
+      typeof attached.customer === 'string'
+        ? attached.customer
+        : attached.customer?.id;
+    if (attachedCustomerId !== input.externalCustomerId) {
+      throw new ApplicationError(
+        'STRIPE_ERROR',
+        'Stripe did not confirm the verified PaymentMethod customer',
+      );
+    }
   }
 
   async setTrialSubscriptionDefaultPaymentMethod(

--- a/src/adapters/gateways/stripe-payment-gateway.ts
+++ b/src/adapters/gateways/stripe-payment-gateway.ts
@@ -3,10 +3,13 @@ import {
   createStripeCheckoutSession,
   createStripeCustomer,
   createStripePortalSession,
+  createStripeTrialPaymentMethodSetupSession,
   processStripeWebhookEvent,
 } from '@/src/adapters/gateways/stripe';
 import type { StripeClient } from '@/src/adapters/shared/stripe-types';
+import { ApplicationError } from '@/src/application/errors';
 import type {
+  AttachTrialPaymentMethodInput,
   CheckoutSessionInput,
   CheckoutSessionOutput,
   CreateCustomerInput,
@@ -15,9 +18,13 @@ import type {
   PaymentGatewayRequestOptions,
   PortalSessionInput,
   PortalSessionOutput,
+  SetTrialSubscriptionDefaultPaymentMethodInput,
+  TrialPaymentMethodSetupSessionInput,
+  TrialPaymentMethodSetupSessionOutput,
   WebhookEventResult,
 } from '@/src/application/ports/gateways';
 import type { Logger } from '@/src/application/ports/logger';
+import { callStripeWithRetry } from './stripe/stripe-retry';
 
 export type StripePaymentGatewayDeps = {
   stripe: StripeClient;
@@ -52,6 +59,66 @@ export class StripePaymentGateway implements PaymentGateway {
       stripe: this.deps.stripe,
       input,
       priceIds: this.deps.priceIds,
+      logger: this.deps.logger,
+    });
+  }
+
+  async createTrialPaymentMethodSetupSession(
+    input: TrialPaymentMethodSetupSessionInput,
+  ): Promise<TrialPaymentMethodSetupSessionOutput> {
+    return createStripeTrialPaymentMethodSetupSession({
+      stripe: this.deps.stripe,
+      input,
+      logger: this.deps.logger,
+      stateSecret: this.deps.webhookSecret,
+    });
+  }
+
+  async attachTrialPaymentMethod(
+    input: AttachTrialPaymentMethodInput,
+  ): Promise<void> {
+    const paymentMethods = this.deps.stripe.paymentMethods;
+    if (!paymentMethods) {
+      throw new ApplicationError(
+        'STRIPE_ERROR',
+        'Stripe PaymentMethod API is unavailable',
+      );
+    }
+    await callStripeWithRetry({
+      operation: 'payment_methods.attach_trial_setup',
+      fn: () =>
+        paymentMethods.attach(
+          input.externalPaymentMethodId,
+          { customer: input.externalCustomerId },
+          {
+            idempotencyKey: `trial_setup:${input.sessionId}:attach_payment_method`,
+          },
+        ),
+      logger: this.deps.logger,
+    });
+  }
+
+  async setTrialSubscriptionDefaultPaymentMethod(
+    input: SetTrialSubscriptionDefaultPaymentMethodInput,
+  ): Promise<void> {
+    const subscriptions = this.deps.stripe.subscriptions;
+    const updateSubscription = subscriptions?.update?.bind(subscriptions);
+    if (!updateSubscription) {
+      throw new ApplicationError(
+        'STRIPE_ERROR',
+        'Stripe Subscription update API is unavailable',
+      );
+    }
+    await callStripeWithRetry({
+      operation: 'subscriptions.set_trial_setup_default_payment_method',
+      fn: () =>
+        updateSubscription(
+          input.externalSubscriptionId,
+          { default_payment_method: input.externalPaymentMethodId },
+          {
+            idempotencyKey: `trial_setup:${input.sessionId}:set_subscription_default`,
+          },
+        ),
       logger: this.deps.logger,
     });
   }

--- a/src/adapters/gateways/stripe/index.ts
+++ b/src/adapters/gateways/stripe/index.ts
@@ -1,5 +1,6 @@
 export {
   createStripeCheckoutSession,
+  createStripeTrialPaymentMethodSetupSession,
   SUBSCRIPTION_LIST_LIMIT,
 } from './stripe-checkout-sessions';
 export type {

--- a/src/adapters/gateways/stripe/stripe-checkout-sessions-concurrency.test.ts
+++ b/src/adapters/gateways/stripe/stripe-checkout-sessions-concurrency.test.ts
@@ -62,6 +62,9 @@ function createConcurrentStripeMock() {
       params: CheckoutSessionCreateParams,
       options?: StripeRequestOptions,
     ) => {
+      if (params.mode === 'setup') {
+        throw new Error('Unexpected setup-mode Checkout Session');
+      }
       const key = options?.idempotencyKey;
       if (key) {
         const replayed = sessionsByIdempotencyKey.get(key);

--- a/src/adapters/gateways/stripe/stripe-checkout-sessions-recovery.test.ts
+++ b/src/adapters/gateways/stripe/stripe-checkout-sessions-recovery.test.ts
@@ -119,6 +119,12 @@ describe('createStripeCheckoutSession recovery', () => {
     const createOptions = sessionsCreate.mock.calls.map(([, options]) => ({
       idempotencyKey: options?.idempotencyKey,
     }));
+    expect(
+      sessionsCreate.mock.calls.map(([params]) => params.consent_collection),
+    ).toEqual([
+      { terms_of_service: 'required' },
+      { terms_of_service: 'required' },
+    ]);
     expect(createOptions[0]).toEqual({
       idempotencyKey: `checkout_session:${appUserId}:monthly:trial:7`,
     });

--- a/src/adapters/gateways/stripe/stripe-checkout-sessions-trial-recovery.test.ts
+++ b/src/adapters/gateways/stripe/stripe-checkout-sessions-trial-recovery.test.ts
@@ -109,7 +109,9 @@ describe('createStripeCheckoutSession trial replacement idempotency', () => {
       idempotencyKey: 'expire_checkout_session:cs_open',
     });
     expect(sessionsCreate).toHaveBeenCalledWith(
-      expect.any(Object),
+      expect.objectContaining({
+        consent_collection: { terms_of_service: 'required' },
+      }),
       expect.objectContaining({
         idempotencyKey: `checkout_session_recovery:${appUserId}:monthly:cs_open:trial:7`,
       }),

--- a/src/adapters/gateways/stripe/stripe-checkout-sessions-trials.test.ts
+++ b/src/adapters/gateways/stripe/stripe-checkout-sessions-trials.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { StripeClient } from '@/src/adapters/shared/stripe-types';
+import type {
+  CheckoutSessionCreateParams,
+  StripeClient,
+  StripeRequestOptions,
+} from '@/src/adapters/shared/stripe-types';
 import { FakeLogger } from '@/src/application/test-helpers/fakes';
-import { createStripeCheckoutSession } from './stripe-checkout-sessions';
+import {
+  createStripeCheckoutSession,
+  createStripeTrialPaymentMethodSetupSession,
+} from './stripe-checkout-sessions';
+import { isValidStripeConsentStateSignature } from './stripe-consent-state';
 
 function createStripeMock(overrides?: {
   openSessionsData?: Array<{ id: string; url: string | null }>;
@@ -10,10 +18,15 @@ function createStripeMock(overrides?: {
   retrievedSessionPaymentMethodCollection?: 'always' | 'if_required';
   shouldThrowOnRetrieve?: boolean;
 }) {
-  const sessionsCreate = vi.fn(async () => ({
-    id: 'cs_new',
-    url: 'https://stripe/checkout/new',
-  }));
+  const sessionsCreate = vi.fn(
+    async (
+      _params: CheckoutSessionCreateParams,
+      _options?: StripeRequestOptions,
+    ) => ({
+      id: 'cs_new',
+      url: 'https://stripe/checkout/new',
+    }),
+  );
   const sessionsRetrieve = vi.fn(async () => {
     if (overrides?.shouldThrowOnRetrieve) {
       throw new Error('retrieve failed');
@@ -101,6 +114,7 @@ describe('createStripeCheckoutSession trial params', () => {
         line_items: [{ price: 'price_m', quantity: 1 }],
         allow_promotion_codes: false,
         billing_address_collection: 'auto',
+        consent_collection: { terms_of_service: 'required' },
         success_url: 'https://app/success',
         cancel_url: 'https://app/cancel',
         client_reference_id: appUserId,
@@ -145,6 +159,7 @@ describe('createStripeCheckoutSession trial params', () => {
         line_items: [{ price: 'price_m', quantity: 1 }],
         allow_promotion_codes: false,
         billing_address_collection: 'auto',
+        consent_collection: { terms_of_service: 'required' },
         success_url: 'https://app/success',
         cancel_url: 'https://app/cancel',
         client_reference_id: appUserId,
@@ -301,5 +316,87 @@ describe('createStripeCheckoutSession trial params', () => {
         idempotencyKey: `checkout_session_recovery:${appUserId}:monthly:cs_existing:trial:7`,
       }),
     );
+  });
+});
+
+describe('createStripeTrialPaymentMethodSetupSession', () => {
+  const appUserId = crypto.randomUUID();
+
+  it('creates a customer-less setup Checkout Session with signed server-owned consent state', async () => {
+    const { stripe, sessionsCreate } = createStripeMock();
+
+    await expect(
+      createStripeTrialPaymentMethodSetupSession({
+        stripe,
+        logger: new FakeLogger(),
+        stateSecret: 'whsec_test_state_secret',
+        input: {
+          userId: appUserId,
+          externalCustomerId: 'cus_123',
+          externalSubscriptionId: 'sub_123',
+          plan: 'monthly',
+          amountCents: 2900,
+          currency: 'usd',
+          frequency: 'month',
+          trialEndsAt: new Date('2026-08-13T12:00:00.000Z'),
+          disclosureVersion: '2026-08-05',
+          termsVersion: '2026-08-05',
+          termsHash: 'terms-sha256',
+          disclosureSnapshot: 'Exact renewal disclosure.',
+          successUrl:
+            'https://app.example.com/app/billing?trial_payment_method=success&session_id={CHECKOUT_SESSION_ID}',
+          cancelUrl:
+            'https://app.example.com/app/billing?trial_payment_method=cancel',
+        },
+      }),
+    ).resolves.toEqual({
+      sessionId: 'cs_new',
+      url: 'https://stripe/checkout/new',
+    });
+
+    expect(sessionsCreate).toHaveBeenCalledTimes(1);
+    const [params, options] = sessionsCreate.mock.calls[0] ?? [];
+    expect(params).toMatchObject({
+      mode: 'setup',
+      currency: 'usd',
+      consent_collection: { terms_of_service: 'required' },
+      success_url:
+        'https://app.example.com/app/billing?trial_payment_method=success&session_id={CHECKOUT_SESSION_ID}',
+      cancel_url:
+        'https://app.example.com/app/billing?trial_payment_method=cancel',
+      client_reference_id: appUserId,
+      metadata: {
+        consent_user_id: appUserId,
+        consent_customer_id: 'cus_123',
+        consent_subscription_id: 'sub_123',
+        consent_plan: 'monthly',
+        consent_amount_cents: '2900',
+        consent_currency: 'usd',
+        consent_frequency: 'month',
+        consent_trial_ends_at: '2026-08-13T12:00:00.000Z',
+        consent_disclosure_version: '2026-08-05',
+        consent_terms_version: '2026-08-05',
+        consent_terms_hash: 'terms-sha256',
+        consent_state_signature: expect.stringMatching(/^[a-f0-9]{64}$/),
+      },
+    });
+    expect(params).not.toHaveProperty('customer');
+    expect(params).not.toHaveProperty('line_items');
+    expect(params).not.toHaveProperty('payment_method_types');
+    if (!params) throw new Error('Expected Checkout Session params');
+    const metadata = params.metadata;
+    if (!metadata) throw new Error('Expected signed consent metadata');
+    const { consent_state_signature: signature, ...signedMetadata } = metadata;
+    expect(signature).toBeTypeOf('string');
+    expect(
+      isValidStripeConsentStateSignature(
+        signedMetadata,
+        signature ?? '',
+        'whsec_test_state_secret',
+      ),
+    ).toBe(true);
+    expect(options).toEqual({
+      idempotencyKey: `trial_setup_session:${appUserId}:sub_123:2026-08-05`,
+    });
   });
 });

--- a/src/adapters/gateways/stripe/stripe-checkout-sessions.test.ts
+++ b/src/adapters/gateways/stripe/stripe-checkout-sessions.test.ts
@@ -170,7 +170,9 @@ describe('createStripeCheckoutSession', () => {
     ).resolves.toEqual({ url: 'https://stripe/checkout/new' });
 
     expect(sessionsCreate).toHaveBeenCalledWith(
-      expect.any(Object),
+      expect.objectContaining({
+        consent_collection: { terms_of_service: 'required' },
+      }),
       expect.objectContaining({
         idempotencyKey: `checkout_session:${appUserId}:monthly`,
       }),

--- a/src/adapters/gateways/stripe/stripe-checkout-sessions.ts
+++ b/src/adapters/gateways/stripe/stripe-checkout-sessions.ts
@@ -10,9 +10,13 @@ import type {
   StripeSubscriptionStatus,
 } from '@/src/adapters/shared/stripe-types';
 import { ApplicationError } from '@/src/application/errors';
-import type { CheckoutSessionInput } from '@/src/application/ports/gateways';
+import type {
+  CheckoutSessionInput,
+  TrialPaymentMethodSetupSessionInput,
+} from '@/src/application/ports/gateways';
 import type { Logger } from '@/src/application/ports/logger';
 import { MS_PER_SECOND } from '@/src/domain/services';
+import { createStripeConsentStateSignature } from './stripe-consent-state';
 import { callStripeWithRetry } from './stripe-retry';
 
 export const SUBSCRIPTION_LIST_LIMIT = 10;
@@ -46,6 +50,64 @@ const STRIPE_IDEMPOTENCY_PARAMETER_MISMATCH_MESSAGE_PATTERNS = [
 ] as const;
 const CHECKOUT_SESSION_VARIANT_METADATA_KEY = 'checkout_variant';
 const STANDARD_CHECKOUT_SESSION_VARIANT = 'standard';
+
+export async function createStripeTrialPaymentMethodSetupSession({
+  stripe,
+  input,
+  logger,
+  stateSecret,
+}: {
+  stripe: StripeClient;
+  input: TrialPaymentMethodSetupSessionInput;
+  logger: Logger;
+  stateSecret: string;
+}): Promise<{ sessionId: string; url: string }> {
+  const metadata = {
+    consent_user_id: input.userId,
+    consent_customer_id: input.externalCustomerId,
+    consent_subscription_id: input.externalSubscriptionId,
+    consent_plan: input.plan,
+    consent_amount_cents: String(input.amountCents),
+    consent_currency: input.currency,
+    consent_frequency: input.frequency,
+    consent_trial_ends_at: input.trialEndsAt.toISOString(),
+    consent_disclosure_version: input.disclosureVersion,
+    consent_terms_version: input.termsVersion,
+    consent_terms_hash: input.termsHash,
+  };
+  const params = {
+    mode: 'setup',
+    currency: input.currency,
+    consent_collection: { terms_of_service: 'required' },
+    success_url: input.successUrl,
+    cancel_url: input.cancelUrl,
+    client_reference_id: input.userId,
+    metadata: {
+      ...metadata,
+      consent_state_signature: createStripeConsentStateSignature(
+        metadata,
+        stateSecret,
+      ),
+    },
+  } satisfies CheckoutSessionCreateParams;
+  const session = await callStripeWithRetry({
+    operation: 'checkout.sessions.create_trial_payment_method_setup',
+    fn: () =>
+      stripe.checkout.sessions.create(params, {
+        idempotencyKey: `trial_setup_session:${input.userId}:${input.externalSubscriptionId}:${input.disclosureVersion}`,
+      }),
+    logger,
+  });
+
+  if (!session.url) {
+    throw new ApplicationError(
+      'STRIPE_ERROR',
+      'Stripe Checkout Session URL is missing',
+    );
+  }
+
+  return { sessionId: session.id, url: session.url };
+}
 
 function getBlockingSubscriptionStatus(
   subscription: StripeListedSubscription | undefined,
@@ -672,6 +734,7 @@ export async function createStripeCheckoutSession({
     line_items: [{ price: priceId, quantity: 1 }],
     allow_promotion_codes: false,
     billing_address_collection: 'auto',
+    consent_collection: { terms_of_service: 'required' },
     success_url: input.successUrl,
     cancel_url: input.cancelUrl,
     client_reference_id: input.userId,

--- a/src/adapters/gateways/stripe/stripe-consent-state.ts
+++ b/src/adapters/gateways/stripe/stripe-consent-state.ts
@@ -1,0 +1,39 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+function stableJsonStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJsonStringify(item)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map(
+        (key) => `${JSON.stringify(key)}:${stableJsonStringify(record[key])}`,
+      )
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'undefined';
+}
+
+export function createStripeConsentStateSignature(
+  metadata: Record<string, string>,
+  stateSecret: string,
+): string {
+  return createHmac('sha256', stateSecret)
+    .update(stableJsonStringify(metadata))
+    .digest('hex');
+}
+
+export function isValidStripeConsentStateSignature(
+  metadata: Record<string, string>,
+  signature: string,
+  stateSecret: string,
+): boolean {
+  const expected = Buffer.from(
+    createStripeConsentStateSignature(metadata, stateSecret),
+    'hex',
+  );
+  const actual = Buffer.from(signature, 'hex');
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}

--- a/src/adapters/gateways/stripe/stripe-webhook-processor.test.ts
+++ b/src/adapters/gateways/stripe/stripe-webhook-processor.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import type { StripePriceIds } from '@/src/adapters/config/stripe-prices';
 import type { StripeClient } from '@/src/adapters/shared/stripe-types';
@@ -73,7 +74,154 @@ function createStripeClient(input: {
   };
 }
 
+function signSetupMetadata(metadata: Record<string, string>): string {
+  const sorted = Object.fromEntries(
+    Object.entries(metadata).sort(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  );
+  return createHmac('sha256', 'whsec_test')
+    .update(JSON.stringify(sorted))
+    .digest('hex');
+}
+
+function createCompletedSetupSession(overrides?: {
+  terms?: 'accepted' | 'required';
+  signature?: string;
+}) {
+  const metadata = {
+    consent_user_id: appUserId,
+    consent_customer_id: 'cus_123',
+    consent_subscription_id: 'sub_123',
+    consent_plan: 'monthly',
+    consent_amount_cents: '2900',
+    consent_currency: 'usd',
+    consent_frequency: 'month',
+    consent_trial_ends_at: '2026-08-13T12:00:00.000Z',
+    consent_disclosure_version: '2026-08-05',
+    consent_terms_version: '2026-08-05',
+    consent_terms_hash: 'terms-hash',
+  };
+  return {
+    id: 'cs_setup_123',
+    mode: 'setup',
+    setup_intent: 'seti_123',
+    consent: { terms_of_service: overrides?.terms ?? 'accepted' },
+    metadata: {
+      ...metadata,
+      consent_state_signature:
+        overrides?.signature ?? signSetupMetadata(metadata),
+    },
+  };
+}
+
 describe('processStripeWebhookEvent', () => {
+  it('normalizes an accepted, signed setup completion and resolves its payment method', async () => {
+    const stripe = createStripeClient({
+      eventFactory: () => ({
+        id: 'evt_setup',
+        type: 'checkout.session.completed',
+        data: { object: createCompletedSetupSession() },
+      }),
+    });
+    stripe.setupIntents = {
+      retrieve: vi.fn(async () => ({
+        id: 'seti_123',
+        payment_method: 'pm_123',
+      })),
+    };
+
+    await expect(
+      processStripeWebhookEvent({
+        stripe,
+        webhookSecret: 'whsec_test',
+        rawBody: '{}',
+        signature: 'sig_test',
+        priceIds,
+        logger: new FakeLogger(),
+      }),
+    ).resolves.toEqual({
+      eventId: 'evt_setup',
+      type: 'checkout.session.completed',
+      trialPaymentMethodSetupCompletion: {
+        sessionId: 'cs_setup_123',
+        userId: appUserId,
+        externalCustomerId: 'cus_123',
+        externalSubscriptionId: 'sub_123',
+        plan: 'monthly',
+        amountCents: 2900,
+        currency: 'usd',
+        frequency: 'month',
+        trialEndsAt: new Date('2026-08-13T12:00:00.000Z'),
+        disclosureVersion: '2026-08-05',
+        termsVersion: '2026-08-05',
+        termsHash: 'terms-hash',
+        stripePaymentMethodId: 'pm_123',
+      },
+    });
+    expect(stripe.setupIntents.retrieve).toHaveBeenCalledWith('seti_123');
+    expect(stripe.subscriptions?.retrieve).not.toHaveBeenCalled();
+  });
+
+  it('rejects a setup completion without accepted Terms before resolving the payment method', async () => {
+    const stripe = createStripeClient({
+      eventFactory: () => ({
+        id: 'evt_setup',
+        type: 'checkout.session.completed',
+        data: {
+          object: createCompletedSetupSession({ terms: 'required' }),
+        },
+      }),
+    });
+    stripe.setupIntents = {
+      retrieve: vi.fn(async () => ({
+        id: 'seti_123',
+        payment_method: 'pm_123',
+      })),
+    };
+
+    await expect(
+      processStripeWebhookEvent({
+        stripe,
+        webhookSecret: 'whsec_test',
+        rawBody: '{}',
+        signature: 'sig_test',
+        priceIds,
+        logger: new FakeLogger(),
+      }),
+    ).rejects.toMatchObject({ code: 'INVALID_WEBHOOK_PAYLOAD' });
+    expect(stripe.setupIntents.retrieve).not.toHaveBeenCalled();
+  });
+
+  it('rejects setup metadata with an invalid server signature before resolving the payment method', async () => {
+    const stripe = createStripeClient({
+      eventFactory: () => ({
+        id: 'evt_setup',
+        type: 'checkout.session.completed',
+        data: {
+          object: createCompletedSetupSession({ signature: 'invalid' }),
+        },
+      }),
+    });
+    stripe.setupIntents = {
+      retrieve: vi.fn(async () => ({
+        id: 'seti_123',
+        payment_method: 'pm_123',
+      })),
+    };
+
+    await expect(
+      processStripeWebhookEvent({
+        stripe,
+        webhookSecret: 'whsec_test',
+        rawBody: '{}',
+        signature: 'sig_test',
+        priceIds,
+        logger: new FakeLogger(),
+      }),
+    ).rejects.toMatchObject({ code: 'INVALID_WEBHOOK_PAYLOAD' });
+    expect(stripe.setupIntents.retrieve).not.toHaveBeenCalled();
+  });
   it('throws INVALID_WEBHOOK_SIGNATURE when Stripe signature verification fails', async () => {
     const logger = new FakeLogger();
     const stripe = {

--- a/src/adapters/gateways/stripe/stripe-webhook-processor.ts
+++ b/src/adapters/gateways/stripe/stripe-webhook-processor.ts
@@ -4,13 +4,104 @@ import { retrieveAndNormalizeStripeSubscription } from '@/src/adapters/gateways/
 import {
   extractSubscriptionRef,
   stripeEventWithSubscriptionRefSchema,
+  stripeSetupIntentSchema,
   stripeSubscriptionSchema,
+  stripeTrialPaymentMethodSetupSessionSchema,
   subscriptionEventTypes,
 } from '@/src/adapters/gateways/stripe/stripe-webhook-schemas';
 import type { StripeClient } from '@/src/adapters/shared/stripe-types';
 import { ApplicationError } from '@/src/application/errors';
 import type { WebhookEventResult } from '@/src/application/ports/gateways';
 import type { Logger } from '@/src/application/ports/logger';
+import { isValidStripeConsentStateSignature } from './stripe-consent-state';
+
+function isSetupSessionPayload(payload: unknown): boolean {
+  return (
+    typeof payload === 'object' &&
+    payload !== null &&
+    (payload as Record<string, unknown>).mode === 'setup'
+  );
+}
+
+function expandableId(value: string | { id: string }): string {
+  return typeof value === 'string' ? value : value.id;
+}
+
+async function getTrialPaymentMethodSetupCompletion(input: {
+  stripe: StripeClient;
+  event: ReturnType<StripeClient['webhooks']['constructEvent']>;
+  stateSecret: string;
+  logger: Logger;
+}): Promise<
+  NonNullable<WebhookEventResult['trialPaymentMethodSetupCompletion']>
+> {
+  const parsed = stripeTrialPaymentMethodSetupSessionSchema.safeParse(
+    input.event.data.object,
+  );
+  if (!parsed.success) {
+    input.logger.error(
+      {
+        eventId: input.event.id,
+        type: input.event.type,
+        error: z.flattenError(parsed.error),
+      },
+      'Invalid Stripe trial payment-method setup completion',
+    );
+    throw new ApplicationError(
+      'INVALID_WEBHOOK_PAYLOAD',
+      'Invalid Stripe trial payment-method setup completion',
+    );
+  }
+
+  const { consent_state_signature: signature, ...signedMetadata } =
+    parsed.data.metadata;
+  if (
+    !isValidStripeConsentStateSignature(
+      signedMetadata,
+      signature,
+      input.stateSecret,
+    )
+  ) {
+    throw new ApplicationError(
+      'INVALID_WEBHOOK_PAYLOAD',
+      'Invalid trial payment-method setup state signature',
+    );
+  }
+
+  const setupIntents = input.stripe.setupIntents;
+  if (!setupIntents) {
+    throw new ApplicationError(
+      'STRIPE_ERROR',
+      'Stripe SetupIntent retrieval is unavailable',
+    );
+  }
+  const setupIntent = stripeSetupIntentSchema.safeParse(
+    await setupIntents.retrieve(expandableId(parsed.data.setup_intent)),
+  );
+  if (!setupIntent.success) {
+    throw new ApplicationError(
+      'INVALID_WEBHOOK_PAYLOAD',
+      'Stripe SetupIntent has no completed payment method',
+    );
+  }
+
+  const metadata = parsed.data.metadata;
+  return {
+    sessionId: parsed.data.id,
+    userId: metadata.consent_user_id,
+    externalCustomerId: metadata.consent_customer_id,
+    externalSubscriptionId: metadata.consent_subscription_id,
+    plan: metadata.consent_plan,
+    amountCents: Number(metadata.consent_amount_cents),
+    currency: metadata.consent_currency,
+    frequency: metadata.consent_frequency,
+    trialEndsAt: new Date(metadata.consent_trial_ends_at),
+    disclosureVersion: metadata.consent_disclosure_version,
+    termsVersion: metadata.consent_terms_version,
+    termsHash: metadata.consent_terms_hash,
+    stripePaymentMethodId: expandableId(setupIntent.data.payment_method),
+  };
+}
 
 async function getSubscriptionUpdateForSubscriptionRefEvent(input: {
   stripe: StripeClient;
@@ -91,6 +182,20 @@ export async function processStripeWebhookEvent({
     eventId: event.id,
     type: event.type,
   };
+
+  if (
+    event.type === 'checkout.session.completed' &&
+    isSetupSessionPayload(event.data.object)
+  ) {
+    const trialPaymentMethodSetupCompletion =
+      await getTrialPaymentMethodSetupCompletion({
+        stripe,
+        event,
+        stateSecret: webhookSecret,
+        logger,
+      });
+    return { ...result, trialPaymentMethodSetupCompletion };
+  }
 
   if (
     event.type === 'checkout.session.completed' ||

--- a/src/adapters/gateways/stripe/stripe-webhook-schemas.ts
+++ b/src/adapters/gateways/stripe/stripe-webhook-schemas.ts
@@ -33,6 +33,45 @@ export const stripeCheckoutSessionSchema = z
   })
   .passthrough();
 
+const stripeExpandableIdSchema = z.union([
+  z.string().min(1),
+  z.object({ id: z.string().min(1) }).passthrough(),
+]);
+
+export const stripeTrialPaymentMethodSetupSessionSchema = z
+  .object({
+    id: z.string().min(1),
+    mode: z.literal('setup'),
+    setup_intent: stripeExpandableIdSchema,
+    consent: z.object({
+      terms_of_service: z.literal('accepted'),
+    }),
+    metadata: z
+      .object({
+        consent_user_id: z.string().min(1),
+        consent_customer_id: z.string().min(1),
+        consent_subscription_id: z.string().min(1),
+        consent_plan: z.enum(['monthly', 'annual']),
+        consent_amount_cents: z.string().regex(/^[1-9]\d*$/),
+        consent_currency: z.literal('usd'),
+        consent_frequency: z.enum(['month', 'year']),
+        consent_trial_ends_at: z.iso.datetime({ offset: true }),
+        consent_disclosure_version: z.string().min(1),
+        consent_terms_version: z.string().min(1),
+        consent_terms_hash: z.string().min(1),
+        consent_state_signature: z.string().regex(/^[a-f0-9]{64}$/),
+      })
+      .strict(),
+  })
+  .passthrough();
+
+export const stripeSetupIntentSchema = z
+  .object({
+    id: z.string().min(1),
+    payment_method: stripeExpandableIdSchema,
+  })
+  .passthrough();
+
 const stripeInvoiceSubscriptionRefSchema = z
   .object({
     parent: z

--- a/src/adapters/repositories/drizzle-subscription-repository.test.ts
+++ b/src/adapters/repositories/drizzle-subscription-repository.test.ts
@@ -1,3 +1,5 @@
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { describe, expect, it, vi } from 'vitest';
 import { ApplicationError } from '@/src/application/errors';
 import { DrizzleSubscriptionRepository } from './drizzle-subscription-repository';
@@ -122,9 +124,11 @@ describe('DrizzleSubscriptionRepository', () => {
   });
 
   it('returns only the external subscription id for a user binding', async () => {
-    const findFirst = vi.fn(async () => ({
-      stripeSubscriptionId: 'sub_123',
-    }));
+    const findFirst = vi.fn(
+      async (_input: { columns: unknown; where: unknown }) => ({
+        stripeSubscriptionId: 'sub_123',
+      }),
+    );
     const db = {
       query: {
         stripeSubscriptions: { findFirst },
@@ -138,6 +142,12 @@ describe('DrizzleSubscriptionRepository', () => {
     expect(findFirst).toHaveBeenCalledWith({
       columns: { stripeSubscriptionId: true },
       where: expect.anything(),
+    });
+    const where = findFirst.mock.calls[0]?.[0].where;
+    if (!where) throw new Error('Expected a subscription lookup predicate');
+    expect(new PgDialect().sqlToQuery(where as SQL)).toMatchObject({
+      sql: expect.stringContaining('"stripe_subscriptions"."user_id" = $1'),
+      params: [userId],
     });
   });
 

--- a/src/adapters/repositories/drizzle-subscription-repository.test.ts
+++ b/src/adapters/repositories/drizzle-subscription-repository.test.ts
@@ -121,6 +121,26 @@ describe('DrizzleSubscriptionRepository', () => {
     });
   });
 
+  it('returns only the external subscription id for a user binding', async () => {
+    const findFirst = vi.fn(async () => ({
+      stripeSubscriptionId: 'sub_123',
+    }));
+    const db = {
+      query: {
+        stripeSubscriptions: { findFirst },
+      },
+    } as const;
+    const repo = createRepo(db, priceIds);
+
+    await expect(repo.findExternalSubscriptionIdByUserId(userId)).resolves.toBe(
+      'sub_123',
+    );
+    expect(findFirst).toHaveBeenCalledWith({
+      columns: { stripeSubscriptionId: true },
+      where: expect.anything(),
+    });
+  });
+
   it('throws INTERNAL_ERROR when a stored subscription has an unknown priceId', async () => {
     const db = {
       query: {

--- a/src/adapters/repositories/drizzle-subscription-repository.ts
+++ b/src/adapters/repositories/drizzle-subscription-repository.ts
@@ -70,6 +70,15 @@ export class DrizzleSubscriptionRepository implements SubscriptionRepository {
     return row ? this.toDomain(row) : null;
   }
 
+  async findExternalSubscriptionIdByUserId(userId: string) {
+    const row = await this.db.query.stripeSubscriptions.findFirst({
+      columns: { stripeSubscriptionId: true },
+      where: eq(stripeSubscriptions.userId, userId),
+    });
+
+    return row?.stripeSubscriptionId ?? null;
+  }
+
   async findObservationVersionByUserId(userId: string) {
     const row = await this.db.query.stripeSubscriptions.findFirst({
       columns: { version: true },

--- a/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository.test.ts
+++ b/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository.test.ts
@@ -112,12 +112,12 @@ describe('DrizzleTrialPaymentMethodSetupOperationRepository', () => {
     );
 
     await expect(
-      repository.claim(
-        'cs_setup_123',
-        'claim_1',
+      repository.claim({
+        sessionId: 'cs_setup_123',
+        claimId: 'claim_1',
         claimedAt,
-        new Date('2026-08-06T11:55:00Z'),
-      ),
+        staleBefore: new Date('2026-08-06T11:55:00Z'),
+      }),
     ).resolves.toEqual(claimedRow);
     expect(updateSet).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository.test.ts
+++ b/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DrizzleTrialPaymentMethodSetupOperationRepository } from './drizzle-trial-payment-method-setup-operation-repository';
+
+type RepoDb = ConstructorParameters<
+  typeof DrizzleTrialPaymentMethodSetupOperationRepository
+>[0];
+
+const pendingInput = {
+  sessionId: 'cs_setup_123',
+  userId: crypto.randomUUID(),
+  stripeCustomerId: 'cus_123',
+  stripeSubscriptionId: 'sub_123',
+  plan: 'monthly' as const,
+  amountCents: 2900,
+  currency: 'usd' as const,
+  frequency: 'month' as const,
+  trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+  disclosureSnapshot: 'Exact disclosure.',
+  disclosureVersion: '2026-08-05',
+  termsVersion: '2026-08-05',
+  termsHash: 'terms-hash',
+};
+
+function createDbMock(input?: {
+  insertRows?: unknown[];
+  updateRows?: unknown[];
+  existingRow?: unknown;
+}) {
+  const insertReturning = vi.fn(async () => input?.insertRows ?? [{}]);
+  const onConflictDoNothing = vi.fn(() => ({ returning: insertReturning }));
+  const insertValues = vi.fn(() => ({ onConflictDoNothing }));
+  const insert = vi.fn(() => ({ values: insertValues }));
+
+  const updateReturning = vi.fn(async () => input?.updateRows ?? []);
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
+
+  const findFirst = vi.fn(async () => input?.existingRow ?? null);
+  const db = {
+    insert,
+    update,
+    query: {
+      trialPaymentMethodSetupOperations: { findFirst },
+    },
+  };
+
+  return {
+    db: db as unknown as RepoDb,
+    insertValues,
+    updateSet,
+    findFirst,
+  };
+}
+
+describe('DrizzleTrialPaymentMethodSetupOperationRepository', () => {
+  it('inserts the immutable pending snapshot', async () => {
+    const { db, insertValues } = createDbMock();
+    const repository = new DrizzleTrialPaymentMethodSetupOperationRepository(
+      db,
+    );
+
+    await repository.createPending(pendingInput);
+
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...pendingInput,
+        status: 'pending',
+      }),
+    );
+  });
+
+  it('rejects a conflicting replay of the same Checkout Session', async () => {
+    const { db } = createDbMock({
+      insertRows: [],
+      existingRow: {
+        ...pendingInput,
+        amountCents: 19900,
+        status: 'pending',
+        claimId: null,
+        claimedAt: null,
+        stripePaymentMethodId: null,
+        paymentMethodAttachedAt: null,
+        subscriptionDefaultSetAt: null,
+        completedAt: null,
+      },
+    });
+    const repository = new DrizzleTrialPaymentMethodSetupOperationRepository(
+      db,
+    );
+
+    await expect(repository.createPending(pendingInput)).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+  });
+
+  it('returns the row claimed by the conditional pending-or-stale update', async () => {
+    const claimedAt = new Date('2026-08-06T12:00:00Z');
+    const claimedRow = {
+      ...pendingInput,
+      status: 'processing',
+      claimId: 'claim_1',
+      claimedAt,
+      stripePaymentMethodId: null,
+      paymentMethodAttachedAt: null,
+      subscriptionDefaultSetAt: null,
+      completedAt: null,
+    };
+    const { db, updateSet } = createDbMock({ updateRows: [claimedRow] });
+    const repository = new DrizzleTrialPaymentMethodSetupOperationRepository(
+      db,
+    );
+
+    await expect(
+      repository.claim(
+        'cs_setup_123',
+        'claim_1',
+        claimedAt,
+        new Date('2026-08-06T11:55:00Z'),
+      ),
+    ).resolves.toEqual(claimedRow);
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'processing',
+        claimId: 'claim_1',
+        claimedAt,
+      }),
+    );
+  });
+});

--- a/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository.ts
+++ b/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository.ts
@@ -3,6 +3,10 @@ import { trialPaymentMethodSetupOperations } from '@/db/schema';
 import type { DrizzleDb } from '@/src/adapters/shared/database-types';
 import { ApplicationError } from '@/src/application/errors';
 import type {
+  ClaimTrialPaymentMethodSetupOperationInput,
+  CompleteTrialPaymentMethodSetupOperationInput,
+  MarkTrialPaymentMethodAttachedInput,
+  MarkTrialSubscriptionDefaultSetInput,
   TrialPaymentMethodSetupOperation,
   TrialPaymentMethodSetupOperationInput,
   TrialPaymentMethodSetupOperationRepository,
@@ -114,12 +118,12 @@ export class DrizzleTrialPaymentMethodSetupOperationRepository
     return row ? toOperation(row) : null;
   }
 
-  async claim(
-    sessionId: string,
-    claimId: string,
-    claimedAt: Date,
-    staleBefore: Date,
-  ): Promise<TrialPaymentMethodSetupOperation | null> {
+  async claim({
+    sessionId,
+    claimId,
+    claimedAt,
+    staleBefore,
+  }: ClaimTrialPaymentMethodSetupOperationInput): Promise<TrialPaymentMethodSetupOperation | null> {
     const [row] = await this.db
       .update(trialPaymentMethodSetupOperations)
       .set({
@@ -144,12 +148,12 @@ export class DrizzleTrialPaymentMethodSetupOperationRepository
     return row ? toOperation(row) : null;
   }
 
-  async markPaymentMethodAttached(
-    sessionId: string,
-    claimId: string,
-    stripePaymentMethodId: string,
-    attachedAt: Date,
-  ): Promise<void> {
+  async markPaymentMethodAttached({
+    sessionId,
+    claimId,
+    stripePaymentMethodId,
+    attachedAt,
+  }: MarkTrialPaymentMethodAttachedInput): Promise<void> {
     await this.updateClaimedOperation(sessionId, claimId, {
       stripePaymentMethodId,
       paymentMethodAttachedAt: attachedAt,
@@ -157,22 +161,22 @@ export class DrizzleTrialPaymentMethodSetupOperationRepository
     });
   }
 
-  async markSubscriptionDefaultSet(
-    sessionId: string,
-    claimId: string,
-    selectedAt: Date,
-  ): Promise<void> {
+  async markSubscriptionDefaultSet({
+    sessionId,
+    claimId,
+    selectedAt,
+  }: MarkTrialSubscriptionDefaultSetInput): Promise<void> {
     await this.updateClaimedOperation(sessionId, claimId, {
       subscriptionDefaultSetAt: selectedAt,
       updatedAt: selectedAt,
     });
   }
 
-  async markCompleted(
-    sessionId: string,
-    claimId: string,
-    completedAt: Date,
-  ): Promise<void> {
+  async markCompleted({
+    sessionId,
+    claimId,
+    completedAt,
+  }: CompleteTrialPaymentMethodSetupOperationInput): Promise<void> {
     await this.updateClaimedOperation(sessionId, claimId, {
       status: 'completed',
       completedAt,

--- a/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository.ts
+++ b/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository.ts
@@ -1,0 +1,206 @@
+import { and, eq, lt, or } from 'drizzle-orm';
+import { trialPaymentMethodSetupOperations } from '@/db/schema';
+import type { DrizzleDb } from '@/src/adapters/shared/database-types';
+import { ApplicationError } from '@/src/application/errors';
+import type {
+  TrialPaymentMethodSetupOperation,
+  TrialPaymentMethodSetupOperationInput,
+  TrialPaymentMethodSetupOperationRepository,
+} from '@/src/application/ports/repositories';
+
+type OperationRow = typeof trialPaymentMethodSetupOperations.$inferSelect;
+
+function toOperation(row: OperationRow): TrialPaymentMethodSetupOperation {
+  if (
+    (row.plan !== 'monthly' && row.plan !== 'annual') ||
+    row.currency !== 'usd' ||
+    (row.frequency !== 'month' && row.frequency !== 'year')
+  ) {
+    throw new ApplicationError(
+      'INTERNAL_ERROR',
+      'Invalid trial payment-method setup operation row',
+    );
+  }
+
+  return {
+    sessionId: row.sessionId,
+    userId: row.userId,
+    stripeCustomerId: row.stripeCustomerId,
+    stripeSubscriptionId: row.stripeSubscriptionId,
+    plan: row.plan,
+    amountCents: row.amountCents,
+    currency: row.currency,
+    frequency: row.frequency,
+    trialEndsAt: row.trialEndsAt,
+    disclosureSnapshot: row.disclosureSnapshot,
+    disclosureVersion: row.disclosureVersion,
+    termsVersion: row.termsVersion,
+    termsHash: row.termsHash,
+    status: row.status,
+    claimId: row.claimId,
+    claimedAt: row.claimedAt,
+    stripePaymentMethodId: row.stripePaymentMethodId,
+    paymentMethodAttachedAt: row.paymentMethodAttachedAt,
+    subscriptionDefaultSetAt: row.subscriptionDefaultSetAt,
+    completedAt: row.completedAt,
+  };
+}
+
+function snapshotsMatch(
+  row: OperationRow,
+  input: TrialPaymentMethodSetupOperationInput,
+): boolean {
+  return (
+    row.sessionId === input.sessionId &&
+    row.userId === input.userId &&
+    row.stripeCustomerId === input.stripeCustomerId &&
+    row.stripeSubscriptionId === input.stripeSubscriptionId &&
+    row.plan === input.plan &&
+    row.amountCents === input.amountCents &&
+    row.currency === input.currency &&
+    row.frequency === input.frequency &&
+    row.trialEndsAt.getTime() === input.trialEndsAt.getTime() &&
+    row.disclosureSnapshot === input.disclosureSnapshot &&
+    row.disclosureVersion === input.disclosureVersion &&
+    row.termsVersion === input.termsVersion &&
+    row.termsHash === input.termsHash
+  );
+}
+
+export class DrizzleTrialPaymentMethodSetupOperationRepository
+  implements TrialPaymentMethodSetupOperationRepository
+{
+  constructor(
+    private readonly db: DrizzleDb,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async createPending(
+    input: TrialPaymentMethodSetupOperationInput,
+  ): Promise<void> {
+    const [inserted] = await this.db
+      .insert(trialPaymentMethodSetupOperations)
+      .values({ ...input, status: 'pending', updatedAt: this.now() })
+      .onConflictDoNothing()
+      .returning({ sessionId: trialPaymentMethodSetupOperations.sessionId });
+    if (inserted) return;
+
+    const existing =
+      await this.db.query.trialPaymentMethodSetupOperations.findFirst({
+        where: eq(trialPaymentMethodSetupOperations.sessionId, input.sessionId),
+      });
+    if (!existing) {
+      throw new ApplicationError(
+        'INTERNAL_ERROR',
+        'Trial payment-method setup operation disappeared after conflict',
+      );
+    }
+    if (!snapshotsMatch(existing, input)) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'Trial payment-method setup snapshot changed for Checkout Session',
+      );
+    }
+  }
+
+  async findBySessionId(
+    sessionId: string,
+  ): Promise<TrialPaymentMethodSetupOperation | null> {
+    const row = await this.db.query.trialPaymentMethodSetupOperations.findFirst(
+      {
+        where: eq(trialPaymentMethodSetupOperations.sessionId, sessionId),
+      },
+    );
+    return row ? toOperation(row) : null;
+  }
+
+  async claim(
+    sessionId: string,
+    claimId: string,
+    claimedAt: Date,
+    staleBefore: Date,
+  ): Promise<TrialPaymentMethodSetupOperation | null> {
+    const [row] = await this.db
+      .update(trialPaymentMethodSetupOperations)
+      .set({
+        status: 'processing',
+        claimId,
+        claimedAt,
+        updatedAt: claimedAt,
+      })
+      .where(
+        and(
+          eq(trialPaymentMethodSetupOperations.sessionId, sessionId),
+          or(
+            eq(trialPaymentMethodSetupOperations.status, 'pending'),
+            and(
+              eq(trialPaymentMethodSetupOperations.status, 'processing'),
+              lt(trialPaymentMethodSetupOperations.claimedAt, staleBefore),
+            ),
+          ),
+        ),
+      )
+      .returning();
+    return row ? toOperation(row) : null;
+  }
+
+  async markPaymentMethodAttached(
+    sessionId: string,
+    claimId: string,
+    stripePaymentMethodId: string,
+    attachedAt: Date,
+  ): Promise<void> {
+    await this.updateClaimedOperation(sessionId, claimId, {
+      stripePaymentMethodId,
+      paymentMethodAttachedAt: attachedAt,
+      updatedAt: attachedAt,
+    });
+  }
+
+  async markSubscriptionDefaultSet(
+    sessionId: string,
+    claimId: string,
+    selectedAt: Date,
+  ): Promise<void> {
+    await this.updateClaimedOperation(sessionId, claimId, {
+      subscriptionDefaultSetAt: selectedAt,
+      updatedAt: selectedAt,
+    });
+  }
+
+  async markCompleted(
+    sessionId: string,
+    claimId: string,
+    completedAt: Date,
+  ): Promise<void> {
+    await this.updateClaimedOperation(sessionId, claimId, {
+      status: 'completed',
+      completedAt,
+      updatedAt: completedAt,
+    });
+  }
+
+  private async updateClaimedOperation(
+    sessionId: string,
+    claimId: string,
+    values: Partial<typeof trialPaymentMethodSetupOperations.$inferInsert>,
+  ): Promise<void> {
+    const [updated] = await this.db
+      .update(trialPaymentMethodSetupOperations)
+      .set(values)
+      .where(
+        and(
+          eq(trialPaymentMethodSetupOperations.sessionId, sessionId),
+          eq(trialPaymentMethodSetupOperations.status, 'processing'),
+          eq(trialPaymentMethodSetupOperations.claimId, claimId),
+        ),
+      )
+      .returning({ sessionId: trialPaymentMethodSetupOperations.sessionId });
+    if (!updated) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'Trial payment-method setup operation is not owned by this claim',
+      );
+    }
+  }
+}

--- a/src/adapters/repositories/index.ts
+++ b/src/adapters/repositories/index.ts
@@ -11,4 +11,5 @@ export { DrizzleStripeCustomerRepository } from './drizzle-stripe-customer-repos
 export { DrizzleStripeEventRepository } from './drizzle-stripe-event-repository';
 export { DrizzleSubscriptionRepository } from './drizzle-subscription-repository';
 export { DrizzleTagRepository } from './drizzle-tag-repository';
+export { DrizzleTrialPaymentMethodSetupOperationRepository } from './drizzle-trial-payment-method-setup-operation-repository';
 export { DrizzleUserRepository } from './drizzle-user-repository';

--- a/src/adapters/shared/stripe-types.ts
+++ b/src/adapters/shared/stripe-types.ts
@@ -69,6 +69,11 @@ export type StripeSetupIntent = {
   payment_method?: string | { id: string } | null;
 };
 
+export type StripePaymentMethod = {
+  id: string;
+  customer?: string | { id: string } | null;
+};
+
 export type StripeCheckoutSessionList = { data: StripeCheckoutSession[] };
 
 export type StripeCheckoutSessionLineItem = {
@@ -170,11 +175,12 @@ export type StripeClient = {
     retrieve(setupIntentId: string): Promise<StripeSetupIntent>;
   };
   paymentMethods?: {
+    retrieve(paymentMethodId: string): Promise<StripePaymentMethod>;
     attach(
       paymentMethodId: string,
       params: { customer: string },
       options?: StripeRequestOptions,
-    ): Promise<{ id: string }>;
+    ): Promise<StripePaymentMethod>;
   };
   billingPortal: {
     sessions: {

--- a/src/adapters/shared/stripe-types.ts
+++ b/src/adapters/shared/stripe-types.ts
@@ -16,27 +16,38 @@ export type CustomerSearchParams = {
 
 export type StripeCustomerSearchResult = { data: StripeCustomer[] };
 
-export type CheckoutSessionCreateParams = {
-  mode: 'subscription' | 'payment' | 'setup';
-  customer: string;
-  line_items: Array<{ price: string; quantity: number }>;
-  allow_promotion_codes?: boolean;
-  billing_address_collection?: 'auto' | 'required';
+type CheckoutSessionCreateParamsBase = {
   success_url: string;
   cancel_url: string;
   client_reference_id?: string;
   metadata?: Record<string, string>;
-  payment_method_collection?: 'always' | 'if_required';
-  subscription_data?: {
-    metadata?: Record<string, string>;
-    trial_period_days?: number;
-    trial_settings?: {
-      end_behavior: {
-        missing_payment_method: 'cancel' | 'pause' | 'create_invoice';
-      };
-    };
+  consent_collection?: {
+    terms_of_service: 'required';
   };
 };
+
+export type CheckoutSessionCreateParams =
+  | (CheckoutSessionCreateParamsBase & {
+      mode: 'subscription' | 'payment';
+      customer: string;
+      line_items: Array<{ price: string; quantity: number }>;
+      allow_promotion_codes?: boolean;
+      billing_address_collection?: 'auto' | 'required';
+      payment_method_collection?: 'always' | 'if_required';
+      subscription_data?: {
+        metadata?: Record<string, string>;
+        trial_period_days?: number;
+        trial_settings?: {
+          end_behavior: {
+            missing_payment_method: 'cancel' | 'pause' | 'create_invoice';
+          };
+        };
+      };
+    })
+  | (CheckoutSessionCreateParamsBase & {
+      mode: 'setup';
+      currency: string;
+    });
 
 export type StripeCheckoutSessionStatus = 'open' | 'complete' | 'expired';
 
@@ -48,6 +59,14 @@ export type StripeCheckoutSession = {
   expires_at?: number | undefined;
   metadata?: Record<string, string> | null;
   payment_method_collection?: 'always' | 'if_required' | null;
+  mode?: 'subscription' | 'payment' | 'setup';
+  setup_intent?: string | { id: string } | null;
+  consent?: { terms_of_service?: 'accepted' | 'required' | null } | null;
+};
+
+export type StripeSetupIntent = {
+  id: string;
+  payment_method?: string | { id: string } | null;
 };
 
 export type StripeCheckoutSessionList = { data: StripeCheckoutSession[] };
@@ -141,6 +160,21 @@ export type StripeClient = {
       params?: undefined,
       options?: StripeRequestOptions,
     ): Promise<StripeSubscription>;
+    update?(
+      subscriptionId: string,
+      params: { default_payment_method: string },
+      options?: StripeRequestOptions,
+    ): Promise<StripeSubscription>;
+  };
+  setupIntents?: {
+    retrieve(setupIntentId: string): Promise<StripeSetupIntent>;
+  };
+  paymentMethods?: {
+    attach(
+      paymentMethodId: string,
+      params: { customer: string },
+      options?: StripeRequestOptions,
+    ): Promise<{ id: string }>;
   };
   billingPortal: {
     sessions: {

--- a/src/application/ports/gateways.ts
+++ b/src/application/ports/gateways.ts
@@ -38,6 +38,40 @@ export type CheckoutSessionInput = {
 
 export type CheckoutSessionOutput = { url: string };
 
+export type TrialPaymentMethodSetupSessionInput = {
+  userId: string;
+  externalCustomerId: string;
+  externalSubscriptionId: string;
+  plan: SubscriptionPlan;
+  amountCents: number;
+  currency: 'usd';
+  frequency: 'month' | 'year';
+  trialEndsAt: Date;
+  disclosureVersion: string;
+  termsVersion: string;
+  termsHash: string;
+  disclosureSnapshot: string;
+  successUrl: string;
+  cancelUrl: string;
+};
+
+export type TrialPaymentMethodSetupSessionOutput = {
+  sessionId: string;
+  url: string;
+};
+
+export type AttachTrialPaymentMethodInput = {
+  sessionId: string;
+  externalPaymentMethodId: string;
+  externalCustomerId: string;
+};
+
+export type SetTrialSubscriptionDefaultPaymentMethodInput = {
+  sessionId: string;
+  externalPaymentMethodId: string;
+  externalSubscriptionId: string;
+};
+
 export type PortalSessionInput = {
   externalCustomerId: string; // opaque external id
   returnUrl: string;
@@ -70,6 +104,21 @@ export type WebhookEventResult = {
     currentPeriodEnd: Date;
     cancelAtPeriodEnd: boolean;
   };
+  trialPaymentMethodSetupCompletion?: {
+    sessionId: string;
+    userId: string;
+    externalCustomerId: string;
+    externalSubscriptionId: string;
+    plan: SubscriptionPlan;
+    amountCents: number;
+    currency: 'usd';
+    frequency: 'month' | 'year';
+    trialEndsAt: Date;
+    disclosureVersion: string;
+    termsVersion: string;
+    termsHash: string;
+    stripePaymentMethodId: string;
+  };
 };
 
 export interface PaymentGateway {
@@ -91,6 +140,16 @@ export interface PaymentGateway {
     input: CheckoutSessionInput,
     options?: PaymentGatewayRequestOptions,
   ): Promise<CheckoutSessionOutput>;
+
+  createTrialPaymentMethodSetupSession(
+    input: TrialPaymentMethodSetupSessionInput,
+  ): Promise<TrialPaymentMethodSetupSessionOutput>;
+
+  attachTrialPaymentMethod(input: AttachTrialPaymentMethodInput): Promise<void>;
+
+  setTrialSubscriptionDefaultPaymentMethod(
+    input: SetTrialSubscriptionDefaultPaymentMethodInput,
+  ): Promise<void>;
 
   createPortalSession(
     input: PortalSessionInput,

--- a/src/application/ports/repositories.ts
+++ b/src/application/ports/repositories.ts
@@ -11,4 +11,5 @@ export * from './stripe-customer-repository';
 export * from './stripe-event-repository';
 export * from './subscription-repository';
 export * from './tag-repository';
+export * from './trial-payment-method-setup-operation-repository';
 export * from './user-repository';

--- a/src/application/ports/subscription-repository.ts
+++ b/src/application/ports/subscription-repository.ts
@@ -26,6 +26,8 @@ export type SubscriptionUpsertResult =
 export interface SubscriptionRepository {
   findByUserId(userId: string): Promise<Subscription | null>;
 
+  findExternalSubscriptionIdByUserId(userId: string): Promise<string | null>;
+
   findObservationVersionByUserId(userId: string): Promise<number | null>;
 
   findByExternalSubscriptionId(

--- a/src/application/ports/trial-payment-method-setup-operation-repository.ts
+++ b/src/application/ports/trial-payment-method-setup-operation-repository.ts
@@ -1,0 +1,62 @@
+import type { SubscriptionPlan } from '@/src/domain/value-objects';
+
+export type TrialPaymentMethodSetupOperationStatus =
+  | 'pending'
+  | 'processing'
+  | 'completed';
+
+export type TrialPaymentMethodSetupOperationInput = {
+  sessionId: string;
+  userId: string;
+  stripeCustomerId: string;
+  stripeSubscriptionId: string;
+  plan: SubscriptionPlan;
+  amountCents: number;
+  currency: 'usd';
+  frequency: 'month' | 'year';
+  trialEndsAt: Date;
+  disclosureSnapshot: string;
+  disclosureVersion: string;
+  termsVersion: string;
+  termsHash: string;
+};
+
+export type TrialPaymentMethodSetupOperation =
+  TrialPaymentMethodSetupOperationInput & {
+    status: TrialPaymentMethodSetupOperationStatus;
+    claimId: string | null;
+    claimedAt: Date | null;
+    stripePaymentMethodId: string | null;
+    paymentMethodAttachedAt: Date | null;
+    subscriptionDefaultSetAt: Date | null;
+    completedAt: Date | null;
+  };
+
+export interface TrialPaymentMethodSetupOperationRepository {
+  createPending(input: TrialPaymentMethodSetupOperationInput): Promise<void>;
+  findBySessionId(
+    sessionId: string,
+  ): Promise<TrialPaymentMethodSetupOperation | null>;
+  claim(
+    sessionId: string,
+    claimId: string,
+    claimedAt: Date,
+    staleBefore: Date,
+  ): Promise<TrialPaymentMethodSetupOperation | null>;
+  markPaymentMethodAttached(
+    sessionId: string,
+    claimId: string,
+    stripePaymentMethodId: string,
+    attachedAt: Date,
+  ): Promise<void>;
+  markSubscriptionDefaultSet(
+    sessionId: string,
+    claimId: string,
+    selectedAt: Date,
+  ): Promise<void>;
+  markCompleted(
+    sessionId: string,
+    claimId: string,
+    completedAt: Date,
+  ): Promise<void>;
+}

--- a/src/application/ports/trial-payment-method-setup-operation-repository.ts
+++ b/src/application/ports/trial-payment-method-setup-operation-repository.ts
@@ -32,31 +32,47 @@ export type TrialPaymentMethodSetupOperation =
     completedAt: Date | null;
   };
 
+export type ClaimTrialPaymentMethodSetupOperationInput = {
+  sessionId: string;
+  claimId: string;
+  claimedAt: Date;
+  staleBefore: Date;
+};
+
+export type MarkTrialPaymentMethodAttachedInput = {
+  sessionId: string;
+  claimId: string;
+  stripePaymentMethodId: string;
+  attachedAt: Date;
+};
+
+export type MarkTrialSubscriptionDefaultSetInput = {
+  sessionId: string;
+  claimId: string;
+  selectedAt: Date;
+};
+
+export type CompleteTrialPaymentMethodSetupOperationInput = {
+  sessionId: string;
+  claimId: string;
+  completedAt: Date;
+};
+
 export interface TrialPaymentMethodSetupOperationRepository {
   createPending(input: TrialPaymentMethodSetupOperationInput): Promise<void>;
   findBySessionId(
     sessionId: string,
   ): Promise<TrialPaymentMethodSetupOperation | null>;
   claim(
-    sessionId: string,
-    claimId: string,
-    claimedAt: Date,
-    staleBefore: Date,
+    input: ClaimTrialPaymentMethodSetupOperationInput,
   ): Promise<TrialPaymentMethodSetupOperation | null>;
   markPaymentMethodAttached(
-    sessionId: string,
-    claimId: string,
-    stripePaymentMethodId: string,
-    attachedAt: Date,
+    input: MarkTrialPaymentMethodAttachedInput,
   ): Promise<void>;
   markSubscriptionDefaultSet(
-    sessionId: string,
-    claimId: string,
-    selectedAt: Date,
+    input: MarkTrialSubscriptionDefaultSetInput,
   ): Promise<void>;
   markCompleted(
-    sessionId: string,
-    claimId: string,
-    completedAt: Date,
+    input: CompleteTrialPaymentMethodSetupOperationInput,
   ): Promise<void>;
 }

--- a/src/application/test-helpers/fakes/fake-gateways.ts
+++ b/src/application/test-helpers/fakes/fake-gateways.ts
@@ -1,5 +1,6 @@
 import { ApplicationError } from '@/src/application/errors';
 import type {
+  AttachTrialPaymentMethodInput,
   AuthGateway,
   CheckoutSessionInput,
   CheckoutSessionOutput,
@@ -12,6 +13,9 @@ import type {
   RateLimiter,
   RateLimitInput,
   RateLimitResult,
+  SetTrialSubscriptionDefaultPaymentMethodInput,
+  TrialPaymentMethodSetupSessionInput,
+  TrialPaymentMethodSetupSessionOutput,
   WebhookEventResult,
 } from '@/src/application/ports/gateways';
 import type { User } from '@/src/domain/entities';
@@ -88,23 +92,33 @@ export class FakePaymentGateway implements PaymentGateway {
   readonly checkoutInputs: CheckoutSessionInput[] = [];
   readonly checkoutOptions: Array<PaymentGatewayRequestOptions | undefined> =
     [];
+  readonly trialSetupInputs: TrialPaymentMethodSetupSessionInput[] = [];
+  readonly trialPaymentMethodAttachInputs: AttachTrialPaymentMethodInput[] = [];
+  readonly trialSubscriptionDefaultInputs: SetTrialSubscriptionDefaultPaymentMethodInput[] =
+    [];
   readonly portalInputs: PortalSessionInput[] = [];
   readonly portalOptions: Array<PaymentGatewayRequestOptions | undefined> = [];
   readonly webhookInputs: Array<{ rawBody: string; signature: string }> = [];
 
   private readonly externalCustomerId: string;
   private readonly checkoutUrl: string;
+  private readonly trialSetupSessionId: string;
+  private readonly trialSetupUrl: string;
   private readonly portalUrl: string;
   private readonly webhookResult: WebhookEventResult;
 
   constructor(input: {
     externalCustomerId: string;
     checkoutUrl: string;
+    trialSetupSessionId?: string;
+    trialSetupUrl?: string;
     portalUrl: string;
     webhookResult: WebhookEventResult;
   }) {
     this.externalCustomerId = input.externalCustomerId;
     this.checkoutUrl = input.checkoutUrl;
+    this.trialSetupSessionId = input.trialSetupSessionId ?? 'cs_setup';
+    this.trialSetupUrl = input.trialSetupUrl ?? input.checkoutUrl;
     this.portalUrl = input.portalUrl;
     this.webhookResult = input.webhookResult;
   }
@@ -125,6 +139,28 @@ export class FakePaymentGateway implements PaymentGateway {
     this.checkoutInputs.push(input);
     this.checkoutOptions.push(options);
     return { url: this.checkoutUrl };
+  }
+
+  async createTrialPaymentMethodSetupSession(
+    input: TrialPaymentMethodSetupSessionInput,
+  ): Promise<TrialPaymentMethodSetupSessionOutput> {
+    this.trialSetupInputs.push(input);
+    return {
+      sessionId: this.trialSetupSessionId,
+      url: this.trialSetupUrl,
+    };
+  }
+
+  async attachTrialPaymentMethod(
+    input: AttachTrialPaymentMethodInput,
+  ): Promise<void> {
+    this.trialPaymentMethodAttachInputs.push(input);
+  }
+
+  async setTrialSubscriptionDefaultPaymentMethod(
+    input: SetTrialSubscriptionDefaultPaymentMethodInput,
+  ): Promise<void> {
+    this.trialSubscriptionDefaultInputs.push(input);
   }
 
   async createPortalSession(

--- a/src/application/test-helpers/fakes/fake-gateways.ts
+++ b/src/application/test-helpers/fakes/fake-gateways.ts
@@ -118,7 +118,7 @@ export class FakePaymentGateway implements PaymentGateway {
     this.externalCustomerId = input.externalCustomerId;
     this.checkoutUrl = input.checkoutUrl;
     this.trialSetupSessionId = input.trialSetupSessionId ?? 'cs_setup';
-    this.trialSetupUrl = input.trialSetupUrl ?? input.checkoutUrl;
+    this.trialSetupUrl = input.trialSetupUrl ?? 'https://fake/trial-setup';
     this.portalUrl = input.portalUrl;
     this.webhookResult = input.webhookResult;
   }

--- a/src/application/test-helpers/fakes/fake-payment-gateway.test.ts
+++ b/src/application/test-helpers/fakes/fake-payment-gateway.test.ts
@@ -5,6 +5,8 @@ function createGateway(): FakePaymentGateway {
   return new FakePaymentGateway({
     externalCustomerId: 'cus_test',
     checkoutUrl: 'https://fake/checkout',
+    trialSetupSessionId: 'cs_setup_test',
+    trialSetupUrl: 'https://fake/trial-setup',
     portalUrl: 'https://fake/portal',
     webhookResult: { eventId: 'evt_1', type: 'checkout.session.completed' },
   });
@@ -45,6 +47,36 @@ describe('FakePaymentGateway', () => {
     });
   });
 
+  describe('createTrialPaymentMethodSetupSession', () => {
+    it('returns configured setup URL/session id and records input', async () => {
+      const gateway = createGateway();
+      const input = {
+        userId: 'user_1',
+        externalCustomerId: 'cus_123',
+        externalSubscriptionId: 'sub_123',
+        plan: 'monthly' as const,
+        amountCents: 2900,
+        currency: 'usd' as const,
+        frequency: 'month' as const,
+        trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+        disclosureVersion: '2026-08-05',
+        termsVersion: '2026-08-05',
+        termsHash: 'terms-hash',
+        disclosureSnapshot: 'Exact disclosure.',
+        successUrl: 'https://app/success',
+        cancelUrl: 'https://app/cancel',
+      };
+
+      await expect(
+        gateway.createTrialPaymentMethodSetupSession(input),
+      ).resolves.toEqual({
+        sessionId: 'cs_setup_test',
+        url: 'https://fake/trial-setup',
+      });
+      expect(gateway.trialSetupInputs).toEqual([input]);
+    });
+  });
+
   describe('createPortalSession', () => {
     it('returns configured portal URL and records input', async () => {
       const gateway = createGateway();
@@ -58,6 +90,26 @@ describe('FakePaymentGateway', () => {
       });
       expect(gateway.portalInputs).toEqual([input]);
     });
+  });
+
+  it('records each explicit trial payment-method write', async () => {
+    const gateway = createGateway();
+    const attachInput = {
+      sessionId: 'cs_setup_123',
+      externalPaymentMethodId: 'pm_123',
+      externalCustomerId: 'cus_123',
+    };
+    const defaultInput = {
+      sessionId: 'cs_setup_123',
+      externalPaymentMethodId: 'pm_123',
+      externalSubscriptionId: 'sub_123',
+    };
+
+    await gateway.attachTrialPaymentMethod(attachInput);
+    await gateway.setTrialSubscriptionDefaultPaymentMethod(defaultInput);
+
+    expect(gateway.trialPaymentMethodAttachInputs).toEqual([attachInput]);
+    expect(gateway.trialSubscriptionDefaultInputs).toEqual([defaultInput]);
   });
 
   describe('processWebhookEvent', () => {

--- a/src/application/test-helpers/fakes/fake-payment-gateway.test.ts
+++ b/src/application/test-helpers/fakes/fake-payment-gateway.test.ts
@@ -75,6 +75,37 @@ describe('FakePaymentGateway', () => {
       });
       expect(gateway.trialSetupInputs).toEqual([input]);
     });
+
+    it('uses a setup-specific fallback URL when none is configured', async () => {
+      const gateway = new FakePaymentGateway({
+        externalCustomerId: 'cus_test',
+        checkoutUrl: 'https://fake/checkout',
+        portalUrl: 'https://fake/portal',
+        webhookResult: {
+          eventId: 'evt_1',
+          type: 'checkout.session.completed',
+        },
+      });
+
+      await expect(
+        gateway.createTrialPaymentMethodSetupSession({
+          userId: 'user_1',
+          externalCustomerId: 'cus_123',
+          externalSubscriptionId: 'sub_123',
+          plan: 'monthly',
+          amountCents: 2900,
+          currency: 'usd',
+          frequency: 'month',
+          trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+          disclosureVersion: '2026-08-05',
+          termsVersion: '2026-08-05',
+          termsHash: 'terms-hash',
+          disclosureSnapshot: 'Exact disclosure.',
+          successUrl: 'https://app/success',
+          cancelUrl: 'https://app/cancel',
+        }),
+      ).resolves.toMatchObject({ url: 'https://fake/trial-setup' });
+    });
   });
 
   describe('createPortalSession', () => {

--- a/src/application/test-helpers/fakes/fake-subscription-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-subscription-repository.test.ts
@@ -43,6 +43,19 @@ describe('FakeSubscriptionRepository', () => {
       });
     });
 
+    it('returns the external subscription id for a locally owned subscription', async () => {
+      const repo = new FakeSubscriptionRepository();
+
+      await repo.upsert(makeUpsertInput());
+
+      await expect(
+        repo.findExternalSubscriptionIdByUserId('user_1'),
+      ).resolves.toBe('sub_123');
+      await expect(
+        repo.findExternalSubscriptionIdByUserId('user_missing'),
+      ).resolves.toBeNull();
+    });
+
     it('throws typed user_missing without writing when the local user is missing', async () => {
       const repo = new FakeSubscriptionRepository();
       repo.markUserMissing('user_1');

--- a/src/application/test-helpers/fakes/fake-subscription-repository.ts
+++ b/src/application/test-helpers/fakes/fake-subscription-repository.ts
@@ -77,6 +77,12 @@ export class FakeSubscriptionRepository implements SubscriptionRepository {
     return this.byUserId.get(userId) ?? null;
   }
 
+  async findExternalSubscriptionIdByUserId(
+    userId: string,
+  ): Promise<string | null> {
+    return this.externalSubscriptionIdByUserId.get(userId) ?? null;
+  }
+
   async findObservationVersionByUserId(userId: string): Promise<number | null> {
     return this.observationVersionByUserId.get(userId) ?? null;
   }

--- a/src/application/test-helpers/fakes/fake-trial-payment-method-setup-operation-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-trial-payment-method-setup-operation-repository.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { FakeTrialPaymentMethodSetupOperationRepository } from './fake-trial-payment-method-setup-operation-repository';
+
+const pendingInput = {
+  sessionId: 'cs_setup_123',
+  userId: 'user_1',
+  stripeCustomerId: 'cus_123',
+  stripeSubscriptionId: 'sub_123',
+  plan: 'monthly' as const,
+  amountCents: 2900,
+  currency: 'usd' as const,
+  frequency: 'month' as const,
+  trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+  disclosureSnapshot: 'Exact disclosure.',
+  disclosureVersion: '2026-08-05',
+  termsVersion: '2026-08-05',
+  termsHash: 'terms-hash',
+};
+
+describe('FakeTrialPaymentMethodSetupOperationRepository', () => {
+  it('persists and replays the exact pending snapshot by Checkout Session id', async () => {
+    const repository = new FakeTrialPaymentMethodSetupOperationRepository();
+
+    await repository.createPending(pendingInput);
+    await repository.createPending(pendingInput);
+
+    await expect(repository.findBySessionId('cs_setup_123')).resolves.toEqual(
+      expect.objectContaining({
+        ...pendingInput,
+        status: 'pending',
+        paymentMethodAttachedAt: null,
+        subscriptionDefaultSetAt: null,
+      }),
+    );
+  });
+
+  it('rejects a Checkout Session replay whose immutable snapshot changed', async () => {
+    const repository = new FakeTrialPaymentMethodSetupOperationRepository();
+    await repository.createPending(pendingInput);
+
+    await expect(
+      repository.createPending({
+        ...pendingInput,
+        amountCents: 19900,
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+
+  it('allows only one of two concurrent workers to claim a pending operation', async () => {
+    const repository = new FakeTrialPaymentMethodSetupOperationRepository();
+    await repository.createPending(pendingInput);
+    const now = new Date('2026-08-06T12:00:00Z');
+
+    const [first, second] = await Promise.all([
+      repository.claim('cs_setup_123', 'claim_1', now, new Date(0)),
+      repository.claim('cs_setup_123', 'claim_2', now, new Date(0)),
+    ]);
+
+    expect([first, second].filter(Boolean)).toHaveLength(1);
+    expect([first?.claimId, second?.claimId].filter(Boolean)).toEqual([
+      'claim_1',
+    ]);
+  });
+
+  it('reclaims an expired processing lease without erasing per-write progress', async () => {
+    const repository = new FakeTrialPaymentMethodSetupOperationRepository();
+    await repository.createPending(pendingInput);
+    await repository.claim(
+      'cs_setup_123',
+      'claim_1',
+      new Date('2026-08-06T10:00:00Z'),
+      new Date(0),
+    );
+    await repository.markPaymentMethodAttached(
+      'cs_setup_123',
+      'claim_1',
+      'pm_123',
+      new Date('2026-08-06T10:00:01Z'),
+    );
+
+    const reclaimed = await repository.claim(
+      'cs_setup_123',
+      'claim_2',
+      new Date('2026-08-06T11:00:00Z'),
+      new Date('2026-08-06T10:55:00Z'),
+    );
+
+    expect(reclaimed).toEqual(
+      expect.objectContaining({
+        claimId: 'claim_2',
+        stripePaymentMethodId: 'pm_123',
+        paymentMethodAttachedAt: new Date('2026-08-06T10:00:01Z'),
+        subscriptionDefaultSetAt: null,
+      }),
+    );
+  });
+
+  it('restores an isolated transaction snapshot', async () => {
+    const repository = new FakeTrialPaymentMethodSetupOperationRepository();
+    await repository.createPending(pendingInput);
+    const snapshot = repository.snapshot();
+    await repository.claim(
+      'cs_setup_123',
+      'claim_1',
+      new Date('2026-08-06T10:00:00Z'),
+      new Date(0),
+    );
+
+    repository.restore(snapshot);
+
+    await expect(repository.findBySessionId('cs_setup_123')).resolves.toEqual(
+      expect.objectContaining({ status: 'pending', claimId: null }),
+    );
+  });
+});

--- a/src/application/test-helpers/fakes/fake-trial-payment-method-setup-operation-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-trial-payment-method-setup-operation-repository.test.ts
@@ -52,8 +52,18 @@ describe('FakeTrialPaymentMethodSetupOperationRepository', () => {
     const now = new Date('2026-08-06T12:00:00Z');
 
     const [first, second] = await Promise.all([
-      repository.claim('cs_setup_123', 'claim_1', now, new Date(0)),
-      repository.claim('cs_setup_123', 'claim_2', now, new Date(0)),
+      repository.claim({
+        sessionId: 'cs_setup_123',
+        claimId: 'claim_1',
+        claimedAt: now,
+        staleBefore: new Date(0),
+      }),
+      repository.claim({
+        sessionId: 'cs_setup_123',
+        claimId: 'claim_2',
+        claimedAt: now,
+        staleBefore: new Date(0),
+      }),
     ]);
 
     expect([first, second].filter(Boolean)).toHaveLength(1);
@@ -65,25 +75,25 @@ describe('FakeTrialPaymentMethodSetupOperationRepository', () => {
   it('reclaims an expired processing lease without erasing per-write progress', async () => {
     const repository = new FakeTrialPaymentMethodSetupOperationRepository();
     await repository.createPending(pendingInput);
-    await repository.claim(
-      'cs_setup_123',
-      'claim_1',
-      new Date('2026-08-06T10:00:00Z'),
-      new Date(0),
-    );
-    await repository.markPaymentMethodAttached(
-      'cs_setup_123',
-      'claim_1',
-      'pm_123',
-      new Date('2026-08-06T10:00:01Z'),
-    );
+    await repository.claim({
+      sessionId: 'cs_setup_123',
+      claimId: 'claim_1',
+      claimedAt: new Date('2026-08-06T10:00:00Z'),
+      staleBefore: new Date(0),
+    });
+    await repository.markPaymentMethodAttached({
+      sessionId: 'cs_setup_123',
+      claimId: 'claim_1',
+      stripePaymentMethodId: 'pm_123',
+      attachedAt: new Date('2026-08-06T10:00:01Z'),
+    });
 
-    const reclaimed = await repository.claim(
-      'cs_setup_123',
-      'claim_2',
-      new Date('2026-08-06T11:00:00Z'),
-      new Date('2026-08-06T10:55:00Z'),
-    );
+    const reclaimed = await repository.claim({
+      sessionId: 'cs_setup_123',
+      claimId: 'claim_2',
+      claimedAt: new Date('2026-08-06T11:00:00Z'),
+      staleBefore: new Date('2026-08-06T10:55:00Z'),
+    });
 
     expect(reclaimed).toEqual(
       expect.objectContaining({
@@ -99,12 +109,12 @@ describe('FakeTrialPaymentMethodSetupOperationRepository', () => {
     const repository = new FakeTrialPaymentMethodSetupOperationRepository();
     await repository.createPending(pendingInput);
     const snapshot = repository.snapshot();
-    await repository.claim(
-      'cs_setup_123',
-      'claim_1',
-      new Date('2026-08-06T10:00:00Z'),
-      new Date(0),
-    );
+    await repository.claim({
+      sessionId: 'cs_setup_123',
+      claimId: 'claim_1',
+      claimedAt: new Date('2026-08-06T10:00:00Z'),
+      staleBefore: new Date(0),
+    });
 
     repository.restore(snapshot);
 

--- a/src/application/test-helpers/fakes/fake-trial-payment-method-setup-operation-repository.ts
+++ b/src/application/test-helpers/fakes/fake-trial-payment-method-setup-operation-repository.ts
@@ -1,5 +1,9 @@
 import { ApplicationError } from '@/src/application/errors';
 import type {
+  ClaimTrialPaymentMethodSetupOperationInput,
+  CompleteTrialPaymentMethodSetupOperationInput,
+  MarkTrialPaymentMethodAttachedInput,
+  MarkTrialSubscriptionDefaultSetInput,
   TrialPaymentMethodSetupOperation,
   TrialPaymentMethodSetupOperationInput,
   TrialPaymentMethodSetupOperationRepository,
@@ -93,12 +97,12 @@ export class FakeTrialPaymentMethodSetupOperationRepository
     return operation ? cloneOperation(operation) : null;
   }
 
-  async claim(
-    sessionId: string,
-    claimId: string,
-    claimedAt: Date,
-    staleBefore: Date,
-  ): Promise<TrialPaymentMethodSetupOperation | null> {
+  async claim({
+    sessionId,
+    claimId,
+    claimedAt,
+    staleBefore,
+  }: ClaimTrialPaymentMethodSetupOperationInput): Promise<TrialPaymentMethodSetupOperation | null> {
     const operation = this.bySessionId.get(sessionId);
     if (!operation || operation.status === 'completed') return null;
     if (
@@ -119,12 +123,12 @@ export class FakeTrialPaymentMethodSetupOperationRepository
     return cloneOperation(claimed);
   }
 
-  async markPaymentMethodAttached(
-    sessionId: string,
-    claimId: string,
-    stripePaymentMethodId: string,
-    attachedAt: Date,
-  ): Promise<void> {
+  async markPaymentMethodAttached({
+    sessionId,
+    claimId,
+    stripePaymentMethodId,
+    attachedAt,
+  }: MarkTrialPaymentMethodAttachedInput): Promise<void> {
     const operation = this.requireClaim(sessionId, claimId);
     this.bySessionId.set(sessionId, {
       ...operation,
@@ -133,11 +137,11 @@ export class FakeTrialPaymentMethodSetupOperationRepository
     });
   }
 
-  async markSubscriptionDefaultSet(
-    sessionId: string,
-    claimId: string,
-    selectedAt: Date,
-  ): Promise<void> {
+  async markSubscriptionDefaultSet({
+    sessionId,
+    claimId,
+    selectedAt,
+  }: MarkTrialSubscriptionDefaultSetInput): Promise<void> {
     const operation = this.requireClaim(sessionId, claimId);
     this.bySessionId.set(sessionId, {
       ...operation,
@@ -145,11 +149,11 @@ export class FakeTrialPaymentMethodSetupOperationRepository
     });
   }
 
-  async markCompleted(
-    sessionId: string,
-    claimId: string,
-    completedAt: Date,
-  ): Promise<void> {
+  async markCompleted({
+    sessionId,
+    claimId,
+    completedAt,
+  }: CompleteTrialPaymentMethodSetupOperationInput): Promise<void> {
     const operation = this.requireClaim(sessionId, claimId);
     this.bySessionId.set(sessionId, {
       ...operation,

--- a/src/application/test-helpers/fakes/fake-trial-payment-method-setup-operation-repository.ts
+++ b/src/application/test-helpers/fakes/fake-trial-payment-method-setup-operation-repository.ts
@@ -1,0 +1,174 @@
+import { ApplicationError } from '@/src/application/errors';
+import type {
+  TrialPaymentMethodSetupOperation,
+  TrialPaymentMethodSetupOperationInput,
+  TrialPaymentMethodSetupOperationRepository,
+} from '@/src/application/ports/trial-payment-method-setup-operation-repository';
+
+function cloneOperation(
+  operation: TrialPaymentMethodSetupOperation,
+): TrialPaymentMethodSetupOperation {
+  return {
+    ...operation,
+    trialEndsAt: new Date(operation.trialEndsAt),
+    claimedAt: operation.claimedAt ? new Date(operation.claimedAt) : null,
+    paymentMethodAttachedAt: operation.paymentMethodAttachedAt
+      ? new Date(operation.paymentMethodAttachedAt)
+      : null,
+    subscriptionDefaultSetAt: operation.subscriptionDefaultSetAt
+      ? new Date(operation.subscriptionDefaultSetAt)
+      : null,
+    completedAt: operation.completedAt ? new Date(operation.completedAt) : null,
+  };
+}
+
+function immutableSnapshot(operation: TrialPaymentMethodSetupOperationInput) {
+  return JSON.stringify({
+    sessionId: operation.sessionId,
+    userId: operation.userId,
+    stripeCustomerId: operation.stripeCustomerId,
+    stripeSubscriptionId: operation.stripeSubscriptionId,
+    plan: operation.plan,
+    amountCents: operation.amountCents,
+    currency: operation.currency,
+    frequency: operation.frequency,
+    trialEndsAt: operation.trialEndsAt.toISOString(),
+    disclosureSnapshot: operation.disclosureSnapshot,
+    disclosureVersion: operation.disclosureVersion,
+    termsVersion: operation.termsVersion,
+    termsHash: operation.termsHash,
+  });
+}
+
+export class FakeTrialPaymentMethodSetupOperationRepository
+  implements TrialPaymentMethodSetupOperationRepository
+{
+  private readonly bySessionId = new Map<
+    string,
+    TrialPaymentMethodSetupOperation
+  >();
+
+  snapshot(): TrialPaymentMethodSetupOperation[] {
+    return Array.from(this.bySessionId.values(), cloneOperation);
+  }
+
+  restore(operations: readonly TrialPaymentMethodSetupOperation[]): void {
+    this.bySessionId.clear();
+    for (const operation of operations) {
+      this.bySessionId.set(operation.sessionId, cloneOperation(operation));
+    }
+  }
+
+  async createPending(
+    input: TrialPaymentMethodSetupOperationInput,
+  ): Promise<void> {
+    const existing = this.bySessionId.get(input.sessionId);
+    if (existing) {
+      if (immutableSnapshot(existing) !== immutableSnapshot(input)) {
+        throw new ApplicationError(
+          'CONFLICT',
+          'Trial payment-method setup snapshot changed for Checkout Session',
+        );
+      }
+      return;
+    }
+
+    this.bySessionId.set(input.sessionId, {
+      ...input,
+      trialEndsAt: new Date(input.trialEndsAt),
+      status: 'pending',
+      claimId: null,
+      claimedAt: null,
+      stripePaymentMethodId: null,
+      paymentMethodAttachedAt: null,
+      subscriptionDefaultSetAt: null,
+      completedAt: null,
+    });
+  }
+
+  async findBySessionId(
+    sessionId: string,
+  ): Promise<TrialPaymentMethodSetupOperation | null> {
+    const operation = this.bySessionId.get(sessionId);
+    return operation ? cloneOperation(operation) : null;
+  }
+
+  async claim(
+    sessionId: string,
+    claimId: string,
+    claimedAt: Date,
+    staleBefore: Date,
+  ): Promise<TrialPaymentMethodSetupOperation | null> {
+    const operation = this.bySessionId.get(sessionId);
+    if (!operation || operation.status === 'completed') return null;
+    if (
+      operation.status === 'processing' &&
+      operation.claimedAt &&
+      operation.claimedAt >= staleBefore
+    ) {
+      return null;
+    }
+
+    const claimed: TrialPaymentMethodSetupOperation = {
+      ...operation,
+      status: 'processing',
+      claimId,
+      claimedAt: new Date(claimedAt),
+    };
+    this.bySessionId.set(sessionId, claimed);
+    return cloneOperation(claimed);
+  }
+
+  async markPaymentMethodAttached(
+    sessionId: string,
+    claimId: string,
+    stripePaymentMethodId: string,
+    attachedAt: Date,
+  ): Promise<void> {
+    const operation = this.requireClaim(sessionId, claimId);
+    this.bySessionId.set(sessionId, {
+      ...operation,
+      stripePaymentMethodId,
+      paymentMethodAttachedAt: new Date(attachedAt),
+    });
+  }
+
+  async markSubscriptionDefaultSet(
+    sessionId: string,
+    claimId: string,
+    selectedAt: Date,
+  ): Promise<void> {
+    const operation = this.requireClaim(sessionId, claimId);
+    this.bySessionId.set(sessionId, {
+      ...operation,
+      subscriptionDefaultSetAt: new Date(selectedAt),
+    });
+  }
+
+  async markCompleted(
+    sessionId: string,
+    claimId: string,
+    completedAt: Date,
+  ): Promise<void> {
+    const operation = this.requireClaim(sessionId, claimId);
+    this.bySessionId.set(sessionId, {
+      ...operation,
+      status: 'completed',
+      completedAt: new Date(completedAt),
+    });
+  }
+
+  private requireClaim(
+    sessionId: string,
+    claimId: string,
+  ): TrialPaymentMethodSetupOperation {
+    const operation = this.bySessionId.get(sessionId);
+    if (operation?.status !== 'processing' || operation.claimId !== claimId) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'Trial payment-method setup operation is not owned by this claim',
+      );
+    }
+    return operation;
+  }
+}

--- a/src/application/test-helpers/fakes/fake-use-cases.ts
+++ b/src/application/test-helpers/fakes/fake-use-cases.ts
@@ -76,6 +76,10 @@ export class FakeCreatePortalSessionUseCase extends FakeUseCase<
   U.CreatePortalSessionInput,
   U.CreatePortalSessionOutput
 > {}
+export class FakeCreateTrialPaymentMethodSetupSessionUseCase extends FakeUseCase<
+  U.CreateTrialPaymentMethodSetupSessionInput,
+  U.CreateTrialPaymentMethodSetupSessionOutput
+> {}
 export class FakeGetAttemptedQuestionsUseCase extends FakeUseCase<
   U.GetAttemptedQuestionsInput,
   U.GetAttemptedQuestionsOutput

--- a/src/application/test-helpers/fakes/index.ts
+++ b/src/application/test-helpers/fakes/index.ts
@@ -20,11 +20,13 @@ export { FakeStripeCustomerRepository } from './fake-stripe-customer-repository'
 export { FakeStripeEventRepository } from './fake-stripe-event-repository';
 export { FakeSubscriptionRepository } from './fake-subscription-repository';
 export { FakeTagRepository } from './fake-tag-repository';
+export { FakeTrialPaymentMethodSetupOperationRepository } from './fake-trial-payment-method-setup-operation-repository';
 export {
   FakeCheckEntitlementUseCase,
   FakeCountAvailableQuestionsUseCase,
   FakeCreateCheckoutSessionUseCase,
   FakeCreatePortalSessionUseCase,
+  FakeCreateTrialPaymentMethodSetupSessionUseCase,
   FakeDiscardPracticeSessionUseCase,
   FakeEndPracticeSessionUseCase,
   FakeFinalizeExamAnswersUseCase,

--- a/src/application/use-cases/create-trial-payment-method-setup-session.test.ts
+++ b/src/application/use-cases/create-trial-payment-method-setup-session.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { ApplicationError } from '@/src/application/errors';
+import type { TrialPaymentMethodSetupOperationInput } from '@/src/application/ports/repositories';
 import {
   FakeLogger,
   FakePaymentGateway,
@@ -11,6 +13,17 @@ import { CreateTrialPaymentMethodSetupSessionUseCase } from './create-trial-paym
 
 const userId = 'user_1';
 const trialEndsAt = new Date('2026-08-13T12:00:00Z');
+
+class FailingSetupOperationRepository extends FakeTrialPaymentMethodSetupOperationRepository {
+  override async createPending(
+    _input: TrialPaymentMethodSetupOperationInput,
+  ): Promise<never> {
+    throw new ApplicationError(
+      'CONFLICT',
+      'raw provider detail user@example.com',
+    );
+  }
+}
 
 function createPaymentGateway() {
   return new FakePaymentGateway({
@@ -26,6 +39,8 @@ function createPaymentGateway() {
 async function createUseCase(input?: {
   status?: 'inTrial' | 'active';
   currentPeriodEnd?: Date;
+  operations?: FakeTrialPaymentMethodSetupOperationRepository;
+  logger?: FakeLogger;
 }) {
   const subscriptions = new FakeSubscriptionRepository([
     {
@@ -40,7 +55,9 @@ async function createUseCase(input?: {
   ]);
   const stripeCustomers = new FakeStripeCustomerRepository();
   await stripeCustomers.insert(userId, 'cus_123');
-  const operations = new FakeTrialPaymentMethodSetupOperationRepository();
+  const operations =
+    input?.operations ?? new FakeTrialPaymentMethodSetupOperationRepository();
+  const logger = input?.logger ?? new FakeLogger();
   const payments = createPaymentGateway();
   const useCase = new CreateTrialPaymentMethodSetupSessionUseCase(
     subscriptions,
@@ -57,11 +74,11 @@ async function createUseCase(input?: {
       termsVersion: '2026-08-05',
       termsHash: 'terms-hash',
     }),
-    new FakeLogger(),
+    logger,
     () => new Date('2026-08-06T12:00:00Z'),
   );
 
-  return { operations, payments, subscriptions, useCase };
+  return { logger, operations, payments, subscriptions, useCase };
 }
 
 describe('CreateTrialPaymentMethodSetupSessionUseCase', () => {
@@ -118,18 +135,43 @@ describe('CreateTrialPaymentMethodSetupSessionUseCase', () => {
       cancelUrl: 'https://app.example.com/cancel',
     };
 
-    await useCase.execute(input);
-    await useCase.execute(input);
+    const first = await useCase.execute(input);
+    const replay = await useCase.execute(input);
 
-    await expect(operations.findBySessionId('cs_setup_123')).resolves.toEqual(
-      expect.objectContaining({ status: 'pending' }),
-    );
+    expect(first).toEqual({ url: 'https://stripe/setup' });
+    expect(replay).toEqual(first);
+
+    await expect(operations.findBySessionId('cs_setup_123')).resolves.toEqual({
+      sessionId: 'cs_setup_123',
+      userId,
+      stripeCustomerId: 'cus_123',
+      stripeSubscriptionId: 'sub_123',
+      plan: 'monthly',
+      amountCents: 2900,
+      currency: 'usd',
+      frequency: 'month',
+      trialEndsAt,
+      disclosureSnapshot: 'Exact renewal disclosure.',
+      disclosureVersion: '2026-08-05',
+      termsVersion: '2026-08-05',
+      termsHash: 'terms-hash',
+      status: 'pending',
+      claimId: null,
+      claimedAt: null,
+      stripePaymentMethodId: null,
+      paymentMethodAttachedAt: null,
+      subscriptionDefaultSetAt: null,
+      completedAt: null,
+    });
   });
 
   it('fails closed when the local subscription is not an unexpired trial', async () => {
     const active = await createUseCase({ status: 'active' });
     const expired = await createUseCase({
       currentPeriodEnd: new Date('2026-08-06T11:59:59Z'),
+    });
+    const expiresNow = await createUseCase({
+      currentPeriodEnd: new Date('2026-08-06T12:00:00Z'),
     });
     const input = {
       userId,
@@ -143,7 +185,35 @@ describe('CreateTrialPaymentMethodSetupSessionUseCase', () => {
     await expect(expired.useCase.execute(input)).rejects.toMatchObject({
       code: 'CONFLICT',
     });
+    await expect(expiresNow.useCase.execute(input)).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
     expect(active.payments.trialSetupInputs).toEqual([]);
     expect(expired.payments.trialSetupInputs).toEqual([]);
+    expect(expiresNow.payments.trialSetupInputs).toEqual([]);
+  });
+
+  it('logs only a safe error code when operation persistence fails', async () => {
+    const operations = new FailingSetupOperationRepository();
+    const logger = new FakeLogger();
+    const { useCase } = await createUseCase({ operations, logger });
+
+    await expect(
+      useCase.execute({
+        userId,
+        successUrl: 'https://app.example.com/success',
+        cancelUrl: 'https://app.example.com/cancel',
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    expect(logger.errorCalls).toEqual([
+      {
+        context: { sessionId: 'cs_setup_123', errorCode: 'CONFLICT' },
+        msg: 'Failed to persist trial payment-method setup operation',
+      },
+    ]);
+    expect(JSON.stringify(logger.errorCalls)).not.toContain(
+      'raw provider detail user@example.com',
+    );
   });
 });

--- a/src/application/use-cases/create-trial-payment-method-setup-session.test.ts
+++ b/src/application/use-cases/create-trial-payment-method-setup-session.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FakeLogger,
+  FakePaymentGateway,
+  FakeStripeCustomerRepository,
+  FakeSubscriptionRepository,
+  FakeTrialPaymentMethodSetupOperationRepository,
+} from '@/src/application/test-helpers/fakes';
+import { createSubscription } from '@/src/domain/test-helpers';
+import { CreateTrialPaymentMethodSetupSessionUseCase } from './create-trial-payment-method-setup-session';
+
+const userId = 'user_1';
+const trialEndsAt = new Date('2026-08-13T12:00:00Z');
+
+function createPaymentGateway() {
+  return new FakePaymentGateway({
+    externalCustomerId: 'cus_unused',
+    checkoutUrl: 'https://stripe/checkout',
+    trialSetupSessionId: 'cs_setup_123',
+    trialSetupUrl: 'https://stripe/setup',
+    portalUrl: 'https://stripe/portal',
+    webhookResult: { eventId: 'evt_1', type: 'checkout.session.completed' },
+  });
+}
+
+async function createUseCase(input?: {
+  status?: 'inTrial' | 'active';
+  currentPeriodEnd?: Date;
+}) {
+  const subscriptions = new FakeSubscriptionRepository([
+    {
+      subscription: createSubscription({
+        userId,
+        plan: 'monthly',
+        status: input?.status ?? 'inTrial',
+        currentPeriodEnd: input?.currentPeriodEnd ?? trialEndsAt,
+      }),
+      externalSubscriptionId: 'sub_123',
+    },
+  ]);
+  const stripeCustomers = new FakeStripeCustomerRepository();
+  await stripeCustomers.insert(userId, 'cus_123');
+  const operations = new FakeTrialPaymentMethodSetupOperationRepository();
+  const payments = createPaymentGateway();
+  const useCase = new CreateTrialPaymentMethodSetupSessionUseCase(
+    subscriptions,
+    stripeCustomers,
+    operations,
+    payments,
+    (plan) => ({
+      plan,
+      amountCents: plan === 'monthly' ? 2900 : 19900,
+      currency: 'usd',
+      frequency: plan === 'monthly' ? 'month' : 'year',
+      disclosureSnapshot: 'Exact renewal disclosure.',
+      disclosureVersion: '2026-08-05',
+      termsVersion: '2026-08-05',
+      termsHash: 'terms-hash',
+    }),
+    new FakeLogger(),
+    () => new Date('2026-08-06T12:00:00Z'),
+  );
+
+  return { operations, payments, subscriptions, useCase };
+}
+
+describe('CreateTrialPaymentMethodSetupSessionUseCase', () => {
+  it('creates a customer-less setup Session and persists the exact pending snapshot', async () => {
+    const { operations, payments, useCase } = await createUseCase();
+
+    await expect(
+      useCase.execute({
+        userId,
+        successUrl:
+          'https://app.example.com/app/billing?trial_payment_method=success&session_id={CHECKOUT_SESSION_ID}',
+        cancelUrl:
+          'https://app.example.com/app/billing?trial_payment_method=cancel',
+      }),
+    ).resolves.toEqual({ url: 'https://stripe/setup' });
+
+    expect(payments.trialSetupInputs).toEqual([
+      {
+        userId,
+        externalCustomerId: 'cus_123',
+        externalSubscriptionId: 'sub_123',
+        plan: 'monthly',
+        amountCents: 2900,
+        currency: 'usd',
+        frequency: 'month',
+        trialEndsAt,
+        disclosureSnapshot: 'Exact renewal disclosure.',
+        disclosureVersion: '2026-08-05',
+        termsVersion: '2026-08-05',
+        termsHash: 'terms-hash',
+        successUrl:
+          'https://app.example.com/app/billing?trial_payment_method=success&session_id={CHECKOUT_SESSION_ID}',
+        cancelUrl:
+          'https://app.example.com/app/billing?trial_payment_method=cancel',
+      },
+    ]);
+    await expect(operations.findBySessionId('cs_setup_123')).resolves.toEqual(
+      expect.objectContaining({
+        sessionId: 'cs_setup_123',
+        userId,
+        stripeCustomerId: 'cus_123',
+        stripeSubscriptionId: 'sub_123',
+        disclosureSnapshot: 'Exact renewal disclosure.',
+        status: 'pending',
+      }),
+    );
+  });
+
+  it('replays the same Session id without changing the pending snapshot', async () => {
+    const { operations, useCase } = await createUseCase();
+    const input = {
+      userId,
+      successUrl: 'https://app.example.com/success',
+      cancelUrl: 'https://app.example.com/cancel',
+    };
+
+    await useCase.execute(input);
+    await useCase.execute(input);
+
+    await expect(operations.findBySessionId('cs_setup_123')).resolves.toEqual(
+      expect.objectContaining({ status: 'pending' }),
+    );
+  });
+
+  it('fails closed when the local subscription is not an unexpired trial', async () => {
+    const active = await createUseCase({ status: 'active' });
+    const expired = await createUseCase({
+      currentPeriodEnd: new Date('2026-08-06T11:59:59Z'),
+    });
+    const input = {
+      userId,
+      successUrl: 'https://app.example.com/success',
+      cancelUrl: 'https://app.example.com/cancel',
+    };
+
+    await expect(active.useCase.execute(input)).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+    await expect(expired.useCase.execute(input)).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+    expect(active.payments.trialSetupInputs).toEqual([]);
+    expect(expired.payments.trialSetupInputs).toEqual([]);
+  });
+});

--- a/src/application/use-cases/create-trial-payment-method-setup-session.ts
+++ b/src/application/use-cases/create-trial-payment-method-setup-session.ts
@@ -1,0 +1,130 @@
+import { ApplicationError } from '@/src/application/errors';
+import type {
+  PaymentGateway,
+  TrialPaymentMethodSetupSessionInput,
+} from '@/src/application/ports/gateways';
+import type { Logger } from '@/src/application/ports/logger';
+import type {
+  StripeCustomerRepository,
+  SubscriptionRepository,
+  TrialPaymentMethodSetupOperationRepository,
+} from '@/src/application/ports/repositories';
+import type { SubscriptionPlan } from '@/src/domain/value-objects';
+
+export type TrialRenewalTerms = Pick<
+  TrialPaymentMethodSetupSessionInput,
+  | 'plan'
+  | 'amountCents'
+  | 'currency'
+  | 'frequency'
+  | 'disclosureSnapshot'
+  | 'disclosureVersion'
+  | 'termsVersion'
+  | 'termsHash'
+>;
+
+export type CreateTrialPaymentMethodSetupSessionInput = {
+  userId: string;
+  successUrl: string;
+  cancelUrl: string;
+};
+
+export type CreateTrialPaymentMethodSetupSessionOutput = { url: string };
+
+export class CreateTrialPaymentMethodSetupSessionUseCase {
+  constructor(
+    private readonly subscriptions: SubscriptionRepository,
+    private readonly stripeCustomers: StripeCustomerRepository,
+    private readonly operations: TrialPaymentMethodSetupOperationRepository,
+    private readonly payments: PaymentGateway,
+    private readonly getRenewalTerms: (
+      plan: SubscriptionPlan,
+    ) => TrialRenewalTerms,
+    private readonly logger: Logger,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async execute(
+    input: CreateTrialPaymentMethodSetupSessionInput,
+  ): Promise<CreateTrialPaymentMethodSetupSessionOutput> {
+    const subscription = await this.subscriptions.findByUserId(input.userId);
+    const now = this.now();
+    if (
+      subscription?.status !== 'inTrial' ||
+      subscription.currentPeriodEnd <= now
+    ) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'An unexpired trial is required to add a payment method',
+      );
+    }
+
+    const [externalSubscriptionId, customer] = await Promise.all([
+      this.subscriptions.findExternalSubscriptionIdByUserId(input.userId),
+      this.stripeCustomers.findByUserId(input.userId),
+    ]);
+    if (!externalSubscriptionId || !customer) {
+      throw new ApplicationError(
+        'INTERNAL_ERROR',
+        'Trial billing identifiers are unavailable',
+      );
+    }
+
+    const terms = this.getRenewalTerms(subscription.plan);
+    if (terms.plan !== subscription.plan) {
+      throw new ApplicationError(
+        'INTERNAL_ERROR',
+        'Trial renewal terms do not match the subscription plan',
+      );
+    }
+
+    const setupInput = {
+      userId: input.userId,
+      externalCustomerId: customer.stripeCustomerId,
+      externalSubscriptionId,
+      plan: subscription.plan,
+      amountCents: terms.amountCents,
+      currency: terms.currency,
+      frequency: terms.frequency,
+      trialEndsAt: subscription.currentPeriodEnd,
+      disclosureSnapshot: terms.disclosureSnapshot,
+      disclosureVersion: terms.disclosureVersion,
+      termsVersion: terms.termsVersion,
+      termsHash: terms.termsHash,
+      successUrl: input.successUrl,
+      cancelUrl: input.cancelUrl,
+    } satisfies TrialPaymentMethodSetupSessionInput;
+    const session =
+      await this.payments.createTrialPaymentMethodSetupSession(setupInput);
+
+    try {
+      await this.operations.createPending({
+        sessionId: session.sessionId,
+        userId: setupInput.userId,
+        stripeCustomerId: setupInput.externalCustomerId,
+        stripeSubscriptionId: setupInput.externalSubscriptionId,
+        plan: setupInput.plan,
+        amountCents: setupInput.amountCents,
+        currency: setupInput.currency,
+        frequency: setupInput.frequency,
+        trialEndsAt: setupInput.trialEndsAt,
+        disclosureSnapshot: setupInput.disclosureSnapshot,
+        disclosureVersion: setupInput.disclosureVersion,
+        termsVersion: setupInput.termsVersion,
+        termsHash: setupInput.termsHash,
+      });
+    } catch (error) {
+      try {
+        this.logger.error(
+          { sessionId: session.sessionId },
+          'Failed to persist trial payment-method setup operation',
+        );
+      } catch {
+        // Logging must not replace the persistence failure.
+      }
+      throw error;
+    }
+
+    return { url: session.url };
+  }
+}

--- a/src/application/use-cases/create-trial-payment-method-setup-session.ts
+++ b/src/application/use-cases/create-trial-payment-method-setup-session.ts
@@ -116,7 +116,10 @@ export class CreateTrialPaymentMethodSetupSessionUseCase {
     } catch (error) {
       try {
         this.logger.error(
-          { sessionId: session.sessionId },
+          {
+            sessionId: session.sessionId,
+            errorCode: error instanceof ApplicationError ? error.code : null,
+          },
           'Failed to persist trial payment-method setup operation',
         );
       } catch {

--- a/src/application/use-cases/index.ts
+++ b/src/application/use-cases/index.ts
@@ -19,6 +19,12 @@ export {
   CreatePortalSessionUseCase,
 } from './create-portal-session';
 export {
+  type CreateTrialPaymentMethodSetupSessionInput,
+  type CreateTrialPaymentMethodSetupSessionOutput,
+  CreateTrialPaymentMethodSetupSessionUseCase,
+  type TrialRenewalTerms,
+} from './create-trial-payment-method-setup-session';
+export {
   type DiscardPracticeSessionInput,
   type DiscardPracticeSessionOutput,
   DiscardPracticeSessionUseCase,

--- a/tests/e2e/helpers/subscription.ts
+++ b/tests/e2e/helpers/subscription.ts
@@ -123,6 +123,13 @@ export async function restoreE2EUserPaidSubscription(): Promise<void> {
 
 export async function completeNoCardTrialCheckout(page: Page): Promise<void> {
   await expect(page).toHaveURL(/checkout\.stripe\.com/, { timeout: 30_000 });
+  const termsCheckbox = page.getByRole('checkbox', {
+    name: /I agree to .*Terms of Service and Privacy Policy/i,
+  });
+  await expect(termsCheckbox).toBeVisible({ timeout: 30_000 });
+  await termsCheckbox.check();
+  await expect(termsCheckbox).toBeChecked();
+
   const startTrialButton = page
     .getByRole('button', {
       name: /start (free )?trial|subscribe|continue/i,

--- a/tests/integration/actions.stripe.integration.test.ts
+++ b/tests/integration/actions.stripe.integration.test.ts
@@ -13,6 +13,7 @@ import { DrizzleIdempotencyKeyRepository } from '@/src/adapters/repositories/dri
 import { DrizzleStripeCustomerRepository } from '@/src/adapters/repositories/drizzle-stripe-customer-repository';
 import {
   FakeAuthGateway,
+  FakeCreateTrialPaymentMethodSetupSessionUseCase,
   FakeLogger,
   FakePaymentGateway,
   FakeSubscriptionRepository,
@@ -115,6 +116,10 @@ describe('billing controllers (integration)', () => {
         logger: new FakeLogger(),
         createCheckoutSessionUseCase,
         createPortalSessionUseCase,
+        createTrialPaymentMethodSetupSessionUseCase:
+          new FakeCreateTrialPaymentMethodSetupSessionUseCase({
+            url: 'https://stripe.test/setup',
+          }),
         idempotencyKeyRepository,
         rateLimiter: {
           limit: async () => ({
@@ -190,6 +195,10 @@ describe('billing controllers (integration)', () => {
         logger: new FakeLogger(),
         createCheckoutSessionUseCase,
         createPortalSessionUseCase,
+        createTrialPaymentMethodSetupSessionUseCase:
+          new FakeCreateTrialPaymentMethodSetupSessionUseCase({
+            url: 'https://stripe.test/setup',
+          }),
         idempotencyKeyRepository,
         rateLimiter: {
           limit: async () => ({
@@ -213,6 +222,10 @@ describe('billing controllers (integration)', () => {
         logger: new FakeLogger(),
         createCheckoutSessionUseCase,
         createPortalSessionUseCase,
+        createTrialPaymentMethodSetupSessionUseCase:
+          new FakeCreateTrialPaymentMethodSetupSessionUseCase({
+            url: 'https://stripe.test/setup',
+          }),
         idempotencyKeyRepository,
         rateLimiter: {
           limit: async () => ({

--- a/tests/integration/bug-regression-post-deletion-webhook-fk.integration.test.ts
+++ b/tests/integration/bug-regression-post-deletion-webhook-fk.integration.test.ts
@@ -10,6 +10,7 @@ import {
 import { DrizzleStripeCustomerRepository } from '@/src/adapters/repositories/drizzle-stripe-customer-repository';
 import { DrizzleStripeEventRepository } from '@/src/adapters/repositories/drizzle-stripe-event-repository';
 import { DrizzleSubscriptionRepository } from '@/src/adapters/repositories/drizzle-subscription-repository';
+import { DrizzleTrialPaymentMethodSetupOperationRepository } from '@/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository';
 import {
   FakeLogger,
   FakePaymentGateway,
@@ -99,6 +100,8 @@ describe('BUG-296 post-deletion Stripe subscription webhook', () => {
             stripeEvents: new DrizzleStripeEventRepository(tx),
             subscriptions: new DrizzleSubscriptionRepository(tx, priceIds),
             stripeCustomers: new DrizzleStripeCustomerRepository(tx),
+            trialPaymentMethodSetupOperations:
+              new DrizzleTrialPaymentMethodSetupOperationRepository(tx),
           }),
         ),
     };
@@ -168,6 +171,8 @@ describe('BUG-296 post-deletion Stripe subscription webhook', () => {
             // This real adapter hits stripe_customers_user_id_users_id_fk,
             // not the narrowly acknowledged subscription constraint.
             stripeCustomers: new DrizzleStripeCustomerRepository(tx),
+            trialPaymentMethodSetupOperations:
+              new DrizzleTrialPaymentMethodSetupOperationRepository(tx),
           }),
         ),
     };

--- a/tests/integration/bug-regression-subscription-observation-version-fence.integration.test.ts
+++ b/tests/integration/bug-regression-subscription-observation-version-fence.integration.test.ts
@@ -6,6 +6,7 @@ import type { ReconcileStripeSubscriptionsDeps } from '@/src/adapters/jobs/recon
 import { DrizzleStripeCustomerRepository } from '@/src/adapters/repositories/drizzle-stripe-customer-repository';
 import { DrizzleStripeEventRepository } from '@/src/adapters/repositories/drizzle-stripe-event-repository';
 import { DrizzleSubscriptionRepository } from '@/src/adapters/repositories/drizzle-subscription-repository';
+import { DrizzleTrialPaymentMethodSetupOperationRepository } from '@/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository';
 import type { WebhookEventResult } from '@/src/application/ports/gateways';
 import {
   FakeLogger,
@@ -152,6 +153,8 @@ async function runWebhook(input: {
             stripeEvents: new DrizzleStripeEventRepository(tx),
             subscriptions: new DrizzleSubscriptionRepository(tx, priceIds),
             stripeCustomers: new DrizzleStripeCustomerRepository(tx),
+            trialPaymentMethodSetupOperations:
+              new DrizzleTrialPaymentMethodSetupOperationRepository(tx),
           }),
         ),
     },

--- a/tests/integration/controllers.integration.test.ts
+++ b/tests/integration/controllers.integration.test.ts
@@ -25,6 +25,7 @@ import { DrizzleQuestionRepository } from '@/src/adapters/repositories/drizzle-q
 import { DrizzleStripeCustomerRepository } from '@/src/adapters/repositories/drizzle-stripe-customer-repository';
 import { DrizzleStripeEventRepository } from '@/src/adapters/repositories/drizzle-stripe-event-repository';
 import { DrizzleSubscriptionRepository } from '@/src/adapters/repositories/drizzle-subscription-repository';
+import { DrizzleTrialPaymentMethodSetupOperationRepository } from '@/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository';
 import { DrizzleUserRepository } from '@/src/adapters/repositories/drizzle-user-repository';
 import {
   FakeAuthGateway,
@@ -1040,6 +1041,8 @@ describe('stripe webhook controller (integration)', () => {
               stripeEvents: new DrizzleStripeEventRepository(tx),
               subscriptions: new DrizzleSubscriptionRepository(tx, priceIds),
               stripeCustomers: new DrizzleStripeCustomerRepository(tx),
+              trialPaymentMethodSetupOperations:
+                new DrizzleTrialPaymentMethodSetupOperationRepository(tx),
             }),
           ),
       },

--- a/tests/integration/stripe-subscription-writer-lock-order.integration.test.ts
+++ b/tests/integration/stripe-subscription-writer-lock-order.integration.test.ts
@@ -16,6 +16,7 @@ import { DrizzlePendingStripeCustomerCleanupRepository } from '@/src/adapters/re
 import { DrizzleStripeCustomerRepository } from '@/src/adapters/repositories/drizzle-stripe-customer-repository';
 import { DrizzleStripeEventRepository } from '@/src/adapters/repositories/drizzle-stripe-event-repository';
 import { DrizzleSubscriptionRepository } from '@/src/adapters/repositories/drizzle-subscription-repository';
+import { DrizzleTrialPaymentMethodSetupOperationRepository } from '@/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository';
 import { DrizzleUserRepository } from '@/src/adapters/repositories/drizzle-user-repository';
 import { acquireSubscriptionWriteLock } from '@/src/adapters/repositories/subscription-write-lock';
 import type { DrizzleDb } from '@/src/adapters/shared/database-types';
@@ -369,6 +370,8 @@ async function runWebhookWriter(input: {
             stripeCustomers: input.deletionCounterparty
               ? new RawDeletionCounterpartyStripeCustomerRepository(tx)
               : new DrizzleStripeCustomerRepository(tx),
+            trialPaymentMethodSetupOperations:
+              new DrizzleTrialPaymentMethodSetupOperationRepository(tx),
           });
         }),
     },
@@ -568,6 +571,8 @@ async function runFirstInsertWebhookWriter(input: {
             stripeEvents: new DrizzleStripeEventRepository(tx),
             subscriptions: new DrizzleSubscriptionRepository(tx, priceIds),
             stripeCustomers: new DrizzleStripeCustomerRepository(tx),
+            trialPaymentMethodSetupOperations:
+              new DrizzleTrialPaymentMethodSetupOperationRepository(tx),
           });
         }),
     },

--- a/tests/integration/stripe-webhook-failure-boundary.integration.test.ts
+++ b/tests/integration/stripe-webhook-failure-boundary.integration.test.ts
@@ -6,6 +6,7 @@ import { processStripeWebhook } from '@/src/adapters/controllers/stripe-webhook-
 import { DrizzleStripeCustomerRepository } from '@/src/adapters/repositories/drizzle-stripe-customer-repository';
 import { DrizzleStripeEventRepository } from '@/src/adapters/repositories/drizzle-stripe-event-repository';
 import { DrizzleSubscriptionRepository } from '@/src/adapters/repositories/drizzle-subscription-repository';
+import { DrizzleTrialPaymentMethodSetupOperationRepository } from '@/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository';
 import { ApplicationError } from '@/src/application/errors';
 import {
   FakeLogger,
@@ -80,6 +81,8 @@ describe('Stripe webhook failure boundary', () => {
                 stripeEvents: new DrizzleStripeEventRepository(tx),
                 subscriptions: new DrizzleSubscriptionRepository(tx, priceIds),
                 stripeCustomers: new DrizzleStripeCustomerRepository(tx),
+                trialPaymentMethodSetupOperations:
+                  new DrizzleTrialPaymentMethodSetupOperationRepository(tx),
               }),
             ),
         },

--- a/tests/integration/trial-payment-method-setup-operations.integration.test.ts
+++ b/tests/integration/trial-payment-method-setup-operations.integration.test.ts
@@ -44,35 +44,35 @@ describe('trial payment-method setup operation persistence', () => {
 
     const claimedAt = new Date('2026-08-06T12:00:00Z');
     const [first, second] = await Promise.all([
-      firstRepository.claim(
-        'cs_setup_concurrent',
-        'claim_1',
+      firstRepository.claim({
+        sessionId: 'cs_setup_concurrent',
+        claimId: 'claim_1',
         claimedAt,
-        new Date(0),
-      ),
-      secondRepository.claim(
-        'cs_setup_concurrent',
-        'claim_2',
+        staleBefore: new Date(0),
+      }),
+      secondRepository.claim({
+        sessionId: 'cs_setup_concurrent',
+        claimId: 'claim_2',
         claimedAt,
-        new Date(0),
-      ),
+        staleBefore: new Date(0),
+      }),
     ]);
     const winner = first ?? second;
     expect([first, second].filter(Boolean)).toHaveLength(1);
     if (!winner?.claimId) throw new Error('Expected one worker claim');
 
-    await firstRepository.markPaymentMethodAttached(
-      'cs_setup_concurrent',
-      winner.claimId,
-      'pm_123',
-      new Date('2026-08-06T12:00:01Z'),
-    );
-    const recovered = await secondRepository.claim(
-      'cs_setup_concurrent',
-      'claim_recovery',
-      new Date('2026-08-06T13:00:00Z'),
-      new Date('2026-08-06T12:55:00Z'),
-    );
+    await firstRepository.markPaymentMethodAttached({
+      sessionId: 'cs_setup_concurrent',
+      claimId: winner.claimId,
+      stripePaymentMethodId: 'pm_123',
+      attachedAt: new Date('2026-08-06T12:00:01Z'),
+    });
+    const recovered = await secondRepository.claim({
+      sessionId: 'cs_setup_concurrent',
+      claimId: 'claim_recovery',
+      claimedAt: new Date('2026-08-06T13:00:00Z'),
+      staleBefore: new Date('2026-08-06T12:55:00Z'),
+    });
 
     expect(recovered).toEqual(
       expect.objectContaining({
@@ -82,5 +82,34 @@ describe('trial payment-method setup operation persistence', () => {
         subscriptionDefaultSetAt: null,
       }),
     );
+
+    await expect(
+      firstRepository.markSubscriptionDefaultSet({
+        sessionId: 'cs_setup_concurrent',
+        claimId: winner.claimId,
+        selectedAt: new Date('2026-08-06T13:00:01Z'),
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+    await secondRepository.markSubscriptionDefaultSet({
+      sessionId: 'cs_setup_concurrent',
+      claimId: 'claim_recovery',
+      selectedAt: new Date('2026-08-06T13:00:01Z'),
+    });
+    await expect(
+      firstRepository.markCompleted({
+        sessionId: 'cs_setup_concurrent',
+        claimId: winner.claimId,
+        completedAt: new Date('2026-08-06T13:00:02Z'),
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    await expect(
+      secondRepository.findBySessionId('cs_setup_concurrent'),
+    ).resolves.toMatchObject({
+      status: 'processing',
+      claimId: 'claim_recovery',
+      subscriptionDefaultSetAt: new Date('2026-08-06T13:00:01Z'),
+      completedAt: null,
+    });
   });
 });

--- a/tests/integration/trial-payment-method-setup-operations.integration.test.ts
+++ b/tests/integration/trial-payment-method-setup-operations.integration.test.ts
@@ -1,0 +1,86 @@
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { DrizzleTrialPaymentMethodSetupOperationRepository } from '@/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository';
+import {
+  cleanupAfterEach,
+  closeConnection,
+  createCleanupState,
+  createIntegrationDb,
+  createUser,
+} from './helpers';
+
+const { db, sql } = createIntegrationDb();
+const cleanup = createCleanupState();
+
+afterEach(async () => {
+  await cleanupAfterEach(db, cleanup);
+});
+
+afterAll(async () => {
+  await closeConnection(sql);
+});
+
+describe('trial payment-method setup operation persistence', () => {
+  it('serializes two concurrent workers and preserves progress across stale-lease recovery', async () => {
+    const user = await createUser(db, cleanup);
+    const firstRepository =
+      new DrizzleTrialPaymentMethodSetupOperationRepository(db);
+    const secondRepository =
+      new DrizzleTrialPaymentMethodSetupOperationRepository(db);
+    await firstRepository.createPending({
+      sessionId: 'cs_setup_concurrent',
+      userId: user.id,
+      stripeCustomerId: 'cus_123',
+      stripeSubscriptionId: 'sub_123',
+      plan: 'monthly',
+      amountCents: 2900,
+      currency: 'usd',
+      frequency: 'month',
+      trialEndsAt: new Date('2026-08-13T12:00:00Z'),
+      disclosureSnapshot: 'Exact disclosure.',
+      disclosureVersion: '2026-08-05',
+      termsVersion: '2026-08-05',
+      termsHash: 'terms-hash',
+    });
+
+    const claimedAt = new Date('2026-08-06T12:00:00Z');
+    const [first, second] = await Promise.all([
+      firstRepository.claim(
+        'cs_setup_concurrent',
+        'claim_1',
+        claimedAt,
+        new Date(0),
+      ),
+      secondRepository.claim(
+        'cs_setup_concurrent',
+        'claim_2',
+        claimedAt,
+        new Date(0),
+      ),
+    ]);
+    const winner = first ?? second;
+    expect([first, second].filter(Boolean)).toHaveLength(1);
+    if (!winner?.claimId) throw new Error('Expected one worker claim');
+
+    await firstRepository.markPaymentMethodAttached(
+      'cs_setup_concurrent',
+      winner.claimId,
+      'pm_123',
+      new Date('2026-08-06T12:00:01Z'),
+    );
+    const recovered = await secondRepository.claim(
+      'cs_setup_concurrent',
+      'claim_recovery',
+      new Date('2026-08-06T13:00:00Z'),
+      new Date('2026-08-06T12:55:00Z'),
+    );
+
+    expect(recovered).toEqual(
+      expect.objectContaining({
+        claimId: 'claim_recovery',
+        stripePaymentMethodId: 'pm_123',
+        paymentMethodAttachedAt: new Date('2026-08-06T12:00:01Z'),
+        subscriptionDefaultSetAt: null,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- require Terms consent for every subscription Checkout creation path
- replace the trial banner billing-portal action with a customer-less Setup-mode Checkout flow
- verify accepted Terms and signed server-owned state before attaching a payment method
- serialize duplicate completions by Checkout Session ID and persist per-write recovery progress
- add the generated setup-operation migration and real-Postgres concurrency coverage

## Release dependency
Production `consent_collection` depends on the Stripe Business Settings Terms URL. The owner has confirmed that live Terms URL is already set before this PR is promoted.

## Deliberately excluded
The 2026-08-06 decision defers all price-increase offer/apply machinery; none is scaffolded here.

## Verification
- `pnpm typecheck`
- `pnpm lint` (24 accepted warnings)
- `pnpm test --run`
- `pnpm test:browser`
- isolated DB migrate + seed + `pnpm test:integration`
- `pnpm build`
- `pnpm test:e2e` (38 tests)

Implements DEBT-414 spec §§ 4-5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a trial checkout flow for securely collecting payment methods before trial conversion.
  * Added required Terms of Service and Privacy Policy links and consent collection during checkout.
  * Automatically attaches the collected payment method and sets it as the subscription’s default.
  * Added safeguards for authentication, expired trials, duplicate requests, concurrent processing, and failed setup attempts.
  * Added pricing renewal details and disclosure metadata for monthly and annual plans.

* **Bug Fixes**
  * Improved handling of setup failures without exposing payment-provider error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->