### PR TITLE
Update security dependency overrides

### DIFF
--- a/docs/dev/supply-chain-overrides.md
+++ b/docs/dev/supply-chain-overrides.md
@@ -92,6 +92,9 @@ out. There are no current package-wide bootstrap exceptions.
 
 ### Worked example: js-yaml CVE-2026-53550 (2026-06-29)
 
+> Historical snapshot: alert #46 later retargeted the patched v3 floor to
+> `3.15.1`; the live override now uses `3.15.1`, not the `3.15.0` shown below.
+
 Dependabot alert #13 flagged `js-yaml` (medium): CVE-2026-53550 /
 GHSA-h67p-54hq-rp68, a quadratic-complexity denial-of-service in merge-key
 handling via repeated aliases, affecting `< 3.15.0`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,14 +5,17 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  postcss: 8.5.15
+  postcss: 8.5.23
   uuid: 14.0.0
   esbuild: '>=0.28.1'
-  undici: 7.28.0
+  undici: 7.29.0
   '@opentelemetry/core': 2.8.0
   '@opentelemetry/resources': 2.8.0
   '@opentelemetry/sdk-trace-base': 2.8.0
-  js-yaml: 3.15.0
+  js-yaml: 3.15.1
+  brace-expansion@5: 5.0.9
+  brace-expansion@1: 1.1.18
+  fast-uri: 3.1.5
   sharp: 0.35.3
 
 importers:
@@ -4277,8 +4280,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
   jsc-safe-url@0.2.4:
@@ -5001,8 +5004,8 @@ packages:
   postal-mime@2.7.5:
     resolution: {integrity: sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres@3.4.9:
@@ -5619,8 +5622,8 @@ packages:
   undici-types@8.9.0:
     resolution: {integrity: sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -6664,7 +6667,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -8776,7 +8779,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
-      postcss: 8.5.15
+      postcss: 8.5.23
       tailwindcss: 4.3.3
 
   '@tanstack/query-core@5.101.4': {}
@@ -9819,7 +9822,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -10132,7 +10135,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -10156,7 +10159,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -10935,7 +10938,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.9
       caniuse-lite: 1.0.30001806
-      postcss: 8.5.15
+      postcss: 8.5.23
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.8)
@@ -11100,7 +11103,7 @@ snapshots:
 
   postal-mime@2.7.5: {}
 
-  postcss@8.5.15:
+  postcss@8.5.23:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -11824,7 +11827,7 @@ snapshots:
 
   undici-types@8.9.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -11905,7 +11908,7 @@ snapshots:
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.15
+      postcss: 8.5.23
       rolldown: 1.2.1
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,14 +3,23 @@ minimumReleaseAgeStrict: true # v11-only: fail when no version satisfies the 7-d
 minimumReleaseAgeIgnoreMissingTime: false # v11-only: fail when registry metadata lacks package publish time.
 blockExoticSubdeps: true
 overrides:
-  postcss: 8.5.15
+  # Security: GHSA-r28c-9q8g-f849 + GHSA-fxqj-rqcc-2cmp — crafted
+  # sourceMappingURL paths could disclose arbitrary .map files, including when
+  # PostCSS has no `from` value. Build-only via Next/Tailwind/Vite over trusted
+  # repo CSS, so defense-in-depth. 8.5.23 satisfies Tailwind's ^8.5.16 and
+  # Vite's ^8.5.23; Next pins 8.4.31 exactly, so this existing override remains
+  # intentionally out-of-range but within PostCSS 8. Aged past the 7-day gate
+  # as of 2026-08-07 (published 2026-07-24).
+  postcss: 8.5.23
   uuid: 14.0.0
   esbuild: '>=0.28.1'
-  # Security: 6 advisories (high→low) — SOCKS5 cross-origin routing & TLS-validation
-  # bypass, Set-Cookie header injection / SameSite downgrade, shared-cache disclosure,
-  # keep-alive response-queue poisoning. All dev-scoped via jsdom/vitest. Patched in
-  # undici 7.28.0 (aged past the 7-day release gate ~2026-06-22; no age exception needed).
-  undici: 7.28.0
+  # Security: GHSA-8xcm-r25x-g524, GHSA-4cwx-7wf7-3272,
+  # GHSA-jr45-8vmc-qm54, GHSA-v3r7-h72x-cjcm, and GHSA-m8rv-5g2x-5cg5 —
+  # response-desync, cache disclosure/crash, cookie-attribute injection, and
+  # CRLF-injection flaws. Dev-scoped via jsdom/vitest, so defense-in-depth.
+  # 7.29.0 satisfies jsdom's ^7.25.0. Aged past the 7-day gate as of 2026-08-07
+  # (published 2026-07-24).
+  undici: 7.29.0
   # Security: GHSA-8988-4f7v-96qf — W3CBaggagePropagator.extract() lacked inbound
   # size caps (unbounded allocation). Patched in OTel 2.8.0. Pinned exact to keep the
   # lockstep trio (core/resources/sdk-trace-base pin each other exactly) coherent;
@@ -18,15 +27,32 @@ overrides:
   '@opentelemetry/core': 2.8.0
   '@opentelemetry/resources': 2.8.0
   '@opentelemetry/sdk-trace-base': 2.8.0
-  # Security: GHSA-h67p-54hq-rp68 / CVE-2026-53550 — quadratic-complexity DoS in js-yaml
-  # merge-key handling via repeated aliases (affected < 3.15.0). Patched in the 3.15.0
-  # v3-legacy backport. js-yaml is transitive-only — gray-matter (seed/build scripts over
-  # first-party markdown) and @clerk/ui's react-native test tooling — with no runtime
-  # attacker-controlled YAML path, so this is defense-in-depth. 3.15.0 satisfies both
-  # consumers' ^3.13.1; it's an upgrade (no-downgrade safe). Aged past the 7-day
-  # release gate ~2026-07-03; the temporary minimumReleaseAgeExclude entry was
-  # removed once it aged in (#539).
-  js-yaml: 3.15.0
+  # Security: GHSA-h67p-54hq-rp68 + GHSA-5p4m-2wfm-xmqj — repeated aliases
+  # and !!omap compact mappings could trigger quadratic CPU use. Transitive via
+  # gray-matter and Clerk test tooling over first-party YAML/Markdown only, so
+  # defense-in-depth. Alert #46 retargeted the v3 backport from 3.15.0 to 3.15.1,
+  # which satisfies both consumers' ^3.13.1. Aged past the 7-day gate as of
+  # 2026-08-07 (published 2026-07-31).
+  js-yaml: 3.15.1
+  # Security: GHSA-mh99-v99m-4gvg + GHSA-rgw5-rvv9-x895 — unbounded brace
+  # expansion could allocate oversized intermediate arrays and exhaust memory.
+  # Build/test globs are repository-controlled. Scoped to minimatch@10's 5.x
+  # line; 5.0.9 satisfies ^5.0.8. Aged past the 7-day gate as of 2026-08-07
+  # (published 2026-07-30).
+  'brace-expansion@5': 5.0.9
+  # Security: GHSA-mh99-v99m-4gvg + GHSA-rgw5-rvv9-x895 — the same unbounded
+  # expansion flaws affect minimatch@3's independent 1.x dependency line.
+  # Build/test globs are repository-controlled. 1.1.18 satisfies ^1.1.7 and is
+  # deliberately scoped away from the 5.x override. Aged past the 7-day gate as
+  # of 2026-08-07 (published 2026-07-30).
+  'brace-expansion@1': 1.1.18
+  # Security: GHSA-v2hh-gcrm-f6hx + GHSA-7p8r-x3mc-p8w7 — literal backslashes
+  # could confuse host/authority parsing relative to WHATWG URL semantics.
+  # Transitive through ajv under Sentry's webpack path; this Turbopack build does
+  # not execute that path, so defense-in-depth (issue #703). Alert #40 retargeted
+  # 3.1.4 to 3.1.5, which satisfies ajv's ^3.0.1. Aged past the 7-day gate as of
+  # 2026-08-07 (published 2026-07-31).
+  fast-uri: 3.1.5
   # Security: GHSA-f88m-g3jw-g9cj — sharp < 0.35.0 bundles a libvips affected by
   # four inherited CVEs (memory-safety on untrusted image input): CVE-2026-33327
   # (VIPS dimension overflow), CVE-2026-33328 (GIF integer overflow, 32-bit),


### PR DESCRIPTION
## Summary

- update the six security override targets that cover the remaining 14 Dependabot alerts after the runtime/tooling wave
- scope both `brace-expansion` overrides to their independent major lines
- retain the issue #703 reachability rationale while retargeting `fast-uri` to the current patched floor

Closes #703

## Alert coverage

- `postcss@8.5.23`: #33, #45
- `undici@7.29.0`: #34–#38
- `js-yaml@3.15.1`: #46
- `brace-expansion@5.0.9`: #32, #39
- `brace-expansion@1.1.18`: #43, #44
- `fast-uri@3.1.5`: #15, #40

## Natural-age evidence

| Target | npm publish timestamp |
| --- | --- |
| `postcss@8.5.23` | `2026-07-24T17:05:13.876Z` |
| `undici@7.29.0` | `2026-07-24T12:52:58.701Z` |
| `js-yaml@3.15.1` | `2026-07-31T17:48:53.128Z` |
| `brace-expansion@5.0.9` | `2026-07-30T10:00:32.762Z` |
| `brace-expansion@1.1.18` | `2026-07-30T10:17:06.961Z` |
| `fast-uri@3.1.5` | `2026-07-31T09:16:56.212Z` |

All targets had naturally aged past the repository's strict seven-day gate on 2026-08-07. No `minimumReleaseAgeExclude` was added.

## Lockfile proof

A fresh `pnpm install` moved only `postcss` 8.5.15→8.5.23, `undici` 7.28.0→7.29.0, and `js-yaml` 3.15.0→3.15.1. The PR-A lock refresh had already selected secure `brace-expansion` 5.0.9 and 1.1.18 and `fast-uri` 3.1.5; this PR adds explicit, major-scoped pins without moving any unrelated lock entries.

Cold validation passed after removing the worktree's complete `node_modules` tree and running `pnpm install --frozen-lockfile` from an empty install state.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test --run` — 435 files / 3,821 tests
- `pnpm test:browser` — 64 files / 398 tests
- `pnpm test:integration` — 38 passed files, 1 skipped / 243 passed tests, 2 skipped
- `pnpm build`
- `pnpm test:e2e` — 37 passed, 1 flaky (transient Clerk redirect recovered on built-in retry; command exited green)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions and package resolutions.
  * Applied security-related updates to improve dependency maintenance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->