### PR TITLE
Fix DEBT-414 renewal notice review findings

### DIFF
--- a/docs/debt/debt-414-public-legal-pages-privacy-terms.md
+++ b/docs/debt/debt-414-public-legal-pages-privacy-terms.md
@@ -357,7 +357,7 @@ Only after the deployed pages return signed-out 200:
 - [ ] SHIELD security and incident programs are adopted and evidence-backed.
 - [x] Stripe legal links are set only after deployment. **Owner-reported done 2026-08-05** — both URLs set in live Public details after production signed-out 200s; support email set to the published `support@addictionboards.com`. Current test-mode Session creation succeeds without any separately observed test-mode setup; the shared-settings-versus-skipped-enforcement mechanism is unresolved (see § 5).
 - [x] **Shortened statement descriptor is 2–10 characters and suffix-compatible.** The settled owner record is corroborated, not replaced, by the 2026-08-06 test-mode Account API: full descriptor `ADDICTIONBOARDS.COM`; separate shortened prefix `ADDICTION` (9 characters). The prior reopening confused the full and shortened fields.
-- [x] Full quality gate passes before push (2026-08-07 third corrective promo-review head: typecheck; lint with the accepted 24-warning baseline; 3,812 unit; 398 browser; 241 integration passed plus 2 skipped; 23-page build; 38 E2E).
+- [x] Full quality gate passes before push (2026-08-07 third corrective promo-review head: typecheck; lint with the accepted 24-warning baseline; 3,816 unit; 398 browser; 241 integration passed plus 2 skipped; 23-page build; 38 E2E).
 - [ ] CodeRabbit reviews the exact final pushed head before merge is requested.
 
 ## Stage 1 adversarial review record (2026-08-05)

--- a/docs/debt/debt-414-public-legal-pages-privacy-terms.md
+++ b/docs/debt/debt-414-public-legal-pages-privacy-terms.md
@@ -357,7 +357,7 @@ Only after the deployed pages return signed-out 200:
 - [ ] SHIELD security and incident programs are adopted and evidence-backed.
 - [x] Stripe legal links are set only after deployment. **Owner-reported done 2026-08-05** — both URLs set in live Public details after production signed-out 200s; support email set to the published `support@addictionboards.com`. Current test-mode Session creation succeeds without any separately observed test-mode setup; the shared-settings-versus-skipped-enforcement mechanism is unresolved (see § 5).
 - [x] **Shortened statement descriptor is 2–10 characters and suffix-compatible.** The settled owner record is corroborated, not replaced, by the 2026-08-06 test-mode Account API: full descriptor `ADDICTIONBOARDS.COM`; separate shortened prefix `ADDICTION` (9 characters). The prior reopening confused the full and shortened fields.
-- [x] Full quality gate passes before push (2026-08-07 second corrective promo-review head: typecheck; lint with the accepted 24-warning baseline; 3,809 unit; 398 browser; 241 integration passed plus 2 skipped; 23-page build; 38 E2E).
+- [x] Full quality gate passes before push (2026-08-07 third corrective promo-review head: typecheck; lint with the accepted 24-warning baseline; 3,812 unit; 398 browser; 241 integration passed plus 2 skipped; 23-page build; 38 E2E).
 - [ ] CodeRabbit reviews the exact final pushed head before merge is requested.
 
 ## Stage 1 adversarial review record (2026-08-05)

--- a/src/adapters/controllers/stripe-webhook-controller.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.test.ts
@@ -29,6 +29,12 @@ class FailingStripeEventRepository extends FakeStripeEventRepository {
   }
 }
 
+class MarkProcessedFailingStripeEventRepository extends FakeStripeEventRepository {
+  override async markProcessed(): Promise<never> {
+    throw new Error('mark processed failed');
+  }
+}
+
 class FailingSubscriptionRepository extends FakeSubscriptionRepository {
   override async upsert(): Promise<never> {
     throw new Error('boom');
@@ -113,6 +119,14 @@ function createDeps(overrides: {
   logger: FakeLogger;
   setupOperations: FakeTrialPaymentMethodSetupOperationRepository;
   renewalConsents: FakeRenewalConsentRecordRepository;
+  renewalNoticeDeliveries: ReturnType<
+    ReturnType<
+      typeof createStripeWebhookRenewalAcknowledgmentTestDeps
+    >['createRenewalNoticeDeliveries']
+  >;
+  acknowledgment: ReturnType<
+    typeof createStripeWebhookRenewalAcknowledgmentTestDeps
+  >;
 } {
   const stripeEvents =
     overrides.stripeEvents ?? new FakeStripeEventRepository();
@@ -151,6 +165,8 @@ function createDeps(overrides: {
     logger,
     setupOperations,
     renewalConsents,
+    renewalNoticeDeliveries: acknowledgment.renewalNoticeDeliveries,
+    acknowledgment,
   };
 }
 
@@ -171,6 +187,14 @@ function createRollbackAwareDeps(overrides: {
   logger: FakeLogger;
   setupOperations: FakeTrialPaymentMethodSetupOperationRepository;
   renewalConsents: FakeRenewalConsentRecordRepository;
+  renewalNoticeDeliveries: ReturnType<
+    ReturnType<
+      typeof createStripeWebhookRenewalAcknowledgmentTestDeps
+    >['createRenewalNoticeDeliveries']
+  >;
+  acknowledgment: ReturnType<
+    typeof createStripeWebhookRenewalAcknowledgmentTestDeps
+  >;
 } {
   const base = createDeps(overrides);
 
@@ -195,12 +219,17 @@ function createRollbackAwareDeps(overrides: {
         const stagingStripeCustomers = new StripeCustomersCtor();
         const stagingSetupOperations = new SetupOperationsCtor();
         const stagingRenewalConsents = new RenewalConsentsCtor();
+        const stagingRenewalNoticeDeliveries =
+          base.acknowledgment.createRenewalNoticeDeliveries();
 
         stagingEvents.restore(base.stripeEvents.snapshot());
         stagingSubscriptions.restore(base.subscriptions.snapshot());
         stagingStripeCustomers.restore(base.stripeCustomers.snapshot());
         stagingSetupOperations.restore(base.setupOperations.snapshot());
         stagingRenewalConsents.restore(base.renewalConsents.snapshot());
+        stagingRenewalNoticeDeliveries.restore(
+          base.renewalNoticeDeliveries.snapshot(),
+        );
 
         const result = await fn({
           stripeEvents: stagingEvents,
@@ -208,7 +237,8 @@ function createRollbackAwareDeps(overrides: {
           stripeCustomers: stagingStripeCustomers,
           trialPaymentMethodSetupOperations: stagingSetupOperations,
           renewalConsentRecords: stagingRenewalConsents,
-          ...createStripeWebhookRenewalAcknowledgmentTestDeps().transaction,
+          renewalNoticeDeliveries: stagingRenewalNoticeDeliveries,
+          users: base.acknowledgment.transaction.users,
         });
 
         base.stripeEvents.restore(stagingEvents.snapshot());
@@ -216,6 +246,9 @@ function createRollbackAwareDeps(overrides: {
         base.stripeCustomers.restore(stagingStripeCustomers.snapshot());
         base.setupOperations.restore(stagingSetupOperations.snapshot());
         base.renewalConsents.restore(stagingRenewalConsents.snapshot());
+        base.renewalNoticeDeliveries.restore(
+          stagingRenewalNoticeDeliveries.snapshot(),
+        );
 
         return result;
       },
@@ -351,7 +384,8 @@ describe('processStripeWebhook', () => {
         },
       },
     });
-    const { deps, renewalConsents } = createDeps({ paymentGateway });
+    const { deps, renewalConsents, renewalNoticeDeliveries } =
+      createRollbackAwareDeps({ paymentGateway });
 
     await processStripeWebhook(deps, { rawBody: 'raw', signature: 'sig' });
 
@@ -366,6 +400,63 @@ describe('processStripeWebhook', () => {
         acceptedAt,
       }),
     ]);
+    expect(renewalNoticeDeliveries.records).toEqual([
+      expect.objectContaining({
+        noticeKind: 'acknowledgment',
+        consentRecordId: renewalConsents.snapshot()[0]?.id,
+        status: 'queued',
+        createdAt: new Date('2026-08-07T12:00:00.000Z'),
+      }),
+    ]);
+  });
+
+  it('rolls back the acknowledgment row when the webhook transaction fails after queueing', async () => {
+    const userId = crypto.randomUUID();
+    const paymentGateway = new FakePaymentGateway({
+      externalCustomerId: 'cus_123',
+      checkoutUrl: 'https://stripe/checkout',
+      portalUrl: 'https://stripe/portal',
+      webhookResult: {
+        eventId: 'evt_checkout_ack_rollback',
+        type: 'checkout.session.completed',
+        subscriptionUpdate: {
+          userId,
+          externalCustomerId: 'cus_123',
+          externalSubscriptionId: 'sub_123',
+          plan: 'monthly',
+          status: 'active',
+          currentPeriodEnd: new Date('2026-09-06T12:00:00Z'),
+          cancelAtPeriodEnd: false,
+        },
+        initialSubscriptionConsent: {
+          checkoutSessionId: 'cs_checkout_ack_rollback',
+          userId,
+          externalCustomerId: 'cus_123',
+          externalSubscriptionId: 'sub_123',
+          plan: 'monthly',
+          amountCents: 2900,
+          currency: 'usd',
+          frequency: 'month',
+          disclosureSnapshot: 'Exact immediate disclosure.',
+          disclosureVersion: '2026-08-05',
+          termsVersion: '2026-08-05',
+          termsHash: 'terms-hash',
+          cancellationMethod:
+            'Billing page in the app or support@addictionboards.com',
+          acceptedAt: new Date('2026-08-06T12:00:00Z'),
+        },
+      },
+    });
+    const stripeEvents = new MarkProcessedFailingStripeEventRepository();
+    const { deps, renewalConsents, renewalNoticeDeliveries } =
+      createRollbackAwareDeps({ paymentGateway, stripeEvents });
+
+    await expect(
+      processStripeWebhook(deps, { rawBody: 'raw', signature: 'sig' }),
+    ).rejects.toThrow('mark processed failed');
+
+    expect(renewalConsents.snapshot()).toEqual([]);
+    expect(renewalNoticeDeliveries.records).toEqual([]);
   });
 
   it('does not persist consent when the subscription write guard rejects the update', async () => {

--- a/src/adapters/controllers/test-helpers/stripe-webhook-renewal-acknowledgment.ts
+++ b/src/adapters/controllers/test-helpers/stripe-webhook-renewal-acknowledgment.ts
@@ -11,6 +11,8 @@ export function createStripeWebhookRenewalAcknowledgmentTestDeps(input?: {
   findUserById?: StripeWebhookTransaction['users']['findById'];
   dispatchRenewalNoticeDelivery?: StripeWebhookDeps['dispatchRenewalNoticeDelivery'];
 }): {
+  createRenewalNoticeDeliveries: () => FakeRenewalNoticeDeliveryRepository;
+  renewalNoticeDeliveries: FakeRenewalNoticeDeliveryRepository;
   webhook: Pick<
     StripeWebhookDeps,
     'appUrl' | 'sha256Hasher' | 'dispatchRenewalNoticeDelivery'
@@ -21,7 +23,15 @@ export function createStripeWebhookRenewalAcknowledgmentTestDeps(input?: {
   >;
 } {
   const sha256Hasher = new FakeSha256Hasher();
+  const createRenewalNoticeDeliveries = () =>
+    new FakeRenewalNoticeDeliveryRepository(
+      () => new Date('2026-08-07T12:00:00.000Z'),
+      sha256Hasher,
+    );
+  const renewalNoticeDeliveries = createRenewalNoticeDeliveries();
   return {
+    createRenewalNoticeDeliveries,
+    renewalNoticeDeliveries,
     webhook: {
       appUrl: 'https://addictionboards.com',
       sha256Hasher,
@@ -30,10 +40,7 @@ export function createStripeWebhookRenewalAcknowledgmentTestDeps(input?: {
       },
     },
     transaction: {
-      renewalNoticeDeliveries: new FakeRenewalNoticeDeliveryRepository(
-        () => new Date('2026-08-07T12:00:00.000Z'),
-        sha256Hasher,
-      ),
+      renewalNoticeDeliveries,
       users: {
         findById:
           input?.findUserById ??

--- a/src/application/shared/renewal-notice-email-format.test.ts
+++ b/src/application/shared/renewal-notice-email-format.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  escapeRenewalNoticeHtml,
+  formatRenewalNoticeDate,
+  RENEWAL_NOTICE_BUSINESS_CONTACT,
+  RENEWAL_NOTICE_FROM,
+  RENEWAL_NOTICE_REPLY_TO,
+} from './renewal-notice-email-format';
+
+describe('renewal notice email format', () => {
+  it('pins sender identity, statutory contact copy, UTC dates, and HTML escaping', () => {
+    expect(RENEWAL_NOTICE_FROM).toBe(
+      'Addiction Boards <notices@addictionboards.com>',
+    );
+    expect(RENEWAL_NOTICE_REPLY_TO).toBe('support@addictionboards.com');
+    expect(RENEWAL_NOTICE_BUSINESS_CONTACT).toBe(
+      'John H. Jung, MD, MS, sole proprietor — support@addictionboards.com',
+    );
+    expect(formatRenewalNoticeDate(new Date('2026-08-07T23:30:00-04:00'))).toBe(
+      'August 8, 2026',
+    );
+    expect(escapeRenewalNoticeHtml(`<&>"'`)).toBe('&lt;&amp;&gt;&quot;&#39;');
+  });
+});

--- a/src/application/shared/renewal-notice-email-format.test.ts
+++ b/src/application/shared/renewal-notice-email-format.test.ts
@@ -8,17 +8,29 @@ import {
 } from './renewal-notice-email-format';
 
 describe('renewal notice email format', () => {
-  it('pins sender identity, statutory contact copy, UTC dates, and HTML escaping', () => {
+  it('pins the sender identity', () => {
     expect(RENEWAL_NOTICE_FROM).toBe(
       'Addiction Boards <notices@addictionboards.com>',
     );
+  });
+
+  it('pins the reply-to address', () => {
     expect(RENEWAL_NOTICE_REPLY_TO).toBe('support@addictionboards.com');
+  });
+
+  it('pins the statutory business contact copy', () => {
     expect(RENEWAL_NOTICE_BUSINESS_CONTACT).toBe(
       'John H. Jung, MD, MS, sole proprietor — support@addictionboards.com',
     );
+  });
+
+  it('formats dates in UTC', () => {
     expect(formatRenewalNoticeDate(new Date('2026-08-07T23:30:00-04:00'))).toBe(
       'August 8, 2026',
     );
+  });
+
+  it('escapes HTML-significant characters', () => {
     expect(escapeRenewalNoticeHtml(`<&>"'`)).toBe('&lt;&amp;&gt;&quot;&#39;');
   });
 });

--- a/src/application/shared/renewal-notice-email-format.ts
+++ b/src/application/shared/renewal-notice-email-format.ts
@@ -1,0 +1,21 @@
+export const RENEWAL_NOTICE_FROM =
+  'Addiction Boards <notices@addictionboards.com>';
+export const RENEWAL_NOTICE_REPLY_TO = 'support@addictionboards.com';
+export const RENEWAL_NOTICE_BUSINESS_CONTACT =
+  'John H. Jung, MD, MS, sole proprietor — support@addictionboards.com';
+
+export function escapeRenewalNoticeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+export function formatRenewalNoticeDate(value: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'long',
+    timeZone: 'UTC',
+  }).format(value);
+}

--- a/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.test.ts
@@ -96,6 +96,29 @@ describe('FakeRenewalNoticeDeliveryRepository', () => {
     });
   });
 
+  it('restores a transaction snapshot without retaining later writes', async () => {
+    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+    await repository.saveQueued(createDelivery());
+    const snapshot = repository.snapshot();
+    const secondId = '33333333-3333-4333-8333-333333333333';
+    await repository.saveQueued(
+      createDelivery({
+        id: secondId,
+        consentRecordId: '44444444-4444-4444-8444-444444444444',
+        providerIdempotencyKey:
+          getRenewalNoticeProviderIdempotencyKey(secondId),
+      }),
+    );
+
+    repository.restore(snapshot);
+
+    expect(repository.records.map((record) => record.id)).toEqual([deliveryId]);
+    const snapshotRecord = snapshot[0];
+    if (!snapshotRecord) throw new Error('expected snapshot record');
+    snapshotRecord.status = 'terminal_failure';
+    expect(repository.records[0]?.status).toBe('queued');
+  });
+
   it('rejects a non-derived provider key and a changed payload hash before persistence', async () => {
     const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
 

--- a/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.ts
+++ b/src/application/test-helpers/fakes/fake-renewal-notice-delivery-repository.ts
@@ -59,6 +59,14 @@ export class FakeRenewalNoticeDeliveryRepository
     private readonly hasher = new FakeSha256Hasher(),
   ) {}
 
+  snapshot(): RenewalNoticeDelivery[] {
+    return this.records.map(cloneDelivery);
+  }
+
+  restore(snapshot: readonly RenewalNoticeDelivery[]): void {
+    this.records.splice(0, this.records.length, ...snapshot.map(cloneDelivery));
+  }
+
   async saveQueued(
     input: NewRenewalNoticeDelivery,
   ): Promise<RenewalNoticeDelivery> {

--- a/src/application/use-cases/send-due-renewal-notices.test.ts
+++ b/src/application/use-cases/send-due-renewal-notices.test.ts
@@ -154,16 +154,21 @@ describe('SendDueRenewalNoticesUseCase', () => {
     });
 
     expect(repository.records).toHaveLength(2);
-    for (const row of repository.records) {
-      const payload = parseTransactionalEmailPayloadSnapshot(
+    const payloads = repository.records.map((row) =>
+      parseTransactionalEmailPayloadSnapshot(
         {
           snapshot: row.payloadSnapshot,
           hash: row.payloadHash,
           destination: row.destination,
         },
         hasher,
-      );
-      expect(payload.text).toContain('Material change effective');
+      ),
+    );
+    expect(payloads[0]?.text).toContain('Material change effective');
+    expect(payloads[0]?.text).not.toContain('Fee change effective');
+    expect(payloads[1]?.text).toContain('Fee change effective');
+    expect(payloads[1]?.text).not.toContain('Material change effective');
+    for (const payload of payloads) {
       expect(payload.text).toContain('Billing page in the app');
       expect(payload.text).toContain('support@addictionboards.com');
     }

--- a/src/application/use-cases/send-due-renewal-notices.ts
+++ b/src/application/use-cases/send-due-renewal-notices.ts
@@ -5,16 +5,19 @@ import type {
   TransactionalEmailPayload,
 } from '@/src/application/ports';
 import {
+  escapeRenewalNoticeHtml,
+  formatRenewalNoticeDate,
+  RENEWAL_NOTICE_BUSINESS_CONTACT,
+  RENEWAL_NOTICE_FROM,
+  RENEWAL_NOTICE_REPLY_TO,
+} from '@/src/application/shared/renewal-notice-email-format';
+import {
   createTransactionalEmailPayloadSnapshot,
   getRenewalNoticeProviderIdempotencyKey,
 } from '@/src/application/shared/transactional-email-payload';
 import type { RenewalNoticeKind } from '@/src/domain/entities';
 import type { DispatchRenewalNoticeDeliveryUseCase } from './dispatch-renewal-notice-delivery';
 
-const FROM = 'Addiction Boards <notices@addictionboards.com>';
-const REPLY_TO = 'support@addictionboards.com';
-const BUSINESS_CONTACT =
-  'John H. Jung, MD, MS, sole proprietor — support@addictionboards.com';
 const PROCESSING_CLAIM_STALE_AFTER_MS = 15 * 60 * 1000;
 const MAX_BATCH_LIMIT = 500;
 const DISPATCH_CONCURRENCY = 4;
@@ -40,22 +43,6 @@ export type SendDueRenewalNoticesResult = {
   staleUnknown: number;
   dispatchFailures: number;
 };
-
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
-}
-
-function formatDate(value: Date): string {
-  return new Intl.DateTimeFormat('en-US', {
-    dateStyle: 'long',
-    timeZone: 'UTC',
-  }).format(value);
-}
 
 function formatAmount(notice: ScheduledRenewalNotice): string {
   return `$${(notice.amountCents / 100).toFixed(2)} ${notice.currency.toUpperCase()} every ${notice.frequency}`;
@@ -85,28 +72,30 @@ function createPayload(
     notice.noticeKind === 'material_change' ||
     notice.noticeKind === 'fee_change'
       ? [
-          `Material change effective: ${formatDate(notice.applicableAt)}.`,
+          `${notice.noticeKind === 'fee_change' ? 'Fee change' : 'Material change'} effective: ${formatRenewalNoticeDate(notice.applicableAt)}.`,
           `Change: ${notice.changeDescription ?? ''}`,
         ]
       : [
-          `Renewal date: ${formatDate(notice.applicableAt)}.`,
+          `Renewal date: ${formatRenewalNoticeDate(notice.applicableAt)}.`,
           `Renewal amount and frequency: ${formatAmount(notice)}.`,
         ];
   const lines = [
     `${heading} for ${notice.planName}.`,
     ...detail,
     `How to cancel before the applicable date: ${notice.cancellationMethod}`,
-    `Business contact: ${BUSINESS_CONTACT}.`,
+    `Business contact: ${RENEWAL_NOTICE_BUSINESS_CONTACT}.`,
     `Terms: ${termsUrl}`,
     `Privacy: ${privacyUrl}`,
   ];
   const text = lines.join('\n');
-  const html = lines.map((line) => `<p>${escapeHtml(line)}</p>`).join('');
+  const html = lines
+    .map((line) => `<p>${escapeRenewalNoticeHtml(line)}</p>`)
+    .join('');
 
   return {
-    from: FROM,
+    from: RENEWAL_NOTICE_FROM,
     to: notice.destination,
-    replyTo: REPLY_TO,
+    replyTo: RENEWAL_NOTICE_REPLY_TO,
     subject: `Addiction Boards — ${heading}`,
     html,
     text,

--- a/src/application/use-cases/send-renewal-acknowledgment.ts
+++ b/src/application/use-cases/send-renewal-acknowledgment.ts
@@ -5,6 +5,13 @@ import type {
   TransactionalEmailPayload,
 } from '@/src/application/ports';
 import {
+  escapeRenewalNoticeHtml,
+  formatRenewalNoticeDate,
+  RENEWAL_NOTICE_BUSINESS_CONTACT,
+  RENEWAL_NOTICE_FROM,
+  RENEWAL_NOTICE_REPLY_TO,
+} from '@/src/application/shared/renewal-notice-email-format';
+import {
   createTransactionalEmailPayloadSnapshot,
   getRenewalNoticeProviderIdempotencyKey,
 } from '@/src/application/shared/transactional-email-payload';
@@ -13,31 +20,10 @@ import type {
   RenewalNoticeDelivery,
 } from '@/src/domain/entities';
 
-const FROM = 'Addiction Boards <notices@addictionboards.com>';
-const REPLY_TO = 'support@addictionboards.com';
-const BUSINESS_CONTACT =
-  'John H. Jung, MD, MS, sole proprietor — support@addictionboards.com';
-
-function formatDate(value: Date): string {
-  return new Intl.DateTimeFormat('en-US', {
-    dateStyle: 'long',
-    timeZone: 'UTC',
-  }).format(value);
-}
-
 function formatAmount(consent: RenewalConsentRecord): string {
   const amount = `$${(consent.amountCents / 100).toFixed(2)}`;
   const interval = consent.frequency === 'month' ? 'month' : 'year';
   return `${amount} ${consent.currency.toUpperCase()} every ${interval}`;
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
 }
 
 function createPayload(input: {
@@ -49,7 +35,7 @@ function createPayload(input: {
   const termsUrl = new URL('/terms', input.appUrl).toString();
   const privacyUrl = new URL('/privacy', input.appUrl).toString();
   const trial = consent.trialEndsAt
-    ? `Trial ends: ${formatDate(consent.trialEndsAt)}.`
+    ? `Trial ends: ${formatRenewalNoticeDate(consent.trialEndsAt)}.`
     : 'No introductory trial was recorded.';
   const lines = [
     'Thank you for confirming your Addiction Boards subscription terms.',
@@ -57,23 +43,25 @@ function createPayload(input: {
     `Accepted renewal terms: ${consent.disclosureSnapshot}`,
     `Price and frequency: ${formatAmount(consent)}.`,
     trial,
-    `Cancellation deadline: ${formatDate(consent.cancellationDeadline)}.`,
+    `Cancellation deadline: ${formatRenewalNoticeDate(consent.cancellationDeadline)}.`,
     `How to cancel: ${consent.cancellationMethod}`,
     `Accepted: ${consent.acceptedAt.toISOString()}.`,
     `Terms version: ${consent.termsVersion}.`,
-    `Business contact: ${BUSINESS_CONTACT}.`,
+    `Business contact: ${RENEWAL_NOTICE_BUSINESS_CONTACT}.`,
     `Terms: ${termsUrl}`,
     `Privacy: ${privacyUrl}`,
   ];
   const text = lines.join('\n');
   const html = lines
-    .map((line) => (line.length === 0 ? '<br>' : `<p>${escapeHtml(line)}</p>`))
+    .map((line) =>
+      line.length === 0 ? '<br>' : `<p>${escapeRenewalNoticeHtml(line)}</p>`,
+    )
     .join('');
 
   return {
-    from: FROM,
+    from: RENEWAL_NOTICE_FROM,
     to: input.destination,
-    replyTo: REPLY_TO,
+    replyTo: RENEWAL_NOTICE_REPLY_TO,
     subject: 'Your Addiction Boards subscription terms',
     html,
     text,

--- a/tests/integration/stripe-webhook-renewal-acknowledgment.integration.test.ts
+++ b/tests/integration/stripe-webhook-renewal-acknowledgment.integration.test.ts
@@ -18,6 +18,7 @@ import { DrizzleStripeEventRepository } from '@/src/adapters/repositories/drizzl
 import { DrizzleSubscriptionRepository } from '@/src/adapters/repositories/drizzle-subscription-repository';
 import { DrizzleTrialPaymentMethodSetupOperationRepository } from '@/src/adapters/repositories/drizzle-trial-payment-method-setup-operation-repository';
 import { DrizzleUserRepository } from '@/src/adapters/repositories/drizzle-user-repository';
+import { getRenewalNoticeProviderIdempotencyKey } from '@/src/application/shared/transactional-email-payload';
 import {
   FakeLogger,
   FakePaymentGateway,
@@ -186,18 +187,27 @@ describe('Stripe renewal acknowledgment transaction', () => {
     expect(consents).toHaveLength(1);
     const consent = consents[0];
     if (!consent) throw new Error('expected consent');
-    await expect(
-      db
-        .select()
-        .from(renewalNoticeDeliveries)
-        .where(eq(renewalNoticeDeliveries.consentRecordId, consent.id)),
-    ).resolves.toEqual([
+    const deliveries = await db
+      .select()
+      .from(renewalNoticeDeliveries)
+      .where(eq(renewalNoticeDeliveries.consentRecordId, consent.id));
+    expect(deliveries).toEqual([
       expect.objectContaining({
         noticeKind: 'acknowledgment',
         destination: user.email,
         status: 'queued',
+        disclosureVersion: consent.disclosureVersion,
       }),
     ]);
+    const delivery = deliveries[0];
+    if (!delivery) throw new Error('expected acknowledgment delivery');
+    expect(delivery.payloadSnapshot).not.toBe('');
+    expect(delivery.payloadHash).toBe(
+      new NobleSha256Hasher().hash(delivery.payloadSnapshot),
+    );
+    expect(delivery.providerIdempotencyKey).toBe(
+      getRenewalNoticeProviderIdempotencyKey(delivery.id),
+    );
   });
 
   it('rolls back consent when the acknowledgment row cannot be persisted', async () => {


### PR DESCRIPTION
## Summary
- fix `fee_change` notice copy to say `Fee change effective` while preserving the material-change label
- make the rollback-aware Stripe webhook harness stage, commit, and roll back renewal-notice deliveries with the same pinned clock/hasher as the base harness
- centralize renewal-email sender/contact/date/escaping values under one application shared module
- assert all persisted acknowledgment evidence columns through the real Drizzle repository

## Adversarial dispositions from promo #747 review 4882161429
- Fixed the real harness defect, but did **not** use the suggested base-repository delegate: mutation testing proved that approach leaks an acknowledgment row from a thrown transaction.
- Fixed the real fee-label mismatch.
- Accepted the DRY finding because sender identity and statutory contact copy are binding single-source concepts in `AGENTS.md`.
- Accepted the evidence assertion as a non-production test-strengthening change.
- Rejected the prototype-delegate refactor: the existing explicit bound object is complete and typechecked; this was maintenance preference, not a defect.
- Rejected raw physical names in the atomic SQL `SET` clause: existing integration tests exercise the statement, schema renames already require migration/SQL review, and changing composition adds no current correctness invariant.

## TDD and self-audit
- Red: 3 targeted failures for fee labeling, missing fake snapshot support, and the discarded committed acknowledgment row.
- Added a post-queue transaction-failure test. Mutation-routing the transaction to the base repository failed exactly on the leaked row; restored staging then passed.
- Added a pinned-clock assertion; it caught the first staging implementation losing the helper clock before the factory seam was corrected.
- No published legal copy, production provider settings, price-change machinery, or production system was changed.

## Full local gate on exact head `1dccde8e737af5be39350177e7a2336ebed896f8`
- `pnpm typecheck`: pass
- `pnpm lint`: pass, accepted 24-warning baseline
- unit: 435 files / 3,812 tests
- browser: 64 files / 398 tests
- integration: 38 passed + 1 skipped files; 241 passed + 2 skipped tests
- build: 23 pages/routes
- E2E: first run exited zero with 37 passed + 1 flaky (`session-continuation`, passed retry); full unchanged rerun clean 38/38
- isolated test DB torn down only after all suites completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Standardized renewal-notice emails with consistent sender details, reply-to information, business contact text, UTC dates, and safe HTML handling.
  - Renewal acknowledgment records now retain consent-version, payload, hash, and delivery-key details for improved traceability.

- **Bug Fixes**
  - Renewal notices now keep change-specific instructions correctly matched to each notice.

- **Tests**
  - Expanded coverage for email formatting, webhook transaction rollback, acknowledgment delivery, and delivery-record restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->