### PR TITLE
Harden DEBT-414 renewal delivery evidence boundaries

### DIFF
--- a/docs/debt/debt-414-public-legal-pages-privacy-terms.md
+++ b/docs/debt/debt-414-public-legal-pages-privacy-terms.md
@@ -357,7 +357,7 @@ Only after the deployed pages return signed-out 200:
 - [ ] SHIELD security and incident programs are adopted and evidence-backed.
 - [x] Stripe legal links are set only after deployment. **Owner-reported done 2026-08-05** — both URLs set in live Public details after production signed-out 200s; support email set to the published `support@addictionboards.com`. Current test-mode Session creation succeeds without any separately observed test-mode setup; the shared-settings-versus-skipped-enforcement mechanism is unresolved (see § 5).
 - [x] **Shortened statement descriptor is 2–10 characters and suffix-compatible.** The settled owner record is corroborated, not replaced, by the 2026-08-06 test-mode Account API: full descriptor `ADDICTIONBOARDS.COM`; separate shortened prefix `ADDICTION` (9 characters). The prior reopening confused the full and shortened fields.
-- [x] Full quality gate passes before push (2026-08-07 corrective promo-review head: typecheck; lint with the accepted 24-warning baseline; 3,794 unit; 398 browser; 239 integration passed plus 2 skipped; 23-page build; 38 E2E).
+- [x] Full quality gate passes before push (2026-08-07 second corrective promo-review head: typecheck; lint with the accepted 24-warning baseline; 3,809 unit; 398 browser; 241 integration passed plus 2 skipped; 23-page build; 38 E2E).
 - [ ] CodeRabbit reviews the exact final pushed head before merge is requested.
 
 ## Stage 1 adversarial review record (2026-08-05)

--- a/src/adapters/controllers/stripe-webhook-controller-renewal-acknowledgment.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller-renewal-acknowledgment.test.ts
@@ -17,6 +17,7 @@ import type { NewRenewalNoticeDelivery } from '@/src/domain/entities';
 import {
   processStripeWebhook,
   type StripeWebhookDeps,
+  type StripeWebhookTransaction,
 } from './stripe-webhook-controller';
 
 const now = new Date('2026-08-07T12:00:00.000Z');
@@ -74,15 +75,7 @@ function createHarness(input?: {
   configured?: boolean;
   clearConsentUserReference?: boolean;
   dispatchError?: Error;
-  findUserById?: StripeWebhookDeps['transaction'] extends (
-    fn: (transaction: infer T) => Promise<unknown>,
-  ) => Promise<unknown>
-    ? T extends { users: infer U }
-      ? U extends { findById: infer F }
-        ? F
-        : never
-      : never
-    : never;
+  findUserById?: StripeWebhookTransaction['users']['findById'];
   userId?: string;
   webhookResult?: WebhookEventResult;
   providerResult?:

--- a/src/adapters/gateways/resend-transactional-email-gateway.test.ts
+++ b/src/adapters/gateways/resend-transactional-email-gateway.test.ts
@@ -100,9 +100,21 @@ describe('ResendTransactionalEmailGateway', () => {
   });
 
   it.each([
-    'invalid_idempotent_request',
-    'validation_error',
+    'invalid_idempotency_key',
+    'missing_api_key',
+    'restricted_api_key',
     'invalid_api_key',
+    'not_found',
+    'method_not_allowed',
+    'invalid_idempotent_request',
+    'invalid_attachment',
+    'invalid_from_address',
+    'invalid_access',
+    'invalid_parameter',
+    'invalid_region',
+    'missing_required_field',
+    'security_error',
+    'validation_error',
   ])('maps known terminal error %s to terminal_failure', async (name) => {
     resendSdk.send.mockResolvedValue({
       data: null,
@@ -115,6 +127,19 @@ describe('ResendTransactionalEmailGateway', () => {
     await expect(gateway.send(input)).resolves.toEqual({
       status: 'terminal_failure',
       failureCode: name,
+    });
+  });
+
+  it('retries an unrecognized provider non-acceptance instead of dropping the notice', async () => {
+    resendSdk.send.mockResolvedValue({
+      data: null,
+      error: { name: 'future_retryable_error', message: 'try later' },
+    });
+    const gateway = new ResendTransactionalEmailGateway({ apiKey: 're_test' });
+
+    await expect(gateway.send(input)).resolves.toEqual({
+      status: 'transient_failure',
+      failureCode: 'future_retryable_error',
     });
   });
 
@@ -171,7 +196,7 @@ describe('ResendTransactionalEmailGateway', () => {
   it.each([
     { id: '' },
     {},
-  ])('maps data without a non-empty provider event ID to outcome_unknown', async (data) => {
+  ])('maps provider data %o without a non-empty event ID to outcome_unknown', async (data) => {
     resendSdk.send.mockResolvedValue({ data, error: null });
     const gateway = new ResendTransactionalEmailGateway({
       apiKey: 're_test',

--- a/src/adapters/gateways/resend-transactional-email-gateway.ts
+++ b/src/adapters/gateways/resend-transactional-email-gateway.ts
@@ -13,6 +13,23 @@ const TRANSIENT_RESEND_ERRORS = new Set<ErrorResponse['name']>([
   'monthly_quota_exceeded',
   'rate_limit_exceeded',
 ]);
+const TERMINAL_RESEND_ERRORS = new Set<ErrorResponse['name']>([
+  'invalid_idempotency_key',
+  'validation_error',
+  'missing_api_key',
+  'restricted_api_key',
+  'invalid_api_key',
+  'not_found',
+  'method_not_allowed',
+  'invalid_idempotent_request',
+  'invalid_attachment',
+  'invalid_from_address',
+  'invalid_access',
+  'invalid_parameter',
+  'invalid_region',
+  'missing_required_field',
+  'security_error',
+]);
 export const RESEND_PROVIDER_TIMEOUT_MS = 10_000;
 
 class ResendProviderTimeoutError extends Error {
@@ -81,10 +98,22 @@ export class ResendTransactionalEmailGateway
             failureCode: error.name,
           };
         }
+        if (TRANSIENT_RESEND_ERRORS.has(error.name)) {
+          return {
+            status: 'transient_failure',
+            failureCode: error.name,
+          };
+        }
+        if (TERMINAL_RESEND_ERRORS.has(error.name)) {
+          return {
+            status: 'terminal_failure',
+            failureCode: error.name,
+          };
+        }
+        // An explicit provider error proves non-acceptance. Unknown future
+        // names are safe to retry; they are not an ambiguous send outcome.
         return {
-          status: TRANSIENT_RESEND_ERRORS.has(error.name)
-            ? 'transient_failure'
-            : 'terminal_failure',
+          status: 'transient_failure',
           failureCode: error.name,
         };
       }

--- a/src/adapters/repositories/drizzle-renewal-notice-delivery-repository.ts
+++ b/src/adapters/repositories/drizzle-renewal-notice-delivery-repository.ts
@@ -70,13 +70,15 @@ export class DrizzleRenewalNoticeDeliveryRepository
     assertValidRenewalNoticeDeliveryPayload(input, this.hasher);
     assertValidKeyShape(input);
     const { externalSubscriptionId, ...vendorNeutralInput } = input;
+    const queuedAt = this.now();
     const [inserted] = await this.db
       .insert(renewalNoticeDeliveries)
       .values({
         ...vendorNeutralInput,
         stripeSubscriptionId: externalSubscriptionId,
         status: 'queued',
-        updatedAt: this.now(),
+        createdAt: queuedAt,
+        updatedAt: queuedAt,
       })
       .onConflictDoNothing()
       .returning();
@@ -341,7 +343,7 @@ export class DrizzleRenewalNoticeDeliveryRepository
     return toDelivery(row);
   }
 
-  private findConflictRow(
+  private async findConflictRow(
     input: NewRenewalNoticeDelivery,
   ): Promise<DeliveryRow | undefined> {
     let identity: SQL | undefined;
@@ -375,15 +377,23 @@ export class DrizzleRenewalNoticeDeliveryRepository
         eq(renewalNoticeDeliveries.destination, input.destination),
       );
     }
+    const exactId = await this.db.query.renewalNoticeDeliveries.findFirst({
+      where: eq(renewalNoticeDeliveries.id, input.id),
+    });
+    if (exactId) return exactId;
+
     return this.db.query.renewalNoticeDeliveries.findFirst({
       where: or(
-        eq(renewalNoticeDeliveries.id, input.id),
         eq(
           renewalNoticeDeliveries.providerIdempotencyKey,
           input.providerIdempotencyKey,
         ),
         identity,
       ),
+      orderBy: [
+        asc(renewalNoticeDeliveries.createdAt),
+        asc(renewalNoticeDeliveries.id),
+      ],
     });
   }
 }

--- a/src/application/ports/renewal-notice-delivery-repository.ts
+++ b/src/application/ports/renewal-notice-delivery-repository.ts
@@ -9,10 +9,17 @@ export type ClaimRenewalNoticeDeliveryInput = {
   startedAt: Date;
 };
 
+export type RenewalNoticeFailureClass =
+  | 'payload_integrity_failure'
+  | 'provider_non_acceptance'
+  | 'provider_terminal_failure'
+  | 'provider_outcome_unknown'
+  | 'stale_processing_claim';
+
 export type MarkRenewalNoticeDeliveryFailureInput = {
   id: string;
   attemptId: string;
-  failureClass: string;
+  failureClass: RenewalNoticeFailureClass;
   failureCode: string;
   failedAt: Date;
 };

--- a/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.test.ts
@@ -223,6 +223,29 @@ describe('FakeRenewalNoticeDeliveryRepository', () => {
     });
   });
 
+  it('persists a delivered outcome for the owning claim', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    await repository.saveQueued(createDelivery());
+    await repository.claim({
+      id: deliveryId,
+      attemptId: 'attempt-1',
+      startedAt: now,
+    });
+
+    await expect(
+      repository.markDelivered({
+        id: deliveryId,
+        attemptId: 'attempt-1',
+        providerEventId: 'email_123',
+        completedAt: now,
+      }),
+    ).resolves.toMatchObject({
+      status: 'delivered',
+      providerEventId: 'email_123',
+      nextAttemptAt: null,
+    });
+  });
+
   it('quarantines stale processing claims as outcome_unknown', async () => {
     const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
     await repository.saveQueued(createDelivery());

--- a/src/application/use-cases/dispatch-renewal-notice-delivery.test.ts
+++ b/src/application/use-cases/dispatch-renewal-notice-delivery.test.ts
@@ -78,24 +78,46 @@ describe('DispatchRenewalNoticeDeliveryUseCase', () => {
     });
   });
 
-  it('rejects a changed payload or provider key before claiming or sending', async () => {
+  it.each([
+    {
+      label: 'provider idempotency key',
+      corrupt: (delivery: NewRenewalNoticeDelivery) => ({
+        ...delivery,
+        providerIdempotencyKey: 'wrong-key',
+      }),
+      failureCode: 'provider_idempotency_key_mismatch',
+    },
+    {
+      label: 'payload snapshot hash',
+      corrupt: (delivery: NewRenewalNoticeDelivery) => ({
+        ...delivery,
+        payloadHash: '0'.repeat(64),
+      }),
+      failureCode: 'payload_snapshot_integrity_failure',
+    },
+  ])('quarantines a corrupted $label without calling the provider', async ({
+    corrupt,
+    failureCode,
+  }) => {
     const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
     const saved = await repository.saveQueued(createDelivery());
     repository.records[0] = {
       ...saved,
-      providerIdempotencyKey: 'wrong-key',
+      ...corrupt(saved),
     };
     const gateway = new FakeTransactionalEmailGateway({ configured: true });
     const useCase = createUseCase({ repository, gateway });
 
-    await expect(useCase.execute({ deliveryId })).rejects.toMatchObject({
-      code: 'CONFLICT',
+    await expect(useCase.execute({ deliveryId })).resolves.toMatchObject({
+      outcome: 'attempted',
+      delivery: {
+        status: 'terminal_failure',
+        attemptCount: 1,
+        failureClass: 'payload_integrity_failure',
+        failureCode,
+      },
     });
     expect(gateway.sendInputs).toEqual([]);
-    expect(repository.records[0]).toMatchObject({
-      status: 'queued',
-      attemptCount: 0,
-    });
   });
 
   it('persists the claim before the provider call and records delivery', async () => {

--- a/src/application/use-cases/dispatch-renewal-notice-delivery.ts
+++ b/src/application/use-cases/dispatch-renewal-notice-delivery.ts
@@ -3,6 +3,7 @@ import type {
   RenewalNoticeDeliveryRepository,
   Sha256Hasher,
   TransactionalEmailGateway,
+  TransactionalEmailPayload,
   TransactionalEmailSendResult,
 } from '@/src/application/ports';
 import {
@@ -44,19 +45,28 @@ export class DispatchRenewalNoticeDeliveryUseCase {
       delivery.id,
     );
     if (delivery.providerIdempotencyKey !== expectedProviderKey) {
-      throw new ApplicationError(
-        'CONFLICT',
-        'Renewal notice provider idempotency key does not match its delivery',
+      return this.quarantineIntegrityFailure(
+        delivery,
+        'provider_idempotency_key_mismatch',
       );
     }
-    const payload = parseTransactionalEmailPayloadSnapshot(
-      {
-        snapshot: delivery.payloadSnapshot,
-        hash: delivery.payloadHash,
-        destination: delivery.destination,
-      },
-      this.hasher,
-    );
+    let payload: TransactionalEmailPayload;
+    try {
+      payload = parseTransactionalEmailPayloadSnapshot(
+        {
+          snapshot: delivery.payloadSnapshot,
+          hash: delivery.payloadHash,
+          destination: delivery.destination,
+        },
+        this.hasher,
+      );
+    } catch (error) {
+      if (!(error instanceof ApplicationError)) throw error;
+      return this.quarantineIntegrityFailure(
+        delivery,
+        'payload_snapshot_integrity_failure',
+      );
+    }
 
     if (!this.emailGateway.isConfigured()) {
       return { outcome: 'skipped_unconfigured', delivery };
@@ -87,6 +97,31 @@ export class DispatchRenewalNoticeDeliveryUseCase {
     return {
       outcome: 'attempted',
       delivery: await this.persistOutcome(claimed, result, this.now()),
+    };
+  }
+
+  private async quarantineIntegrityFailure(
+    delivery: RenewalNoticeDelivery,
+    failureCode: string,
+  ): Promise<DispatchRenewalNoticeDeliveryResult> {
+    const startedAt = this.now();
+    const attemptId = this.createAttemptId();
+    const claimed = await this.deliveryRepository.claim({
+      id: delivery.id,
+      attemptId,
+      startedAt,
+    });
+    if (!claimed) return { outcome: 'claim_lost', delivery: null };
+
+    return {
+      outcome: 'attempted',
+      delivery: await this.deliveryRepository.markTerminalFailure({
+        id: claimed.id,
+        attemptId,
+        failureClass: 'payload_integrity_failure',
+        failureCode,
+        failedAt: this.now(),
+      }),
     };
   }
 

--- a/tests/integration/renewal-notice-deliveries.integration.test.ts
+++ b/tests/integration/renewal-notice-deliveries.integration.test.ts
@@ -117,6 +117,46 @@ describe('renewal notice delivery persistence', () => {
     });
   });
 
+  it('uses one injected timestamp for newly queued delivery evidence', async () => {
+    const repository = new DrizzleRenewalNoticeDeliveryRepository(
+      primary.db,
+      hasher,
+      () => now,
+    );
+
+    await expect(
+      repository.saveQueued(createDelivery()),
+    ).resolves.toMatchObject({
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+
+  it('rejects an ID collision even when another row matches the business key', async () => {
+    const repository = new DrizzleRenewalNoticeDeliveryRepository(
+      primary.db,
+      hasher,
+      () => now,
+    );
+    const businessKeyRow = createDelivery();
+    const idRow = createDelivery();
+    await repository.saveQueued(businessKeyRow);
+    await repository.saveQueued(idRow);
+
+    await expect(
+      repository.saveQueued({
+        ...businessKeyRow,
+        id: idRow.id,
+        providerIdempotencyKey: getRenewalNoticeProviderIdempotencyKey(
+          idRow.id,
+        ),
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Renewal notice delivery identity is bound to another payload',
+    });
+  });
+
   it('rejects malformed immutable evidence before inserting a row', async () => {
     const repository = new DrizzleRenewalNoticeDeliveryRepository(
       primary.db,
@@ -342,6 +382,12 @@ describe('renewal notice delivery persistence', () => {
       attemptId: 'attempt-1',
       startedAt: new Date('2026-08-06T17:00:00.000Z'),
     });
+    const fresh = await repository.saveQueued(createDelivery());
+    await repository.claim({
+      id: fresh.id,
+      attemptId: 'fresh-attempt',
+      startedAt: now,
+    });
 
     await expect(
       repository.markStaleProcessingUnknown({
@@ -350,6 +396,10 @@ describe('renewal notice delivery persistence', () => {
         limit: 10,
       }),
     ).resolves.toBe(1);
+    await expect(repository.findById(fresh.id)).resolves.toMatchObject({
+      status: 'processing',
+      attemptId: 'fresh-attempt',
+    });
     await expect(
       repository.requeue({
         id: saved.id,
@@ -375,6 +425,8 @@ describe('renewal notice delivery persistence', () => {
         expect.objectContaining({
           priorStatus: 'outcome_unknown',
           confirmedNoSend: true,
+          reason: 'Confirmed in Resend that no email exists',
+          requeuedBy: 'operator@example.com',
         }),
       ],
     });


### PR DESCRIPTION
## Why

A forced full review of promo #747 found two runtime defects and several test/evidence gaps after the first corrective squash. This PR feeds only verified fixes back through `dev`; promo #747 remains the sole `dev`→`main` promotion.

## Verified fixes

- atomically quarantine corrupted delivery keys/payload snapshots as terminal evidence instead of leaving poison rows queued forever
- classify explicit unknown future Resend error names as retryable non-acceptance, while preserving the known terminal allowlist and ambiguous concurrent-idempotency outcome
- use one injected timestamp for queued evidence
- make exact-ID conflicts win deterministically over a different row matching the business key
- type the persisted failure taxonomy and strengthen delivered, stale-sweep, audit-field, and provider-response tests
- update the DEBT-414 exact gate counts

## Deliberate non-changes

- No acknowledgment-ID reset: retries occur only on a returned version conflict before acknowledgment queueing. A thrown/rolled-back transaction exits; Drizzle does not replay this callback here, so the reported stale-ID path is unreachable.
- No queue-loop concurrency/metrics expansion: current pre-revenue volume does not establish a timeout defect, and adding telemetry plus concurrent writes would be scope expansion without a failing invariant.

## TDD evidence

Red before implementation:
- 3 focused unit failures for unknown provider classification and poisoned delivery rows
- 2 real-Postgres failures for timestamp divergence and cross-key collision selection

Green on exact head `83a4cf20`:
- typecheck: pass
- lint: pass with accepted 24-warning baseline
- unit: 434 files / 3,809 tests
- browser: 100 suites / 398 tests
- integration: 38 passed + 1 skipped files; 241 passed + 2 skipped tests
- build: pass, 23 routes/pages
- hermetic E2E: 38/38

The isolated test database was torn down only after every suite completed. No production system or provider setting was touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved renewal notification delivery reliability by detecting corrupted identifiers or payloads and safely quarantining affected deliveries.
  * Improved handling of email provider errors, distinguishing retryable failures from permanent failures and treating unknown outcomes as retryable.
  * Prevented duplicate delivery records and improved processing of stale or conflicting delivery attempts.
  * Preserved delivery and requeue audit details for better traceability.

* **Tests**
  * Expanded automated coverage for delivery recovery, collision handling, timestamp tracking, and provider error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->