### PR TITLE
Add transactional renewal email delivery state machine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,12 @@ NEXT_PUBLIC_STRIPE_PRICE_ID_ANNUAL=price_***
 NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY=price_***
 
 # =============================================================================
+# RESEND (Transactional email) - Optional
+# =============================================================================
+# Leave unset to keep renewal-notice deliveries queued without a provider call.
+# RESEND_API_KEY=re_***
+
+# =============================================================================
 # SENTRY (Error Tracking) - Get DSN from https://sentry.io → Project → Client Keys
 # =============================================================================
 # Optional: leave blank to disable Sentry telemetry.

--- a/lib/container.test.ts
+++ b/lib/container.test.ts
@@ -72,6 +72,7 @@ vi.mock('stripe', () => ({
 
 const ORIGINAL_ENV = snapshotProcessEnv();
 
+delete process.env.RESEND_API_KEY;
 process.env.DATABASE_URL ??=
   'postgresql://user:pass@localhost:5432/addiction_boards_test';
 process.env.STRIPE_SECRET_KEY ??= 'sk_test_dummy';

--- a/lib/container.test.ts
+++ b/lib/container.test.ts
@@ -3,6 +3,7 @@ import type { StripeWebhookDeps } from '@/src/adapters/controllers/stripe-webhoo
 import {
   ClerkAuthGateway,
   DrizzleRateLimiter,
+  ResendTransactionalEmailGateway,
   StripePaymentGateway,
 } from '@/src/adapters/gateways';
 import {
@@ -16,6 +17,7 @@ import {
   DrizzleQuestionFeedbackRepository,
   DrizzleQuestionRepository,
   DrizzleRenewalConsentRecordRepository,
+  DrizzleRenewalNoticeDeliveryRepository,
   DrizzleStripeCustomerRepository,
   DrizzleStripeEventRepository,
   DrizzleSubscriptionRepository,
@@ -37,6 +39,7 @@ import {
   CreatePortalSessionUseCase,
   CreateTrialPaymentMethodSetupSessionUseCase,
   DiscardPracticeSessionUseCase,
+  DispatchRenewalNoticeDeliveryUseCase,
   EndPracticeSessionUseCase,
   FinalizeExamAnswersUseCase,
   GetAttemptedQuestionsUseCase,
@@ -51,6 +54,7 @@ import {
   PruneRenewalConsentsUseCase,
   RateQuestionUseCase,
   RecordRenewalConsentUseCase,
+  RequeueRenewalNoticeDeliveryUseCase,
   SetBookmarkUseCase,
   StartPracticeSessionUseCase,
   SubmitAnswerUseCase,
@@ -125,6 +129,9 @@ describe('container factories', () => {
     expect(typeof container.createRenewalConsentRecordRepository).toBe(
       'function',
     );
+    expect(typeof container.createRenewalNoticeDeliveryRepository).toBe(
+      'function',
+    );
     expect(typeof container.createTagRepository).toBe('function');
     expect(
       container.createTrialPaymentMethodSetupOperationRepository(),
@@ -137,8 +144,15 @@ describe('container factories', () => {
     expect(typeof container.createAuthGateway).toBe('function');
     expect(typeof container.createPaymentGateway).toBe('function');
     expect(typeof container.createRateLimiter).toBe('function');
+    expect(typeof container.createTransactionalEmailGateway).toBe('function');
 
     expect(typeof container.createCheckEntitlementUseCase).toBe('function');
+    expect(typeof container.createDispatchRenewalNoticeDeliveryUseCase).toBe(
+      'function',
+    );
+    expect(typeof container.createRequeueRenewalNoticeDeliveryUseCase).toBe(
+      'function',
+    );
     expect(typeof container.createGetNextQuestionUseCase).toBe('function');
     expect(typeof container.createGetPreviousAttemptUseCase).toBe('function');
     expect(typeof container.createGetQuestionRatingUseCase).toBe('function');
@@ -219,6 +233,9 @@ describe('container factories', () => {
     expect(container.createRenewalConsentRecordRepository()).toBeInstanceOf(
       DrizzleRenewalConsentRecordRepository,
     );
+    expect(container.createRenewalNoticeDeliveryRepository()).toBeInstanceOf(
+      DrizzleRenewalNoticeDeliveryRepository,
+    );
     expect(container.createTagRepository()).toBeInstanceOf(
       DrizzleTagRepository,
     );
@@ -240,6 +257,9 @@ describe('container factories', () => {
       StripePaymentGateway,
     );
     expect(container.createRateLimiter()).toBeInstanceOf(DrizzleRateLimiter);
+    const emailGateway = container.createTransactionalEmailGateway();
+    expect(emailGateway).toBeInstanceOf(ResendTransactionalEmailGateway);
+    expect(emailGateway.isConfigured()).toBe(false);
 
     expect(container.createCheckEntitlementUseCase()).toBeInstanceOf(
       CheckEntitlementUseCase,
@@ -304,6 +324,12 @@ describe('container factories', () => {
     expect(container.createPruneRenewalConsentsUseCase()).toBeInstanceOf(
       PruneRenewalConsentsUseCase,
     );
+    expect(
+      container.createDispatchRenewalNoticeDeliveryUseCase(),
+    ).toBeInstanceOf(DispatchRenewalNoticeDeliveryUseCase);
+    expect(
+      container.createRequeueRenewalNoticeDeliveryUseCase(),
+    ).toBeInstanceOf(RequeueRenewalNoticeDeliveryUseCase);
     expect(container.createFinalizeExamAnswersUseCase()).toBeInstanceOf(
       FinalizeExamAnswersUseCase,
     );

--- a/lib/container/gateways.ts
+++ b/lib/container/gateways.ts
@@ -3,6 +3,7 @@ import {
   type ClerkUserLike,
   type ClerkUserLookup,
   DrizzleRateLimiter,
+  ResendTransactionalEmailGateway,
   StripePaymentGateway,
 } from '@/src/adapters/gateways';
 import type {
@@ -45,5 +46,9 @@ export function createGatewayFactories(input: {
       }),
     createRateLimiter: () =>
       new DrizzleRateLimiter(primitives.db, primitives.now, primitives.logger),
+    createTransactionalEmailGateway: () =>
+      new ResendTransactionalEmailGateway({
+        apiKey: primitives.env.RESEND_API_KEY,
+      }),
   };
 }

--- a/lib/container/gateways.ts
+++ b/lib/container/gateways.ts
@@ -3,6 +3,7 @@ import {
   type ClerkUserLike,
   type ClerkUserLookup,
   DrizzleRateLimiter,
+  NobleSha256Hasher,
   ResendTransactionalEmailGateway,
   StripePaymentGateway,
 } from '@/src/adapters/gateways';
@@ -46,6 +47,7 @@ export function createGatewayFactories(input: {
       }),
     createRateLimiter: () =>
       new DrizzleRateLimiter(primitives.db, primitives.now, primitives.logger),
+    createSha256Hasher: () => new NobleSha256Hasher(),
     createTransactionalEmailGateway: () =>
       new ResendTransactionalEmailGateway({
         apiKey: primitives.env.RESEND_API_KEY,

--- a/lib/container/repositories.ts
+++ b/lib/container/repositories.ts
@@ -1,3 +1,4 @@
+import { NobleSha256Hasher } from '@/src/adapters/gateways';
 import {
   DrizzleAttemptRepository,
   DrizzleBookmarkRepository,
@@ -54,7 +55,11 @@ export function createRepositoryFactories(
     createRenewalConsentRecordRepository: (dbOverride = primitives.db) =>
       new DrizzleRenewalConsentRecordRepository(dbOverride, primitives.now),
     createRenewalNoticeDeliveryRepository: (dbOverride = primitives.db) =>
-      new DrizzleRenewalNoticeDeliveryRepository(dbOverride, primitives.now),
+      new DrizzleRenewalNoticeDeliveryRepository(
+        dbOverride,
+        new NobleSha256Hasher(),
+        primitives.now,
+      ),
     createTagRepository: (dbOverride = primitives.db) =>
       new DrizzleTagRepository(dbOverride),
     createTrialPaymentMethodSetupOperationRepository: (

--- a/lib/container/repositories.ts
+++ b/lib/container/repositories.ts
@@ -9,6 +9,7 @@ import {
   DrizzleQuestionFeedbackRepository,
   DrizzleQuestionRepository,
   DrizzleRenewalConsentRecordRepository,
+  DrizzleRenewalNoticeDeliveryRepository,
   DrizzleStripeCustomerRepository,
   DrizzleStripeEventRepository,
   DrizzleSubscriptionRepository,
@@ -52,6 +53,8 @@ export function createRepositoryFactories(
       new DrizzleQuestionRepository(dbOverride),
     createRenewalConsentRecordRepository: (dbOverride = primitives.db) =>
       new DrizzleRenewalConsentRecordRepository(dbOverride, primitives.now),
+    createRenewalNoticeDeliveryRepository: (dbOverride = primitives.db) =>
+      new DrizzleRenewalNoticeDeliveryRepository(dbOverride, primitives.now),
     createTagRepository: (dbOverride = primitives.db) =>
       new DrizzleTagRepository(dbOverride),
     createTrialPaymentMethodSetupOperationRepository: (

--- a/lib/container/types.ts
+++ b/lib/container/types.ts
@@ -33,6 +33,7 @@ import type {
   TrialPaymentMethodSetupOperationRepository,
   UserRepository,
 } from '@/src/application/ports/repositories';
+import type { Sha256Hasher } from '@/src/application/ports/sha256-hasher';
 import type { TransactionalEmailGateway } from '@/src/application/ports/transactional-email-gateway';
 import type {
   CheckEntitlementUseCase,
@@ -131,6 +132,7 @@ export type GatewayFactories = {
   createAuthGateway: () => AuthGateway;
   createPaymentGateway: () => PaymentGateway;
   createRateLimiter: () => RateLimiter;
+  createSha256Hasher: () => Sha256Hasher;
   createTransactionalEmailGateway: () => TransactionalEmailGateway;
 };
 

--- a/lib/container/types.ts
+++ b/lib/container/types.ts
@@ -25,6 +25,7 @@ import type {
   QuestionFeedbackRepository,
   QuestionRepository,
   RenewalConsentRecordRepository,
+  RenewalNoticeDeliveryRepository,
   StripeCustomerRepository,
   StripeEventRepository,
   SubscriptionRepository,
@@ -32,6 +33,7 @@ import type {
   TrialPaymentMethodSetupOperationRepository,
   UserRepository,
 } from '@/src/application/ports/repositories';
+import type { TransactionalEmailGateway } from '@/src/application/ports/transactional-email-gateway';
 import type {
   CheckEntitlementUseCase,
   CountAvailableQuestionsUseCase,
@@ -39,6 +41,7 @@ import type {
   CreatePortalSessionUseCase,
   CreateTrialPaymentMethodSetupSessionUseCase,
   DiscardPracticeSessionUseCase,
+  DispatchRenewalNoticeDeliveryUseCase,
   EndPracticeSessionUseCase,
   FinalizeExamAnswersUseCase,
   GetAttemptedQuestionsUseCase,
@@ -57,6 +60,7 @@ import type {
   PruneRenewalConsentsUseCase,
   RateQuestionUseCase,
   RecordRenewalConsentUseCase,
+  RequeueRenewalNoticeDeliveryUseCase,
   SaveExamDraftAnswerUseCase,
   SetBookmarkUseCase,
   SetPracticeSessionQuestionMarkUseCase,
@@ -104,6 +108,9 @@ export type RepositoryFactories = {
   createRenewalConsentRecordRepository: (
     dbOverride?: DrizzleDb,
   ) => RenewalConsentRecordRepository;
+  createRenewalNoticeDeliveryRepository: (
+    dbOverride?: DrizzleDb,
+  ) => RenewalNoticeDeliveryRepository;
   createTagRepository: (dbOverride?: DrizzleDb) => TagRepository;
   createTrialPaymentMethodSetupOperationRepository: (
     dbOverride?: DrizzleDb,
@@ -124,6 +131,7 @@ export type GatewayFactories = {
   createAuthGateway: () => AuthGateway;
   createPaymentGateway: () => PaymentGateway;
   createRateLimiter: () => RateLimiter;
+  createTransactionalEmailGateway: () => TransactionalEmailGateway;
 };
 
 export type UseCaseFactories = {
@@ -131,6 +139,8 @@ export type UseCaseFactories = {
   createCheckoutSessionUseCase: () => CreateCheckoutSessionUseCase;
   createPortalSessionUseCase: () => CreatePortalSessionUseCase;
   createTrialPaymentMethodSetupSessionUseCase: () => CreateTrialPaymentMethodSetupSessionUseCase;
+  createDispatchRenewalNoticeDeliveryUseCase: () => DispatchRenewalNoticeDeliveryUseCase;
+  createRequeueRenewalNoticeDeliveryUseCase: () => RequeueRenewalNoticeDeliveryUseCase;
   createRecordRenewalConsentUseCase: () => RecordRenewalConsentUseCase;
   createPruneRenewalConsentsUseCase: () => PruneRenewalConsentsUseCase;
   createCountAvailableQuestionsUseCase: () => CountAvailableQuestionsUseCase;

--- a/lib/container/use-cases.ts
+++ b/lib/container/use-cases.ts
@@ -280,6 +280,7 @@ export function createUseCaseFactories(input: {
       new DispatchRenewalNoticeDeliveryUseCase(
         repositories.createRenewalNoticeDeliveryRepository(),
         gateways.createTransactionalEmailGateway(),
+        gateways.createSha256Hasher(),
         primitives.now,
       ),
     createRequeueRenewalNoticeDeliveryUseCase: () =>

--- a/lib/container/use-cases.ts
+++ b/lib/container/use-cases.ts
@@ -26,6 +26,7 @@ import {
   CreatePortalSessionUseCase,
   CreateTrialPaymentMethodSetupSessionUseCase,
   DiscardPracticeSessionUseCase,
+  DispatchRenewalNoticeDeliveryUseCase,
   EndPracticeSessionUseCase,
   FinalizeExamAnswersUseCase,
   GetAttemptedQuestionsUseCase,
@@ -44,6 +45,7 @@ import {
   PruneRenewalConsentsUseCase,
   RateQuestionUseCase,
   RecordRenewalConsentUseCase,
+  RequeueRenewalNoticeDeliveryUseCase,
   SaveExamDraftAnswerUseCase,
   SetBookmarkUseCase,
   SetPracticeSessionQuestionMarkUseCase,
@@ -272,6 +274,17 @@ export function createUseCaseFactories(input: {
     createPruneRenewalConsentsUseCase: () =>
       new PruneRenewalConsentsUseCase(
         repositories.createRenewalConsentRecordRepository(),
+        primitives.now,
+      ),
+    createDispatchRenewalNoticeDeliveryUseCase: () =>
+      new DispatchRenewalNoticeDeliveryUseCase(
+        repositories.createRenewalNoticeDeliveryRepository(),
+        gateways.createTransactionalEmailGateway(),
+        primitives.now,
+      ),
+    createRequeueRenewalNoticeDeliveryUseCase: () =>
+      new RequeueRenewalNoticeDeliveryUseCase(
+        repositories.createRenewalNoticeDeliveryRepository(),
         primitives.now,
       ),
     createCountAvailableQuestionsUseCase: () =>

--- a/lib/env.test.ts
+++ b/lib/env.test.ts
@@ -52,6 +52,26 @@ describe('env', () => {
     await expect(import('@/lib/env')).resolves.toHaveProperty('env');
   });
 
+  it('rejects a configured Resend API key without the provider prefix', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.DATABASE_URL =
+      'postgresql://postgres:postgres@localhost:5432/db';
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+    process.env.STRIPE_SECRET_KEY = 'sk_test_dummy';
+    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = 'pk_test_dummy';
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_dummy';
+    process.env.NEXT_PUBLIC_STRIPE_PRICE_ID_MONTHLY = 'price_dummy_monthly';
+    process.env.NEXT_PUBLIC_STRIPE_PRICE_ID_ANNUAL = 'price_dummy_annual';
+    process.env.NEXT_PUBLIC_SKIP_CLERK = 'true';
+    process.env.RESEND_API_KEY = 'not-a-resend-key';
+
+    vi.resetModules();
+
+    await expect(import('@/lib/env')).rejects.toThrow(
+      'Invalid environment variables',
+    );
+  });
+
   it('allows NEXT_PUBLIC_SKIP_CLERK=true when VERCEL_ENV is not production', async () => {
     delete process.env.VERCEL_ENV;
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -59,6 +59,9 @@ const envSchema = z.object({
     .min(1)
     .regex(/^price_/, 'Must start with "price_"'),
 
+  // Transactional email (optional until the owner provisions Resend)
+  RESEND_API_KEY: z.string().min(1).optional(),
+
   // App
   NEXT_PUBLIC_APP_URL: z.string().url(),
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -60,7 +60,11 @@ const envSchema = z.object({
     .regex(/^price_/, 'Must start with "price_"'),
 
   // Transactional email (optional until the owner provisions Resend)
-  RESEND_API_KEY: z.string().min(1).optional(),
+  RESEND_API_KEY: z
+    .string()
+    .min(1)
+    .regex(/^re_/, 'Must start with "re_"')
+    .optional(),
 
   // App
   NEXT_PUBLIC_APP_URL: z.string().url(),

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-markdown": "^10.1.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "resend": "6.18.0",
     "server-only": "^0.0.1",
     "stripe": "^22.3.0",
     "tailwind-merge": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@clerk/nextjs": "^7.4.1",
     "@clerk/ui": "^1.13.1",
+    "@noble/hashes": "1.8.0",
     "@sentry/nextjs": "^10.53.1",
     "@tailwindcss/postcss": "4.3.2",
     "@typescript/native": "npm:typescript@^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@clerk/ui':
         specifier: ^1.13.1
         version: 1.25.2(@solana/web3.js@1.98.4(@typescript/typescript6@6.0.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(@typescript/typescript6@6.0.2)(bs58@6.0.0)(bufferutil@4.1.0)(react-dom@19.2.7(react@19.2.7))(react-native@0.84.1(@babel/core@7.29.7)(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(utf-8-validate@6.0.6)
+      '@noble/hashes':
+        specifier: 1.8.0
+        version: 1.8.0
       '@sentry/nextjs':
         specifier: ^10.53.1
         version: 10.65.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.105.0(esbuild@0.28.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      resend:
+        specifier: 6.18.0
+        version: 6.18.0
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -4967,6 +4970,9 @@ packages:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
 
+  postal-mime@2.7.5:
+    resolution: {integrity: sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==}
+
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5143,6 +5149,15 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  resend@6.18.0:
+    resolution: {integrity: sha512-EjxZ9AVzywJgOlUoIJe9ytBWVrfbUtJbjeoLnRSvpU1sv97Hh9DSwhw+k8kiujrG4Rg4bzTBsjlmwWWuoOxSug==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -11067,6 +11082,8 @@ snapshots:
 
   pngjs@7.0.0: {}
 
+  postal-mime@2.7.5: {}
+
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.16
@@ -11349,6 +11366,11 @@ snapshots:
       - supports-color
 
   require-main-filename@2.0.0: {}
+
+  resend@6.18.0:
+    dependencies:
+      postal-mime: 2.7.5
+      standardwebhooks: 1.0.0
 
   resolve-from@4.0.0: {}
 

--- a/src/adapters/gateways/index.ts
+++ b/src/adapters/gateways/index.ts
@@ -1,3 +1,4 @@
 export * from './clerk-auth-gateway';
 export * from './drizzle-rate-limiter';
+export * from './resend-transactional-email-gateway';
 export * from './stripe-payment-gateway';

--- a/src/adapters/gateways/index.ts
+++ b/src/adapters/gateways/index.ts
@@ -1,4 +1,5 @@
 export * from './clerk-auth-gateway';
 export * from './drizzle-rate-limiter';
+export * from './noble-sha256-hasher';
 export * from './resend-transactional-email-gateway';
 export * from './stripe-payment-gateway';

--- a/src/adapters/gateways/noble-sha256-hasher.test.ts
+++ b/src/adapters/gateways/noble-sha256-hasher.test.ts
@@ -1,0 +1,13 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { NobleSha256Hasher } from './noble-sha256-hasher';
+
+describe('NobleSha256Hasher', () => {
+  it('returns the lowercase hexadecimal SHA-256 digest', () => {
+    const input = 'immutable renewal notice payload';
+
+    expect(new NobleSha256Hasher().hash(input)).toBe(
+      createHash('sha256').update(input).digest('hex'),
+    );
+  });
+});

--- a/src/adapters/gateways/noble-sha256-hasher.ts
+++ b/src/adapters/gateways/noble-sha256-hasher.ts
@@ -1,0 +1,9 @@
+import { sha256 } from '@noble/hashes/sha2';
+import { bytesToHex } from '@noble/hashes/utils';
+import type { Sha256Hasher } from '@/src/application/ports';
+
+export class NobleSha256Hasher implements Sha256Hasher {
+  hash(input: string): string {
+    return bytesToHex(sha256(new TextEncoder().encode(input)));
+  }
+}

--- a/src/adapters/gateways/resend-transactional-email-gateway.test.ts
+++ b/src/adapters/gateways/resend-transactional-email-gateway.test.ts
@@ -31,6 +31,7 @@ const input = {
 
 describe('ResendTransactionalEmailGateway', () => {
   beforeEach(() => {
+    vi.useRealTimers();
     resendSdk.constructorInputs.length = 0;
     resendSdk.send.mockReset();
   });
@@ -127,6 +128,34 @@ describe('ResendTransactionalEmailGateway', () => {
       status: 'outcome_unknown',
       failureCode: 'ETIMEDOUT',
     });
+  });
+
+  it('uses the fallback failure code for an unstructured thrown value', async () => {
+    resendSdk.send.mockRejectedValue('provider disconnected');
+    const gateway = new ResendTransactionalEmailGateway({ apiKey: 're_test' });
+
+    await expect(gateway.send(input)).resolves.toEqual({
+      status: 'outcome_unknown',
+      failureCode: 'provider_exception',
+    });
+  });
+
+  it('bounds a stalled provider call and clears its timeout', async () => {
+    vi.useFakeTimers();
+    resendSdk.send.mockImplementation(() => new Promise(() => undefined));
+    const gateway = new ResendTransactionalEmailGateway({
+      apiKey: 're_test',
+      timeoutMs: 25,
+    });
+
+    const result = gateway.send(input);
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(result).resolves.toEqual({
+      status: 'outcome_unknown',
+      failureCode: 'provider_timeout',
+    });
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('maps a response without data or error to outcome_unknown', async () => {

--- a/src/adapters/gateways/resend-transactional-email-gateway.test.ts
+++ b/src/adapters/gateways/resend-transactional-email-gateway.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const resendSdk = vi.hoisted(() => ({
+  constructorInputs: [] as string[],
+  send: vi.fn(),
+}));
+
+vi.mock('resend', () => ({
+  Resend: class ResendMock {
+    readonly emails = { send: resendSdk.send };
+
+    constructor(apiKey: string) {
+      resendSdk.constructorInputs.push(apiKey);
+    }
+  },
+}));
+
+import { ResendTransactionalEmailGateway } from './resend-transactional-email-gateway';
+
+const input = {
+  idempotencyKey: 'renewal-notice/11111111-1111-4111-8111-111111111111',
+  payload: {
+    from: 'Addiction Boards <notices@addictionboards.com>',
+    to: 'subscriber@example.com',
+    replyTo: 'support@addictionboards.com',
+    subject: 'Your renewal terms',
+    html: '<p>Renewal terms</p>',
+    text: 'Renewal terms',
+  },
+};
+
+describe('ResendTransactionalEmailGateway', () => {
+  beforeEach(() => {
+    resendSdk.constructorInputs.length = 0;
+    resendSdk.send.mockReset();
+  });
+
+  it('reports unconfigured without constructing or calling the SDK', async () => {
+    const gateway = new ResendTransactionalEmailGateway({ apiKey: undefined });
+
+    expect(gateway.isConfigured()).toBe(false);
+    await expect(gateway.send(input)).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+    });
+    expect(resendSdk.constructorInputs).toEqual([]);
+    expect(resendSdk.send).not.toHaveBeenCalled();
+  });
+
+  it('passes the immutable payload and stable idempotency key to Resend', async () => {
+    resendSdk.send.mockResolvedValue({
+      data: { id: 'email_123' },
+      error: null,
+    });
+    const gateway = new ResendTransactionalEmailGateway({ apiKey: 're_test' });
+
+    await expect(gateway.send(input)).resolves.toEqual({
+      status: 'delivered',
+      providerEventId: 'email_123',
+    });
+    expect(resendSdk.constructorInputs).toEqual(['re_test']);
+    expect(resendSdk.send).toHaveBeenCalledWith(input.payload, {
+      idempotencyKey: input.idempotencyKey,
+    });
+  });
+
+  it.each([
+    'application_error',
+    'daily_quota_exceeded',
+    'monthly_quota_exceeded',
+    'rate_limit_exceeded',
+    'internal_server_error',
+  ])('maps known non-acceptance %s to transient_failure', async (name) => {
+    resendSdk.send.mockResolvedValue({
+      data: null,
+      error: { name, message: 'try later' },
+    });
+    const gateway = new ResendTransactionalEmailGateway({ apiKey: 're_test' });
+
+    await expect(gateway.send(input)).resolves.toEqual({
+      status: 'transient_failure',
+      failureCode: name,
+    });
+  });
+
+  it('quarantines concurrent idempotent requests because provider acceptance is unresolved', async () => {
+    resendSdk.send.mockResolvedValue({
+      data: null,
+      error: {
+        name: 'concurrent_idempotent_requests',
+        message: 'another request is still processing',
+      },
+    });
+    const gateway = new ResendTransactionalEmailGateway({ apiKey: 're_test' });
+
+    await expect(gateway.send(input)).resolves.toEqual({
+      status: 'outcome_unknown',
+      failureCode: 'concurrent_idempotent_requests',
+    });
+  });
+
+  it.each([
+    'invalid_idempotent_request',
+    'validation_error',
+    'invalid_api_key',
+  ])('maps known terminal error %s to terminal_failure', async (name) => {
+    resendSdk.send.mockResolvedValue({
+      data: null,
+      error: { name, message: 'do not retry' },
+    });
+    const gateway = new ResendTransactionalEmailGateway({
+      apiKey: 're_test',
+    });
+
+    await expect(gateway.send(input)).resolves.toEqual({
+      status: 'terminal_failure',
+      failureCode: name,
+    });
+  });
+
+  it('maps a thrown provider call to outcome_unknown', async () => {
+    resendSdk.send.mockRejectedValue(
+      Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' }),
+    );
+    const gateway = new ResendTransactionalEmailGateway({ apiKey: 're_test' });
+
+    await expect(gateway.send(input)).resolves.toEqual({
+      status: 'outcome_unknown',
+      failureCode: 'ETIMEDOUT',
+    });
+  });
+
+  it('maps a response without data or error to outcome_unknown', async () => {
+    resendSdk.send.mockResolvedValue({ data: null, error: null });
+    const gateway = new ResendTransactionalEmailGateway({ apiKey: 're_test' });
+
+    await expect(gateway.send(input)).resolves.toEqual({
+      status: 'outcome_unknown',
+      failureCode: 'invalid_provider_response',
+    });
+  });
+});

--- a/src/adapters/gateways/resend-transactional-email-gateway.test.ts
+++ b/src/adapters/gateways/resend-transactional-email-gateway.test.ts
@@ -167,4 +167,19 @@ describe('ResendTransactionalEmailGateway', () => {
       failureCode: 'invalid_provider_response',
     });
   });
+
+  it.each([
+    { id: '' },
+    {},
+  ])('maps data without a non-empty provider event ID to outcome_unknown', async (data) => {
+    resendSdk.send.mockResolvedValue({ data, error: null });
+    const gateway = new ResendTransactionalEmailGateway({
+      apiKey: 're_test',
+    });
+
+    await expect(gateway.send(input)).resolves.toEqual({
+      status: 'outcome_unknown',
+      failureCode: 'invalid_provider_response',
+    });
+  });
 });

--- a/src/adapters/gateways/resend-transactional-email-gateway.ts
+++ b/src/adapters/gateways/resend-transactional-email-gateway.ts
@@ -88,7 +88,7 @@ export class ResendTransactionalEmailGateway
           failureCode: error.name,
         };
       }
-      if (data) {
+      if (data && typeof data.id === 'string' && data.id.length > 0) {
         return { status: 'delivered', providerEventId: data.id };
       }
       return {

--- a/src/adapters/gateways/resend-transactional-email-gateway.ts
+++ b/src/adapters/gateways/resend-transactional-email-gateway.ts
@@ -13,6 +13,11 @@ const TRANSIENT_RESEND_ERRORS = new Set<ErrorResponse['name']>([
   'monthly_quota_exceeded',
   'rate_limit_exceeded',
 ]);
+export const RESEND_PROVIDER_TIMEOUT_MS = 10_000;
+
+class ResendProviderTimeoutError extends Error {
+  readonly code = 'provider_timeout';
+}
 
 function getThrownFailureCode(error: unknown): string {
   if (
@@ -30,9 +35,11 @@ export class ResendTransactionalEmailGateway
   implements TransactionalEmailGateway
 {
   private readonly client: Resend | null;
+  private readonly timeoutMs: number;
 
-  constructor(input: { apiKey: string | undefined }) {
+  constructor(input: { apiKey: string | undefined; timeoutMs?: number }) {
     this.client = input.apiKey ? new Resend(input.apiKey) : null;
+    this.timeoutMs = input.timeoutMs ?? RESEND_PROVIDER_TIMEOUT_MS;
   }
 
   isConfigured(): boolean {
@@ -50,8 +57,21 @@ export class ResendTransactionalEmailGateway
     }
 
     try {
-      const { data, error } = await this.client.emails.send(input.payload, {
+      const providerCall = this.client.emails.send(input.payload, {
         idempotencyKey: input.idempotencyKey,
+      });
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const timeoutResult = new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new ResendProviderTimeoutError()),
+          this.timeoutMs,
+        );
+      });
+      const { data, error } = await Promise.race([
+        providerCall,
+        timeoutResult,
+      ]).finally(() => {
+        if (timeout) clearTimeout(timeout);
       });
 
       if (error) {

--- a/src/adapters/gateways/resend-transactional-email-gateway.ts
+++ b/src/adapters/gateways/resend-transactional-email-gateway.ts
@@ -1,0 +1,85 @@
+import { type ErrorResponse, Resend } from 'resend';
+import { ApplicationError } from '@/src/application/errors';
+import type {
+  TransactionalEmailGateway,
+  TransactionalEmailSendInput,
+  TransactionalEmailSendResult,
+} from '@/src/application/ports/transactional-email-gateway';
+
+const TRANSIENT_RESEND_ERRORS = new Set<ErrorResponse['name']>([
+  'application_error',
+  'daily_quota_exceeded',
+  'internal_server_error',
+  'monthly_quota_exceeded',
+  'rate_limit_exceeded',
+]);
+
+function getThrownFailureCode(error: unknown): string {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof error.code === 'string'
+  ) {
+    return error.code;
+  }
+  return 'provider_exception';
+}
+
+export class ResendTransactionalEmailGateway
+  implements TransactionalEmailGateway
+{
+  private readonly client: Resend | null;
+
+  constructor(input: { apiKey: string | undefined }) {
+    this.client = input.apiKey ? new Resend(input.apiKey) : null;
+  }
+
+  isConfigured(): boolean {
+    return this.client !== null;
+  }
+
+  async send(
+    input: TransactionalEmailSendInput,
+  ): Promise<TransactionalEmailSendResult> {
+    if (!this.client) {
+      throw new ApplicationError(
+        'INTERNAL_ERROR',
+        'Transactional email gateway is not configured',
+      );
+    }
+
+    try {
+      const { data, error } = await this.client.emails.send(input.payload, {
+        idempotencyKey: input.idempotencyKey,
+      });
+
+      if (error) {
+        if (error.name === 'concurrent_idempotent_requests') {
+          return {
+            status: 'outcome_unknown',
+            failureCode: error.name,
+          };
+        }
+        return {
+          status: TRANSIENT_RESEND_ERRORS.has(error.name)
+            ? 'transient_failure'
+            : 'terminal_failure',
+          failureCode: error.name,
+        };
+      }
+      if (data) {
+        return { status: 'delivered', providerEventId: data.id };
+      }
+      return {
+        status: 'outcome_unknown',
+        failureCode: 'invalid_provider_response',
+      };
+    } catch (error) {
+      return {
+        status: 'outcome_unknown',
+        failureCode: getThrownFailureCode(error),
+      };
+    }
+  }
+}

--- a/src/adapters/repositories/drizzle-renewal-notice-delivery-repository.ts
+++ b/src/adapters/repositories/drizzle-renewal-notice-delivery-repository.ts
@@ -1,0 +1,382 @@
+import { and, asc, eq, lte, or, sql } from 'drizzle-orm';
+import { renewalNoticeDeliveries } from '@/db/schema';
+import type { DrizzleDb } from '@/src/adapters/shared/database-types';
+import { ApplicationError } from '@/src/application/errors';
+import type {
+  ClaimRenewalNoticeDeliveryInput,
+  MarkRenewalNoticeDeliveryFailureInput,
+  RenewalNoticeDeliveryRepository,
+} from '@/src/application/ports/repositories';
+import { assertValidRenewalNoticeDeliveryPayload } from '@/src/application/shared/transactional-email-payload';
+import type {
+  NewRenewalNoticeDelivery,
+  RenewalNoticeDelivery,
+} from '@/src/domain/entities';
+import { isValidRenewalNoticeDeliveryKeyShape } from '@/src/domain/entities';
+
+type DeliveryRow = typeof renewalNoticeDeliveries.$inferSelect;
+
+function toDelivery(row: DeliveryRow): RenewalNoticeDelivery {
+  const { stripeSubscriptionId, ...vendorNeutralRow } = row;
+  return {
+    ...vendorNeutralRow,
+    externalSubscriptionId: stripeSubscriptionId,
+  };
+}
+
+function datesMatch(left: Date | null, right: Date | null): boolean {
+  if (left === null || right === null) return left === right;
+  return left.getTime() === right.getTime();
+}
+
+function immutableFieldsMatch(
+  row: DeliveryRow,
+  input: NewRenewalNoticeDelivery,
+): boolean {
+  return (
+    row.noticeKind === input.noticeKind &&
+    row.consentRecordId === input.consentRecordId &&
+    row.stripeSubscriptionId === input.externalSubscriptionId &&
+    datesMatch(row.applicableAt, input.applicableAt) &&
+    row.disclosureVersion === input.disclosureVersion &&
+    row.destination === input.destination &&
+    row.payloadSnapshot === input.payloadSnapshot &&
+    row.payloadHash === input.payloadHash
+  );
+}
+
+function assertValidKeyShape(input: NewRenewalNoticeDelivery): void {
+  if (!isValidRenewalNoticeDeliveryKeyShape(input)) {
+    throw new ApplicationError(
+      'VALIDATION_ERROR',
+      'Renewal notice delivery does not match its notice-kind key shape',
+    );
+  }
+}
+
+export class DrizzleRenewalNoticeDeliveryRepository
+  implements RenewalNoticeDeliveryRepository
+{
+  constructor(
+    private readonly db: DrizzleDb,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async saveQueued(
+    input: NewRenewalNoticeDelivery,
+  ): Promise<RenewalNoticeDelivery> {
+    assertValidRenewalNoticeDeliveryPayload(input);
+    assertValidKeyShape(input);
+    const { externalSubscriptionId, ...vendorNeutralInput } = input;
+    const [inserted] = await this.db
+      .insert(renewalNoticeDeliveries)
+      .values({
+        ...vendorNeutralInput,
+        stripeSubscriptionId: externalSubscriptionId,
+        status: 'queued',
+        updatedAt: this.now(),
+      })
+      .onConflictDoNothing()
+      .returning();
+    if (inserted) return toDelivery(inserted);
+
+    const existing = await this.findConflictRow(input);
+    if (!existing) {
+      throw new ApplicationError(
+        'INTERNAL_ERROR',
+        'Renewal notice delivery disappeared after conflict',
+      );
+    }
+    if (!immutableFieldsMatch(existing, input)) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'Renewal notice delivery identity is bound to another payload',
+      );
+    }
+    return toDelivery(existing);
+  }
+
+  async findById(id: string): Promise<RenewalNoticeDelivery | null> {
+    const row = await this.db.query.renewalNoticeDeliveries.findFirst({
+      where: eq(renewalNoticeDeliveries.id, id),
+    });
+    return row ? toDelivery(row) : null;
+  }
+
+  async findDue(input: {
+    now: Date;
+    limit: number;
+  }): Promise<RenewalNoticeDelivery[]> {
+    if (!Number.isInteger(input.limit) || input.limit <= 0) return [];
+    const rows = await this.db
+      .select()
+      .from(renewalNoticeDeliveries)
+      .where(
+        or(
+          eq(renewalNoticeDeliveries.status, 'queued'),
+          and(
+            eq(renewalNoticeDeliveries.status, 'transient_failure'),
+            lte(renewalNoticeDeliveries.nextAttemptAt, input.now),
+          ),
+        ),
+      )
+      .orderBy(
+        asc(renewalNoticeDeliveries.createdAt),
+        asc(renewalNoticeDeliveries.id),
+      )
+      .limit(input.limit);
+    return rows.map(toDelivery);
+  }
+
+  async claim(
+    input: ClaimRenewalNoticeDeliveryInput,
+  ): Promise<RenewalNoticeDelivery | null> {
+    const [row] = await this.db
+      .update(renewalNoticeDeliveries)
+      .set({
+        status: 'processing',
+        attemptCount: sql`${renewalNoticeDeliveries.attemptCount} + 1`,
+        attemptId: input.attemptId,
+        attemptStartedAt: input.startedAt,
+        lastAttemptAt: input.startedAt,
+        nextAttemptAt: null,
+        failureClass: null,
+        failureCode: null,
+        updatedAt: input.startedAt,
+      })
+      .where(
+        and(
+          eq(renewalNoticeDeliveries.id, input.id),
+          or(
+            eq(renewalNoticeDeliveries.status, 'queued'),
+            and(
+              eq(renewalNoticeDeliveries.status, 'transient_failure'),
+              lte(renewalNoticeDeliveries.nextAttemptAt, input.startedAt),
+            ),
+          ),
+        ),
+      )
+      .returning();
+    return row ? toDelivery(row) : null;
+  }
+
+  markDelivered(input: {
+    id: string;
+    attemptId: string;
+    providerEventId: string;
+    completedAt: Date;
+  }): Promise<RenewalNoticeDelivery> {
+    return this.updateOwnedClaim(input.id, input.attemptId, {
+      status: 'delivered',
+      providerEventId: input.providerEventId,
+      nextAttemptAt: null,
+      failureClass: null,
+      failureCode: null,
+      updatedAt: input.completedAt,
+    });
+  }
+
+  markTransientFailure(
+    input: MarkRenewalNoticeDeliveryFailureInput & { nextAttemptAt: Date },
+  ): Promise<RenewalNoticeDelivery> {
+    return this.markFailure('transient_failure', input, input.nextAttemptAt);
+  }
+
+  markTerminalFailure(
+    input: MarkRenewalNoticeDeliveryFailureInput,
+  ): Promise<RenewalNoticeDelivery> {
+    return this.markFailure('terminal_failure', input, null);
+  }
+
+  markOutcomeUnknown(
+    input: MarkRenewalNoticeDeliveryFailureInput,
+  ): Promise<RenewalNoticeDelivery> {
+    return this.markFailure('outcome_unknown', input, null);
+  }
+
+  async markStaleProcessingUnknown(input: {
+    staleBefore: Date;
+    observedAt: Date;
+    limit: number;
+  }): Promise<number> {
+    if (!Number.isInteger(input.limit) || input.limit <= 0) return 0;
+    const staleBefore = sql.param(
+      input.staleBefore,
+      renewalNoticeDeliveries.attemptStartedAt,
+    );
+    const observedAt = sql.param(
+      input.observedAt,
+      renewalNoticeDeliveries.updatedAt,
+    );
+    const updated = await this.db.execute<{ id: string }>(sql`
+      WITH candidates AS (
+        SELECT ${renewalNoticeDeliveries.id} AS id
+        FROM ${renewalNoticeDeliveries}
+        WHERE ${renewalNoticeDeliveries.status} = 'processing'
+          AND ${renewalNoticeDeliveries.attemptStartedAt} < ${staleBefore}
+        ORDER BY
+          ${renewalNoticeDeliveries.attemptStartedAt},
+          ${renewalNoticeDeliveries.id}
+        LIMIT ${input.limit}
+        FOR UPDATE SKIP LOCKED
+      )
+      UPDATE ${renewalNoticeDeliveries}
+      SET
+        status = 'outcome_unknown',
+        next_attempt_at = NULL,
+        failure_class = 'stale_processing_claim',
+        failure_code = 'worker_outcome_unknown',
+        updated_at = ${observedAt}
+      FROM candidates
+      WHERE ${renewalNoticeDeliveries.id} = candidates.id
+        AND ${renewalNoticeDeliveries.status} = 'processing'
+        AND ${renewalNoticeDeliveries.attemptStartedAt} < ${staleBefore}
+      RETURNING ${renewalNoticeDeliveries.id} AS id
+    `);
+    return updated.length;
+  }
+
+  async requeue(input: {
+    id: string;
+    reason: string;
+    requeuedBy: string;
+    requeuedAt: Date;
+    confirmedNoSend: boolean;
+  }): Promise<RenewalNoticeDelivery> {
+    const existing = await this.findById(input.id);
+    if (
+      !existing ||
+      (existing.status !== 'terminal_failure' &&
+        existing.status !== 'outcome_unknown')
+    ) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'Renewal notice delivery is not eligible for requeue',
+      );
+    }
+    if (existing.status === 'outcome_unknown' && !input.confirmedNoSend) {
+      throw new ApplicationError(
+        'VALIDATION_ERROR',
+        'Unknown delivery outcome requires confirmation that no send occurred',
+      );
+    }
+
+    const [row] = await this.db
+      .update(renewalNoticeDeliveries)
+      .set({
+        status: 'queued',
+        providerEventId: null,
+        nextAttemptAt: null,
+        failureClass: null,
+        failureCode: null,
+        requeueReason: input.reason,
+        requeuedAt: input.requeuedAt,
+        requeuedBy: input.requeuedBy,
+        requeueAudit: [
+          ...existing.requeueAudit,
+          {
+            reason: input.reason,
+            requeuedAt: input.requeuedAt.toISOString(),
+            requeuedBy: input.requeuedBy,
+            confirmedNoSend: input.confirmedNoSend,
+            priorStatus: existing.status,
+          },
+        ],
+        updatedAt: input.requeuedAt,
+      })
+      .where(
+        and(
+          eq(renewalNoticeDeliveries.id, input.id),
+          eq(renewalNoticeDeliveries.status, existing.status),
+        ),
+      )
+      .returning();
+    if (!row) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'Renewal notice delivery changed before requeue',
+      );
+    }
+    return toDelivery(row);
+  }
+
+  private markFailure(
+    status: 'transient_failure' | 'terminal_failure' | 'outcome_unknown',
+    input: MarkRenewalNoticeDeliveryFailureInput,
+    nextAttemptAt: Date | null,
+  ): Promise<RenewalNoticeDelivery> {
+    return this.updateOwnedClaim(input.id, input.attemptId, {
+      status,
+      nextAttemptAt,
+      failureClass: input.failureClass,
+      failureCode: input.failureCode,
+      updatedAt: input.failedAt,
+    });
+  }
+
+  private async updateOwnedClaim(
+    id: string,
+    attemptId: string,
+    values: Partial<typeof renewalNoticeDeliveries.$inferInsert>,
+  ): Promise<RenewalNoticeDelivery> {
+    const [row] = await this.db
+      .update(renewalNoticeDeliveries)
+      .set(values)
+      .where(
+        and(
+          eq(renewalNoticeDeliveries.id, id),
+          eq(renewalNoticeDeliveries.status, 'processing'),
+          eq(renewalNoticeDeliveries.attemptId, attemptId),
+        ),
+      )
+      .returning();
+    if (!row) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'Renewal notice delivery is not owned by this attempt',
+      );
+    }
+    return toDelivery(row);
+  }
+
+  private findConflictRow(
+    input: NewRenewalNoticeDelivery,
+  ): Promise<DeliveryRow | undefined> {
+    const identity =
+      input.noticeKind === 'acknowledgment'
+        ? and(
+            eq(renewalNoticeDeliveries.noticeKind, 'acknowledgment'),
+            eq(
+              renewalNoticeDeliveries.consentRecordId,
+              input.consentRecordId as string,
+            ),
+            eq(renewalNoticeDeliveries.destination, input.destination),
+          )
+        : and(
+            eq(renewalNoticeDeliveries.noticeKind, input.noticeKind),
+            eq(
+              renewalNoticeDeliveries.stripeSubscriptionId,
+              input.externalSubscriptionId as string,
+            ),
+            eq(
+              renewalNoticeDeliveries.applicableAt,
+              input.applicableAt as Date,
+            ),
+            eq(
+              renewalNoticeDeliveries.disclosureVersion,
+              input.disclosureVersion,
+            ),
+            eq(renewalNoticeDeliveries.destination, input.destination),
+          );
+    return this.db.query.renewalNoticeDeliveries.findFirst({
+      where: or(
+        eq(renewalNoticeDeliveries.id, input.id),
+        eq(
+          renewalNoticeDeliveries.providerIdempotencyKey,
+          input.providerIdempotencyKey,
+        ),
+        identity,
+      ),
+    });
+  }
+}

--- a/src/adapters/repositories/drizzle-renewal-notice-delivery-repository.ts
+++ b/src/adapters/repositories/drizzle-renewal-notice-delivery-repository.ts
@@ -7,6 +7,7 @@ import type {
   MarkRenewalNoticeDeliveryFailureInput,
   RenewalNoticeDeliveryRepository,
 } from '@/src/application/ports/repositories';
+import type { Sha256Hasher } from '@/src/application/ports/sha256-hasher';
 import { assertValidRenewalNoticeDeliveryPayload } from '@/src/application/shared/transactional-email-payload';
 import type {
   NewRenewalNoticeDelivery,
@@ -59,13 +60,14 @@ export class DrizzleRenewalNoticeDeliveryRepository
 {
   constructor(
     private readonly db: DrizzleDb,
+    private readonly hasher: Sha256Hasher,
     private readonly now: () => Date = () => new Date(),
   ) {}
 
   async saveQueued(
     input: NewRenewalNoticeDelivery,
   ): Promise<RenewalNoticeDelivery> {
-    assertValidRenewalNoticeDeliveryPayload(input);
+    assertValidRenewalNoticeDeliveryPayload(input, this.hasher);
     assertValidKeyShape(input);
     const { externalSubscriptionId, ...vendorNeutralInput } = input;
     const [inserted] = await this.db

--- a/src/adapters/repositories/drizzle-renewal-notice-delivery-repository.ts
+++ b/src/adapters/repositories/drizzle-renewal-notice-delivery-repository.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, lte, or, sql } from 'drizzle-orm';
+import { and, asc, eq, lte, or, type SQL, sql } from 'drizzle-orm';
 import { renewalNoticeDeliveries } from '@/db/schema';
 import type { DrizzleDb } from '@/src/adapters/shared/database-types';
 import { ApplicationError } from '@/src/application/errors';
@@ -342,32 +342,37 @@ export class DrizzleRenewalNoticeDeliveryRepository
   private findConflictRow(
     input: NewRenewalNoticeDelivery,
   ): Promise<DeliveryRow | undefined> {
-    const identity =
-      input.noticeKind === 'acknowledgment'
-        ? and(
-            eq(renewalNoticeDeliveries.noticeKind, 'acknowledgment'),
-            eq(
-              renewalNoticeDeliveries.consentRecordId,
-              input.consentRecordId as string,
-            ),
-            eq(renewalNoticeDeliveries.destination, input.destination),
-          )
-        : and(
-            eq(renewalNoticeDeliveries.noticeKind, input.noticeKind),
-            eq(
-              renewalNoticeDeliveries.stripeSubscriptionId,
-              input.externalSubscriptionId as string,
-            ),
-            eq(
-              renewalNoticeDeliveries.applicableAt,
-              input.applicableAt as Date,
-            ),
-            eq(
-              renewalNoticeDeliveries.disclosureVersion,
-              input.disclosureVersion,
-            ),
-            eq(renewalNoticeDeliveries.destination, input.destination),
-          );
+    let identity: SQL | undefined;
+    if (input.noticeKind === 'acknowledgment') {
+      if (!input.consentRecordId) {
+        throw new ApplicationError(
+          'VALIDATION_ERROR',
+          'Acknowledgment delivery requires a consent record ID',
+        );
+      }
+      identity = and(
+        eq(renewalNoticeDeliveries.noticeKind, 'acknowledgment'),
+        eq(renewalNoticeDeliveries.consentRecordId, input.consentRecordId),
+        eq(renewalNoticeDeliveries.destination, input.destination),
+      );
+    } else {
+      if (!input.externalSubscriptionId || !input.applicableAt) {
+        throw new ApplicationError(
+          'VALIDATION_ERROR',
+          'Scheduled delivery requires a subscription and applicable date',
+        );
+      }
+      identity = and(
+        eq(renewalNoticeDeliveries.noticeKind, input.noticeKind),
+        eq(
+          renewalNoticeDeliveries.stripeSubscriptionId,
+          input.externalSubscriptionId,
+        ),
+        eq(renewalNoticeDeliveries.applicableAt, input.applicableAt),
+        eq(renewalNoticeDeliveries.disclosureVersion, input.disclosureVersion),
+        eq(renewalNoticeDeliveries.destination, input.destination),
+      );
+    }
     return this.db.query.renewalNoticeDeliveries.findFirst({
       where: or(
         eq(renewalNoticeDeliveries.id, input.id),

--- a/src/adapters/repositories/index.ts
+++ b/src/adapters/repositories/index.ts
@@ -8,6 +8,7 @@ export { DrizzlePracticeSessionRepository } from './drizzle-practice-session-rep
 export { DrizzleQuestionFeedbackRepository } from './drizzle-question-feedback-repository';
 export { DrizzleQuestionRepository } from './drizzle-question-repository';
 export { DrizzleRenewalConsentRecordRepository } from './drizzle-renewal-consent-record-repository';
+export { DrizzleRenewalNoticeDeliveryRepository } from './drizzle-renewal-notice-delivery-repository';
 export { DrizzleStripeCustomerRepository } from './drizzle-stripe-customer-repository';
 export { DrizzleStripeEventRepository } from './drizzle-stripe-event-repository';
 export { DrizzleSubscriptionRepository } from './drizzle-subscription-repository';

--- a/src/application/ports/index.ts
+++ b/src/application/ports/index.ts
@@ -3,4 +3,5 @@ export * from './bookmarks';
 export * from './gateways';
 export * from './logger';
 export * from './repositories';
+export * from './sha256-hasher';
 export * from './transactional-email-gateway';

--- a/src/application/ports/index.ts
+++ b/src/application/ports/index.ts
@@ -3,3 +3,4 @@ export * from './bookmarks';
 export * from './gateways';
 export * from './logger';
 export * from './repositories';
+export * from './transactional-email-gateway';

--- a/src/application/ports/renewal-notice-delivery-repository.ts
+++ b/src/application/ports/renewal-notice-delivery-repository.ts
@@ -1,0 +1,57 @@
+import type {
+  NewRenewalNoticeDelivery,
+  RenewalNoticeDelivery,
+} from '@/src/domain/entities';
+
+export type ClaimRenewalNoticeDeliveryInput = {
+  id: string;
+  attemptId: string;
+  startedAt: Date;
+};
+
+export type MarkRenewalNoticeDeliveryFailureInput = {
+  id: string;
+  attemptId: string;
+  failureClass: string;
+  failureCode: string;
+  failedAt: Date;
+};
+
+export interface RenewalNoticeDeliveryRepository {
+  saveQueued(input: NewRenewalNoticeDelivery): Promise<RenewalNoticeDelivery>;
+  findById(id: string): Promise<RenewalNoticeDelivery | null>;
+  findDue(input: {
+    now: Date;
+    limit: number;
+  }): Promise<RenewalNoticeDelivery[]>;
+  claim(
+    input: ClaimRenewalNoticeDeliveryInput,
+  ): Promise<RenewalNoticeDelivery | null>;
+  markDelivered(input: {
+    id: string;
+    attemptId: string;
+    providerEventId: string;
+    completedAt: Date;
+  }): Promise<RenewalNoticeDelivery>;
+  markTransientFailure(
+    input: MarkRenewalNoticeDeliveryFailureInput & { nextAttemptAt: Date },
+  ): Promise<RenewalNoticeDelivery>;
+  markTerminalFailure(
+    input: MarkRenewalNoticeDeliveryFailureInput,
+  ): Promise<RenewalNoticeDelivery>;
+  markOutcomeUnknown(
+    input: MarkRenewalNoticeDeliveryFailureInput,
+  ): Promise<RenewalNoticeDelivery>;
+  markStaleProcessingUnknown(input: {
+    staleBefore: Date;
+    observedAt: Date;
+    limit: number;
+  }): Promise<number>;
+  requeue(input: {
+    id: string;
+    reason: string;
+    requeuedBy: string;
+    requeuedAt: Date;
+    confirmedNoSend: boolean;
+  }): Promise<RenewalNoticeDelivery>;
+}

--- a/src/application/ports/repositories.ts
+++ b/src/application/ports/repositories.ts
@@ -8,6 +8,7 @@ export * from './practice-session-repository';
 export * from './question-feedback-repository';
 export * from './question-repository';
 export * from './renewal-consent-record-repository';
+export * from './renewal-notice-delivery-repository';
 export * from './stripe-customer-repository';
 export * from './stripe-event-repository';
 export * from './subscription-repository';

--- a/src/application/ports/sha256-hasher.ts
+++ b/src/application/ports/sha256-hasher.ts
@@ -1,0 +1,3 @@
+export interface Sha256Hasher {
+  hash(input: string): string;
+}

--- a/src/application/ports/transactional-email-gateway.ts
+++ b/src/application/ports/transactional-email-gateway.ts
@@ -1,0 +1,26 @@
+export type TransactionalEmailPayload = {
+  from: string;
+  to: string;
+  replyTo: string;
+  subject: string;
+  html: string;
+  text: string;
+};
+
+export type TransactionalEmailSendInput = {
+  idempotencyKey: string;
+  payload: TransactionalEmailPayload;
+};
+
+export type TransactionalEmailSendResult =
+  | { status: 'delivered'; providerEventId: string }
+  | { status: 'transient_failure'; failureCode: string }
+  | { status: 'terminal_failure'; failureCode: string }
+  | { status: 'outcome_unknown'; failureCode: string };
+
+export interface TransactionalEmailGateway {
+  isConfigured(): boolean;
+  send(
+    input: TransactionalEmailSendInput,
+  ): Promise<TransactionalEmailSendResult>;
+}

--- a/src/application/shared/transactional-email-payload.test.ts
+++ b/src/application/shared/transactional-email-payload.test.ts
@@ -17,6 +17,14 @@ const payload = {
   text: 'Renewal terms',
 };
 
+function evidenceFor(snapshot: string) {
+  return {
+    snapshot,
+    hash: createHash('sha256').update(snapshot).digest('hex'),
+    destination: payload.to,
+  };
+}
+
 describe('transactional email payload snapshot', () => {
   it('creates canonical JSON and its SHA-256 hash', () => {
     const result = createTransactionalEmailPayloadSnapshot(payload);
@@ -27,6 +35,18 @@ describe('transactional email payload snapshot', () => {
     expect(result.hash).toBe(
       createHash('sha256').update(result.snapshot).digest('hex'),
     );
+  });
+
+  it.each([
+    { label: 'empty', subject: '' },
+    { label: 'missing', subject: undefined },
+  ])('rejects a $label required field before snapshotting', ({ subject }) => {
+    expect(() =>
+      createTransactionalEmailPayloadSnapshot({
+        ...payload,
+        subject: subject as string,
+      }),
+    ).toThrow('valid non-empty fields');
   });
 
   it('parses only a matching immutable snapshot and destination', () => {
@@ -54,6 +74,28 @@ describe('transactional email payload snapshot', () => {
       }),
     ).toThrow('destination');
   });
+
+  it('rejects non-JSON and exact-shape violations with valid hashes', () => {
+    expect(() =>
+      parseTransactionalEmailPayloadSnapshot(evidenceFor('not-json')),
+    ).toThrow('not valid JSON');
+
+    const missingField = JSON.stringify({
+      from: payload.from,
+      to: payload.to,
+      replyTo: payload.replyTo,
+      subject: payload.subject,
+      html: payload.html,
+    });
+    expect(() =>
+      parseTransactionalEmailPayloadSnapshot(evidenceFor(missingField)),
+    ).toThrow('invalid shape');
+
+    const extraField = JSON.stringify({ ...payload, trackingId: 'unexpected' });
+    expect(() =>
+      parseTransactionalEmailPayloadSnapshot(evidenceFor(extraField)),
+    ).toThrow('invalid shape');
+  });
 });
 
 describe('renewal notice provider invariants', () => {
@@ -76,6 +118,9 @@ describe('renewal notice provider invariants', () => {
     );
     expect(getRenewalNoticeRetryAt(failedAt, 20).getTime()).toBe(
       failedAt.getTime() + RENEWAL_NOTICE_RETRY_MAX_DELAY_MS,
+    );
+    expect(() => getRenewalNoticeRetryAt(failedAt, 0)).toThrow(
+      'requires a completed attempt',
     );
   });
 });

--- a/src/application/shared/transactional-email-payload.test.ts
+++ b/src/application/shared/transactional-email-payload.test.ts
@@ -1,0 +1,81 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  createTransactionalEmailPayloadSnapshot,
+  getRenewalNoticeProviderIdempotencyKey,
+  getRenewalNoticeRetryAt,
+  parseTransactionalEmailPayloadSnapshot,
+  RENEWAL_NOTICE_RETRY_MAX_DELAY_MS,
+} from './transactional-email-payload';
+
+const payload = {
+  from: 'Addiction Boards <notices@addictionboards.com>',
+  to: 'subscriber@example.com',
+  replyTo: 'support@addictionboards.com',
+  subject: 'Your renewal terms',
+  html: '<p>Renewal terms</p>',
+  text: 'Renewal terms',
+};
+
+describe('transactional email payload snapshot', () => {
+  it('creates canonical JSON and its SHA-256 hash', () => {
+    const result = createTransactionalEmailPayloadSnapshot(payload);
+
+    expect(result.snapshot).toBe(
+      '{"from":"Addiction Boards <notices@addictionboards.com>","to":"subscriber@example.com","replyTo":"support@addictionboards.com","subject":"Your renewal terms","html":"<p>Renewal terms</p>","text":"Renewal terms"}',
+    );
+    expect(result.hash).toBe(
+      createHash('sha256').update(result.snapshot).digest('hex'),
+    );
+  });
+
+  it('parses only a matching immutable snapshot and destination', () => {
+    const { snapshot, hash } = createTransactionalEmailPayloadSnapshot(payload);
+
+    expect(
+      parseTransactionalEmailPayloadSnapshot({
+        snapshot,
+        hash,
+        destination: payload.to,
+      }),
+    ).toEqual(payload);
+    expect(() =>
+      parseTransactionalEmailPayloadSnapshot({
+        snapshot: snapshot.replace('renewal terms', 'changed terms'),
+        hash,
+        destination: payload.to,
+      }),
+    ).toThrow('payload hash');
+    expect(() =>
+      parseTransactionalEmailPayloadSnapshot({
+        snapshot,
+        hash,
+        destination: 'other@example.com',
+      }),
+    ).toThrow('destination');
+  });
+});
+
+describe('renewal notice provider invariants', () => {
+  it('derives the stable provider key from the delivery UUID', () => {
+    expect(
+      getRenewalNoticeProviderIdempotencyKey(
+        '11111111-1111-4111-8111-111111111111',
+      ),
+    ).toBe('renewal-notice/11111111-1111-4111-8111-111111111111');
+  });
+
+  it('uses capped exponential backoff from the completed attempt count', () => {
+    const failedAt = new Date('2026-08-06T18:00:00.000Z');
+
+    expect(getRenewalNoticeRetryAt(failedAt, 1).toISOString()).toBe(
+      '2026-08-06T18:15:00.000Z',
+    );
+    expect(getRenewalNoticeRetryAt(failedAt, 2).toISOString()).toBe(
+      '2026-08-06T18:30:00.000Z',
+    );
+    expect(getRenewalNoticeRetryAt(failedAt, 20).getTime()).toBe(
+      failedAt.getTime() + RENEWAL_NOTICE_RETRY_MAX_DELAY_MS,
+    );
+  });
+});

--- a/src/application/shared/transactional-email-payload.test.ts
+++ b/src/application/shared/transactional-email-payload.test.ts
@@ -1,5 +1,5 @@
-import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
+import { FakeSha256Hasher } from '@/src/application/test-helpers/fakes';
 import {
   createTransactionalEmailPayloadSnapshot,
   getRenewalNoticeProviderIdempotencyKey,
@@ -16,25 +16,25 @@ const payload = {
   html: '<p>Renewal terms</p>',
   text: 'Renewal terms',
 };
+const hasher = new FakeSha256Hasher();
 
 function evidenceFor(snapshot: string) {
   return {
     snapshot,
-    hash: createHash('sha256').update(snapshot).digest('hex'),
+    hash: hasher.hash(snapshot),
     destination: payload.to,
   };
 }
 
 describe('transactional email payload snapshot', () => {
-  it('creates canonical JSON and its SHA-256 hash', () => {
-    const result = createTransactionalEmailPayloadSnapshot(payload);
+  it('creates canonical JSON and delegates its digest to the SHA-256 port', () => {
+    const result = createTransactionalEmailPayloadSnapshot(payload, hasher);
 
     expect(result.snapshot).toBe(
       '{"from":"Addiction Boards <notices@addictionboards.com>","to":"subscriber@example.com","replyTo":"support@addictionboards.com","subject":"Your renewal terms","html":"<p>Renewal terms</p>","text":"Renewal terms"}',
     );
-    expect(result.hash).toBe(
-      createHash('sha256').update(result.snapshot).digest('hex'),
-    );
+    expect(result.hash).toBe(`sha256:${result.snapshot}`);
+    expect(hasher.inputs.at(-1)).toBe(result.snapshot);
   });
 
   it.each([
@@ -42,42 +42,57 @@ describe('transactional email payload snapshot', () => {
     { label: 'missing', subject: undefined },
   ])('rejects a $label required field before snapshotting', ({ subject }) => {
     expect(() =>
-      createTransactionalEmailPayloadSnapshot({
-        ...payload,
-        subject: subject as string,
-      }),
+      createTransactionalEmailPayloadSnapshot(
+        {
+          ...payload,
+          subject: subject as string,
+        },
+        hasher,
+      ),
     ).toThrow('valid non-empty fields');
   });
 
   it('parses only a matching immutable snapshot and destination', () => {
-    const { snapshot, hash } = createTransactionalEmailPayloadSnapshot(payload);
+    const { snapshot, hash } = createTransactionalEmailPayloadSnapshot(
+      payload,
+      hasher,
+    );
 
     expect(
-      parseTransactionalEmailPayloadSnapshot({
-        snapshot,
-        hash,
-        destination: payload.to,
-      }),
+      parseTransactionalEmailPayloadSnapshot(
+        {
+          snapshot,
+          hash,
+          destination: payload.to,
+        },
+        hasher,
+      ),
     ).toEqual(payload);
     expect(() =>
-      parseTransactionalEmailPayloadSnapshot({
-        snapshot: snapshot.replace('renewal terms', 'changed terms'),
-        hash,
-        destination: payload.to,
-      }),
+      parseTransactionalEmailPayloadSnapshot(
+        {
+          snapshot: snapshot.replace('renewal terms', 'changed terms'),
+          hash,
+          destination: payload.to,
+        },
+        hasher,
+      ),
     ).toThrow('payload hash');
     expect(() =>
-      parseTransactionalEmailPayloadSnapshot({
-        snapshot,
-        hash,
-        destination: 'other@example.com',
-      }),
+      parseTransactionalEmailPayloadSnapshot(
+        {
+          snapshot,
+          hash,
+          destination: 'other@example.com',
+        },
+        hasher,
+      ),
     ).toThrow('destination');
   });
 
   it('rejects non-JSON and exact-shape violations with valid hashes', () => {
     expect(() =>
-      parseTransactionalEmailPayloadSnapshot(evidenceFor('not-json')),
+      parseTransactionalEmailPayloadSnapshot(evidenceFor('not-json'), hasher),
     ).toThrow('not valid JSON');
 
     const missingField = JSON.stringify({
@@ -88,12 +103,12 @@ describe('transactional email payload snapshot', () => {
       html: payload.html,
     });
     expect(() =>
-      parseTransactionalEmailPayloadSnapshot(evidenceFor(missingField)),
+      parseTransactionalEmailPayloadSnapshot(evidenceFor(missingField), hasher),
     ).toThrow('invalid shape');
 
     const extraField = JSON.stringify({ ...payload, trackingId: 'unexpected' });
     expect(() =>
-      parseTransactionalEmailPayloadSnapshot(evidenceFor(extraField)),
+      parseTransactionalEmailPayloadSnapshot(evidenceFor(extraField), hasher),
     ).toThrow('invalid shape');
   });
 });

--- a/src/application/shared/transactional-email-payload.ts
+++ b/src/application/shared/transactional-email-payload.ts
@@ -1,7 +1,8 @@
-import { sha256 } from '@noble/hashes/sha2';
-import { bytesToHex } from '@noble/hashes/utils';
 import { ApplicationError } from '@/src/application/errors';
-import type { TransactionalEmailPayload } from '@/src/application/ports';
+import type {
+  Sha256Hasher,
+  TransactionalEmailPayload,
+} from '@/src/application/ports';
 import type { NewRenewalNoticeDelivery } from '@/src/domain/entities';
 
 export const RENEWAL_NOTICE_RETRY_BASE_DELAY_MS = 15 * 60 * 1000;
@@ -15,10 +16,6 @@ const PAYLOAD_KEYS = [
   'html',
   'text',
 ] as const;
-
-function hashPayload(snapshot: string): string {
-  return bytesToHex(sha256(new TextEncoder().encode(snapshot)));
-}
 
 function isTransactionalEmailPayload(
   value: unknown,
@@ -35,6 +32,7 @@ function isTransactionalEmailPayload(
 
 export function createTransactionalEmailPayloadSnapshot(
   payload: TransactionalEmailPayload,
+  hasher: Sha256Hasher,
 ): { snapshot: string; hash: string } {
   if (!isTransactionalEmailPayload(payload)) {
     throw new ApplicationError(
@@ -50,15 +48,18 @@ export function createTransactionalEmailPayloadSnapshot(
     html: payload.html,
     text: payload.text,
   });
-  return { snapshot, hash: hashPayload(snapshot) };
+  return { snapshot, hash: hasher.hash(snapshot) };
 }
 
-export function parseTransactionalEmailPayloadSnapshot(input: {
-  snapshot: string;
-  hash: string;
-  destination: string;
-}): TransactionalEmailPayload {
-  if (hashPayload(input.snapshot) !== input.hash) {
+export function parseTransactionalEmailPayloadSnapshot(
+  input: {
+    snapshot: string;
+    hash: string;
+    destination: string;
+  },
+  hasher: Sha256Hasher,
+): TransactionalEmailPayload {
+  if (hasher.hash(input.snapshot) !== input.hash) {
     throw new ApplicationError(
       'CONFLICT',
       'Renewal notice payload hash does not match its immutable snapshot',
@@ -104,6 +105,7 @@ export function assertValidRenewalNoticeDeliveryPayload(
     | 'payloadSnapshot'
     | 'payloadHash'
   >,
+  hasher: Sha256Hasher,
 ): void {
   if (
     input.providerIdempotencyKey !==
@@ -114,11 +116,14 @@ export function assertValidRenewalNoticeDeliveryPayload(
       'Renewal notice provider idempotency key is not derived from its delivery ID',
     );
   }
-  parseTransactionalEmailPayloadSnapshot({
-    snapshot: input.payloadSnapshot,
-    hash: input.payloadHash,
-    destination: input.destination,
-  });
+  parseTransactionalEmailPayloadSnapshot(
+    {
+      snapshot: input.payloadSnapshot,
+      hash: input.payloadHash,
+      destination: input.destination,
+    },
+    hasher,
+  );
 }
 
 export function getRenewalNoticeRetryAt(

--- a/src/application/shared/transactional-email-payload.ts
+++ b/src/application/shared/transactional-email-payload.ts
@@ -1,4 +1,5 @@
-import { createHash } from 'node:crypto';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
 import { ApplicationError } from '@/src/application/errors';
 import type { TransactionalEmailPayload } from '@/src/application/ports';
 import type { NewRenewalNoticeDelivery } from '@/src/domain/entities';
@@ -16,7 +17,7 @@ const PAYLOAD_KEYS = [
 ] as const;
 
 function hashPayload(snapshot: string): string {
-  return createHash('sha256').update(snapshot).digest('hex');
+  return bytesToHex(sha256(new TextEncoder().encode(snapshot)));
 }
 
 function isTransactionalEmailPayload(

--- a/src/application/shared/transactional-email-payload.ts
+++ b/src/application/shared/transactional-email-payload.ts
@@ -1,0 +1,132 @@
+import { createHash } from 'node:crypto';
+import { ApplicationError } from '@/src/application/errors';
+import type { TransactionalEmailPayload } from '@/src/application/ports';
+import type { NewRenewalNoticeDelivery } from '@/src/domain/entities';
+
+export const RENEWAL_NOTICE_RETRY_BASE_DELAY_MS = 15 * 60 * 1000;
+export const RENEWAL_NOTICE_RETRY_MAX_DELAY_MS = 24 * 60 * 60 * 1000;
+
+const PAYLOAD_KEYS = [
+  'from',
+  'to',
+  'replyTo',
+  'subject',
+  'html',
+  'text',
+] as const;
+
+function hashPayload(snapshot: string): string {
+  return createHash('sha256').update(snapshot).digest('hex');
+}
+
+function isTransactionalEmailPayload(
+  value: unknown,
+): value is TransactionalEmailPayload {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    Object.keys(record).length === PAYLOAD_KEYS.length &&
+    PAYLOAD_KEYS.every(
+      (key) => typeof record[key] === 'string' && record[key].length > 0,
+    )
+  );
+}
+
+export function createTransactionalEmailPayloadSnapshot(
+  payload: TransactionalEmailPayload,
+): { snapshot: string; hash: string } {
+  const snapshot = JSON.stringify({
+    from: payload.from,
+    to: payload.to,
+    replyTo: payload.replyTo,
+    subject: payload.subject,
+    html: payload.html,
+    text: payload.text,
+  });
+  return { snapshot, hash: hashPayload(snapshot) };
+}
+
+export function parseTransactionalEmailPayloadSnapshot(input: {
+  snapshot: string;
+  hash: string;
+  destination: string;
+}): TransactionalEmailPayload {
+  if (hashPayload(input.snapshot) !== input.hash) {
+    throw new ApplicationError(
+      'CONFLICT',
+      'Renewal notice payload hash does not match its immutable snapshot',
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input.snapshot);
+  } catch {
+    throw new ApplicationError(
+      'INTERNAL_ERROR',
+      'Renewal notice payload snapshot is not valid JSON',
+    );
+  }
+  if (!isTransactionalEmailPayload(parsed)) {
+    throw new ApplicationError(
+      'INTERNAL_ERROR',
+      'Renewal notice payload snapshot has an invalid shape',
+    );
+  }
+  if (parsed.to !== input.destination) {
+    throw new ApplicationError(
+      'CONFLICT',
+      'Renewal notice payload destination does not match the delivery row',
+    );
+  }
+  return parsed;
+}
+
+export function getRenewalNoticeProviderIdempotencyKey(
+  deliveryId: string,
+): string {
+  return `renewal-notice/${deliveryId}`;
+}
+
+export function assertValidRenewalNoticeDeliveryPayload(
+  input: Pick<
+    NewRenewalNoticeDelivery,
+    | 'id'
+    | 'destination'
+    | 'providerIdempotencyKey'
+    | 'payloadSnapshot'
+    | 'payloadHash'
+  >,
+): void {
+  if (
+    input.providerIdempotencyKey !==
+    getRenewalNoticeProviderIdempotencyKey(input.id)
+  ) {
+    throw new ApplicationError(
+      'CONFLICT',
+      'Renewal notice provider idempotency key is not derived from its delivery ID',
+    );
+  }
+  parseTransactionalEmailPayloadSnapshot({
+    snapshot: input.payloadSnapshot,
+    hash: input.payloadHash,
+    destination: input.destination,
+  });
+}
+
+export function getRenewalNoticeRetryAt(
+  failedAt: Date,
+  attemptCount: number,
+): Date {
+  if (!Number.isInteger(attemptCount) || attemptCount < 1) {
+    throw new ApplicationError(
+      'VALIDATION_ERROR',
+      'Renewal notice retry requires a completed attempt',
+    );
+  }
+  const delay = Math.min(
+    RENEWAL_NOTICE_RETRY_BASE_DELAY_MS * 2 ** (attemptCount - 1),
+    RENEWAL_NOTICE_RETRY_MAX_DELAY_MS,
+  );
+  return new Date(failedAt.getTime() + delay);
+}

--- a/src/application/shared/transactional-email-payload.ts
+++ b/src/application/shared/transactional-email-payload.ts
@@ -1,4 +1,4 @@
-import { sha256 } from '@noble/hashes/sha256';
+import { sha256 } from '@noble/hashes/sha2';
 import { bytesToHex } from '@noble/hashes/utils';
 import { ApplicationError } from '@/src/application/errors';
 import type { TransactionalEmailPayload } from '@/src/application/ports';
@@ -36,6 +36,12 @@ function isTransactionalEmailPayload(
 export function createTransactionalEmailPayloadSnapshot(
   payload: TransactionalEmailPayload,
 ): { snapshot: string; hash: string } {
+  if (!isTransactionalEmailPayload(payload)) {
+    throw new ApplicationError(
+      'VALIDATION_ERROR',
+      'Transactional email payload requires valid non-empty fields',
+    );
+  }
   const snapshot = JSON.stringify({
     from: payload.from,
     to: payload.to,

--- a/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@/src/application/shared/transactional-email-payload';
 import type { NewRenewalNoticeDelivery } from '@/src/domain/entities';
 import { FakeRenewalNoticeDeliveryRepository } from './fake-renewal-notice-delivery-repository';
+import { FakeSha256Hasher } from './fake-sha256-hasher';
 
 const now = new Date('2026-08-06T18:00:00.000Z');
 const deliveryId = '11111111-1111-4111-8111-111111111111';
@@ -17,7 +18,8 @@ const emailPayload = {
   html: '<p>Renewal terms</p>',
   text: 'Renewal terms',
 };
-const payload = createTransactionalEmailPayloadSnapshot(emailPayload);
+const hasher = new FakeSha256Hasher();
+const payload = createTransactionalEmailPayloadSnapshot(emailPayload, hasher);
 
 function createDelivery(
   overrides: Partial<NewRenewalNoticeDelivery> = {},
@@ -70,10 +72,13 @@ describe('FakeRenewalNoticeDeliveryRepository', () => {
     expect(replay).toEqual(first);
     expect(businessKeyReplay).toEqual(first);
     expect(repository.records).toHaveLength(1);
-    const changedPayload = createTransactionalEmailPayloadSnapshot({
-      ...emailPayload,
-      subject: 'Changed renewal terms',
-    });
+    const changedPayload = createTransactionalEmailPayloadSnapshot(
+      {
+        ...emailPayload,
+        subject: 'Changed renewal terms',
+      },
+      hasher,
+    );
     const changedId = '44444444-4444-4444-8444-444444444444';
     await expect(
       repository.saveQueued(

--- a/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.test.ts
@@ -9,14 +9,15 @@ import { FakeRenewalNoticeDeliveryRepository } from './fake-renewal-notice-deliv
 const now = new Date('2026-08-06T18:00:00.000Z');
 const deliveryId = '11111111-1111-4111-8111-111111111111';
 const consentRecordId = '22222222-2222-4222-8222-222222222222';
-const payload = createTransactionalEmailPayloadSnapshot({
+const emailPayload = {
   from: 'Addiction Boards <notices@addictionboards.com>',
   to: 'subscriber@example.com',
   replyTo: 'support@addictionboards.com',
   subject: 'Your renewal terms',
   html: '<p>Renewal terms</p>',
   text: 'Renewal terms',
-});
+};
+const payload = createTransactionalEmailPayloadSnapshot(emailPayload);
 
 function createDelivery(
   overrides: Partial<NewRenewalNoticeDelivery> = {},
@@ -61,21 +62,33 @@ describe('FakeRenewalNoticeDeliveryRepository', () => {
     const businessKeyReplay = await repository.saveQueued(
       createDelivery({
         id: replacementId,
-        providerIdempotencyKey: `renewal-notice/${replacementId}`,
+        providerIdempotencyKey:
+          getRenewalNoticeProviderIdempotencyKey(replacementId),
       }),
     );
 
     expect(replay).toEqual(first);
     expect(businessKeyReplay).toEqual(first);
     expect(repository.records).toHaveLength(1);
+    const changedPayload = createTransactionalEmailPayloadSnapshot({
+      ...emailPayload,
+      subject: 'Changed renewal terms',
+    });
+    const changedId = '44444444-4444-4444-8444-444444444444';
     await expect(
       repository.saveQueued(
         createDelivery({
-          id: '44444444-4444-4444-8444-444444444444',
-          payloadSnapshot: '{"subject":"Changed"}',
+          id: changedId,
+          providerIdempotencyKey:
+            getRenewalNoticeProviderIdempotencyKey(changedId),
+          payloadSnapshot: changedPayload.snapshot,
+          payloadHash: changedPayload.hash,
         }),
       ),
-    ).rejects.toMatchObject({ code: 'CONFLICT' });
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Renewal notice delivery identity is bound to another payload',
+    });
   });
 
   it('rejects a non-derived provider key and a changed payload hash before persistence', async () => {
@@ -96,12 +109,12 @@ describe('FakeRenewalNoticeDeliveryRepository', () => {
   it('selects only queued and due transient failures', async () => {
     const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
     const statuses = [
-      { id: deliveryId, status: 'queued' as const, nextAttemptAt: null },
       {
         id: '33333333-3333-4333-8333-333333333333',
         status: 'transient_failure' as const,
         nextAttemptAt: new Date('2026-08-06T17:59:00.000Z'),
       },
+      { id: deliveryId, status: 'queued' as const, nextAttemptAt: null },
       {
         id: '44444444-4444-4444-8444-444444444444',
         status: 'transient_failure' as const,

--- a/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createTransactionalEmailPayloadSnapshot,
+  getRenewalNoticeProviderIdempotencyKey,
+} from '@/src/application/shared/transactional-email-payload';
+import type { NewRenewalNoticeDelivery } from '@/src/domain/entities';
+import { FakeRenewalNoticeDeliveryRepository } from './fake-renewal-notice-delivery-repository';
+
+const now = new Date('2026-08-06T18:00:00.000Z');
+const deliveryId = '11111111-1111-4111-8111-111111111111';
+const consentRecordId = '22222222-2222-4222-8222-222222222222';
+const payload = createTransactionalEmailPayloadSnapshot({
+  from: 'Addiction Boards <notices@addictionboards.com>',
+  to: 'subscriber@example.com',
+  replyTo: 'support@addictionboards.com',
+  subject: 'Your renewal terms',
+  html: '<p>Renewal terms</p>',
+  text: 'Renewal terms',
+});
+
+function createDelivery(
+  overrides: Partial<NewRenewalNoticeDelivery> = {},
+): NewRenewalNoticeDelivery {
+  return {
+    id: deliveryId,
+    noticeKind: 'acknowledgment',
+    consentRecordId,
+    externalSubscriptionId: null,
+    applicableAt: null,
+    disclosureVersion: '2026-08-05',
+    destination: 'subscriber@example.com',
+    providerIdempotencyKey: getRenewalNoticeProviderIdempotencyKey(deliveryId),
+    payloadSnapshot: payload.snapshot,
+    payloadHash: payload.hash,
+    ...overrides,
+  };
+}
+
+describe('FakeRenewalNoticeDeliveryRepository', () => {
+  it('rejects a notice-kind key shape the database would reject', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+
+    await expect(
+      repository.saveQueued(
+        createDelivery({
+          noticeKind: 'renewal_notice',
+          consentRecordId,
+          externalSubscriptionId: null,
+          applicableAt: null,
+        }),
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+  });
+
+  it('keeps exact queue creation idempotent and rejects changed payload', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+
+    const first = await repository.saveQueued(createDelivery());
+    const replay = await repository.saveQueued(createDelivery());
+    const replacementId = '33333333-3333-4333-8333-333333333333';
+    const businessKeyReplay = await repository.saveQueued(
+      createDelivery({
+        id: replacementId,
+        providerIdempotencyKey: `renewal-notice/${replacementId}`,
+      }),
+    );
+
+    expect(replay).toEqual(first);
+    expect(businessKeyReplay).toEqual(first);
+    expect(repository.records).toHaveLength(1);
+    await expect(
+      repository.saveQueued(
+        createDelivery({
+          id: '44444444-4444-4444-8444-444444444444',
+          payloadSnapshot: '{"subject":"Changed"}',
+        }),
+      ),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+
+  it('rejects a non-derived provider key and a changed payload hash before persistence', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+
+    await expect(
+      repository.saveQueued(
+        createDelivery({ providerIdempotencyKey: 'renewal-notice/wrong' }),
+      ),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+    await expect(
+      repository.saveQueued(createDelivery({ payloadHash: '0'.repeat(64) })),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    expect(repository.records).toEqual([]);
+  });
+
+  it('selects only queued and due transient failures', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    const statuses = [
+      { id: deliveryId, status: 'queued' as const, nextAttemptAt: null },
+      {
+        id: '33333333-3333-4333-8333-333333333333',
+        status: 'transient_failure' as const,
+        nextAttemptAt: new Date('2026-08-06T17:59:00.000Z'),
+      },
+      {
+        id: '44444444-4444-4444-8444-444444444444',
+        status: 'transient_failure' as const,
+        nextAttemptAt: new Date('2026-08-06T18:01:00.000Z'),
+      },
+      {
+        id: '55555555-5555-4555-8555-555555555555',
+        status: 'terminal_failure' as const,
+        nextAttemptAt: null,
+      },
+      {
+        id: '66666666-6666-4666-8666-666666666666',
+        status: 'outcome_unknown' as const,
+        nextAttemptAt: null,
+      },
+    ];
+    for (const [index, state] of statuses.entries()) {
+      const saved = await repository.saveQueued(
+        createDelivery({
+          id: state.id,
+          consentRecordId:
+            `${index + 1}`.padStart(8, '0') + '-0000-4000-8000-000000000000',
+          providerIdempotencyKey: `renewal-notice/${state.id}`,
+        }),
+      );
+      repository.records[index] = {
+        ...saved,
+        status: state.status,
+        nextAttemptAt: state.nextAttemptAt,
+      };
+    }
+
+    const due = await repository.findDue({ now, limit: 10 });
+
+    expect(due.map((delivery) => delivery.id)).toEqual([
+      deliveryId,
+      '33333333-3333-4333-8333-333333333333',
+    ]);
+  });
+
+  it('allows only one worker to atomically claim a queued delivery', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    await repository.saveQueued(createDelivery());
+
+    const [first, second] = await Promise.all([
+      repository.claim({
+        id: deliveryId,
+        attemptId: 'attempt-1',
+        startedAt: now,
+      }),
+      repository.claim({
+        id: deliveryId,
+        attemptId: 'attempt-2',
+        startedAt: now,
+      }),
+    ]);
+
+    expect([first, second].filter(Boolean)).toHaveLength(1);
+    expect(repository.records[0]).toMatchObject({
+      status: 'processing',
+      attemptCount: 1,
+      attemptId: first?.attemptId ?? second?.attemptId,
+      attemptStartedAt: now,
+      lastAttemptAt: now,
+    });
+  });
+
+  it('persists delivered and failed outcomes only for the owning claim', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    await repository.saveQueued(createDelivery());
+    await repository.claim({
+      id: deliveryId,
+      attemptId: 'attempt-1',
+      startedAt: now,
+    });
+
+    await expect(
+      repository.markDelivered({
+        id: deliveryId,
+        attemptId: 'other-attempt',
+        providerEventId: 'email_wrong',
+        completedAt: now,
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+    await expect(
+      repository.markTransientFailure({
+        id: deliveryId,
+        attemptId: 'attempt-1',
+        failureClass: 'provider_non_acceptance',
+        failureCode: 'rate_limit_exceeded',
+        failedAt: now,
+        nextAttemptAt: new Date('2026-08-06T18:15:00.000Z'),
+      }),
+    ).resolves.toMatchObject({
+      status: 'transient_failure',
+      attemptId: 'attempt-1',
+      attemptStartedAt: now,
+      failureCode: 'rate_limit_exceeded',
+      nextAttemptAt: new Date('2026-08-06T18:15:00.000Z'),
+    });
+  });
+
+  it('quarantines stale processing claims as outcome_unknown', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    await repository.saveQueued(createDelivery());
+    await repository.claim({
+      id: deliveryId,
+      attemptId: 'attempt-1',
+      startedAt: new Date('2026-08-06T17:00:00.000Z'),
+    });
+
+    await expect(
+      repository.markStaleProcessingUnknown({
+        staleBefore: new Date('2026-08-06T17:45:00.000Z'),
+        observedAt: now,
+        limit: 10,
+      }),
+    ).resolves.toBe(1);
+    expect(repository.records[0]).toMatchObject({
+      status: 'outcome_unknown',
+      attemptId: 'attempt-1',
+      attemptStartedAt: new Date('2026-08-06T17:00:00.000Z'),
+      failureClass: 'stale_processing_claim',
+      failureCode: 'worker_outcome_unknown',
+      nextAttemptAt: null,
+    });
+  });
+
+  it('requires no-send confirmation to requeue unknown outcomes and preserves audit', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    const saved = await repository.saveQueued(createDelivery());
+    repository.records[0] = {
+      ...saved,
+      status: 'outcome_unknown',
+      attemptId: 'attempt-1',
+      attemptStartedAt: now,
+      lastAttemptAt: now,
+    };
+
+    await expect(
+      repository.requeue({
+        id: deliveryId,
+        reason: 'Confirmed in Resend that no email exists',
+        requeuedBy: 'operator@example.com',
+        requeuedAt: now,
+        confirmedNoSend: false,
+      }),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    await expect(
+      repository.requeue({
+        id: deliveryId,
+        reason: 'Confirmed in Resend that no email exists',
+        requeuedBy: 'operator@example.com',
+        requeuedAt: now,
+        confirmedNoSend: true,
+      }),
+    ).resolves.toMatchObject({
+      status: 'queued',
+      attemptId: 'attempt-1',
+      requeueAudit: [
+        {
+          reason: 'Confirmed in Resend that no email exists',
+          requeuedBy: 'operator@example.com',
+          requeuedAt: now.toISOString(),
+          confirmedNoSend: true,
+          priorStatus: 'outcome_unknown',
+        },
+      ],
+    });
+  });
+});

--- a/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.test.ts
@@ -243,6 +243,43 @@ describe('FakeRenewalNoticeDeliveryRepository', () => {
     });
   });
 
+  it('quarantines the oldest stale processing claim first when limited', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    const newerId = '33333333-3333-4333-8333-333333333333';
+    await repository.saveQueued(createDelivery());
+    await repository.saveQueued(
+      createDelivery({
+        id: newerId,
+        consentRecordId: '33333333-3333-4333-8333-333333333333',
+        providerIdempotencyKey: getRenewalNoticeProviderIdempotencyKey(newerId),
+      }),
+    );
+    await repository.claim({
+      id: newerId,
+      attemptId: 'newer-attempt',
+      startedAt: new Date('2026-08-06T17:30:00.000Z'),
+    });
+    await repository.claim({
+      id: deliveryId,
+      attemptId: 'oldest-attempt',
+      startedAt: new Date('2026-08-06T17:00:00.000Z'),
+    });
+
+    await expect(
+      repository.markStaleProcessingUnknown({
+        staleBefore: new Date('2026-08-06T17:45:00.000Z'),
+        observedAt: now,
+        limit: 1,
+      }),
+    ).resolves.toBe(1);
+    await expect(repository.findById(deliveryId)).resolves.toMatchObject({
+      status: 'outcome_unknown',
+    });
+    await expect(repository.findById(newerId)).resolves.toMatchObject({
+      status: 'processing',
+    });
+  });
+
   it('requires no-send confirmation to requeue unknown outcomes and preserves audit', async () => {
     const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
     const saved = await repository.saveQueued(createDelivery());

--- a/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.ts
+++ b/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.ts
@@ -1,0 +1,307 @@
+import { ApplicationError } from '@/src/application/errors';
+import type {
+  ClaimRenewalNoticeDeliveryInput,
+  MarkRenewalNoticeDeliveryFailureInput,
+  RenewalNoticeDeliveryRepository,
+} from '@/src/application/ports/renewal-notice-delivery-repository';
+import { assertValidRenewalNoticeDeliveryPayload } from '@/src/application/shared/transactional-email-payload';
+import type {
+  NewRenewalNoticeDelivery,
+  RenewalNoticeDelivery,
+} from '@/src/domain/entities';
+import { isValidRenewalNoticeDeliveryKeyShape } from '@/src/domain/entities';
+
+function cloneDelivery(delivery: RenewalNoticeDelivery): RenewalNoticeDelivery {
+  return structuredClone(delivery);
+}
+
+function identityKey(delivery: NewRenewalNoticeDelivery): string {
+  return delivery.noticeKind === 'acknowledgment'
+    ? [
+        delivery.noticeKind,
+        delivery.consentRecordId,
+        delivery.destination,
+      ].join(':')
+    : [
+        delivery.noticeKind,
+        delivery.externalSubscriptionId,
+        delivery.applicableAt?.toISOString(),
+        delivery.disclosureVersion,
+        delivery.destination,
+      ].join(':');
+}
+
+function immutableFieldsMatch(
+  existing: RenewalNoticeDelivery,
+  input: NewRenewalNoticeDelivery,
+): boolean {
+  return (
+    identityKey(existing) === identityKey(input) &&
+    existing.noticeKind === input.noticeKind &&
+    existing.consentRecordId === input.consentRecordId &&
+    existing.externalSubscriptionId === input.externalSubscriptionId &&
+    existing.applicableAt?.getTime() === input.applicableAt?.getTime() &&
+    existing.disclosureVersion === input.disclosureVersion &&
+    existing.destination === input.destination &&
+    existing.payloadSnapshot === input.payloadSnapshot &&
+    existing.payloadHash === input.payloadHash
+  );
+}
+
+export class FakeRenewalNoticeDeliveryRepository
+  implements RenewalNoticeDeliveryRepository
+{
+  readonly records: RenewalNoticeDelivery[] = [];
+
+  constructor(private readonly now: () => Date = () => new Date()) {}
+
+  async saveQueued(
+    input: NewRenewalNoticeDelivery,
+  ): Promise<RenewalNoticeDelivery> {
+    assertValidRenewalNoticeDeliveryPayload(input);
+    if (!isValidRenewalNoticeDeliveryKeyShape(input)) {
+      throw new ApplicationError(
+        'VALIDATION_ERROR',
+        'Renewal notice delivery does not match its notice-kind key shape',
+      );
+    }
+    const inputIdentity = identityKey(input);
+    const existing = this.records.find(
+      (record) =>
+        record.id === input.id ||
+        record.providerIdempotencyKey === input.providerIdempotencyKey ||
+        identityKey(record) === inputIdentity,
+    );
+    if (existing) {
+      if (!immutableFieldsMatch(existing, input)) {
+        throw new ApplicationError(
+          'CONFLICT',
+          'Renewal notice delivery identity is bound to another payload',
+        );
+      }
+      return cloneDelivery(existing);
+    }
+
+    const createdAt = this.now();
+    const delivery: RenewalNoticeDelivery = {
+      ...structuredClone(input),
+      status: 'queued',
+      providerEventId: null,
+      attemptCount: 0,
+      attemptId: null,
+      attemptStartedAt: null,
+      lastAttemptAt: null,
+      nextAttemptAt: null,
+      failureClass: null,
+      failureCode: null,
+      requeueReason: null,
+      requeuedAt: null,
+      requeuedBy: null,
+      requeueAudit: [],
+      createdAt,
+      updatedAt: createdAt,
+    };
+    this.records.push(delivery);
+    return cloneDelivery(delivery);
+  }
+
+  async findById(id: string): Promise<RenewalNoticeDelivery | null> {
+    const record = this.records.find((candidate) => candidate.id === id);
+    return record ? cloneDelivery(record) : null;
+  }
+
+  async findDue(input: {
+    now: Date;
+    limit: number;
+  }): Promise<RenewalNoticeDelivery[]> {
+    if (!Number.isInteger(input.limit) || input.limit <= 0) return [];
+    return this.records
+      .filter(
+        (record) =>
+          record.status === 'queued' ||
+          (record.status === 'transient_failure' &&
+            record.nextAttemptAt !== null &&
+            record.nextAttemptAt.getTime() <= input.now.getTime()),
+      )
+      .sort(
+        (left, right) => left.createdAt.getTime() - right.createdAt.getTime(),
+      )
+      .slice(0, input.limit)
+      .map(cloneDelivery);
+  }
+
+  async claim(
+    input: ClaimRenewalNoticeDeliveryInput,
+  ): Promise<RenewalNoticeDelivery | null> {
+    const record = this.records.find((candidate) => candidate.id === input.id);
+    if (
+      !record ||
+      (record.status !== 'queued' &&
+        !(
+          record.status === 'transient_failure' &&
+          record.nextAttemptAt !== null &&
+          record.nextAttemptAt.getTime() <= input.startedAt.getTime()
+        ))
+    ) {
+      return null;
+    }
+
+    Object.assign(record, {
+      status: 'processing' as const,
+      attemptCount: record.attemptCount + 1,
+      attemptId: input.attemptId,
+      attemptStartedAt: input.startedAt,
+      lastAttemptAt: input.startedAt,
+      nextAttemptAt: null,
+      failureClass: null,
+      failureCode: null,
+      updatedAt: input.startedAt,
+    });
+    return cloneDelivery(record);
+  }
+
+  async markDelivered(input: {
+    id: string;
+    attemptId: string;
+    providerEventId: string;
+    completedAt: Date;
+  }): Promise<RenewalNoticeDelivery> {
+    const record = this.requireOwnedClaim(input.id, input.attemptId);
+    Object.assign(record, {
+      status: 'delivered' as const,
+      providerEventId: input.providerEventId,
+      nextAttemptAt: null,
+      failureClass: null,
+      failureCode: null,
+      updatedAt: input.completedAt,
+    });
+    return cloneDelivery(record);
+  }
+
+  markTransientFailure(
+    input: MarkRenewalNoticeDeliveryFailureInput & { nextAttemptAt: Date },
+  ): Promise<RenewalNoticeDelivery> {
+    return this.markFailure('transient_failure', input, input.nextAttemptAt);
+  }
+
+  markTerminalFailure(
+    input: MarkRenewalNoticeDeliveryFailureInput,
+  ): Promise<RenewalNoticeDelivery> {
+    return this.markFailure('terminal_failure', input, null);
+  }
+
+  markOutcomeUnknown(
+    input: MarkRenewalNoticeDeliveryFailureInput,
+  ): Promise<RenewalNoticeDelivery> {
+    return this.markFailure('outcome_unknown', input, null);
+  }
+
+  async markStaleProcessingUnknown(input: {
+    staleBefore: Date;
+    observedAt: Date;
+    limit: number;
+  }): Promise<number> {
+    if (!Number.isInteger(input.limit) || input.limit <= 0) return 0;
+    const stale = this.records
+      .filter(
+        (record) =>
+          record.status === 'processing' &&
+          record.attemptStartedAt !== null &&
+          record.attemptStartedAt.getTime() < input.staleBefore.getTime(),
+      )
+      .sort(
+        (left, right) =>
+          (left.attemptStartedAt?.getTime() ?? 0) -
+          (right.attemptStartedAt?.getTime() ?? 0),
+      )
+      .slice(0, input.limit);
+
+    for (const record of stale) {
+      Object.assign(record, {
+        status: 'outcome_unknown' as const,
+        nextAttemptAt: null,
+        failureClass: 'stale_processing_claim',
+        failureCode: 'worker_outcome_unknown',
+        updatedAt: input.observedAt,
+      });
+    }
+    return stale.length;
+  }
+
+  async requeue(input: {
+    id: string;
+    reason: string;
+    requeuedBy: string;
+    requeuedAt: Date;
+    confirmedNoSend: boolean;
+  }): Promise<RenewalNoticeDelivery> {
+    const record = this.records.find((candidate) => candidate.id === input.id);
+    if (
+      !record ||
+      (record.status !== 'terminal_failure' &&
+        record.status !== 'outcome_unknown')
+    ) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'Renewal notice delivery is not eligible for requeue',
+      );
+    }
+    if (record.status === 'outcome_unknown' && !input.confirmedNoSend) {
+      throw new ApplicationError(
+        'VALIDATION_ERROR',
+        'Unknown delivery outcome requires confirmation that no send occurred',
+      );
+    }
+
+    const priorStatus = record.status;
+    record.requeueAudit.push({
+      reason: input.reason,
+      requeuedAt: input.requeuedAt.toISOString(),
+      requeuedBy: input.requeuedBy,
+      confirmedNoSend: input.confirmedNoSend,
+      priorStatus,
+    });
+    Object.assign(record, {
+      status: 'queued' as const,
+      providerEventId: null,
+      nextAttemptAt: null,
+      failureClass: null,
+      failureCode: null,
+      requeueReason: input.reason,
+      requeuedAt: input.requeuedAt,
+      requeuedBy: input.requeuedBy,
+      updatedAt: input.requeuedAt,
+    });
+    return cloneDelivery(record);
+  }
+
+  private async markFailure(
+    status: 'transient_failure' | 'terminal_failure' | 'outcome_unknown',
+    input: MarkRenewalNoticeDeliveryFailureInput,
+    nextAttemptAt: Date | null,
+  ): Promise<RenewalNoticeDelivery> {
+    const record = this.requireOwnedClaim(input.id, input.attemptId);
+    Object.assign(record, {
+      status,
+      nextAttemptAt,
+      failureClass: input.failureClass,
+      failureCode: input.failureCode,
+      updatedAt: input.failedAt,
+    });
+    return cloneDelivery(record);
+  }
+
+  private requireOwnedClaim(
+    id: string,
+    attemptId: string,
+  ): RenewalNoticeDelivery {
+    const record = this.records.find((candidate) => candidate.id === id);
+    if (record?.status !== 'processing' || record.attemptId !== attemptId) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'Renewal notice delivery is not owned by this attempt',
+      );
+    }
+    return record;
+  }
+}

--- a/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.ts
+++ b/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.ts
@@ -10,6 +10,7 @@ import type {
   RenewalNoticeDelivery,
 } from '@/src/domain/entities';
 import { isValidRenewalNoticeDeliveryKeyShape } from '@/src/domain/entities';
+import { FakeSha256Hasher } from './fake-sha256-hasher';
 
 function cloneDelivery(delivery: RenewalNoticeDelivery): RenewalNoticeDelivery {
   return structuredClone(delivery);
@@ -53,12 +54,15 @@ export class FakeRenewalNoticeDeliveryRepository
 {
   readonly records: RenewalNoticeDelivery[] = [];
 
-  constructor(private readonly now: () => Date = () => new Date()) {}
+  constructor(
+    private readonly now: () => Date = () => new Date(),
+    private readonly hasher = new FakeSha256Hasher(),
+  ) {}
 
   async saveQueued(
     input: NewRenewalNoticeDelivery,
   ): Promise<RenewalNoticeDelivery> {
-    assertValidRenewalNoticeDeliveryPayload(input);
+    assertValidRenewalNoticeDeliveryPayload(input, this.hasher);
     if (!isValidRenewalNoticeDeliveryKeyShape(input)) {
       throw new ApplicationError(
         'VALIDATION_ERROR',

--- a/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.ts
+++ b/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.ts
@@ -123,9 +123,13 @@ export class FakeRenewalNoticeDeliveryRepository
             record.nextAttemptAt !== null &&
             record.nextAttemptAt.getTime() <= input.now.getTime()),
       )
-      .sort(
-        (left, right) => left.createdAt.getTime() - right.createdAt.getTime(),
-      )
+      .sort((left, right) => {
+        const createdAtDifference =
+          left.createdAt.getTime() - right.createdAt.getTime();
+        return createdAtDifference !== 0
+          ? createdAtDifference
+          : left.id.localeCompare(right.id);
+      })
       .slice(0, input.limit)
       .map(cloneDelivery);
   }

--- a/src/application/test-helpers/fakes/fake-sha256-hasher.ts
+++ b/src/application/test-helpers/fakes/fake-sha256-hasher.ts
@@ -1,0 +1,10 @@
+import type { Sha256Hasher } from '@/src/application/ports';
+
+export class FakeSha256Hasher implements Sha256Hasher {
+  readonly inputs: string[] = [];
+
+  hash(input: string): string {
+    this.inputs.push(input);
+    return `sha256:${input}`;
+  }
+}

--- a/src/application/test-helpers/fakes/fake-transactional-email-gateway.test.ts
+++ b/src/application/test-helpers/fakes/fake-transactional-email-gateway.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { FakeTransactionalEmailGateway } from './fake-transactional-email-gateway';
+
+const input = {
+  idempotencyKey: 'renewal-notice/11111111-1111-4111-8111-111111111111',
+  payload: {
+    from: 'Addiction Boards <notices@addictionboards.com>',
+    to: 'subscriber@example.com',
+    replyTo: 'support@addictionboards.com',
+    subject: 'Your renewal terms',
+    html: '<p>Renewal terms</p>',
+    text: 'Renewal terms',
+  },
+};
+
+describe('FakeTransactionalEmailGateway', () => {
+  it('reports whether delivery is configured', () => {
+    expect(
+      new FakeTransactionalEmailGateway({ configured: false }).isConfigured(),
+    ).toBe(false);
+    expect(
+      new FakeTransactionalEmailGateway({ configured: true }).isConfigured(),
+    ).toBe(true);
+  });
+
+  it('records the immutable send input and returns the configured outcome', async () => {
+    const gateway = new FakeTransactionalEmailGateway({
+      configured: true,
+      results: [{ status: 'delivered', providerEventId: 'email_123' }],
+    });
+
+    await expect(gateway.send(input)).resolves.toEqual({
+      status: 'delivered',
+      providerEventId: 'email_123',
+    });
+    expect(gateway.sendInputs).toEqual([input]);
+  });
+
+  it('fails loudly when unconfigured code attempts a provider call', async () => {
+    const gateway = new FakeTransactionalEmailGateway({ configured: false });
+
+    await expect(gateway.send(input)).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+    });
+    expect(gateway.sendInputs).toEqual([]);
+  });
+});

--- a/src/application/test-helpers/fakes/fake-transactional-email-gateway.ts
+++ b/src/application/test-helpers/fakes/fake-transactional-email-gateway.ts
@@ -1,0 +1,51 @@
+import { ApplicationError } from '@/src/application/errors';
+import type {
+  TransactionalEmailGateway,
+  TransactionalEmailSendInput,
+  TransactionalEmailSendResult,
+} from '@/src/application/ports/transactional-email-gateway';
+
+export class FakeTransactionalEmailGateway
+  implements TransactionalEmailGateway
+{
+  readonly sendInputs: TransactionalEmailSendInput[] = [];
+  private readonly configured: boolean;
+  private readonly results: TransactionalEmailSendResult[];
+  private readonly onSend:
+    | ((input: TransactionalEmailSendInput) => void | Promise<void>)
+    | undefined;
+
+  constructor(input: {
+    configured: boolean;
+    results?: readonly TransactionalEmailSendResult[];
+    onSend?: (input: TransactionalEmailSendInput) => void | Promise<void>;
+  }) {
+    this.configured = input.configured;
+    this.results = [...(input.results ?? [])];
+    this.onSend = input.onSend;
+  }
+
+  isConfigured(): boolean {
+    return this.configured;
+  }
+
+  async send(
+    input: TransactionalEmailSendInput,
+  ): Promise<TransactionalEmailSendResult> {
+    if (!this.configured) {
+      throw new ApplicationError(
+        'INTERNAL_ERROR',
+        'Transactional email gateway is not configured',
+      );
+    }
+
+    this.sendInputs.push(structuredClone(input));
+    await this.onSend?.(input);
+    return (
+      this.results.shift() ?? {
+        status: 'delivered',
+        providerEventId: 'fake-email-event',
+      }
+    );
+  }
+}

--- a/src/application/test-helpers/fakes/index.ts
+++ b/src/application/test-helpers/fakes/index.ts
@@ -17,10 +17,12 @@ export {
 export { FakeQuestionFeedbackRepository } from './fake-question-feedback-repository';
 export { FakeQuestionRepository } from './fake-question-repository';
 export { FakeRenewalConsentRecordRepository } from './fake-renewal-consent-record-repository';
+export { FakeRenewalNoticeDeliveryRepository } from './fake-renewal-notice-delivery-repository';
 export { FakeStripeCustomerRepository } from './fake-stripe-customer-repository';
 export { FakeStripeEventRepository } from './fake-stripe-event-repository';
 export { FakeSubscriptionRepository } from './fake-subscription-repository';
 export { FakeTagRepository } from './fake-tag-repository';
+export { FakeTransactionalEmailGateway } from './fake-transactional-email-gateway';
 export { FakeTrialPaymentMethodSetupOperationRepository } from './fake-trial-payment-method-setup-operation-repository';
 export {
   FakeCheckEntitlementUseCase,

--- a/src/application/test-helpers/fakes/index.ts
+++ b/src/application/test-helpers/fakes/index.ts
@@ -18,6 +18,7 @@ export { FakeQuestionFeedbackRepository } from './fake-question-feedback-reposit
 export { FakeQuestionRepository } from './fake-question-repository';
 export { FakeRenewalConsentRecordRepository } from './fake-renewal-consent-record-repository';
 export { FakeRenewalNoticeDeliveryRepository } from './fake-renewal-notice-delivery-repository';
+export { FakeSha256Hasher } from './fake-sha256-hasher';
 export { FakeStripeCustomerRepository } from './fake-stripe-customer-repository';
 export { FakeStripeEventRepository } from './fake-stripe-event-repository';
 export { FakeSubscriptionRepository } from './fake-subscription-repository';

--- a/src/application/use-cases/dispatch-renewal-notice-delivery.test.ts
+++ b/src/application/use-cases/dispatch-renewal-notice-delivery.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@/src/application/shared/transactional-email-payload';
 import {
   FakeRenewalNoticeDeliveryRepository,
+  FakeSha256Hasher,
   FakeTransactionalEmailGateway,
 } from '@/src/application/test-helpers/fakes';
 import type { NewRenewalNoticeDelivery } from '@/src/domain/entities';
@@ -20,11 +21,15 @@ const payload = {
   html: '<p>Renewal terms</p>',
   text: 'Renewal terms',
 };
+const hasher = new FakeSha256Hasher();
 
 function createDelivery(
   overrides: Partial<NewRenewalNoticeDelivery> = {},
 ): NewRenewalNoticeDelivery {
-  const { snapshot, hash } = createTransactionalEmailPayloadSnapshot(payload);
+  const { snapshot, hash } = createTransactionalEmailPayloadSnapshot(
+    payload,
+    hasher,
+  );
   return {
     id: deliveryId,
     noticeKind: 'acknowledgment',
@@ -48,6 +53,7 @@ function createUseCase(input: {
   return new DispatchRenewalNoticeDeliveryUseCase(
     input.repository,
     input.gateway,
+    hasher,
     input.currentTime ?? (() => now),
     () => 'attempt-1',
   );
@@ -223,6 +229,7 @@ describe('DispatchRenewalNoticeDeliveryUseCase', () => {
     const useCase = new DispatchRenewalNoticeDeliveryUseCase(
       repository,
       gateway,
+      hasher,
       () => currentTime,
       () => `attempt-${++attempt}`,
     );

--- a/src/application/use-cases/dispatch-renewal-notice-delivery.test.ts
+++ b/src/application/use-cases/dispatch-renewal-notice-delivery.test.ts
@@ -54,15 +54,15 @@ function createUseCase(input: {
 }
 
 describe('DispatchRenewalNoticeDeliveryUseCase', () => {
-  it('leaves a queued row untouched when the provider key is missing', async () => {
+  it('leaves a queued row untouched when the gateway is unconfigured', async () => {
     const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
     await repository.saveQueued(createDelivery());
     const gateway = new FakeTransactionalEmailGateway({ configured: false });
     const useCase = createUseCase({ repository, gateway });
 
     await expect(useCase.execute({ deliveryId })).resolves.toMatchObject({
-      status: 'queued',
-      attemptCount: 0,
+      outcome: 'skipped_unconfigured',
+      delivery: { status: 'queued', attemptCount: 0 },
     });
     expect(gateway.sendInputs).toEqual([]);
     expect(repository.records[0]).toMatchObject({
@@ -95,23 +95,28 @@ describe('DispatchRenewalNoticeDeliveryUseCase', () => {
   it('persists the claim before the provider call and records delivery', async () => {
     const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
     await repository.saveQueued(createDelivery());
+    let stateObservedDuringSend: unknown;
     const gateway = new FakeTransactionalEmailGateway({
       configured: true,
       results: [{ status: 'delivered', providerEventId: 'email_123' }],
       onSend: () => {
-        expect(repository.records[0]).toMatchObject({
-          status: 'processing',
-          attemptCount: 1,
-          attemptId: 'attempt-1',
-          attemptStartedAt: now,
-        });
+        stateObservedDuringSend = structuredClone(repository.records[0]);
       },
     });
     const useCase = createUseCase({ repository, gateway });
 
     await expect(useCase.execute({ deliveryId })).resolves.toMatchObject({
-      status: 'delivered',
-      providerEventId: 'email_123',
+      outcome: 'attempted',
+      delivery: {
+        status: 'delivered',
+        providerEventId: 'email_123',
+        attemptCount: 1,
+        attemptId: 'attempt-1',
+        attemptStartedAt: now,
+      },
+    });
+    expect(stateObservedDuringSend).toMatchObject({
+      status: 'processing',
       attemptCount: 1,
       attemptId: 'attempt-1',
       attemptStartedAt: now,
@@ -150,7 +155,7 @@ describe('DispatchRenewalNoticeDeliveryUseCase', () => {
       expectedNextAttemptAt: null,
     },
   ])('persists $expectedStatus and returns successfully', async ({
-    result,
+    result: gatewayResult,
     expectedStatus,
     expectedNextAttemptAt,
   }) => {
@@ -158,17 +163,20 @@ describe('DispatchRenewalNoticeDeliveryUseCase', () => {
     await repository.saveQueued(createDelivery());
     const gateway = new FakeTransactionalEmailGateway({
       configured: true,
-      results: [result],
+      results: [gatewayResult],
     });
     const useCase = createUseCase({ repository, gateway });
 
-    const delivery = await useCase.execute({ deliveryId });
+    const result = await useCase.execute({ deliveryId });
 
-    expect(delivery).toMatchObject({
-      status: expectedStatus,
-      failureCode: result.failureCode,
+    expect(result).toMatchObject({
+      outcome: 'attempted',
+      delivery: {
+        status: expectedStatus,
+        failureCode: gatewayResult.failureCode,
+      },
     });
-    expect(delivery?.nextAttemptAt?.toISOString() ?? null).toBe(
+    expect(result.delivery?.nextAttemptAt?.toISOString() ?? null).toBe(
       expectedNextAttemptAt,
     );
   });
@@ -189,9 +197,15 @@ describe('DispatchRenewalNoticeDeliveryUseCase', () => {
 
     expect(gateway.sendInputs).toHaveLength(1);
     expect(
-      results.filter((result) => result?.status === 'delivered'),
+      results.filter(
+        (result) =>
+          result.outcome === 'attempted' &&
+          result.delivery.status === 'delivered',
+      ),
     ).toHaveLength(1);
-    expect(results.filter((result) => result === null)).toHaveLength(1);
+    expect(
+      results.filter((result) => result.outcome === 'claim_lost'),
+    ).toHaveLength(1);
   });
 
   it('reuses the stable key and immutable payload after a due transient failure', async () => {
@@ -222,6 +236,37 @@ describe('DispatchRenewalNoticeDeliveryUseCase', () => {
     expect(repository.records[0]).toMatchObject({
       status: 'delivered',
       attemptCount: 2,
+    });
+  });
+
+  it('returns not found before attempting a provider call', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    const gateway = new FakeTransactionalEmailGateway({ configured: true });
+    const useCase = createUseCase({ repository, gateway });
+
+    await expect(useCase.execute({ deliveryId })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+    expect(gateway.sendInputs).toEqual([]);
+  });
+
+  it('quarantines an unexpected gateway exception as outcome unknown', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    await repository.saveQueued(createDelivery());
+    const gateway = new FakeTransactionalEmailGateway({
+      configured: true,
+      onSend: () => {
+        throw new Error('unexpected adapter failure');
+      },
+    });
+    const useCase = createUseCase({ repository, gateway });
+
+    await expect(useCase.execute({ deliveryId })).resolves.toMatchObject({
+      outcome: 'attempted',
+      delivery: {
+        status: 'outcome_unknown',
+        failureCode: 'unexpected_gateway_exception',
+      },
     });
   });
 });

--- a/src/application/use-cases/dispatch-renewal-notice-delivery.test.ts
+++ b/src/application/use-cases/dispatch-renewal-notice-delivery.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createTransactionalEmailPayloadSnapshot,
+  getRenewalNoticeProviderIdempotencyKey,
+} from '@/src/application/shared/transactional-email-payload';
+import {
+  FakeRenewalNoticeDeliveryRepository,
+  FakeTransactionalEmailGateway,
+} from '@/src/application/test-helpers/fakes';
+import type { NewRenewalNoticeDelivery } from '@/src/domain/entities';
+import { DispatchRenewalNoticeDeliveryUseCase } from './dispatch-renewal-notice-delivery';
+
+const now = new Date('2026-08-06T18:00:00.000Z');
+const deliveryId = '11111111-1111-4111-8111-111111111111';
+const payload = {
+  from: 'Addiction Boards <notices@addictionboards.com>',
+  to: 'subscriber@example.com',
+  replyTo: 'support@addictionboards.com',
+  subject: 'Your renewal terms',
+  html: '<p>Renewal terms</p>',
+  text: 'Renewal terms',
+};
+
+function createDelivery(
+  overrides: Partial<NewRenewalNoticeDelivery> = {},
+): NewRenewalNoticeDelivery {
+  const { snapshot, hash } = createTransactionalEmailPayloadSnapshot(payload);
+  return {
+    id: deliveryId,
+    noticeKind: 'acknowledgment',
+    consentRecordId: '22222222-2222-4222-8222-222222222222',
+    externalSubscriptionId: null,
+    applicableAt: null,
+    disclosureVersion: '2026-08-05',
+    destination: payload.to,
+    providerIdempotencyKey: getRenewalNoticeProviderIdempotencyKey(deliveryId),
+    payloadSnapshot: snapshot,
+    payloadHash: hash,
+    ...overrides,
+  };
+}
+
+function createUseCase(input: {
+  repository: FakeRenewalNoticeDeliveryRepository;
+  gateway: FakeTransactionalEmailGateway;
+  currentTime?: () => Date;
+}) {
+  return new DispatchRenewalNoticeDeliveryUseCase(
+    input.repository,
+    input.gateway,
+    input.currentTime ?? (() => now),
+    () => 'attempt-1',
+  );
+}
+
+describe('DispatchRenewalNoticeDeliveryUseCase', () => {
+  it('leaves a queued row untouched when the provider key is missing', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    await repository.saveQueued(createDelivery());
+    const gateway = new FakeTransactionalEmailGateway({ configured: false });
+    const useCase = createUseCase({ repository, gateway });
+
+    await expect(useCase.execute({ deliveryId })).resolves.toMatchObject({
+      status: 'queued',
+      attemptCount: 0,
+    });
+    expect(gateway.sendInputs).toEqual([]);
+    expect(repository.records[0]).toMatchObject({
+      status: 'queued',
+      attemptCount: 0,
+      attemptId: null,
+    });
+  });
+
+  it('rejects a changed payload or provider key before claiming or sending', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    const saved = await repository.saveQueued(createDelivery());
+    repository.records[0] = {
+      ...saved,
+      providerIdempotencyKey: 'wrong-key',
+    };
+    const gateway = new FakeTransactionalEmailGateway({ configured: true });
+    const useCase = createUseCase({ repository, gateway });
+
+    await expect(useCase.execute({ deliveryId })).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+    expect(gateway.sendInputs).toEqual([]);
+    expect(repository.records[0]).toMatchObject({
+      status: 'queued',
+      attemptCount: 0,
+    });
+  });
+
+  it('persists the claim before the provider call and records delivery', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    await repository.saveQueued(createDelivery());
+    const gateway = new FakeTransactionalEmailGateway({
+      configured: true,
+      results: [{ status: 'delivered', providerEventId: 'email_123' }],
+      onSend: () => {
+        expect(repository.records[0]).toMatchObject({
+          status: 'processing',
+          attemptCount: 1,
+          attemptId: 'attempt-1',
+          attemptStartedAt: now,
+        });
+      },
+    });
+    const useCase = createUseCase({ repository, gateway });
+
+    await expect(useCase.execute({ deliveryId })).resolves.toMatchObject({
+      status: 'delivered',
+      providerEventId: 'email_123',
+      attemptCount: 1,
+      attemptId: 'attempt-1',
+      attemptStartedAt: now,
+    });
+    expect(gateway.sendInputs).toEqual([
+      {
+        idempotencyKey: getRenewalNoticeProviderIdempotencyKey(deliveryId),
+        payload,
+      },
+    ]);
+  });
+
+  it.each([
+    {
+      result: {
+        status: 'transient_failure' as const,
+        failureCode: 'rate_limit_exceeded',
+      },
+      expectedStatus: 'transient_failure',
+      expectedNextAttemptAt: '2026-08-06T18:15:00.000Z',
+    },
+    {
+      result: {
+        status: 'terminal_failure' as const,
+        failureCode: 'invalid_idempotent_request',
+      },
+      expectedStatus: 'terminal_failure',
+      expectedNextAttemptAt: null,
+    },
+    {
+      result: {
+        status: 'outcome_unknown' as const,
+        failureCode: 'ETIMEDOUT',
+      },
+      expectedStatus: 'outcome_unknown',
+      expectedNextAttemptAt: null,
+    },
+  ])('persists $expectedStatus and returns successfully', async ({
+    result,
+    expectedStatus,
+    expectedNextAttemptAt,
+  }) => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    await repository.saveQueued(createDelivery());
+    const gateway = new FakeTransactionalEmailGateway({
+      configured: true,
+      results: [result],
+    });
+    const useCase = createUseCase({ repository, gateway });
+
+    const delivery = await useCase.execute({ deliveryId });
+
+    expect(delivery).toMatchObject({
+      status: expectedStatus,
+      failureCode: result.failureCode,
+    });
+    expect(delivery?.nextAttemptAt?.toISOString() ?? null).toBe(
+      expectedNextAttemptAt,
+    );
+  });
+
+  it('uses one provider call when two workers dispatch the same row', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    await repository.saveQueued(createDelivery());
+    const gateway = new FakeTransactionalEmailGateway({
+      configured: true,
+      results: [{ status: 'delivered', providerEventId: 'email_123' }],
+    });
+    const useCase = createUseCase({ repository, gateway });
+
+    const results = await Promise.all([
+      useCase.execute({ deliveryId }),
+      useCase.execute({ deliveryId }),
+    ]);
+
+    expect(gateway.sendInputs).toHaveLength(1);
+    expect(
+      results.filter((result) => result?.status === 'delivered'),
+    ).toHaveLength(1);
+    expect(results.filter((result) => result === null)).toHaveLength(1);
+  });
+
+  it('reuses the stable key and immutable payload after a due transient failure', async () => {
+    let currentTime = now;
+    let attempt = 0;
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    await repository.saveQueued(createDelivery());
+    const gateway = new FakeTransactionalEmailGateway({
+      configured: true,
+      results: [
+        { status: 'transient_failure', failureCode: 'rate_limit_exceeded' },
+        { status: 'delivered', providerEventId: 'email_123' },
+      ],
+    });
+    const useCase = new DispatchRenewalNoticeDeliveryUseCase(
+      repository,
+      gateway,
+      () => currentTime,
+      () => `attempt-${++attempt}`,
+    );
+
+    await useCase.execute({ deliveryId });
+    currentTime = new Date('2026-08-06T18:15:00.000Z');
+    await useCase.execute({ deliveryId });
+
+    expect(gateway.sendInputs).toHaveLength(2);
+    expect(gateway.sendInputs[1]).toEqual(gateway.sendInputs[0]);
+    expect(repository.records[0]).toMatchObject({
+      status: 'delivered',
+      attemptCount: 2,
+    });
+  });
+});

--- a/src/application/use-cases/dispatch-renewal-notice-delivery.ts
+++ b/src/application/use-cases/dispatch-renewal-notice-delivery.ts
@@ -1,6 +1,7 @@
 import { ApplicationError } from '@/src/application/errors';
 import type {
   RenewalNoticeDeliveryRepository,
+  Sha256Hasher,
   TransactionalEmailGateway,
   TransactionalEmailSendResult,
 } from '@/src/application/ports';
@@ -23,6 +24,7 @@ export class DispatchRenewalNoticeDeliveryUseCase {
   constructor(
     private readonly deliveryRepository: RenewalNoticeDeliveryRepository,
     private readonly emailGateway: TransactionalEmailGateway,
+    private readonly hasher: Sha256Hasher,
     private readonly now: () => Date = () => new Date(),
     private readonly createAttemptId: () => string = () => crypto.randomUUID(),
   ) {}
@@ -47,11 +49,14 @@ export class DispatchRenewalNoticeDeliveryUseCase {
         'Renewal notice provider idempotency key does not match its delivery',
       );
     }
-    const payload = parseTransactionalEmailPayloadSnapshot({
-      snapshot: delivery.payloadSnapshot,
-      hash: delivery.payloadHash,
-      destination: delivery.destination,
-    });
+    const payload = parseTransactionalEmailPayloadSnapshot(
+      {
+        snapshot: delivery.payloadSnapshot,
+        hash: delivery.payloadHash,
+        destination: delivery.destination,
+      },
+      this.hasher,
+    );
 
     if (!this.emailGateway.isConfigured()) {
       return { outcome: 'skipped_unconfigured', delivery };

--- a/src/application/use-cases/dispatch-renewal-notice-delivery.ts
+++ b/src/application/use-cases/dispatch-renewal-notice-delivery.ts
@@ -1,0 +1,124 @@
+import { ApplicationError } from '@/src/application/errors';
+import type {
+  RenewalNoticeDeliveryRepository,
+  TransactionalEmailGateway,
+  TransactionalEmailSendResult,
+} from '@/src/application/ports';
+import {
+  getRenewalNoticeProviderIdempotencyKey,
+  getRenewalNoticeRetryAt,
+  parseTransactionalEmailPayloadSnapshot,
+} from '@/src/application/shared/transactional-email-payload';
+import type { RenewalNoticeDelivery } from '@/src/domain/entities';
+
+export class DispatchRenewalNoticeDeliveryUseCase {
+  constructor(
+    private readonly deliveryRepository: RenewalNoticeDeliveryRepository,
+    private readonly emailGateway: TransactionalEmailGateway,
+    private readonly now: () => Date = () => new Date(),
+    private readonly createAttemptId: () => string = () => crypto.randomUUID(),
+  ) {}
+
+  async execute(input: {
+    deliveryId: string;
+  }): Promise<RenewalNoticeDelivery | null> {
+    const delivery = await this.deliveryRepository.findById(input.deliveryId);
+    if (!delivery) {
+      throw new ApplicationError(
+        'NOT_FOUND',
+        'Renewal notice delivery not found',
+      );
+    }
+
+    const expectedProviderKey = getRenewalNoticeProviderIdempotencyKey(
+      delivery.id,
+    );
+    if (delivery.providerIdempotencyKey !== expectedProviderKey) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'Renewal notice provider idempotency key does not match its delivery',
+      );
+    }
+    const payload = parseTransactionalEmailPayloadSnapshot({
+      snapshot: delivery.payloadSnapshot,
+      hash: delivery.payloadHash,
+      destination: delivery.destination,
+    });
+
+    if (!this.emailGateway.isConfigured()) return delivery;
+
+    const startedAt = this.now();
+    const attemptId = this.createAttemptId();
+    const claimed = await this.deliveryRepository.claim({
+      id: delivery.id,
+      attemptId,
+      startedAt,
+    });
+    if (!claimed) return null;
+
+    let result: TransactionalEmailSendResult;
+    try {
+      result = await this.emailGateway.send({
+        idempotencyKey: expectedProviderKey,
+        payload,
+      });
+    } catch {
+      result = {
+        status: 'outcome_unknown',
+        failureCode: 'unexpected_gateway_exception',
+      };
+    }
+
+    return this.persistOutcome(claimed, result, this.now());
+  }
+
+  private persistOutcome(
+    claimed: RenewalNoticeDelivery,
+    result: TransactionalEmailSendResult,
+    completedAt: Date,
+  ): Promise<RenewalNoticeDelivery> {
+    const attemptId = claimed.attemptId;
+    if (!attemptId) {
+      throw new ApplicationError(
+        'INTERNAL_ERROR',
+        'Claimed renewal notice delivery is missing its attempt ID',
+      );
+    }
+
+    if (result.status === 'delivered') {
+      return this.deliveryRepository.markDelivered({
+        id: claimed.id,
+        attemptId,
+        providerEventId: result.providerEventId,
+        completedAt,
+      });
+    }
+
+    const failure = {
+      id: claimed.id,
+      attemptId,
+      failureCode: result.failureCode,
+      failedAt: completedAt,
+    };
+    if (result.status === 'transient_failure') {
+      return this.deliveryRepository.markTransientFailure({
+        ...failure,
+        failureClass: 'provider_non_acceptance',
+        nextAttemptAt: getRenewalNoticeRetryAt(
+          completedAt,
+          claimed.attemptCount,
+        ),
+      });
+    }
+    if (result.status === 'terminal_failure') {
+      return this.deliveryRepository.markTerminalFailure({
+        ...failure,
+        failureClass: 'provider_terminal_failure',
+      });
+    }
+    return this.deliveryRepository.markOutcomeUnknown({
+      ...failure,
+      failureClass: 'provider_outcome_unknown',
+    });
+  }
+}

--- a/src/application/use-cases/dispatch-renewal-notice-delivery.ts
+++ b/src/application/use-cases/dispatch-renewal-notice-delivery.ts
@@ -11,6 +11,14 @@ import {
 } from '@/src/application/shared/transactional-email-payload';
 import type { RenewalNoticeDelivery } from '@/src/domain/entities';
 
+export type DispatchRenewalNoticeDeliveryResult =
+  | {
+      outcome: 'skipped_unconfigured';
+      delivery: RenewalNoticeDelivery;
+    }
+  | { outcome: 'claim_lost'; delivery: null }
+  | { outcome: 'attempted'; delivery: RenewalNoticeDelivery };
+
 export class DispatchRenewalNoticeDeliveryUseCase {
   constructor(
     private readonly deliveryRepository: RenewalNoticeDeliveryRepository,
@@ -21,7 +29,7 @@ export class DispatchRenewalNoticeDeliveryUseCase {
 
   async execute(input: {
     deliveryId: string;
-  }): Promise<RenewalNoticeDelivery | null> {
+  }): Promise<DispatchRenewalNoticeDeliveryResult> {
     const delivery = await this.deliveryRepository.findById(input.deliveryId);
     if (!delivery) {
       throw new ApplicationError(
@@ -45,7 +53,9 @@ export class DispatchRenewalNoticeDeliveryUseCase {
       destination: delivery.destination,
     });
 
-    if (!this.emailGateway.isConfigured()) return delivery;
+    if (!this.emailGateway.isConfigured()) {
+      return { outcome: 'skipped_unconfigured', delivery };
+    }
 
     const startedAt = this.now();
     const attemptId = this.createAttemptId();
@@ -54,7 +64,7 @@ export class DispatchRenewalNoticeDeliveryUseCase {
       attemptId,
       startedAt,
     });
-    if (!claimed) return null;
+    if (!claimed) return { outcome: 'claim_lost', delivery: null };
 
     let result: TransactionalEmailSendResult;
     try {
@@ -69,7 +79,10 @@ export class DispatchRenewalNoticeDeliveryUseCase {
       };
     }
 
-    return this.persistOutcome(claimed, result, this.now());
+    return {
+      outcome: 'attempted',
+      delivery: await this.persistOutcome(claimed, result, this.now()),
+    };
   }
 
   private persistOutcome(

--- a/src/application/use-cases/index.ts
+++ b/src/application/use-cases/index.ts
@@ -29,6 +29,7 @@ export {
   type DiscardPracticeSessionOutput,
   DiscardPracticeSessionUseCase,
 } from './discard-practice-session';
+export { DispatchRenewalNoticeDeliveryUseCase } from './dispatch-renewal-notice-delivery';
 export {
   type EndPracticeSessionInput,
   type EndPracticeSessionOutput,
@@ -126,6 +127,10 @@ export {
   type RecordRenewalConsentOutput,
   RecordRenewalConsentUseCase,
 } from './record-renewal-consent';
+export {
+  type RequeueRenewalNoticeDeliveryInput,
+  RequeueRenewalNoticeDeliveryUseCase,
+} from './requeue-renewal-notice-delivery';
 export {
   type SaveExamDraftAnswerInput,
   type SaveExamDraftAnswerOutput,

--- a/src/application/use-cases/requeue-renewal-notice-delivery.test.ts
+++ b/src/application/use-cases/requeue-renewal-notice-delivery.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createTransactionalEmailPayloadSnapshot,
+  getRenewalNoticeProviderIdempotencyKey,
+} from '@/src/application/shared/transactional-email-payload';
+import { FakeRenewalNoticeDeliveryRepository } from '@/src/application/test-helpers/fakes';
+import type { RenewalNoticeDeliveryStatus } from '@/src/domain/entities';
+import { RequeueRenewalNoticeDeliveryUseCase } from './requeue-renewal-notice-delivery';
+
+const now = new Date('2026-08-06T18:00:00.000Z');
+const deliveryId = '11111111-1111-4111-8111-111111111111';
+
+async function createRepository(status: RenewalNoticeDeliveryStatus) {
+  const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+  const payload = createTransactionalEmailPayloadSnapshot({
+    from: 'Addiction Boards <notices@addictionboards.com>',
+    to: 'subscriber@example.com',
+    replyTo: 'support@addictionboards.com',
+    subject: 'Your renewal terms',
+    html: '<p>Renewal terms</p>',
+    text: 'Renewal terms',
+  });
+  const saved = await repository.saveQueued({
+    id: deliveryId,
+    noticeKind: 'acknowledgment',
+    consentRecordId: '22222222-2222-4222-8222-222222222222',
+    externalSubscriptionId: null,
+    applicableAt: null,
+    disclosureVersion: '2026-08-05',
+    destination: 'subscriber@example.com',
+    providerIdempotencyKey: getRenewalNoticeProviderIdempotencyKey(deliveryId),
+    payloadSnapshot: payload.snapshot,
+    payloadHash: payload.hash,
+  });
+  repository.records[0] = {
+    ...saved,
+    status,
+    failureClass: 'provider_outcome_unknown',
+    failureCode: 'ETIMEDOUT',
+  };
+  return repository;
+}
+
+describe('RequeueRenewalNoticeDeliveryUseCase', () => {
+  it('requeues an unknown outcome only with no-send confirmation and preserves an audit entry', async () => {
+    const repository = await createRepository('outcome_unknown');
+    const useCase = new RequeueRenewalNoticeDeliveryUseCase(
+      repository,
+      () => now,
+    );
+
+    await expect(
+      useCase.execute({
+        deliveryId,
+        reason: 'Confirmed in Resend that no email exists',
+        operator: 'operator@example.com',
+        confirmedNoSend: true,
+      }),
+    ).resolves.toMatchObject({
+      status: 'queued',
+      requeueAudit: [
+        {
+          reason: 'Confirmed in Resend that no email exists',
+          requeuedAt: now.toISOString(),
+          requeuedBy: 'operator@example.com',
+          confirmedNoSend: true,
+          priorStatus: 'outcome_unknown',
+        },
+      ],
+    });
+  });
+
+  it('rejects an unknown outcome without no-send confirmation', async () => {
+    const repository = await createRepository('outcome_unknown');
+    const useCase = new RequeueRenewalNoticeDeliveryUseCase(repository);
+
+    await expect(
+      useCase.execute({
+        deliveryId,
+        reason: 'Retry requested',
+        operator: 'operator@example.com',
+        confirmedNoSend: false,
+      }),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+    expect(repository.records[0]?.status).toBe('outcome_unknown');
+    expect(repository.records[0]?.requeueAudit).toEqual([]);
+  });
+
+  it('rejects missing operator evidence and delivered rows', async () => {
+    const repository = await createRepository('terminal_failure');
+    const useCase = new RequeueRenewalNoticeDeliveryUseCase(repository);
+
+    await expect(
+      useCase.execute({
+        deliveryId,
+        reason: '   ',
+        operator: 'operator@example.com',
+        confirmedNoSend: false,
+      }),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+    await expect(
+      useCase.execute({
+        deliveryId,
+        reason: 'Operator requested a retry',
+        operator: '   ',
+        confirmedNoSend: false,
+      }),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    const existing = repository.records[0];
+    if (!existing) throw new Error('Expected a delivery fixture');
+    repository.records[0] = {
+      ...existing,
+      status: 'delivered',
+    };
+    await expect(
+      useCase.execute({
+        deliveryId,
+        reason: 'Operator requested a retry',
+        operator: 'operator@example.com',
+        confirmedNoSend: false,
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+});

--- a/src/application/use-cases/requeue-renewal-notice-delivery.test.ts
+++ b/src/application/use-cases/requeue-renewal-notice-delivery.test.ts
@@ -3,23 +3,30 @@ import {
   createTransactionalEmailPayloadSnapshot,
   getRenewalNoticeProviderIdempotencyKey,
 } from '@/src/application/shared/transactional-email-payload';
-import { FakeRenewalNoticeDeliveryRepository } from '@/src/application/test-helpers/fakes';
+import {
+  FakeRenewalNoticeDeliveryRepository,
+  FakeSha256Hasher,
+} from '@/src/application/test-helpers/fakes';
 import type { RenewalNoticeDeliveryStatus } from '@/src/domain/entities';
 import { RequeueRenewalNoticeDeliveryUseCase } from './requeue-renewal-notice-delivery';
 
 const now = new Date('2026-08-06T18:00:00.000Z');
 const deliveryId = '11111111-1111-4111-8111-111111111111';
+const hasher = new FakeSha256Hasher();
 
 async function createRepository(status: RenewalNoticeDeliveryStatus) {
   const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
-  const payload = createTransactionalEmailPayloadSnapshot({
-    from: 'Addiction Boards <notices@addictionboards.com>',
-    to: 'subscriber@example.com',
-    replyTo: 'support@addictionboards.com',
-    subject: 'Your renewal terms',
-    html: '<p>Renewal terms</p>',
-    text: 'Renewal terms',
-  });
+  const payload = createTransactionalEmailPayloadSnapshot(
+    {
+      from: 'Addiction Boards <notices@addictionboards.com>',
+      to: 'subscriber@example.com',
+      replyTo: 'support@addictionboards.com',
+      subject: 'Your renewal terms',
+      html: '<p>Renewal terms</p>',
+      text: 'Renewal terms',
+    },
+    hasher,
+  );
   const saved = await repository.saveQueued({
     id: deliveryId,
     noticeKind: 'acknowledgment',

--- a/src/application/use-cases/requeue-renewal-notice-delivery.test.ts
+++ b/src/application/use-cases/requeue-renewal-notice-delivery.test.ts
@@ -70,6 +70,30 @@ describe('RequeueRenewalNoticeDeliveryUseCase', () => {
     });
   });
 
+  it('normalizes operator evidence before persisting the audit entry', async () => {
+    const repository = await createRepository('terminal_failure');
+    const useCase = new RequeueRenewalNoticeDeliveryUseCase(
+      repository,
+      () => now,
+    );
+
+    await expect(
+      useCase.execute({
+        deliveryId,
+        reason: '  Retry approved after provider review  ',
+        operator: '  operator@example.com  ',
+        confirmedNoSend: false,
+      }),
+    ).resolves.toMatchObject({
+      requeueAudit: [
+        {
+          reason: 'Retry approved after provider review',
+          requeuedBy: 'operator@example.com',
+        },
+      ],
+    });
+  });
+
   it('rejects an unknown outcome without no-send confirmation', async () => {
     const repository = await createRepository('outcome_unknown');
     const useCase = new RequeueRenewalNoticeDeliveryUseCase(repository);

--- a/src/application/use-cases/requeue-renewal-notice-delivery.ts
+++ b/src/application/use-cases/requeue-renewal-notice-delivery.ts
@@ -1,0 +1,39 @@
+import { ApplicationError } from '@/src/application/errors';
+import type { RenewalNoticeDeliveryRepository } from '@/src/application/ports/repositories';
+import type { RenewalNoticeDelivery } from '@/src/domain/entities';
+
+export type RequeueRenewalNoticeDeliveryInput = {
+  deliveryId: string;
+  reason: string;
+  operator: string;
+  confirmedNoSend: boolean;
+};
+
+export class RequeueRenewalNoticeDeliveryUseCase {
+  constructor(
+    private readonly repository: RenewalNoticeDeliveryRepository,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async execute(
+    input: RequeueRenewalNoticeDeliveryInput,
+  ): Promise<RenewalNoticeDelivery> {
+    if (
+      input.reason.trim().length === 0 ||
+      input.operator.trim().length === 0
+    ) {
+      throw new ApplicationError(
+        'VALIDATION_ERROR',
+        'Renewal notice requeue requires an operator and an audit reason',
+      );
+    }
+
+    return this.repository.requeue({
+      id: input.deliveryId,
+      reason: input.reason,
+      requeuedBy: input.operator,
+      requeuedAt: this.now(),
+      confirmedNoSend: input.confirmedNoSend,
+    });
+  }
+}

--- a/src/application/use-cases/requeue-renewal-notice-delivery.ts
+++ b/src/application/use-cases/requeue-renewal-notice-delivery.ts
@@ -30,8 +30,8 @@ export class RequeueRenewalNoticeDeliveryUseCase {
 
     return this.repository.requeue({
       id: input.deliveryId,
-      reason: input.reason,
-      requeuedBy: input.operator,
+      reason: input.reason.trim(),
+      requeuedBy: input.operator.trim(),
       requeuedAt: this.now(),
       confirmedNoSend: input.confirmedNoSend,
     });

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -29,6 +29,14 @@ export {
   type RenewalConsentRecordInput,
   terminateRenewalConsentRecord,
 } from './renewal-consent-record';
+export type {
+  NewRenewalNoticeDelivery,
+  RenewalNoticeDelivery,
+  RenewalNoticeDeliveryStatus,
+  RenewalNoticeKind,
+  RenewalNoticeRequeueAuditEntry,
+} from './renewal-notice-delivery';
+export { isValidRenewalNoticeDeliveryKeyShape } from './renewal-notice-delivery';
 export type { Subscription } from './subscription';
 export type { Tag } from './tag';
 export type { User } from './user';

--- a/src/domain/entities/renewal-notice-delivery.ts
+++ b/src/domain/entities/renewal-notice-delivery.ts
@@ -1,0 +1,65 @@
+export type RenewalNoticeKind =
+  | 'acknowledgment'
+  | 'annual_reminder'
+  | 'renewal_notice'
+  | 'material_change'
+  | 'fee_change';
+
+export type RenewalNoticeDeliveryStatus =
+  | 'queued'
+  | 'processing'
+  | 'delivered'
+  | 'transient_failure'
+  | 'terminal_failure'
+  | 'outcome_unknown';
+
+export type RenewalNoticeRequeueAuditEntry = {
+  reason: string;
+  requeuedAt: string;
+  requeuedBy: string;
+  confirmedNoSend: boolean;
+  priorStatus: 'terminal_failure' | 'outcome_unknown';
+};
+
+export type NewRenewalNoticeDelivery = {
+  id: string;
+  noticeKind: RenewalNoticeKind;
+  consentRecordId: string | null;
+  externalSubscriptionId: string | null;
+  applicableAt: Date | null;
+  disclosureVersion: string;
+  destination: string;
+  providerIdempotencyKey: string;
+  payloadSnapshot: string;
+  payloadHash: string;
+};
+
+export type RenewalNoticeDelivery = NewRenewalNoticeDelivery & {
+  status: RenewalNoticeDeliveryStatus;
+  providerEventId: string | null;
+  attemptCount: number;
+  attemptId: string | null;
+  attemptStartedAt: Date | null;
+  lastAttemptAt: Date | null;
+  nextAttemptAt: Date | null;
+  failureClass: string | null;
+  failureCode: string | null;
+  requeueReason: string | null;
+  requeuedAt: Date | null;
+  requeuedBy: string | null;
+  requeueAudit: RenewalNoticeRequeueAuditEntry[];
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export function isValidRenewalNoticeDeliveryKeyShape(
+  delivery: NewRenewalNoticeDelivery,
+): boolean {
+  return delivery.noticeKind === 'acknowledgment'
+    ? delivery.consentRecordId !== null &&
+        delivery.externalSubscriptionId === null &&
+        delivery.applicableAt === null
+    : delivery.consentRecordId === null &&
+        delivery.externalSubscriptionId !== null &&
+        delivery.applicableAt !== null;
+}

--- a/tests/architecture-boundaries.test.ts
+++ b/tests/architecture-boundaries.test.ts
@@ -47,16 +47,18 @@ describe('Clean Architecture import boundaries', () => {
           import { getQuestion } from '@/src/adapters/controllers/question-controller';
           import React from 'react';
           import type Stripe from 'stripe';
+          import { sha256 } from '@noble/hashes/sha2';
           import 'server-only';
         `,
       ),
     ]);
 
     expect(issues).toEqual([
-      "src/application/use-cases/bad-use-case.ts:2 application code must not import adapters/framework code; found '@/src/adapters/controllers/question-controller'.",
-      "src/application/use-cases/bad-use-case.ts:3 application code must not import adapters/framework code; found 'react'.",
-      "src/application/use-cases/bad-use-case.ts:4 application code must not import adapters/framework code; found 'stripe'.",
-      "src/application/use-cases/bad-use-case.ts:5 application code must not import adapters/framework code; found 'server-only'.",
+      "src/application/use-cases/bad-use-case.ts:2 application code must not import outer-layer or package code; found '@/src/adapters/controllers/question-controller'.",
+      "src/application/use-cases/bad-use-case.ts:3 application code must not import outer-layer or package code; found 'react'.",
+      "src/application/use-cases/bad-use-case.ts:4 application code must not import outer-layer or package code; found 'stripe'.",
+      "src/application/use-cases/bad-use-case.ts:5 application code must not import outer-layer or package code; found '@noble/hashes/sha2'.",
+      "src/application/use-cases/bad-use-case.ts:6 application code must not import outer-layer or package code; found 'server-only'.",
     ]);
   });
 

--- a/tests/architecture-boundary-source-scan.ts
+++ b/tests/architecture-boundary-source-scan.ts
@@ -46,21 +46,6 @@ const APPLICATION_BANNED_LOCAL_PREFIXES = [
 
 const APPLICATION_BANNED_EXACT_LOCAL_IMPORTS = new Set(['db']);
 
-const APPLICATION_BANNED_PACKAGE_PREFIXES = [
-  'next',
-  'next/',
-  'react',
-  'react/',
-  'react-dom',
-  'react-dom/',
-  '@clerk/',
-  'stripe',
-  'stripe/',
-  'drizzle-orm',
-  'drizzle-orm/',
-  'server-only',
-];
-
 const ADAPTER_BANNED_LOCAL_PREFIXES = ['app/', 'components/'];
 const OUTER_BYPASS_LOCAL_ROOTS = [
   'src/application/use-cases',
@@ -156,7 +141,7 @@ export function collectArchitectureBoundaryIssues(
           isBannedApplicationPackageImport(occurrence.specifier)
         ) {
           issues.push(
-            `${sourceFile.filePath}:${occurrence.lineNumber} application code must not import adapters/framework code; found '${occurrence.specifier}'.`,
+            `${sourceFile.filePath}:${occurrence.lineNumber} application code must not import outer-layer or package code; found '${occurrence.specifier}'.`,
           );
         }
         continue;
@@ -381,10 +366,7 @@ function isBannedApplicationLocalImport(localTarget: string | null): boolean {
 }
 
 function isBannedApplicationPackageImport(specifier: string): boolean {
-  return APPLICATION_BANNED_PACKAGE_PREFIXES.some((prefix) => {
-    const exactSpecifier = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
-    return specifier === exactSpecifier || specifier.startsWith(prefix);
-  });
+  return !isRelativeImport(specifier) && !specifier.startsWith('@/');
 }
 
 function isOuterLayerPath(filePath: string): boolean {

--- a/tests/integration/renewal-notice-deliveries.integration.test.ts
+++ b/tests/integration/renewal-notice-deliveries.integration.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { eq, inArray } from 'drizzle-orm';
 import { afterAll, afterEach, describe, expect, it } from 'vitest';
 import { renewalNoticeDeliveries } from '@/db/schema';
+import { NobleSha256Hasher } from '@/src/adapters/gateways/noble-sha256-hasher';
 import { DrizzleRenewalNoticeDeliveryRepository } from '@/src/adapters/repositories/drizzle-renewal-notice-delivery-repository';
 import {
   createTransactionalEmailPayloadSnapshot,
@@ -14,6 +15,7 @@ const primary = createIntegrationDb();
 const competing = createIntegrationDb();
 const deliveryIds: string[] = [];
 const now = new Date('2026-08-06T18:00:00.000Z');
+const hasher = new NobleSha256Hasher();
 
 afterEach(async () => {
   if (deliveryIds.length > 0) {
@@ -43,7 +45,10 @@ function createDelivery(
     html: '<p>Annual subscription reminder</p>',
     text: 'Annual subscription reminder',
   };
-  const { snapshot, hash } = createTransactionalEmailPayloadSnapshot(payload);
+  const { snapshot, hash } = createTransactionalEmailPayloadSnapshot(
+    payload,
+    hasher,
+  );
   deliveryIds.push(id);
   return {
     id,
@@ -64,10 +69,12 @@ describe('renewal notice delivery persistence', () => {
   it('keeps concurrent exact creation idempotent and rejects changed payload', async () => {
     const firstRepository = new DrizzleRenewalNoticeDeliveryRepository(
       primary.db,
+      hasher,
       () => now,
     );
     const secondRepository = new DrizzleRenewalNoticeDeliveryRepository(
       competing.db,
+      hasher,
       () => now,
     );
     const input = createDelivery();
@@ -87,14 +94,17 @@ describe('renewal notice delivery persistence', () => {
 
     expect(replay).toEqual(first);
     expect(businessKeyReplay).toEqual(first);
-    const changedPayload = createTransactionalEmailPayloadSnapshot({
-      from: 'Addiction Boards <notices@addictionboards.com>',
-      to: input.destination,
-      replyTo: 'support@addictionboards.com',
-      subject: 'Changed annual subscription reminder',
-      html: '<p>Changed annual subscription reminder</p>',
-      text: 'Changed annual subscription reminder',
-    });
+    const changedPayload = createTransactionalEmailPayloadSnapshot(
+      {
+        from: 'Addiction Boards <notices@addictionboards.com>',
+        to: input.destination,
+        replyTo: 'support@addictionboards.com',
+        subject: 'Changed annual subscription reminder',
+        html: '<p>Changed annual subscription reminder</p>',
+        text: 'Changed annual subscription reminder',
+      },
+      hasher,
+    );
     await expect(
       secondRepository.saveQueued({
         ...input,
@@ -110,6 +120,7 @@ describe('renewal notice delivery persistence', () => {
   it('rejects malformed immutable evidence before inserting a row', async () => {
     const repository = new DrizzleRenewalNoticeDeliveryRepository(
       primary.db,
+      hasher,
       () => now,
     );
     const wrongKey = createDelivery({
@@ -130,10 +141,12 @@ describe('renewal notice delivery persistence', () => {
   it('allows only one connection to claim a queued row', async () => {
     const firstRepository = new DrizzleRenewalNoticeDeliveryRepository(
       primary.db,
+      hasher,
       () => now,
     );
     const secondRepository = new DrizzleRenewalNoticeDeliveryRepository(
       competing.db,
+      hasher,
       () => now,
     );
     const saved = await firstRepository.saveQueued(createDelivery());
@@ -163,6 +176,7 @@ describe('renewal notice delivery persistence', () => {
   it('selects queued and due transient rows but excludes terminal and unknown rows', async () => {
     const repository = new DrizzleRenewalNoticeDeliveryRepository(
       primary.db,
+      hasher,
       () => now,
     );
     const queued = await repository.saveQueued(createDelivery());
@@ -203,6 +217,7 @@ describe('renewal notice delivery persistence', () => {
   it('requires claim ownership for outcomes and persists retry scheduling', async () => {
     const repository = new DrizzleRenewalNoticeDeliveryRepository(
       primary.db,
+      hasher,
       () => now,
     );
     const saved = await repository.saveQueued(createDelivery());
@@ -241,6 +256,7 @@ describe('renewal notice delivery persistence', () => {
   it('persists delivered, terminal, and unknown outcomes with their last attempt evidence', async () => {
     const repository = new DrizzleRenewalNoticeDeliveryRepository(
       primary.db,
+      hasher,
       () => now,
     );
     const delivered = await repository.saveQueued(createDelivery());
@@ -308,6 +324,7 @@ describe('renewal notice delivery persistence', () => {
   it('quarantines stale claims and requires audited no-send confirmation to requeue', async () => {
     const repository = new DrizzleRenewalNoticeDeliveryRepository(
       primary.db,
+      hasher,
       () => now,
     );
     const saved = await repository.saveQueued(createDelivery());

--- a/tests/integration/renewal-notice-deliveries.integration.test.ts
+++ b/tests/integration/renewal-notice-deliveries.integration.test.ts
@@ -87,12 +87,24 @@ describe('renewal notice delivery persistence', () => {
 
     expect(replay).toEqual(first);
     expect(businessKeyReplay).toEqual(first);
+    const changedPayload = createTransactionalEmailPayloadSnapshot({
+      from: 'Addiction Boards <notices@addictionboards.com>',
+      to: input.destination,
+      replyTo: 'support@addictionboards.com',
+      subject: 'Changed annual subscription reminder',
+      html: '<p>Changed annual subscription reminder</p>',
+      text: 'Changed annual subscription reminder',
+    });
     await expect(
       secondRepository.saveQueued({
         ...input,
-        payloadSnapshot: '{"subject":"changed"}',
+        payloadSnapshot: changedPayload.snapshot,
+        payloadHash: changedPayload.hash,
       }),
-    ).rejects.toMatchObject({ code: 'CONFLICT' });
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Renewal notice delivery identity is bound to another payload',
+    });
   });
 
   it('rejects malformed immutable evidence before inserting a row', async () => {

--- a/tests/integration/renewal-notice-deliveries.integration.test.ts
+++ b/tests/integration/renewal-notice-deliveries.integration.test.ts
@@ -1,0 +1,324 @@
+import { randomUUID } from 'node:crypto';
+import { eq, inArray } from 'drizzle-orm';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { renewalNoticeDeliveries } from '@/db/schema';
+import { DrizzleRenewalNoticeDeliveryRepository } from '@/src/adapters/repositories/drizzle-renewal-notice-delivery-repository';
+import {
+  createTransactionalEmailPayloadSnapshot,
+  getRenewalNoticeProviderIdempotencyKey,
+} from '@/src/application/shared/transactional-email-payload';
+import type { NewRenewalNoticeDelivery } from '@/src/domain/entities';
+import { closeConnection, createIntegrationDb } from './helpers';
+
+const primary = createIntegrationDb();
+const competing = createIntegrationDb();
+const deliveryIds: string[] = [];
+const now = new Date('2026-08-06T18:00:00.000Z');
+
+afterEach(async () => {
+  if (deliveryIds.length > 0) {
+    await primary.db
+      .delete(renewalNoticeDeliveries)
+      .where(inArray(renewalNoticeDeliveries.id, deliveryIds));
+  }
+  deliveryIds.length = 0;
+});
+
+afterAll(async () => {
+  await Promise.all([
+    closeConnection(primary.sql),
+    closeConnection(competing.sql),
+  ]);
+});
+
+function createDelivery(
+  overrides: Partial<NewRenewalNoticeDelivery> = {},
+): NewRenewalNoticeDelivery {
+  const id = overrides.id ?? randomUUID();
+  const payload = {
+    from: 'Addiction Boards <notices@addictionboards.com>',
+    to: `subscriber-${id}@example.com`,
+    replyTo: 'support@addictionboards.com',
+    subject: 'Annual subscription reminder',
+    html: '<p>Annual subscription reminder</p>',
+    text: 'Annual subscription reminder',
+  };
+  const { snapshot, hash } = createTransactionalEmailPayloadSnapshot(payload);
+  deliveryIds.push(id);
+  return {
+    id,
+    noticeKind: 'annual_reminder',
+    consentRecordId: null,
+    externalSubscriptionId: `sub_${id}`,
+    applicableAt: new Date('2027-08-06T18:00:00.000Z'),
+    disclosureVersion: '2026-08-05',
+    destination: payload.to,
+    providerIdempotencyKey: getRenewalNoticeProviderIdempotencyKey(id),
+    payloadSnapshot: snapshot,
+    payloadHash: hash,
+    ...overrides,
+  };
+}
+
+describe('renewal notice delivery persistence', () => {
+  it('keeps concurrent exact creation idempotent and rejects changed payload', async () => {
+    const firstRepository = new DrizzleRenewalNoticeDeliveryRepository(
+      primary.db,
+      () => now,
+    );
+    const secondRepository = new DrizzleRenewalNoticeDeliveryRepository(
+      competing.db,
+      () => now,
+    );
+    const input = createDelivery();
+
+    const [first, replay] = await Promise.all([
+      firstRepository.saveQueued(input),
+      secondRepository.saveQueued(input),
+    ]);
+    const replacementId = randomUUID();
+    deliveryIds.push(replacementId);
+    const businessKeyReplay = await secondRepository.saveQueued({
+      ...input,
+      id: replacementId,
+      providerIdempotencyKey:
+        getRenewalNoticeProviderIdempotencyKey(replacementId),
+    });
+
+    expect(replay).toEqual(first);
+    expect(businessKeyReplay).toEqual(first);
+    await expect(
+      secondRepository.saveQueued({
+        ...input,
+        payloadSnapshot: '{"subject":"changed"}',
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+
+  it('rejects malformed immutable evidence before inserting a row', async () => {
+    const repository = new DrizzleRenewalNoticeDeliveryRepository(
+      primary.db,
+      () => now,
+    );
+    const wrongKey = createDelivery({
+      providerIdempotencyKey: 'renewal-notice/wrong',
+    });
+    const wrongHash = createDelivery({ payloadHash: '0'.repeat(64) });
+
+    await expect(repository.saveQueued(wrongKey)).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+    await expect(repository.saveQueued(wrongHash)).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+    await expect(repository.findById(wrongKey.id)).resolves.toBeNull();
+    await expect(repository.findById(wrongHash.id)).resolves.toBeNull();
+  });
+
+  it('allows only one connection to claim a queued row', async () => {
+    const firstRepository = new DrizzleRenewalNoticeDeliveryRepository(
+      primary.db,
+      () => now,
+    );
+    const secondRepository = new DrizzleRenewalNoticeDeliveryRepository(
+      competing.db,
+      () => now,
+    );
+    const saved = await firstRepository.saveQueued(createDelivery());
+
+    const [first, second] = await Promise.all([
+      firstRepository.claim({
+        id: saved.id,
+        attemptId: 'attempt-1',
+        startedAt: now,
+      }),
+      secondRepository.claim({
+        id: saved.id,
+        attemptId: 'attempt-2',
+        startedAt: now,
+      }),
+    ]);
+
+    expect([first, second].filter(Boolean)).toHaveLength(1);
+    await expect(firstRepository.findById(saved.id)).resolves.toMatchObject({
+      status: 'processing',
+      attemptCount: 1,
+      attemptId: first?.attemptId ?? second?.attemptId,
+      attemptStartedAt: now,
+    });
+  });
+
+  it('selects queued and due transient rows but excludes terminal and unknown rows', async () => {
+    const repository = new DrizzleRenewalNoticeDeliveryRepository(
+      primary.db,
+      () => now,
+    );
+    const queued = await repository.saveQueued(createDelivery());
+    const dueTransient = await repository.saveQueued(createDelivery());
+    const futureTransient = await repository.saveQueued(createDelivery());
+    const terminal = await repository.saveQueued(createDelivery());
+    const unknown = await repository.saveQueued(createDelivery());
+    await primary.db
+      .update(renewalNoticeDeliveries)
+      .set({
+        status: 'transient_failure',
+        nextAttemptAt: new Date('2026-08-06T17:59:00.000Z'),
+      })
+      .where(eq(renewalNoticeDeliveries.id, dueTransient.id));
+    await primary.db
+      .update(renewalNoticeDeliveries)
+      .set({
+        status: 'transient_failure',
+        nextAttemptAt: new Date('2026-08-06T18:01:00.000Z'),
+      })
+      .where(eq(renewalNoticeDeliveries.id, futureTransient.id));
+    await primary.db
+      .update(renewalNoticeDeliveries)
+      .set({ status: 'terminal_failure' })
+      .where(eq(renewalNoticeDeliveries.id, terminal.id));
+    await primary.db
+      .update(renewalNoticeDeliveries)
+      .set({ status: 'outcome_unknown' })
+      .where(eq(renewalNoticeDeliveries.id, unknown.id));
+
+    const due = await repository.findDue({ now, limit: 10 });
+
+    expect(new Set(due.map((delivery) => delivery.id))).toEqual(
+      new Set([queued.id, dueTransient.id]),
+    );
+  });
+
+  it('requires claim ownership for outcomes and persists retry scheduling', async () => {
+    const repository = new DrizzleRenewalNoticeDeliveryRepository(
+      primary.db,
+      () => now,
+    );
+    const saved = await repository.saveQueued(createDelivery());
+    await repository.claim({
+      id: saved.id,
+      attemptId: 'attempt-1',
+      startedAt: now,
+    });
+
+    await expect(
+      repository.markDelivered({
+        id: saved.id,
+        attemptId: 'other-attempt',
+        providerEventId: 'email_wrong',
+        completedAt: now,
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+    await expect(
+      repository.markTransientFailure({
+        id: saved.id,
+        attemptId: 'attempt-1',
+        failureClass: 'provider_non_acceptance',
+        failureCode: 'rate_limit_exceeded',
+        failedAt: now,
+        nextAttemptAt: new Date('2026-08-06T18:15:00.000Z'),
+      }),
+    ).resolves.toMatchObject({
+      status: 'transient_failure',
+      attemptId: 'attempt-1',
+      attemptStartedAt: now,
+      failureCode: 'rate_limit_exceeded',
+      nextAttemptAt: new Date('2026-08-06T18:15:00.000Z'),
+    });
+  });
+
+  it('persists delivered and terminal outcomes with their last attempt evidence', async () => {
+    const repository = new DrizzleRenewalNoticeDeliveryRepository(
+      primary.db,
+      () => now,
+    );
+    const delivered = await repository.saveQueued(createDelivery());
+    const terminal = await repository.saveQueued(createDelivery());
+    await repository.claim({
+      id: delivered.id,
+      attemptId: 'delivered-attempt',
+      startedAt: now,
+    });
+    await repository.claim({
+      id: terminal.id,
+      attemptId: 'terminal-attempt',
+      startedAt: now,
+    });
+
+    await expect(
+      repository.markDelivered({
+        id: delivered.id,
+        attemptId: 'delivered-attempt',
+        providerEventId: 'email_123',
+        completedAt: now,
+      }),
+    ).resolves.toMatchObject({
+      status: 'delivered',
+      providerEventId: 'email_123',
+      attemptId: 'delivered-attempt',
+      attemptStartedAt: now,
+    });
+    await expect(
+      repository.markTerminalFailure({
+        id: terminal.id,
+        attemptId: 'terminal-attempt',
+        failureClass: 'provider_terminal_failure',
+        failureCode: 'invalid_idempotent_request',
+        failedAt: now,
+      }),
+    ).resolves.toMatchObject({
+      status: 'terminal_failure',
+      failureCode: 'invalid_idempotent_request',
+      attemptId: 'terminal-attempt',
+      attemptStartedAt: now,
+    });
+  });
+
+  it('quarantines stale claims and requires audited no-send confirmation to requeue', async () => {
+    const repository = new DrizzleRenewalNoticeDeliveryRepository(
+      primary.db,
+      () => now,
+    );
+    const saved = await repository.saveQueued(createDelivery());
+    await repository.claim({
+      id: saved.id,
+      attemptId: 'attempt-1',
+      startedAt: new Date('2026-08-06T17:00:00.000Z'),
+    });
+
+    await expect(
+      repository.markStaleProcessingUnknown({
+        staleBefore: new Date('2026-08-06T17:45:00.000Z'),
+        observedAt: now,
+        limit: 10,
+      }),
+    ).resolves.toBe(1);
+    await expect(
+      repository.requeue({
+        id: saved.id,
+        reason: 'Confirmed in Resend that no email exists',
+        requeuedBy: 'operator@example.com',
+        requeuedAt: now,
+        confirmedNoSend: false,
+      }),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+    await expect(
+      repository.requeue({
+        id: saved.id,
+        reason: 'Confirmed in Resend that no email exists',
+        requeuedBy: 'operator@example.com',
+        requeuedAt: now,
+        confirmedNoSend: true,
+      }),
+    ).resolves.toMatchObject({
+      status: 'queued',
+      attemptId: 'attempt-1',
+      attemptStartedAt: new Date('2026-08-06T17:00:00.000Z'),
+      requeueAudit: [
+        expect.objectContaining({
+          priorStatus: 'outcome_unknown',
+          confirmedNoSend: true,
+        }),
+      ],
+    });
+  });
+});

--- a/tests/integration/renewal-notice-deliveries.integration.test.ts
+++ b/tests/integration/renewal-notice-deliveries.integration.test.ts
@@ -238,13 +238,14 @@ describe('renewal notice delivery persistence', () => {
     });
   });
 
-  it('persists delivered and terminal outcomes with their last attempt evidence', async () => {
+  it('persists delivered, terminal, and unknown outcomes with their last attempt evidence', async () => {
     const repository = new DrizzleRenewalNoticeDeliveryRepository(
       primary.db,
       () => now,
     );
     const delivered = await repository.saveQueued(createDelivery());
     const terminal = await repository.saveQueued(createDelivery());
+    const unknown = await repository.saveQueued(createDelivery());
     await repository.claim({
       id: delivered.id,
       attemptId: 'delivered-attempt',
@@ -253,6 +254,11 @@ describe('renewal notice delivery persistence', () => {
     await repository.claim({
       id: terminal.id,
       attemptId: 'terminal-attempt',
+      startedAt: now,
+    });
+    await repository.claim({
+      id: unknown.id,
+      attemptId: 'unknown-attempt',
       startedAt: now,
     });
 
@@ -281,6 +287,20 @@ describe('renewal notice delivery persistence', () => {
       status: 'terminal_failure',
       failureCode: 'invalid_idempotent_request',
       attemptId: 'terminal-attempt',
+      attemptStartedAt: now,
+    });
+    await expect(
+      repository.markOutcomeUnknown({
+        id: unknown.id,
+        attemptId: 'unknown-attempt',
+        failureClass: 'provider_outcome_unknown',
+        failureCode: 'provider_timeout',
+        failedAt: now,
+      }),
+    ).resolves.toMatchObject({
+      status: 'outcome_unknown',
+      failureCode: 'provider_timeout',
+      attemptId: 'unknown-attempt',
       attemptStartedAt: now,
     });
   });

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -15,12 +15,15 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       '@clerk/nextjs/server',
+      '@noble/hashes/sha256',
+      '@noble/hashes/utils',
       '@sentry/nextjs',
       'drizzle-orm',
       'drizzle-orm/pg-core',
       'drizzle-orm/postgres-js',
       'pino',
       'postgres',
+      'resend',
       'server-only',
       'stripe',
       'zod',

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       '@clerk/nextjs/server',
-      '@noble/hashes/sha256',
+      '@noble/hashes/sha2',
       '@noble/hashes/utils',
       '@sentry/nextjs',
       'drizzle-orm',


### PR DESCRIPTION
## Summary
- add the provider-independent transactional-email port/fake and the Resend SDK adapter
- persist and dispatch the six-state renewal delivery machine with atomic claims, immutable payload evidence, stable provider idempotency keys, bounded retry scheduling, stale-claim quarantine, and audited operator requeue
- wire the repository, gateway, dispatch, and requeue seams through the composition root
- keep Resend inactive and queued when `RESEND_API_KEY` is absent; this PR performs no owner/dashboard/credential action

## Contract notes
- Implements DEBT-414 Stage 2 PR-3 / spec §7 only.
- Resend is pinned to trusted `6.18.0`; `6.18.1` was rejected by the repository's `trustPolicy: no-downgrade` gate, which was not bypassed.
- The price-increase machinery remains deliberately excluded and unscaffolded.
- No production Stripe, Clerk, Vercel, Resend, database, or credential settings were touched.

## Self-audit
- No prior production behavior was removed or weakened.
- Malformed derived keys and payload hashes are rejected before persistence by both the fake and Drizzle adapter; the real-database regression proves no row is inserted.
- `concurrent_idempotent_requests`, thrown calls, invalid provider responses, and stale claims are quarantined as `outcome_unknown`; they are not blindly retried.
- The two-worker claim test uses two independently opened database connections.
- The first local browser gate exposed a Node-only `node:crypto` barrel import; the current head uses browser-safe `@noble/hashes`, checked against an independent Node SHA-256 oracle.
- First remote CI on `b6a9a22e` exposed a cold-cache Vite dependency reload during browser coverage. The current head pre-bundles the exact three dependencies named by Vite, and a deliberately cold-cache local browser-coverage run passed 398/398 without reload.
- Published Privacy/Security copy remains accurate: the adapter now exists, but no `RESEND_API_KEY` exists and no provider call occurs while it is absent.
- Unfiled findings: none.

## Full quality gate (exact head `7594c5b43eef3d9dad570b33439e535635bfc062`)
- `pnpm typecheck`: pass
- `pnpm lint`: pass (24 accepted baseline warnings, 2 infos)
- `pnpm test --run`: 428 files, 3,737 tests passed
- `pnpm test:browser`: 64 files, 398 tests passed
- cold-cache `pnpm test:browser:coverage`: 64 files, 398 tests passed
- canonical migrated/seeded local integration gate: 36 passed files + 1 skipped; 232 passed tests + 2 skipped
- `pnpm build`: pass; 22 routes generated
- first final-head `pnpm test:e2e`: command passed with 37 direct passes + 1 Clerk-auth retry; recorded as flaky, not clean
- clean unchanged-head E2E rerun: 38 passed
- local test DB torn down after all suites
- push hook rerun: 3,737 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transactional email delivery for renewal notices through Resend.
  * Added delivery tracking with duplicate prevention, retry scheduling, and outcome handling.
  * Added recovery and audited requeue support for uncertain deliveries.

* **Configuration**
  * Added optional `RESEND_API_KEY` configuration. Without it, notices remain queued without contacting the email provider.

* **Tests**
  * Added comprehensive coverage for delivery, retries, recovery, and database behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->