### PR TITLE
Upgrade Biome to 2.5.6

### DIFF
--- a/app/(app)/app/shared/idempotency-request-identity.test.ts
+++ b/app/(app)/app/shared/idempotency-request-identity.test.ts
@@ -235,50 +235,53 @@ describe.each([
   ['Quick Practice submit', submitQuickPracticeSurface],
   ['practice-session submit', createPracticeSessionSurface(sessionAId)],
   ['standalone question-page submit', createStandaloneSurface()],
-] as const)('%s request identity across the real idempotency wrapper', (_, surface) => {
-  it('replays a same-choice lost response and retires the consumed key', async () => {
-    const server = createSubmitServer();
-    const tokenCell: TokenCell = { current: null };
+] as const)(
+  '%s request identity across the real idempotency wrapper',
+  (_, surface) => {
+    it('replays a same-choice lost response and retires the consumed key', async () => {
+      const server = createSubmitServer();
+      const tokenCell: TokenCell = { current: null };
 
-    await loseSubmitResponse(surface, server, tokenCell, choiceAId);
-    const preservedKey = tokenCell.current?.key;
-    const result = await receiveSubmitResponse(
-      surface,
-      server,
-      tokenCell,
-      choiceAId,
-    );
+      await loseSubmitResponse(surface, server, tokenCell, choiceAId);
+      const preservedKey = tokenCell.current?.key;
+      const result = await receiveSubmitResponse(
+        surface,
+        server,
+        tokenCell,
+        choiceAId,
+      );
 
-    expect(preservedKey).toBeTypeOf('string');
-    expect(server.executions).toHaveLength(1);
-    expect(result?.isCorrect).toBe(true);
-    expect(tokenCell.current).toBeNull();
-  });
+      expect(preservedKey).toBeTypeOf('string');
+      expect(server.executions).toHaveLength(1);
+      expect(result?.isCorrect).toBe(true);
+      expect(tokenCell.current).toBeNull();
+    });
 
-  it('executes a changed choice under a fresh key instead of replaying the old grade', async () => {
-    const server = createSubmitServer();
-    const tokenCell: TokenCell = { current: null };
+    it('executes a changed choice under a fresh key instead of replaying the old grade', async () => {
+      const server = createSubmitServer();
+      const tokenCell: TokenCell = { current: null };
 
-    await loseSubmitResponse(surface, server, tokenCell, choiceAId);
-    const oldKey = tokenCell.current?.key;
-    const result = await receiveSubmitResponse(
-      surface,
-      server,
-      tokenCell,
-      choiceBId,
-    );
+      await loseSubmitResponse(surface, server, tokenCell, choiceAId);
+      const oldKey = tokenCell.current?.key;
+      const result = await receiveSubmitResponse(
+        surface,
+        server,
+        tokenCell,
+        choiceBId,
+      );
 
-    expect(server.executions).toHaveLength(2);
-    expect(server.executions.map((request) => request.choiceId)).toEqual([
-      choiceAId,
-      choiceBId,
-    ]);
-    expect(server.executions[1]?.idempotencyKey).not.toBe(oldKey);
-    expect(result?.isCorrect).toBe(false);
-    expect(result?.explanationMd).toBe(`Graded ${choiceBId}`);
-    expect(tokenCell.current).toBeNull();
-  });
-});
+      expect(server.executions).toHaveLength(2);
+      expect(server.executions.map((request) => request.choiceId)).toEqual([
+        choiceAId,
+        choiceBId,
+      ]);
+      expect(server.executions[1]?.idempotencyKey).not.toBe(oldKey);
+      expect(result?.isCorrect).toBe(false);
+      expect(result?.explanationMd).toBe(`Graded ${choiceBId}`);
+      expect(tokenCell.current).toBeNull();
+    });
+  },
+);
 
 describe('submit identity context', () => {
   it('binds an active-session submit key to the session id', async () => {

--- a/app/(marketing)/checkout/success/page.test.ts
+++ b/app/(marketing)/checkout/success/page.test.ts
@@ -811,97 +811,96 @@ describe('syncCheckoutSuccess', () => {
         },
       },
     },
-  ])('logs %s before redirecting to pricing error', async ({
-    reason,
-    input,
-    session,
-    subscription,
-  }) => {
-    const logger = new FakeLogger();
-    const authGateway = new FakeAuthGateway({
-      id: fixtureUser1Id,
-      email: 'user@example.com',
-      createdAt: new Date('2026-02-01T00:00:00Z'),
-      updatedAt: new Date('2026-02-01T00:00:00Z'),
-    });
+  ])(
+    'logs %s before redirecting to pricing error',
+    async ({ reason, input, session, subscription }) => {
+      const logger = new FakeLogger();
+      const authGateway = new FakeAuthGateway({
+        id: fixtureUser1Id,
+        email: 'user@example.com',
+        createdAt: new Date('2026-02-01T00:00:00Z'),
+        updatedAt: new Date('2026-02-01T00:00:00Z'),
+      });
 
-    const deps = {
-      authGateway,
-      subscriptionVersions: {
-        findObservationVersionByUserId: async () => null,
-      },
-      getClerkAuth: async () => ({
-        userId: 'clerk_user_1',
-        redirectToSignIn: () => {
-          throw new Error('should not redirect to sign-in');
+      const deps = {
+        authGateway,
+        subscriptionVersions: {
+          findObservationVersionByUserId: async () => null,
         },
-      }),
-      logger,
-      stripe: {
-        checkout: {
-          sessions: {
+        getClerkAuth: async () => ({
+          userId: 'clerk_user_1',
+          redirectToSignIn: () => {
+            throw new Error('should not redirect to sign-in');
+          },
+        }),
+        logger,
+        stripe: {
+          checkout: {
+            sessions: {
+              retrieve: async () => {
+                if (!session)
+                  throw new Error('should not fetch Stripe session');
+                return session;
+              },
+            },
+          },
+          subscriptions: {
             retrieve: async () => {
-              if (!session) throw new Error('should not fetch Stripe session');
-              return session;
+              if (!subscription)
+                throw new Error('should not fetch Stripe subscription');
+              return {
+                id: 'sub_123',
+                customer: 'cus_123',
+                status: 'active',
+                cancel_at_period_end: false,
+                metadata: { user_id: fixtureUser1Id },
+                items: {
+                  data: [
+                    {
+                      current_period_end: 2_000_000_000,
+                      price: { id: 'price_monthly' },
+                    },
+                  ],
+                },
+                ...subscription,
+              };
             },
           },
         },
-        subscriptions: {
-          retrieve: async () => {
-            if (!subscription)
-              throw new Error('should not fetch Stripe subscription');
-            return {
-              id: 'sub_123',
-              customer: 'cus_123',
-              status: 'active',
-              cancel_at_period_end: false,
-              metadata: { user_id: fixtureUser1Id },
-              items: {
-                data: [
-                  {
-                    current_period_end: 2_000_000_000,
-                    price: { id: 'price_monthly' },
-                  },
-                ],
-              },
-              ...subscription,
-            };
-          },
+        priceIds: { monthly: 'price_monthly', annual: 'price_annual' },
+        appUrl: 'https://example.com',
+        transaction: async () => {
+          throw new Error('should not start a transaction');
         },
-      },
-      priceIds: { monthly: 'price_monthly', annual: 'price_annual' },
-      appUrl: 'https://example.com',
-      transaction: async () => {
-        throw new Error('should not start a transaction');
-      },
-    };
+      };
 
-    const redirectFn = (url: string): never => {
-      throw new RedirectError(url);
-    };
+      const redirectFn = (url: string): never => {
+        throw new RedirectError(url);
+      };
 
-    await expect(
-      syncCheckoutSuccess(input, deps as never, redirectFn),
-    ).rejects.toMatchObject({
-      url: CHECKOUT_ERROR_ROUTE,
-    });
+      await expect(
+        syncCheckoutSuccess(input, deps as never, redirectFn),
+      ).rejects.toMatchObject({
+        url: CHECKOUT_ERROR_ROUTE,
+      });
 
-    expect(logger.errorCalls).toHaveLength(1);
-    expect(logger.errorCalls[0]).toMatchObject({
-      msg: 'Checkout success validation failed',
-      context: expect.objectContaining({ reason }),
-    });
-    expect(logger.infoCalls).toHaveLength(1);
-    expect(logger.infoCalls[0]).toMatchObject({
-      msg: 'Checkout success redirected to checkout error',
-      context: expect.objectContaining({
-        reason,
-        route: ROUTES.CHECKOUT_SUCCESS,
-      }),
-    });
+      expect(logger.errorCalls).toHaveLength(1);
+      expect(logger.errorCalls[0]).toMatchObject({
+        msg: 'Checkout success validation failed',
+        context: expect.objectContaining({ reason }),
+      });
+      expect(logger.infoCalls).toHaveLength(1);
+      expect(logger.infoCalls[0]).toMatchObject({
+        msg: 'Checkout success redirected to checkout error',
+        context: expect.objectContaining({
+          reason,
+          route: ROUTES.CHECKOUT_SUCCESS,
+        }),
+      });
 
-    expect(logger.warnCalls).toHaveLength(0);
-  });
+      expect(logger.warnCalls).toHaveLength(0);
+    },
+  );
 
   it('returns redirect to pricing with reason=payment_processing when subscription is not entitled', async () => {
     const stripeCustomers = new FakeStripeCustomerRepository();

--- a/app/pricing/page.test.tsx
+++ b/app/pricing/page.test.tsx
@@ -1380,12 +1380,15 @@ describe('app/pricing', () => {
       expectedMessage: string,
       expectedAction: string,
     ]
-  >)('preserves banner rendering for pricing query params %#', async (searchParams, expectedMessage, expectedAction) => {
-    const { html } = await renderAnonymousPricingPage(searchParams);
+  >)(
+    'preserves banner rendering for pricing query params %#',
+    async (searchParams, expectedMessage, expectedAction) => {
+      const { html } = await renderAnonymousPricingPage(searchParams);
 
-    expect(html).toContain(expectedMessage);
-    expect(html).toContain(expectedAction);
-  });
+      expect(html).toContain(expectedMessage);
+      expect(html).toContain(expectedAction);
+    },
+  );
 
   it('renders the manage billing action when reason is a repeated query param', async () => {
     const checkEntitlementUseCase = new FakeUseCase<

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -44,12 +44,7 @@
       "linter": {
         "rules": {
           "style": {
-            "noExcessiveLinesPerFile": {
-              "level": "warn",
-              "options": {
-                "maxLines": 800
-              }
-            }
+            "noExcessiveLinesPerFile": "off"
           }
         }
       }

--- a/lib/container-practice-session-state-transactions.test.ts
+++ b/lib/container-practice-session-state-transactions.test.ts
@@ -175,56 +175,56 @@ class ThrowingRetryWarnLogger extends FakeLogger {
 }
 
 describe('container factories — practice session state write transactions', () => {
-  it.each([
-    '40001',
-    '40P01',
-  ] as const)('retries the complete discard transaction on %s with a fresh transaction handle', async (code) => {
-    vi.useFakeTimers();
-    vi.spyOn(Math, 'random').mockReturnValue(0);
-    const fixture = createPracticeSessionStateWriteFixture('exam');
-    const transactionHandles: DrizzleDb[] = [];
-    const repositoryHandles: Array<DrizzleDb | undefined> = [];
-    const postgresFailure = { code };
-    const drizzleFailure = new Error('Failed query', {
-      cause: postgresFailure,
-    });
-    const transaction = vi.fn<TestTransaction>(async (fn) => {
-      const tx = createUnexpectedNestedTransactionDb();
-      transactionHandles.push(tx);
-      const result = await fn(tx);
-      if (transactionHandles.length === 1) {
-        throw drizzleFailure;
-      }
-      return result;
-    });
+  it.each(['40001', '40P01'] as const)(
+    'retries the complete discard transaction on %s with a fresh transaction handle',
+    async (code) => {
+      vi.useFakeTimers();
+      vi.spyOn(Math, 'random').mockReturnValue(0);
+      const fixture = createPracticeSessionStateWriteFixture('exam');
+      const transactionHandles: DrizzleDb[] = [];
+      const repositoryHandles: Array<DrizzleDb | undefined> = [];
+      const postgresFailure = { code };
+      const drizzleFailure = new Error('Failed query', {
+        cause: postgresFailure,
+      });
+      const transaction = vi.fn<TestTransaction>(async (fn) => {
+        const tx = createUnexpectedNestedTransactionDb();
+        transactionHandles.push(tx);
+        const result = await fn(tx);
+        if (transactionHandles.length === 1) {
+          throw drizzleFailure;
+        }
+        return result;
+      });
 
-    const container = createContainer({
-      primitives: {
-        db: createTransactionOnlyDb(transaction),
-      },
-      repositories: {
-        createPracticeSessionRepository: (dbOverride) => {
-          repositoryHandles.push(dbOverride);
-          return fixture.sessions;
+      const container = createContainer({
+        primitives: {
+          db: createTransactionOnlyDb(transaction),
         },
-      },
-    } satisfies ContainerOverrides);
-    const result = container.createDiscardPracticeSessionUseCase().execute({
-      userId: fixture.userId,
-      sessionId: fixture.sessionId,
-    });
+        repositories: {
+          createPracticeSessionRepository: (dbOverride) => {
+            repositoryHandles.push(dbOverride);
+            return fixture.sessions;
+          },
+        },
+      } satisfies ContainerOverrides);
+      const result = container.createDiscardPracticeSessionUseCase().execute({
+        userId: fixture.userId,
+        sessionId: fixture.sessionId,
+      });
 
-    await vi.runAllTimersAsync();
+      await vi.runAllTimersAsync();
 
-    await expect(result).resolves.toEqual({ discarded: true });
-    expect(transaction).toHaveBeenCalledTimes(2);
-    expect(transactionHandles).toHaveLength(2);
-    expect(transactionHandles[0]).not.toBe(transactionHandles[1]);
-    expect(repositoryHandles).toEqual(transactionHandles);
-    expect(transaction).toHaveBeenLastCalledWith(expect.any(Function), {
-      isolationLevel: 'repeatable read',
-    });
-  });
+      await expect(result).resolves.toEqual({ discarded: true });
+      expect(transaction).toHaveBeenCalledTimes(2);
+      expect(transactionHandles).toHaveLength(2);
+      expect(transactionHandles[0]).not.toBe(transactionHandles[1]);
+      expect(repositoryHandles).toEqual(transactionHandles);
+      expect(transaction).toHaveBeenLastCalledWith(expect.any(Function), {
+        isolationLevel: 'repeatable read',
+      });
+    },
+  );
 
   it('maps exhausted discard serialization failures to a typed state-changed CONFLICT', async () => {
     vi.useFakeTimers();
@@ -399,46 +399,46 @@ describe('container factories — practice session state write transactions', ()
     expect(transaction).toHaveBeenCalledTimes(3);
   });
 
-  it.each([
-    '40001',
-    '40P01',
-  ] as const)('logs one safe retry observation for %s', async (code) => {
-    vi.useFakeTimers();
-    vi.spyOn(Math, 'random').mockReturnValue(0.5);
-    const fixture = createPracticeSessionStateWriteFixture('exam');
-    const logger = new FakeLogger();
-    const tx = createUnexpectedNestedTransactionDb();
-    const transaction = vi.fn<TestTransaction>(async (fn) => {
-      if (transaction.mock.calls.length === 1) {
-        throw { code };
-      }
-      return fn(tx);
-    });
-    const container = createPracticeSessionStateWriteContainer({
-      transaction,
-      fixture,
-      logger,
-    });
+  it.each(['40001', '40P01'] as const)(
+    'logs one safe retry observation for %s',
+    async (code) => {
+      vi.useFakeTimers();
+      vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const fixture = createPracticeSessionStateWriteFixture('exam');
+      const logger = new FakeLogger();
+      const tx = createUnexpectedNestedTransactionDb();
+      const transaction = vi.fn<TestTransaction>(async (fn) => {
+        if (transaction.mock.calls.length === 1) {
+          throw { code };
+        }
+        return fn(tx);
+      });
+      const container = createPracticeSessionStateWriteContainer({
+        transaction,
+        fixture,
+        logger,
+      });
 
-    const result = container.createFinalizeExamAnswersUseCase().execute({
-      userId: fixture.userId,
-      sessionId: fixture.sessionId,
-    });
-    await vi.runAllTimersAsync();
-    await result;
+      const result = container.createFinalizeExamAnswersUseCase().execute({
+        userId: fixture.userId,
+        sessionId: fixture.sessionId,
+      });
+      await vi.runAllTimersAsync();
+      await result;
 
-    expect(logger.warnCalls).toEqual([
-      {
-        context: {
-          attempt: 1,
-          max: 3,
-          code,
-          delay: 37,
+      expect(logger.warnCalls).toEqual([
+        {
+          context: {
+            attempt: 1,
+            max: 3,
+            code,
+            delay: 37,
+          },
+          msg: 'Retrying practice session state write transaction',
         },
-        msg: 'Retrying practice session state write transaction',
-      },
-    ]);
-  });
+      ]);
+    },
+  );
 
   it('continues retrying when retry observation logging fails', async () => {
     vi.useFakeTimers();

--- a/lib/pricing-data.test.ts
+++ b/lib/pricing-data.test.ts
@@ -29,18 +29,20 @@ describe('PRICING_DATA renewal disclosures', () => {
     ],
   ] as const;
 
-  it.each(
-    disclosures,
-  )('%s names the real cancellation path (Billing page), not a nonexistent surface', (_name, disclosure) => {
-    expect(disclosure).toContain('Billing page');
-    expect(disclosure).not.toContain('Account Settings');
-  });
+  it.each(disclosures)(
+    '%s names the real cancellation path (Billing page), not a nonexistent surface',
+    (_name, disclosure) => {
+      expect(disclosure).toContain('Billing page');
+      expect(disclosure).not.toContain('Account Settings');
+    },
+  );
 
-  it.each(
-    disclosures,
-  )('%s names the support contact as a cancellation fallback', (_name, disclosure) => {
-    expect(disclosure).toContain('support@addictionboards.com');
-  });
+  it.each(disclosures)(
+    '%s names the support contact as a cancellation fallback',
+    (_name, disclosure) => {
+      expect(disclosure).toContain('support@addictionboards.com');
+    },
+  );
 
   it('pins machine-readable renewal terms to the rendered disclosure and Terms version', () => {
     expect(CANCELLATION_METHOD).toBe(

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.1",
+    "@biomejs/biome": "^2.5.6",
     "@clerk/testing": "^2.0.33",
     "@playwright/test": "^1.61.1",
     "@types/node": "^24.12.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.1
-        version: 2.5.3
+        specifier: ^2.5.6
+        version: 2.5.6
       '@clerk/testing':
         specifier: ^2.0.33
         version: 2.2.16(@playwright/test@1.62.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -367,59 +367,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.5.3':
-    resolution: {integrity: sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==}
+  '@biomejs/biome@2.5.6':
+    resolution: {integrity: sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.3':
-    resolution: {integrity: sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==}
+  '@biomejs/cli-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.3':
-    resolution: {integrity: sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==}
+  '@biomejs/cli-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.3':
-    resolution: {integrity: sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==}
+  '@biomejs/cli-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.3':
-    resolution: {integrity: sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==}
+  '@biomejs/cli-linux-arm64@2.5.6':
+    resolution: {integrity: sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.3':
-    resolution: {integrity: sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==}
+  '@biomejs/cli-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.3':
-    resolution: {integrity: sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==}
+  '@biomejs/cli-linux-x64@2.5.6':
+    resolution: {integrity: sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.3':
-    resolution: {integrity: sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==}
+  '@biomejs/cli-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.3':
-    resolution: {integrity: sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==}
+  '@biomejs/cli-win32-x64@2.5.6':
+    resolution: {integrity: sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -6193,39 +6193,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@2.5.3':
+  '@biomejs/biome@2.5.6':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.3
-      '@biomejs/cli-darwin-x64': 2.5.3
-      '@biomejs/cli-linux-arm64': 2.5.3
-      '@biomejs/cli-linux-arm64-musl': 2.5.3
-      '@biomejs/cli-linux-x64': 2.5.3
-      '@biomejs/cli-linux-x64-musl': 2.5.3
-      '@biomejs/cli-win32-arm64': 2.5.3
-      '@biomejs/cli-win32-x64': 2.5.3
+      '@biomejs/cli-darwin-arm64': 2.5.6
+      '@biomejs/cli-darwin-x64': 2.5.6
+      '@biomejs/cli-linux-arm64': 2.5.6
+      '@biomejs/cli-linux-arm64-musl': 2.5.6
+      '@biomejs/cli-linux-x64': 2.5.6
+      '@biomejs/cli-linux-x64-musl': 2.5.6
+      '@biomejs/cli-win32-arm64': 2.5.6
+      '@biomejs/cli-win32-x64': 2.5.6
 
-  '@biomejs/cli-darwin-arm64@2.5.3':
+  '@biomejs/cli-darwin-arm64@2.5.6':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.3':
+  '@biomejs/cli-darwin-x64@2.5.6':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.3':
+  '@biomejs/cli-linux-arm64-musl@2.5.6':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.3':
+  '@biomejs/cli-linux-arm64@2.5.6':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.3':
+  '@biomejs/cli-linux-x64-musl@2.5.6':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.3':
+  '@biomejs/cli-linux-x64@2.5.6':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.3':
+  '@biomejs/cli-win32-arm64@2.5.6':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.3':
+  '@biomejs/cli-win32-x64@2.5.6':
     optional: true
 
   '@blazediff/core@1.9.1': {}

--- a/scripts/database-target.test.ts
+++ b/scripts/database-target.test.ts
@@ -77,33 +77,32 @@ describe('database target authorization', () => {
     ).toMatchObject({ acknowledgement });
   });
 
-  it.each([
-    undefined,
-    '',
-    '["wrong.example/app"]',
-  ])('rejects missing or wrong remote acknowledgement %s without leaking credentials', (acknowledgement) => {
-    const databaseUrl =
-      'postgresql://operator:super-secret@db.example/app?sslmode=require';
+  it.each([undefined, '', '["wrong.example/app"]'])(
+    'rejects missing or wrong remote acknowledgement %s without leaking credentials',
+    (acknowledgement) => {
+      const databaseUrl =
+        'postgresql://operator:super-secret@db.example/app?sslmode=require';
 
-    expect(() =>
-      authorizeHumanDatabaseTargets({
-        databaseUrls: [databaseUrl],
-        acknowledgement,
-      }),
-    ).toThrow('DB_TARGET_ACK must exactly equal ["db.example/app"]');
+      expect(() =>
+        authorizeHumanDatabaseTargets({
+          databaseUrls: [databaseUrl],
+          acknowledgement,
+        }),
+      ).toThrow('DB_TARGET_ACK must exactly equal ["db.example/app"]');
 
-    try {
-      authorizeHumanDatabaseTargets({
-        databaseUrls: [databaseUrl],
-        acknowledgement,
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      expect(message).not.toContain('operator');
-      expect(message).not.toContain('super-secret');
-      expect(message).not.toContain('sslmode');
-    }
-  });
+      try {
+        authorizeHumanDatabaseTargets({
+          databaseUrls: [databaseUrl],
+          acknowledgement,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message).not.toContain('operator');
+        expect(message).not.toContain('super-secret');
+        expect(message).not.toContain('sslmode');
+      }
+    },
+  );
 
   it('does not accept CI, Vercel, env, or CLI-shaped values as a managed bypass', () => {
     const databaseUrl = 'postgresql://user:password@db.example/app';

--- a/scripts/seed-production.test.ts
+++ b/scripts/seed-production.test.ts
@@ -27,22 +27,24 @@ function createDependencies(): SeedEnvironmentDependencies & {
 }
 
 describe('db:seed:prod', () => {
-  it.each([
-    undefined,
-    '["wrong-host/proddb"]',
-  ])('requires the exact Production target token %s before writes', async (acknowledgement) => {
-    const dependencies = createDependencies();
+  it.each([undefined, '["wrong-host/proddb"]'])(
+    'requires the exact Production target token %s before writes',
+    async (acknowledgement) => {
+      const dependencies = createDependencies();
 
-    await expect(
-      runProductionSeed({
-        acknowledgement,
-        dependencies,
-        env: {},
-      }),
-    ).rejects.toThrow('DB_TARGET_ACK must exactly equal ["prod-host/proddb"]');
-    expect(dependencies.prepareCorpus).not.toHaveBeenCalled();
-    expect(dependencies.seedDatabase).not.toHaveBeenCalled();
-  });
+      await expect(
+        runProductionSeed({
+          acknowledgement,
+          dependencies,
+          env: {},
+        }),
+      ).rejects.toThrow(
+        'DB_TARGET_ACK must exactly equal ["prod-host/proddb"]',
+      );
+      expect(dependencies.prepareCorpus).not.toHaveBeenCalled();
+      expect(dependencies.seedDatabase).not.toHaveBeenCalled();
+    },
+  );
 
   it('resolves and seeds only the named Production identity after exact consent', async () => {
     const dependencies = createDependencies();

--- a/scripts/seed.test.ts
+++ b/scripts/seed.test.ts
@@ -338,11 +338,10 @@ describe('parseSeedQuestionFile', () => {
     expect(placeholders.length).toBeGreaterThan(0);
   });
 
-  it.each(
-    readPlaceholderSeedFiles(),
-  )('parses tracked placeholder seed file $fileName with the Phase 2 schema', ({
-    raw,
-  }) => {
-    expect(() => parseSeedQuestionFile(raw)).not.toThrow();
-  });
+  it.each(readPlaceholderSeedFiles())(
+    'parses tracked placeholder seed file $fileName with the Phase 2 schema',
+    ({ raw }) => {
+      expect(() => parseSeedQuestionFile(raw)).not.toThrow();
+    },
+  );
 });

--- a/scripts/verify-migration-ledger.test.ts
+++ b/scripts/verify-migration-ledger.test.ts
@@ -9,14 +9,12 @@ describe('migration ledger verification CLI', () => {
     expect(parseMigrationLedgerVerificationPhase(input)).toBe(expected);
   });
 
-  it.each([
-    undefined,
-    '',
-    'managed',
-    '--pre',
-  ])('rejects unsupported phase %s', (input) => {
-    expect(() => parseMigrationLedgerVerificationPhase(input)).toThrow(
-      'Usage: verify-migration-ledger.ts <pre|post>',
-    );
-  });
+  it.each([undefined, '', 'managed', '--pre'])(
+    'rejects unsupported phase %s',
+    (input) => {
+      expect(() => parseMigrationLedgerVerificationPhase(input)).toThrow(
+        'Usage: verify-migration-ledger.ts <pre|post>',
+      );
+    },
+  );
 });

--- a/src/adapters/controllers/controller-output-datetime-contract.test.ts
+++ b/src/adapters/controllers/controller-output-datetime-contract.test.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/noExcessiveLinesPerFile: Keep the DEBT-397 AST scanner and assertions colocated so the controller-output datetime contract is auditable in one guardrail.
 import { readdirSync, readFileSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
 import ts from 'typescript';

--- a/src/adapters/controllers/shared/idempotency-error-policy.test.ts
+++ b/src/adapters/controllers/shared/idempotency-error-policy.test.ts
@@ -88,14 +88,14 @@ describe('start-practice-session idempotency error policy', () => {
     expect(shouldCacheStartPracticeSessionError(error)).toBe(false);
   });
 
-  it.each([
-    'VALIDATION_ERROR',
-    'NOT_FOUND',
-  ] as const)('caches the determinate %s outcome', (code) => {
-    expect(
-      shouldCacheStartPracticeSessionError(new ApplicationError(code, code)),
-    ).toBe(true);
-  });
+  it.each(['VALIDATION_ERROR', 'NOT_FOUND'] as const)(
+    'caches the determinate %s outcome',
+    (code) => {
+      expect(
+        shouldCacheStartPracticeSessionError(new ApplicationError(code, code)),
+      ).toBe(true);
+    },
+  );
 
   it('caches the typed incomplete-session conflict', () => {
     expect(
@@ -122,12 +122,12 @@ describe.each([
   ['question rating', shouldCacheQuestionRatingError],
   ['question report', shouldCacheQuestionReportError],
 ] as const)('%s idempotency error policy', (_name, policy) => {
-  it.each([
-    'VALIDATION_ERROR',
-    'NOT_FOUND',
-  ] as const)('caches the determinate %s outcome', (code) => {
-    expect(policy(new ApplicationError(code, code))).toBe(true);
-  });
+  it.each(['VALIDATION_ERROR', 'NOT_FOUND'] as const)(
+    'caches the determinate %s outcome',
+    (code) => {
+      expect(policy(new ApplicationError(code, code))).toBe(true);
+    },
+  );
 });
 
 describe('submit-answer idempotency error policy', () => {
@@ -154,14 +154,14 @@ describe('submit-answer idempotency error policy', () => {
     expect(shouldCacheSubmitAnswerError(error)).toBe(true);
   });
 
-  it.each([
-    'VALIDATION_ERROR',
-    'NOT_FOUND',
-  ] as const)('caches the determinate %s outcome', (code) => {
-    expect(shouldCacheSubmitAnswerError(new ApplicationError(code, code))).toBe(
-      true,
-    );
-  });
+  it.each(['VALIDATION_ERROR', 'NOT_FOUND'] as const)(
+    'caches the determinate %s outcome',
+    (code) => {
+      expect(
+        shouldCacheSubmitAnswerError(new ApplicationError(code, code)),
+      ).toBe(true);
+    },
+  );
 
   it('caches a typed terminal practice-session conflict', () => {
     expect(
@@ -179,11 +179,12 @@ describe('submit-answer idempotency error policy', () => {
 });
 
 describe('question-mark idempotency error policy', () => {
-  it.each(
-    transientCases,
-  )('aborts the naturally replay-safe desired-state write for %s', (_caseName, error) => {
-    expect(shouldCacheQuestionMarkError(error)).toBe(false);
-  });
+  it.each(transientCases)(
+    'aborts the naturally replay-safe desired-state write for %s',
+    (_caseName, error) => {
+      expect(shouldCacheQuestionMarkError(error)).toBe(false);
+    },
+  );
 
   it('aborts a rollback-certain persistence failure', () => {
     expect(
@@ -201,14 +202,14 @@ describe('question-mark idempotency error policy', () => {
     ).toBe(false);
   });
 
-  it.each([
-    'VALIDATION_ERROR',
-    'NOT_FOUND',
-  ] as const)('caches the determinate %s outcome', (code) => {
-    expect(shouldCacheQuestionMarkError(new ApplicationError(code, code))).toBe(
-      true,
-    );
-  });
+  it.each(['VALIDATION_ERROR', 'NOT_FOUND'] as const)(
+    'caches the determinate %s outcome',
+    (code) => {
+      expect(
+        shouldCacheQuestionMarkError(new ApplicationError(code, code)),
+      ).toBe(true);
+    },
+  );
 
   it('caches a typed terminal practice-session conflict', () => {
     expect(
@@ -363,11 +364,14 @@ describe('client idempotency-key rotation policy', () => {
         },
       }),
     ],
-  ] as const)('rotates %s after a determinate cached error', (action, error) => {
-    expect(shouldRotateIdempotencyKeyAfterActionError(action, error)).toBe(
-      true,
-    );
-  });
+  ] as const)(
+    'rotates %s after a determinate cached error',
+    (action, error) => {
+      expect(shouldRotateIdempotencyKeyAfterActionError(action, error)).toBe(
+        true,
+      );
+    },
+  );
 
   it.each([
     [
@@ -390,9 +394,12 @@ describe('client idempotency-key rotation policy', () => {
         },
       }),
     ],
-  ] as const)('preserves %s after an indeterminate or aborted error', (action, error) => {
-    expect(shouldRotateIdempotencyKeyAfterActionError(action, error)).toBe(
-      false,
-    );
-  });
+  ] as const)(
+    'preserves %s after an indeterminate or aborted error',
+    (action, error) => {
+      expect(shouldRotateIdempotencyKeyAfterActionError(action, error)).toBe(
+        false,
+      );
+    },
+  );
 });

--- a/src/adapters/controllers/stripe-webhook-controller.test.ts
+++ b/src/adapters/controllers/stripe-webhook-controller.test.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/noExcessiveLinesPerFile: Keep the Stripe webhook transaction, failure-ledger, and setup-operation concurrency cases in one controller contract suite.
 import { describe, expect, it, vi } from 'vitest';
 import { STRIPE_SUBSCRIPTION_METADATA_E2E_OWNER_FIELD } from '@/src/adapters/shared/stripe-subscription-errors';
 import { ApplicationError } from '@/src/application/errors';

--- a/src/adapters/gateways/resend-transactional-email-gateway.test.ts
+++ b/src/adapters/gateways/resend-transactional-email-gateway.test.ts
@@ -81,21 +81,23 @@ describe('ResendTransactionalEmailGateway', () => {
     });
   });
 
-  it.each([
-    'application_error',
-    'internal_server_error',
-  ])('quarantines ambiguous provider 5xx error %s as outcome_unknown', async (name) => {
-    resendSdk.send.mockResolvedValue({
-      data: null,
-      error: { name, message: 'provider infrastructure failure' },
-    });
-    const gateway = new ResendTransactionalEmailGateway({ apiKey: 're_test' });
+  it.each(['application_error', 'internal_server_error'])(
+    'quarantines ambiguous provider 5xx error %s as outcome_unknown',
+    async (name) => {
+      resendSdk.send.mockResolvedValue({
+        data: null,
+        error: { name, message: 'provider infrastructure failure' },
+      });
+      const gateway = new ResendTransactionalEmailGateway({
+        apiKey: 're_test',
+      });
 
-    await expect(gateway.send(input)).resolves.toEqual({
-      status: 'outcome_unknown',
-      failureCode: name,
-    });
-  });
+      await expect(gateway.send(input)).resolves.toEqual({
+        status: 'outcome_unknown',
+        failureCode: name,
+      });
+    },
+  );
 
   it('quarantines concurrent idempotent requests because provider acceptance is unresolved', async () => {
     resendSdk.send.mockResolvedValue({
@@ -207,18 +209,18 @@ describe('ResendTransactionalEmailGateway', () => {
     });
   });
 
-  it.each([
-    { id: '' },
-    {},
-  ])('maps provider data %o without a non-empty event ID to outcome_unknown', async (data) => {
-    resendSdk.send.mockResolvedValue({ data, error: null });
-    const gateway = new ResendTransactionalEmailGateway({
-      apiKey: 're_test',
-    });
+  it.each([{ id: '' }, {}])(
+    'maps provider data %o without a non-empty event ID to outcome_unknown',
+    async (data) => {
+      resendSdk.send.mockResolvedValue({ data, error: null });
+      const gateway = new ResendTransactionalEmailGateway({
+        apiKey: 're_test',
+      });
 
-    await expect(gateway.send(input)).resolves.toEqual({
-      status: 'outcome_unknown',
-      failureCode: 'invalid_provider_response',
-    });
-  });
+      await expect(gateway.send(input)).resolves.toEqual({
+        status: 'outcome_unknown',
+        failureCode: 'invalid_provider_response',
+      });
+    },
+  );
 });

--- a/src/adapters/gateways/stripe-payment-gateway.test.ts
+++ b/src/adapters/gateways/stripe-payment-gateway.test.ts
@@ -456,32 +456,35 @@ describe('StripePaymentGateway', () => {
     'unpaid',
     'incomplete',
     'paused',
-  ] as const)('throws ALREADY_SUBSCRIBED when Stripe has a %s subscription for the customer', async (status) => {
-    const { stripe, sessionsCreate, subscriptionsList } = createStripeMock({
-      withSubscriptions: true,
-    });
-    subscriptionsList.mockResolvedValue({
-      data: [{ id: 'sub_blocking_1', status }],
-    });
-    const gateway = createGateway(stripe);
+  ] as const)(
+    'throws ALREADY_SUBSCRIBED when Stripe has a %s subscription for the customer',
+    async (status) => {
+      const { stripe, sessionsCreate, subscriptionsList } = createStripeMock({
+        withSubscriptions: true,
+      });
+      subscriptionsList.mockResolvedValue({
+        data: [{ id: 'sub_blocking_1', status }],
+      });
+      const gateway = createGateway(stripe);
 
-    await expect(
-      gateway.createCheckoutSession({
-        userId: appUserId,
-        externalCustomerId: 'cus_123',
-        ...createTestRenewalTerms('monthly'),
-        successUrl: 'https://app/success',
-        cancelUrl: 'https://app/cancel',
-      }),
-    ).rejects.toMatchObject({ code: 'ALREADY_SUBSCRIBED' });
+      await expect(
+        gateway.createCheckoutSession({
+          userId: appUserId,
+          externalCustomerId: 'cus_123',
+          ...createTestRenewalTerms('monthly'),
+          successUrl: 'https://app/success',
+          cancelUrl: 'https://app/cancel',
+        }),
+      ).rejects.toMatchObject({ code: 'ALREADY_SUBSCRIBED' });
 
-    expect(subscriptionsList).toHaveBeenCalledWith({
-      customer: 'cus_123',
-      status: 'all',
-      limit: SUBSCRIPTION_LIST_LIMIT,
-    });
-    expect(sessionsCreate).not.toHaveBeenCalled();
-  });
+      expect(subscriptionsList).toHaveBeenCalledWith({
+        customer: 'cus_123',
+        status: 'all',
+        limit: SUBSCRIPTION_LIST_LIMIT,
+      });
+      expect(sessionsCreate).not.toHaveBeenCalled();
+    },
+  );
 
   it('creates a checkout session when Stripe subscriptions are only ended or canceled', async () => {
     const { stripe, sessionsCreate, subscriptionsList } = createStripeMock({
@@ -845,46 +848,52 @@ describe('StripePaymentGateway', () => {
     ['invoice.payment_failed', 'evt_invoice_1'],
     ['invoice.payment_succeeded', 'evt_invoice_success_1'],
     ['invoice.payment_action_required', 'evt_invoice_action_required_1'],
-  ] as const)('normalizes %s events by retrieving the subscription', async (type, eventId) => {
-    const subscriptionEvent = loadJsonFixture<{
-      data: { object: { id: string } };
-    }>('stripe/customer.subscription.updated.json');
-    const subscription = withSubscriptionUserId(subscriptionEvent.data.object);
+  ] as const)(
+    'normalizes %s events by retrieving the subscription',
+    async (type, eventId) => {
+      const subscriptionEvent = loadJsonFixture<{
+        data: { object: { id: string } };
+      }>('stripe/customer.subscription.updated.json');
+      const subscription = withSubscriptionUserId(
+        subscriptionEvent.data.object,
+      );
 
-    const constructedEvent = {
-      id: eventId,
-      type,
-      data: {
-        object: {
-          subscription: subscription.id,
+      const constructedEvent = {
+        id: eventId,
+        type,
+        data: {
+          object: {
+            subscription: subscription.id,
+          },
         },
-      },
-    };
-    const { stripe, constructEvent, subscriptionsRetrieve } = createStripeMock({
-      withSubscriptions: true,
-    });
-    constructEvent.mockReturnValue(constructedEvent);
-    subscriptionsRetrieve.mockResolvedValue(subscription);
-    const gateway = createGateway(stripe);
+      };
+      const { stripe, constructEvent, subscriptionsRetrieve } =
+        createStripeMock({
+          withSubscriptions: true,
+        });
+      constructEvent.mockReturnValue(constructedEvent);
+      subscriptionsRetrieve.mockResolvedValue(subscription);
+      const gateway = createGateway(stripe);
 
-    await expect(
-      gateway.processWebhookEvent('raw_body', 'sig_1'),
-    ).resolves.toEqual({
-      eventId,
-      type,
-      subscriptionUpdate: {
-        userId: appUserId,
-        externalCustomerId: 'cus_123',
-        externalSubscriptionId: 'sub_123',
-        plan: 'monthly',
-        status: 'active',
-        currentPeriodEnd: new Date(1_700_000_000 * 1000),
-        cancelAtPeriodEnd: false,
-      },
-    });
+      await expect(
+        gateway.processWebhookEvent('raw_body', 'sig_1'),
+      ).resolves.toEqual({
+        eventId,
+        type,
+        subscriptionUpdate: {
+          userId: appUserId,
+          externalCustomerId: 'cus_123',
+          externalSubscriptionId: 'sub_123',
+          plan: 'monthly',
+          status: 'active',
+          currentPeriodEnd: new Date(1_700_000_000 * 1000),
+          cancelAtPeriodEnd: false,
+        },
+      });
 
-    expect(subscriptionsRetrieve).toHaveBeenCalledWith(subscription.id);
-  });
+      expect(subscriptionsRetrieve).toHaveBeenCalledWith(subscription.id);
+    },
+  );
 
   it('normalizes invoice.payment_succeeded events with a nested Clover subscription reference', async () => {
     const subscriptionEvent = loadJsonFixture<{

--- a/src/adapters/gateways/stripe/stripe-checkout-sessions-trials.test.ts
+++ b/src/adapters/gateways/stripe/stripe-checkout-sessions-trials.test.ts
@@ -351,40 +351,41 @@ describe('createStripeCheckoutSession trial params', () => {
       name: 'the existing session price cannot be determined',
       overrides: { retrievedSessionPriceId: null },
     },
-  ])('creates trial checkout with a replacement idempotency key when $name', async ({
-    overrides,
-  }) => {
-    const { stripe, sessionsCreate, sessionsExpire } = createStripeMock({
-      openSessionsData: [
-        { id: 'cs_existing', url: 'https://stripe/checkout/existing' },
-      ],
-      ...overrides,
-    });
+  ])(
+    'creates trial checkout with a replacement idempotency key when $name',
+    async ({ overrides }) => {
+      const { stripe, sessionsCreate, sessionsExpire } = createStripeMock({
+        openSessionsData: [
+          { id: 'cs_existing', url: 'https://stripe/checkout/existing' },
+        ],
+        ...overrides,
+      });
 
-    await expect(
-      createStripeCheckoutSession({
-        stripe,
-        input: trialInput,
-        priceIds,
-        logger,
-      }),
-    ).resolves.toEqual({ url: 'https://stripe/checkout/new' });
-
-    expect(sessionsExpire).toHaveBeenCalledWith('cs_existing', undefined, {
-      idempotencyKey: 'expire_checkout_session:cs_existing',
-    });
-    expect(sessionsCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        payment_method_collection: 'if_required',
-        subscription_data: expect.objectContaining({
-          trial_period_days: 7,
+      await expect(
+        createStripeCheckoutSession({
+          stripe,
+          input: trialInput,
+          priceIds,
+          logger,
         }),
-      }),
-      expect.objectContaining({
-        idempotencyKey: `checkout_session_recovery:${appUserId}:monthly:cs_existing:trial:7`,
-      }),
-    );
-  });
+      ).resolves.toEqual({ url: 'https://stripe/checkout/new' });
+
+      expect(sessionsExpire).toHaveBeenCalledWith('cs_existing', undefined, {
+        idempotencyKey: 'expire_checkout_session:cs_existing',
+      });
+      expect(sessionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payment_method_collection: 'if_required',
+          subscription_data: expect.objectContaining({
+            trial_period_days: 7,
+          }),
+        }),
+        expect.objectContaining({
+          idempotencyKey: `checkout_session_recovery:${appUserId}:monthly:cs_existing:trial:7`,
+        }),
+      );
+    },
+  );
 });
 
 describe('createStripeTrialPaymentMethodSetupSession', () => {

--- a/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
+++ b/src/adapters/jobs/reconcile-stripe-subscriptions.test.ts
@@ -1124,55 +1124,55 @@ describe('reconcileStripeSubscriptions', () => {
     { stripeStatus: 'unpaid' as const, duplicateId: 'sub_unpaid' },
     { stripeStatus: 'incomplete' as const, duplicateId: 'sub_incomplete' },
     { stripeStatus: 'paused' as const, duplicateId: 'sub_paused' },
-  ])('keeps an active subscription over a later $stripeStatus duplicate', async ({
-    stripeStatus,
-    duplicateId,
-  }) => {
-    const active = createUserSubscriptionFixture('sub_active', {
-      status: 'active',
-      currentPeriodEnd: 1_800_000_000,
-    });
-    const duplicate = createUserSubscriptionFixture(duplicateId, {
-      status: stripeStatus,
-      currentPeriodEnd: 1_900_000_000,
-    });
+  ])(
+    'keeps an active subscription over a later $stripeStatus duplicate',
+    async ({ stripeStatus, duplicateId }) => {
+      const active = createUserSubscriptionFixture('sub_active', {
+        status: 'active',
+        currentPeriodEnd: 1_800_000_000,
+      });
+      const duplicate = createUserSubscriptionFixture(duplicateId, {
+        status: stripeStatus,
+        currentPeriodEnd: 1_900_000_000,
+      });
 
-    const stripe = createStripeFromFixtures({
-      fixtures: [{ fixture: active }, { fixture: duplicate }],
-    });
+      const stripe = createStripeFromFixtures({
+        fixtures: [{ fixture: active }, { fixture: duplicate }],
+      });
 
-    const scenario = createSingleRowScenario({
-      stripe,
-      subscriptionId: active.id,
-    });
+      const scenario = createSingleRowScenario({
+        stripe,
+        subscriptionId: active.id,
+      });
 
-    const result = await scenario.run({ dryRun: false });
+      const result = await scenario.run({ dryRun: false });
 
-    expect(result).toEqual({
-      scanned: 1,
-      updated: 1,
-      failed: 0,
-      failures: [],
-    });
-    expect(stripe.subscriptions.cancel).toHaveBeenCalledTimes(1);
-    expect(stripe.subscriptions.cancel).toHaveBeenCalledWith(
-      duplicateId,
-      undefined,
-      {
-        idempotencyKey: `reconcile_duplicate_subscription:${duplicateId}`,
-      },
-    );
-    await expect(
-      scenario.subscriptions.findByExternalSubscriptionId('sub_active'),
-    ).resolves.toMatchObject({
-      userId: primaryUserId,
-      status: 'active',
-      currentPeriodEnd: new Date(1_800_000_000 * 1000),
-    });
-    await expect(
-      scenario.subscriptions.findByExternalSubscriptionId(duplicateId),
-    ).resolves.toBeNull();
-  });
+      expect(result).toEqual({
+        scanned: 1,
+        updated: 1,
+        failed: 0,
+        failures: [],
+      });
+      expect(stripe.subscriptions.cancel).toHaveBeenCalledTimes(1);
+      expect(stripe.subscriptions.cancel).toHaveBeenCalledWith(
+        duplicateId,
+        undefined,
+        {
+          idempotencyKey: `reconcile_duplicate_subscription:${duplicateId}`,
+        },
+      );
+      await expect(
+        scenario.subscriptions.findByExternalSubscriptionId('sub_active'),
+      ).resolves.toMatchObject({
+        userId: primaryUserId,
+        status: 'active',
+        currentPeriodEnd: new Date(1_800_000_000 * 1000),
+      });
+      await expect(
+        scenario.subscriptions.findByExternalSubscriptionId(duplicateId),
+      ).resolves.toBeNull();
+    },
+  );
 
   it('keeps the local row active over a later unpaid duplicate in dry-run mode', async () => {
     const active = createUserSubscriptionFixture('sub_active', {

--- a/src/adapters/jobs/send-due-renewal-notices.test.ts
+++ b/src/adapters/jobs/send-due-renewal-notices.test.ts
@@ -164,23 +164,26 @@ describe('sendDueRenewalNotices job', () => {
       expectedSubscriptionLimit: 1,
       expectedDispatchLimit: 1,
     },
-  ])('normalizes $label independently', async ({
-    subscriptionLimit,
-    dispatchLimit,
-    expectedSubscriptionLimit,
-    expectedDispatchLimit,
-  }) => {
-    const { deps, listAnnualSubscriptionsDue, execute } = createDeps();
+  ])(
+    'normalizes $label independently',
+    async ({
+      subscriptionLimit,
+      dispatchLimit,
+      expectedSubscriptionLimit,
+      expectedDispatchLimit,
+    }) => {
+      const { deps, listAnnualSubscriptionsDue, execute } = createDeps();
 
-    await sendDueRenewalNotices({ subscriptionLimit, dispatchLimit }, deps);
+      await sendDueRenewalNotices({ subscriptionLimit, dispatchLimit }, deps);
 
-    expect(listAnnualSubscriptionsDue).toHaveBeenCalledWith(
-      expect.objectContaining({ limit: expectedSubscriptionLimit }),
-    );
-    expect(execute).toHaveBeenCalledWith(
-      expect.objectContaining({ limit: expectedDispatchLimit }),
-    );
-  });
+      expect(listAnnualSubscriptionsDue).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: expectedSubscriptionLimit }),
+      );
+      expect(execute).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: expectedDispatchLimit }),
+      );
+    },
+  );
 
   it('bounds worst-case provider wait below the cron runtime budget', () => {
     const providerWaitMs =

--- a/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
+++ b/src/adapters/repositories/drizzle-practice-session-repository-session-writes.test.ts
@@ -495,62 +495,64 @@ describe('DrizzlePracticeSessionRepository session writes', () => {
       currentEndedAt: new Date('2026-02-01T01:03:00.000Z'),
       expectedCode: 'CONFLICT',
     },
-  ] as const)('keeps the guarded-update fallback as $expectedCode', async ({
-    currentEndedAt,
-    expectedCode,
-  }) => {
-    const row = {
-      id: sessionId,
-      userId,
-      mode: 'tutor',
-      paramsJson: {
-        count: 1,
-        tagSlugs: [],
-        difficulties: [],
-        questionIds: [firstQuestionId],
-      },
-      startedAt: new Date('2026-02-01T00:00:00.000Z'),
-      endedAt: null,
-    } as const;
-    const findFirst = vi
-      .fn()
-      .mockResolvedValueOnce(row)
-      .mockResolvedValueOnce(
-        currentEndedAt === null ? null : { ...row, endedAt: currentEndedAt },
-      );
-    const stateRows = [
-      createStateRow({
-        practiceSessionId: sessionId,
-        questionId: firstQuestionId,
-        position: 0,
-      }),
-    ];
-    const tx = {
-      query: { practiceSessions: { findFirst } },
-      select: createStateSelect(stateRows),
-    };
-    const db = {
-      transaction: vi.fn(async (fn: (client: typeof tx) => Promise<unknown>) =>
-        fn(tx),
-      ),
-      query: tx.query,
-      select: tx.select,
-      update: vi.fn(() => ({
-        set: () => ({
-          where: () => ({ returning: async () => [] }),
+  ] as const)(
+    'keeps the guarded-update fallback as $expectedCode',
+    async ({ currentEndedAt, expectedCode }) => {
+      const row = {
+        id: sessionId,
+        userId,
+        mode: 'tutor',
+        paramsJson: {
+          count: 1,
+          tagSlugs: [],
+          difficulties: [],
+          questionIds: [firstQuestionId],
+        },
+        startedAt: new Date('2026-02-01T00:00:00.000Z'),
+        endedAt: null,
+      } as const;
+      const findFirst = vi
+        .fn()
+        .mockResolvedValueOnce(row)
+        .mockResolvedValueOnce(
+          currentEndedAt === null ? null : { ...row, endedAt: currentEndedAt },
+        );
+      const stateRows = [
+        createStateRow({
+          practiceSessionId: sessionId,
+          questionId: firstQuestionId,
+          position: 0,
         }),
-      })),
-    } as const;
-    type RepoDb = ConstructorParameters<
-      typeof DrizzlePracticeSessionRepository
-    >[0];
-    const repo = new DrizzlePracticeSessionRepository(db as unknown as RepoDb);
+      ];
+      const tx = {
+        query: { practiceSessions: { findFirst } },
+        select: createStateSelect(stateRows),
+      };
+      const db = {
+        transaction: vi.fn(
+          async (fn: (client: typeof tx) => Promise<unknown>) => fn(tx),
+        ),
+        query: tx.query,
+        select: tx.select,
+        update: vi.fn(() => ({
+          set: () => ({
+            where: () => ({ returning: async () => [] }),
+          }),
+        })),
+      } as const;
+      type RepoDb = ConstructorParameters<
+        typeof DrizzlePracticeSessionRepository
+      >[0];
+      const repo = new DrizzlePracticeSessionRepository(
+        db as unknown as RepoDb,
+      );
 
-    await expect(repo.end(sessionId, userId)).rejects.toMatchObject({
-      code: expectedCode,
-    });
-    expect(db.update).toHaveBeenCalledTimes(1);
-  });
+      await expect(repo.end(sessionId, userId)).rejects.toMatchObject({
+        code: expectedCode,
+      });
+      expect(db.update).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it('ends an active practice session', async () => {
     const now = new Date('2026-02-01T01:02:03.000Z');

--- a/src/application/test-helpers/fakes/fake-user-repository.test.ts
+++ b/src/application/test-helpers/fakes/fake-user-repository.test.ts
@@ -34,60 +34,60 @@ describe('FakeUserRepository', () => {
   });
 
   describe('upsertByClerkId', () => {
-    it.each([
-      'upsertByClerkId',
-      'updateEmailByClerkId',
-    ] as const)('ignores a stale existing-identity write to a foreign-owned email through %s', async (operation) => {
-      const repo = new FakeUserRepository();
-      const staleObservedAt = new Date('2026-02-01T00:00:00.000Z');
-      const currentObservedAt = new Date('2026-02-02T00:00:00.000Z');
-      await repo.upsertByClerkId('clerk-owner', 'owned@example.com', {
-        observedAt: currentObservedAt,
-      });
-      const incoming = await repo.upsertByClerkId(
-        'clerk-incoming',
-        'incoming@example.com',
-        { observedAt: currentObservedAt },
-      );
+    it.each(['upsertByClerkId', 'updateEmailByClerkId'] as const)(
+      'ignores a stale existing-identity write to a foreign-owned email through %s',
+      async (operation) => {
+        const repo = new FakeUserRepository();
+        const staleObservedAt = new Date('2026-02-01T00:00:00.000Z');
+        const currentObservedAt = new Date('2026-02-02T00:00:00.000Z');
+        await repo.upsertByClerkId('clerk-owner', 'owned@example.com', {
+          observedAt: currentObservedAt,
+        });
+        const incoming = await repo.upsertByClerkId(
+          'clerk-incoming',
+          'incoming@example.com',
+          { observedAt: currentObservedAt },
+        );
 
-      await expect(
-        repo[operation]('clerk-incoming', 'owned@example.com', {
-          observedAt: staleObservedAt,
-        }),
-      ).resolves.toEqual(incoming);
-      await expect(repo.findByClerkId('clerk-incoming')).resolves.toEqual(
-        incoming,
-      );
-    });
+        await expect(
+          repo[operation]('clerk-incoming', 'owned@example.com', {
+            observedAt: staleObservedAt,
+          }),
+        ).resolves.toEqual(incoming);
+        await expect(repo.findByClerkId('clerk-incoming')).resolves.toEqual(
+          incoming,
+        );
+      },
+    );
 
-    it.each([
-      'upsertByClerkId',
-      'updateEmailByClerkId',
-    ] as const)('stores the newer observation timestamp for a same-email write through %s', async (operation) => {
-      const repo = new FakeUserRepository();
-      const initialObservedAt = new Date('2026-02-01T00:00:00.000Z');
-      const newerObservedAt = new Date('2026-02-02T00:00:00.000Z');
-      const existing = await repo.upsertByClerkId(
-        'clerk-1',
-        'user@example.com',
-        { observedAt: initialObservedAt },
-      );
+    it.each(['upsertByClerkId', 'updateEmailByClerkId'] as const)(
+      'stores the newer observation timestamp for a same-email write through %s',
+      async (operation) => {
+        const repo = new FakeUserRepository();
+        const initialObservedAt = new Date('2026-02-01T00:00:00.000Z');
+        const newerObservedAt = new Date('2026-02-02T00:00:00.000Z');
+        const existing = await repo.upsertByClerkId(
+          'clerk-1',
+          'user@example.com',
+          { observedAt: initialObservedAt },
+        );
 
-      await expect(
-        repo[operation]('clerk-1', 'user@example.com', {
-          observedAt: newerObservedAt,
-        }),
-      ).resolves.toMatchObject({
-        id: existing.id,
-        email: 'user@example.com',
-        updatedAt: newerObservedAt,
-      });
-      await expect(repo.findByClerkId('clerk-1')).resolves.toMatchObject({
-        id: existing.id,
-        email: 'user@example.com',
-        updatedAt: newerObservedAt,
-      });
-    });
+        await expect(
+          repo[operation]('clerk-1', 'user@example.com', {
+            observedAt: newerObservedAt,
+          }),
+        ).resolves.toMatchObject({
+          id: existing.id,
+          email: 'user@example.com',
+          updatedAt: newerObservedAt,
+        });
+        await expect(repo.findByClerkId('clerk-1')).resolves.toMatchObject({
+          id: existing.id,
+          email: 'user@example.com',
+          updatedAt: newerObservedAt,
+        });
+      },
+    );
 
     it('creates new user when not exists', async () => {
       const repo = new FakeUserRepository();

--- a/src/application/use-cases/dispatch-renewal-notice-delivery.test.ts
+++ b/src/application/use-cases/dispatch-renewal-notice-delivery.test.ts
@@ -98,30 +98,30 @@ describe('DispatchRenewalNoticeDeliveryUseCase', () => {
       }),
       failureCode: 'payload_snapshot_integrity_failure',
     },
-  ])('quarantines a corrupted $label without calling the provider', async ({
-    corrupt,
-    failureCode,
-  }) => {
-    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
-    const saved = await repository.saveQueued(createDelivery());
-    repository.records[0] = {
-      ...saved,
-      ...corrupt(saved),
-    };
-    const gateway = new FakeTransactionalEmailGateway({ configured: true });
-    const useCase = createUseCase({ repository, gateway });
+  ])(
+    'quarantines a corrupted $label without calling the provider',
+    async ({ corrupt, failureCode }) => {
+      const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+      const saved = await repository.saveQueued(createDelivery());
+      repository.records[0] = {
+        ...saved,
+        ...corrupt(saved),
+      };
+      const gateway = new FakeTransactionalEmailGateway({ configured: true });
+      const useCase = createUseCase({ repository, gateway });
 
-    await expect(useCase.execute({ deliveryId })).resolves.toMatchObject({
-      outcome: 'attempted',
-      delivery: {
-        status: 'terminal_failure',
-        attemptCount: 1,
-        failureClass: 'payload_integrity_failure',
-        failureCode,
-      },
-    });
-    expect(gateway.sendInputs).toEqual([]);
-  });
+      await expect(useCase.execute({ deliveryId })).resolves.toMatchObject({
+        outcome: 'attempted',
+        delivery: {
+          status: 'terminal_failure',
+          attemptCount: 1,
+          failureClass: 'payload_integrity_failure',
+          failureCode,
+        },
+      });
+      expect(gateway.sendInputs).toEqual([]);
+    },
+  );
 
   it('persists the claim before the provider call and records delivery', async () => {
     const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
@@ -185,32 +185,35 @@ describe('DispatchRenewalNoticeDeliveryUseCase', () => {
       expectedStatus: 'outcome_unknown',
       expectedNextAttemptAt: null,
     },
-  ])('persists $expectedStatus and returns successfully', async ({
-    result: gatewayResult,
-    expectedStatus,
-    expectedNextAttemptAt,
-  }) => {
-    const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
-    await repository.saveQueued(createDelivery());
-    const gateway = new FakeTransactionalEmailGateway({
-      configured: true,
-      results: [gatewayResult],
-    });
-    const useCase = createUseCase({ repository, gateway });
-
-    const result = await useCase.execute({ deliveryId });
-
-    expect(result).toMatchObject({
-      outcome: 'attempted',
-      delivery: {
-        status: expectedStatus,
-        failureCode: gatewayResult.failureCode,
-      },
-    });
-    expect(result.delivery?.nextAttemptAt?.toISOString() ?? null).toBe(
+  ])(
+    'persists $expectedStatus and returns successfully',
+    async ({
+      result: gatewayResult,
+      expectedStatus,
       expectedNextAttemptAt,
-    );
-  });
+    }) => {
+      const repository = new FakeRenewalNoticeDeliveryRepository(() => now);
+      await repository.saveQueued(createDelivery());
+      const gateway = new FakeTransactionalEmailGateway({
+        configured: true,
+        results: [gatewayResult],
+      });
+      const useCase = createUseCase({ repository, gateway });
+
+      const result = await useCase.execute({ deliveryId });
+
+      expect(result).toMatchObject({
+        outcome: 'attempted',
+        delivery: {
+          status: expectedStatus,
+          failureCode: gatewayResult.failureCode,
+        },
+      });
+      expect(result.delivery?.nextAttemptAt?.toISOString() ?? null).toBe(
+        expectedNextAttemptAt,
+      );
+    },
+  );
 
   it('uses one provider call when two workers dispatch the same row', async () => {
     const repository = new FakeRenewalNoticeDeliveryRepository(() => now);

--- a/src/application/use-cases/finalize-exam-answers.test.ts
+++ b/src/application/use-cases/finalize-exam-answers.test.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/noExcessiveLinesPerFile: Keep all FinalizeExamAnswersUseCase behavior (drafted grading, BUG-238 cumulative bounds, BUG-252 nullable drafts, BUG-254 expiry flush) in one file so the use-case contract stays auditable next to its shared fakes/helpers.
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ApplicationError,

--- a/src/application/use-cases/get-completed-session-questions-with-feedback.test.ts
+++ b/src/application/use-cases/get-completed-session-questions-with-feedback.test.ts
@@ -140,22 +140,22 @@ describe('GetCompletedSessionQuestionsWithFeedbackUseCase', () => {
       attemptIsCorrect: true,
       stateIsCorrect: null,
     },
-  ])('does not warn when $name', async ({
-    attemptIsCorrect,
-    stateIsCorrect,
-  }) => {
-    const fixture = createCorrectnessComparisonFixture({
-      attemptIsCorrect,
-      stateIsCorrect,
-    });
+  ])(
+    'does not warn when $name',
+    async ({ attemptIsCorrect, stateIsCorrect }) => {
+      const fixture = createCorrectnessComparisonFixture({
+        attemptIsCorrect,
+        stateIsCorrect,
+      });
 
-    await fixture.useCase.execute({
-      userId: fixture.userId,
-      sessionId: fixture.sessionId,
-    });
+      await fixture.useCase.execute({
+        userId: fixture.userId,
+        sessionId: fixture.sessionId,
+      });
 
-    expect(fixture.logger.warnCalls).toEqual([]);
-  });
+      expect(fixture.logger.warnCalls).toEqual([]);
+    },
+  );
 
   it('preserves the attempt-preferred output when divergence logging fails', async () => {
     const fixture = createCorrectnessComparisonFixture({

--- a/src/domain/services/subscription-write-guard.test.ts
+++ b/src/domain/services/subscription-write-guard.test.ts
@@ -128,41 +128,39 @@ describe('shouldPersistSubscriptionWrite', () => {
     );
   });
 
-  it.each<SubscriptionStatus>([
-    'paymentProcessing',
-    'unpaid',
-    'paused',
-  ])('rejects a different %s write over a current entitled row', (status) => {
-    expect(
-      shouldPersistSubscriptionWrite({
-        stored: candidate({ status: 'active' }),
-        incoming: candidate({
-          subscriptionIdentity: 'sub_recoverable',
-          status,
-          currentPeriodEnd: FUTURE,
+  it.each<SubscriptionStatus>(['paymentProcessing', 'unpaid', 'paused'])(
+    'rejects a different %s write over a current entitled row',
+    (status) => {
+      expect(
+        shouldPersistSubscriptionWrite({
+          stored: candidate({ status: 'active' }),
+          incoming: candidate({
+            subscriptionIdentity: 'sub_recoverable',
+            status,
+            currentPeriodEnd: FUTURE,
+          }),
+          now: NOW,
         }),
-        now: NOW,
-      }),
-    ).toBe(false);
-  });
+      ).toBe(false);
+    },
+  );
 
-  it.each<SubscriptionStatus>([
-    'active',
-    'inTrial',
-    'pastDue',
-  ])('allows a different current-entitled %s canonical winner', (status) => {
-    expect(
-      shouldPersistSubscriptionWrite({
-        stored: candidate({ status: 'active' }),
-        incoming: candidate({
-          subscriptionIdentity: 'sub_canonical',
-          status,
-          currentPeriodEnd: FUTURE,
+  it.each<SubscriptionStatus>(['active', 'inTrial', 'pastDue'])(
+    'allows a different current-entitled %s canonical winner',
+    (status) => {
+      expect(
+        shouldPersistSubscriptionWrite({
+          stored: candidate({ status: 'active' }),
+          incoming: candidate({
+            subscriptionIdentity: 'sub_canonical',
+            status,
+            currentPeriodEnd: FUTURE,
+          }),
+          now: NOW,
         }),
-        now: NOW,
-      }),
-    ).toBe(true);
-  });
+      ).toBe(true);
+    },
+  );
 
   it('rejects a different current-entitled write that loses canonical ordering', () => {
     expect(
@@ -182,26 +180,25 @@ describe('shouldPersistSubscriptionWrite', () => {
     ).toBe(false);
   });
 
-  it.each<SubscriptionStatus>([
-    'paymentProcessing',
-    'unpaid',
-    'paused',
-  ])('allows same-subscription %s lifecycle updates', (status) => {
-    expect(
-      shouldPersistSubscriptionWrite({
-        stored: candidate({
-          subscriptionIdentity: 'sub_current',
-          status: 'active',
+  it.each<SubscriptionStatus>(['paymentProcessing', 'unpaid', 'paused'])(
+    'allows same-subscription %s lifecycle updates',
+    (status) => {
+      expect(
+        shouldPersistSubscriptionWrite({
+          stored: candidate({
+            subscriptionIdentity: 'sub_current',
+            status: 'active',
+          }),
+          incoming: candidate({
+            subscriptionIdentity: 'sub_current',
+            status,
+            currentPeriodEnd: FUTURE,
+          }),
+          now: NOW,
         }),
-        incoming: candidate({
-          subscriptionIdentity: 'sub_current',
-          status,
-          currentPeriodEnd: FUTURE,
-        }),
-        now: NOW,
-      }),
-    ).toBe(true);
-  });
+      ).toBe(true);
+    },
+  );
 
   it('allows a different unpaid write when the stored active period has expired', () => {
     expect(

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -27,14 +27,14 @@ function findStepBlock(workflow: string, stepName: string): string {
 }
 
 describe('CI workflow', () => {
-  it.each([
-    'Validate E2E credential inputs',
-    'E2E smoke',
-  ])('does not run %s on Dependabot pull requests because secrets are unavailable', (stepName) => {
-    const stepBlock = findStepBlock(readCiWorkflow(), stepName);
+  it.each(['Validate E2E credential inputs', 'E2E smoke'])(
+    'does not run %s on Dependabot pull requests because secrets are unavailable',
+    (stepName) => {
+      const stepBlock = findStepBlock(readCiWorkflow(), stepName);
 
-    expect(stepBlock).toContain("github.event_name == 'push'");
-    expect(stepBlock).toContain(HUMAN_SAME_REPO_PR_CONDITION);
-    expect(stepBlock).toContain(DEPENDABOT_ACTOR_GUARD);
-  });
+      expect(stepBlock).toContain("github.event_name == 'push'");
+      expect(stepBlock).toContain(HUMAN_SAME_REPO_PR_CONDITION);
+      expect(stepBlock).toContain(DEPENDABOT_ACTOR_GUARD);
+    },
+  );
 });

--- a/tests/e2e/helpers/reset-e2e-user-state.test.ts
+++ b/tests/e2e/helpers/reset-e2e-user-state.test.ts
@@ -614,35 +614,35 @@ describe('runE2EUserStateReset default service diagnostics', () => {
           queryFailure: sourceError,
         }),
     },
-  ])('surfaces, sanitizes, and preserves cause for $label failures', async ({
-    expectedCode,
-    client,
-  }) => {
-    await importResetWithPostgresMock();
-    const sourceError = createSensitiveError();
-    postgresMock.mockReturnValue(client(sourceError));
-    const fetchSpy = mockClerkUserFetch();
+  ])(
+    'surfaces, sanitizes, and preserves cause for $label failures',
+    async ({ expectedCode, client }) => {
+      await importResetWithPostgresMock();
+      const sourceError = createSensitiveError();
+      postgresMock.mockReturnValue(client(sourceError));
+      const fetchSpy = mockClerkUserFetch();
 
-    try {
-      const error = await captureRejectedError(() =>
-        dynamicRunE2EUserStateReset({ env: createEnv() }),
-      );
-      const resetError = error.cause as Error & {
-        code?: string;
-        cause?: unknown;
-      };
+      try {
+        const error = await captureRejectedError(() =>
+          dynamicRunE2EUserStateReset({ env: createEnv() }),
+        );
+        const resetError = error.cause as Error & {
+          code?: string;
+          cause?: unknown;
+        };
 
-      expect(error.message).toContain(`[${expectedCode}]`);
-      expect(error.message).toContain(NON_SECRET_DB_ERROR);
-      expect(resetError.code).toBe(expectedCode);
-      expect(resetError.message).toContain(NON_SECRET_DB_ERROR);
-      expect(resetError.cause).toBe(sourceError);
-      expectNoSensitiveParts(error.message);
-      expectNoSensitiveParts(resetError.message);
-    } finally {
-      fetchSpy.mockRestore();
-    }
-  });
+        expect(error.message).toContain(`[${expectedCode}]`);
+        expect(error.message).toContain(NON_SECRET_DB_ERROR);
+        expect(resetError.code).toBe(expectedCode);
+        expect(resetError.message).toContain(NON_SECRET_DB_ERROR);
+        expect(resetError.cause).toBe(sourceError);
+        expectNoSensitiveParts(error.message);
+        expectNoSensitiveParts(resetError.message);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    },
+  );
 
   it('fails stale deterministic baseline owners before seeding mutations', async () => {
     await importResetWithPostgresMock();
@@ -753,25 +753,30 @@ describe('runE2EUserStateReset default service diagnostics', () => {
         bookmarkCount: 2,
       }),
     },
-  ])('surfaces invalid baseline verification for $label without wrapping the explicit reset error', async ({
-    baselineRow,
-  }) => {
-    await importResetWithPostgresMock();
-    const sqlClient = createRoutingSqlClient({ baselineRows: [baselineRow] });
-    postgresMock.mockReturnValue(sqlClient);
-    const fetchSpy = mockClerkUserFetch();
+  ])(
+    'surfaces invalid baseline verification for $label without wrapping the explicit reset error',
+    async ({ baselineRow }) => {
+      await importResetWithPostgresMock();
+      const sqlClient = createRoutingSqlClient({ baselineRows: [baselineRow] });
+      postgresMock.mockReturnValue(sqlClient);
+      const fetchSpy = mockClerkUserFetch();
 
-    try {
-      const error = await captureRejectedError(() =>
-        dynamicRunE2EUserStateReset({ env: createEnv() }),
-      );
+      try {
+        const error = await captureRejectedError(() =>
+          dynamicRunE2EUserStateReset({ env: createEnv() }),
+        );
 
-      expect(error.message).toContain('[E2E_RESET:BASELINE_STATE_INCOMPLETE]');
-      expect(error.message).not.toContain('[E2E_RESET:DATABASE_QUERY_FAILED]');
-    } finally {
-      fetchSpy.mockRestore();
-    }
-  });
+        expect(error.message).toContain(
+          '[E2E_RESET:BASELINE_STATE_INCOMPLETE]',
+        );
+        expect(error.message).not.toContain(
+          '[E2E_RESET:DATABASE_QUERY_FAILED]',
+        );
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    },
+  );
 
   it('uses one SQL client lifecycle for the reset path including app-user lookup', async () => {
     await importResetWithPostgresMock();

--- a/tests/integration/idempotency-determinacy.integration.test.ts
+++ b/tests/integration/idempotency-determinacy.integration.test.ts
@@ -77,42 +77,26 @@ describe('idempotency determinacy with real Postgres', () => {
       'practice:startPracticeSession',
       shouldCacheStartPracticeSessionError,
     ],
-  ] as const)('aborts and re-executes %s after rollback-certain 57014', async (_name, action, shouldCacheError) => {
-    const user = await createUser(db, cleanup);
-    const repo = new DrizzleIdempotencyKeyRepository(db);
-    const logger = new FakeLogger();
-    const key = randomUUID();
-    const now = () => new Date();
-    let executionCount = 0;
-    let injectCancellation = true;
-    const execute = async () => {
-      executionCount += 1;
-      if (injectCancellation) {
-        injectCancellation = false;
-        return throwRealStatementCancellation();
-      }
-      return { committed: true };
-    };
+  ] as const)(
+    'aborts and re-executes %s after rollback-certain 57014',
+    async (_name, action, shouldCacheError) => {
+      const user = await createUser(db, cleanup);
+      const repo = new DrizzleIdempotencyKeyRepository(db);
+      const logger = new FakeLogger();
+      const key = randomUUID();
+      const now = () => new Date();
+      let executionCount = 0;
+      let injectCancellation = true;
+      const execute = async () => {
+        executionCount += 1;
+        if (injectCancellation) {
+          injectCancellation = false;
+          return throwRealStatementCancellation();
+        }
+        return { committed: true };
+      };
 
-    const first = withIdempotency({
-      repo,
-      logger,
-      userId: user.id,
-      action,
-      key,
-      now,
-      shouldCacheError,
-      execute,
-    });
-
-    await expect(first).rejects.toMatchObject({
-      code: 'INTERNAL_ERROR',
-      determinacy: 'rollback_certain',
-    });
-    await expect(repo.find(user.id, action, key)).resolves.toBeNull();
-
-    await expect(
-      withIdempotency({
+      const first = withIdempotency({
         repo,
         logger,
         userId: user.id,
@@ -121,10 +105,29 @@ describe('idempotency determinacy with real Postgres', () => {
         now,
         shouldCacheError,
         execute,
-      }),
-    ).resolves.toEqual({ committed: true });
-    expect(executionCount).toBe(2);
-  });
+      });
+
+      await expect(first).rejects.toMatchObject({
+        code: 'INTERNAL_ERROR',
+        determinacy: 'rollback_certain',
+      });
+      await expect(repo.find(user.id, action, key)).resolves.toBeNull();
+
+      await expect(
+        withIdempotency({
+          repo,
+          logger,
+          userId: user.id,
+          action,
+          key,
+          now,
+          shouldCacheError,
+          execute,
+        }),
+      ).resolves.toEqual({ committed: true });
+      expect(executionCount).toBe(2);
+    },
+  );
 
   it('aborts and re-executes session start after a transient internal error', async () => {
     const user = await createUser(db, cleanup);

--- a/tests/integration/pending-stripe-customer-cleanup-contract.integration.test.ts
+++ b/tests/integration/pending-stripe-customer-cleanup-contract.integration.test.ts
@@ -77,85 +77,92 @@ const harnesses = [
   ['real Postgres', createRealHarness],
 ] as const;
 
-describe.each(
-  harnesses,
-)('PendingStripeCustomerCleanupRepository contract (%s)', (_label, createHarness) => {
-  const t0 = new Date('2026-06-12T12:00:00.000Z');
-  const t1 = new Date('2026-06-12T12:01:00.000Z');
-  const t2 = new Date('2026-06-12T12:02:00.000Z');
-  const cutoffAfterAll = new Date('2026-06-12T12:15:00.000Z');
+describe.each(harnesses)(
+  'PendingStripeCustomerCleanupRepository contract (%s)',
+  (_label, createHarness) => {
+    const t0 = new Date('2026-06-12T12:00:00.000Z');
+    const t1 = new Date('2026-06-12T12:01:00.000Z');
+    const t2 = new Date('2026-06-12T12:02:00.000Z');
+    const cutoffAfterAll = new Date('2026-06-12T12:15:00.000Z');
 
-  it('schedule() inserts a new obligation that is findable and listable', async () => {
-    const harness = createHarness();
-    const eventId = `evt_${randomUUID().replaceAll('-', '')}`;
-    await harness.seedEvent(eventId);
+    it('schedule() inserts a new obligation that is findable and listable', async () => {
+      const harness = createHarness();
+      const eventId = `evt_${randomUUID().replaceAll('-', '')}`;
+      await harness.seedEvent(eventId);
 
-    await harness.repo.schedule(eventId, 'cus_inserted');
+      await harness.repo.schedule(eventId, 'cus_inserted');
 
-    await expect(harness.repo.findByEventId(eventId)).resolves.toEqual({
-      stripeCustomerId: 'cus_inserted',
-    });
-    const farFutureCutoff = new Date(Date.now() + 60 * 60 * 1000);
-    const rows = await harness.repo.listStale(farFutureCutoff, 100);
-    expect(rows.map((row) => row.eventId)).toContain(eventId);
-  });
-
-  it('finds a scheduled obligation by event id and deletes idempotently', async () => {
-    const harness = createHarness();
-    const eventId = `evt_${randomUUID().replaceAll('-', '')}`;
-    await harness.seed(eventId, 'cus_contract', t0);
-
-    await expect(harness.repo.findByEventId(eventId)).resolves.toEqual({
-      stripeCustomerId: 'cus_contract',
+      await expect(harness.repo.findByEventId(eventId)).resolves.toEqual({
+        stripeCustomerId: 'cus_inserted',
+      });
+      const farFutureCutoff = new Date(Date.now() + 60 * 60 * 1000);
+      const rows = await harness.repo.listStale(farFutureCutoff, 100);
+      expect(rows.map((row) => row.eventId)).toContain(eventId);
     });
 
-    await harness.repo.deleteByEventId(eventId);
-    await expect(harness.repo.findByEventId(eventId)).resolves.toBeNull();
-    await expect(
-      harness.repo.deleteByEventId(eventId),
-    ).resolves.toBeUndefined();
-  });
+    it('finds a scheduled obligation by event id and deletes idempotently', async () => {
+      const harness = createHarness();
+      const eventId = `evt_${randomUUID().replaceAll('-', '')}`;
+      await harness.seed(eventId, 'cus_contract', t0);
 
-  it('re-scheduling updates the customer id but preserves the staleness clock', async () => {
-    const harness = createHarness();
-    const eventId = `evt_${randomUUID().replaceAll('-', '')}`;
-    await harness.seed(eventId, 'cus_first', t0);
+      await expect(harness.repo.findByEventId(eventId)).resolves.toEqual({
+        stripeCustomerId: 'cus_contract',
+      });
 
-    await harness.repo.schedule(eventId, 'cus_second');
-
-    await expect(harness.repo.findByEventId(eventId)).resolves.toEqual({
-      stripeCustomerId: 'cus_second',
+      await harness.repo.deleteByEventId(eventId);
+      await expect(harness.repo.findByEventId(eventId)).resolves.toBeNull();
+      await expect(
+        harness.repo.deleteByEventId(eventId),
+      ).resolves.toBeUndefined();
     });
-    const [row] = await harness.repo.listStale(cutoffAfterAll, 10);
-    expect(row).toEqual({
-      eventId,
-      stripeCustomerId: 'cus_second',
-      createdAt: t0,
+
+    it('re-scheduling updates the customer id but preserves the staleness clock', async () => {
+      const harness = createHarness();
+      const eventId = `evt_${randomUUID().replaceAll('-', '')}`;
+      await harness.seed(eventId, 'cus_first', t0);
+
+      await harness.repo.schedule(eventId, 'cus_second');
+
+      await expect(harness.repo.findByEventId(eventId)).resolves.toEqual({
+        stripeCustomerId: 'cus_second',
+      });
+      const [row] = await harness.repo.listStale(cutoffAfterAll, 10);
+      expect(row).toEqual({
+        eventId,
+        stripeCustomerId: 'cus_second',
+        createdAt: t0,
+      });
     });
-  });
 
-  it('lists stale rows oldest-first with cutoff, limit, and exclusions', async () => {
-    const harness = createHarness();
-    const eventA = `evt_${randomUUID().replaceAll('-', '')}`;
-    const eventB = `evt_${randomUUID().replaceAll('-', '')}`;
-    const eventC = `evt_${randomUUID().replaceAll('-', '')}`;
-    await harness.seed(eventB, 'cus_b', t1);
-    await harness.seed(eventA, 'cus_a', t0);
-    await harness.seed(eventC, 'cus_c', t2);
+    it('lists stale rows oldest-first with cutoff, limit, and exclusions', async () => {
+      const harness = createHarness();
+      const eventA = `evt_${randomUUID().replaceAll('-', '')}`;
+      const eventB = `evt_${randomUUID().replaceAll('-', '')}`;
+      const eventC = `evt_${randomUUID().replaceAll('-', '')}`;
+      await harness.seed(eventB, 'cus_b', t1);
+      await harness.seed(eventA, 'cus_a', t0);
+      await harness.seed(eventC, 'cus_c', t2);
 
-    const ordered = await harness.repo.listStale(cutoffAfterAll, 10);
-    expect(ordered.map((row) => row.eventId)).toEqual([eventA, eventB, eventC]);
+      const ordered = await harness.repo.listStale(cutoffAfterAll, 10);
+      expect(ordered.map((row) => row.eventId)).toEqual([
+        eventA,
+        eventB,
+        eventC,
+      ]);
 
-    const limited = await harness.repo.listStale(cutoffAfterAll, 2);
-    expect(limited.map((row) => row.eventId)).toEqual([eventA, eventB]);
+      const limited = await harness.repo.listStale(cutoffAfterAll, 2);
+      expect(limited.map((row) => row.eventId)).toEqual([eventA, eventB]);
 
-    const excluded = await harness.repo.listStale(cutoffAfterAll, 2, [eventA]);
-    expect(excluded.map((row) => row.eventId)).toEqual([eventB, eventC]);
+      const excluded = await harness.repo.listStale(cutoffAfterAll, 2, [
+        eventA,
+      ]);
+      expect(excluded.map((row) => row.eventId)).toEqual([eventB, eventC]);
 
-    const cutoffBetween = await harness.repo.listStale(
-      new Date(t1.getTime() + 1),
-      10,
-    );
-    expect(cutoffBetween.map((row) => row.eventId)).toEqual([eventA, eventB]);
-  });
-});
+      const cutoffBetween = await harness.repo.listStale(
+        new Date(t1.getTime() + 1),
+        10,
+      );
+      expect(cutoffBetween.map((row) => row.eventId)).toEqual([eventA, eventB]);
+    });
+  },
+);

--- a/tests/integration/stripe-subscription-writer-lock-order.integration.test.ts
+++ b/tests/integration/stripe-subscription-writer-lock-order.integration.test.ts
@@ -626,111 +626,111 @@ afterAll(async () => {
 });
 
 describe('Stripe subscription writer lock order', () => {
-  it.each([
-    'webhook',
-    'reconcile',
-  ] as const)('serializes the deletion writer and %s writer without a 40P01 deadlock', async (writerKind) => {
-    const user = await createUser(control.db, cleanup);
-    const storedUser = await control.db.query.users.findFirst({
-      columns: { clerkUserId: true },
-      where: eq(schema.users.id, user.id),
-    });
-    if (!storedUser) throw new Error('Failed to reload integration user');
-
-    const externalCustomerId = `cus_${randomUUID().replaceAll('-', '')}`;
-    const externalSubscriptionId = `sub_${randomUUID().replaceAll('-', '')}`;
-    const stripeEventId = `evt_${randomUUID().replaceAll('-', '')}`;
-    const clerkEventId = `evt_${randomUUID().replaceAll('-', '')}`;
-    if (writerKind === 'webhook') {
-      cleanup.stripeEventIds.push(stripeEventId);
-    }
-    clerkEventIds.push(clerkEventId);
-    deletedClerkUserIds.push(storedUser.clerkUserId);
-
-    await new DrizzleStripeCustomerRepository(control.db).insert(
-      user.id,
-      externalCustomerId,
-    );
-    await new DrizzleSubscriptionRepository(control.db, priceIds).upsert({
-      userId: user.id,
-      externalSubscriptionId,
-      plan: 'monthly',
-      status: 'active',
-      expectedVersion: null,
-      currentPeriodEnd: new Date('2029-01-01T00:00:00.000Z'),
-      cancelAtPeriodEnd: false,
-    });
-
-    const counterpartyLockHeld = createDeferred<void>();
-    const releaseCounterparty = createDeferred<void>();
-    let reconciliationTransactionError: unknown;
-    const counterpartyPromise =
-      writerKind === 'webhook'
-        ? runWebhookWriter({
-            userId: user.id,
-            externalCustomerId,
-            externalSubscriptionId,
-            eventId: stripeEventId,
-            lockHeld: () => counterpartyLockHeld.resolve(),
-            release: releaseCounterparty.promise,
-            deletionCounterparty: true,
-          })
-        : runReconciliationWriter({
-            userId: user.id,
-            externalCustomerId,
-            externalSubscriptionId,
-            lockHeld: () => counterpartyLockHeld.resolve(),
-            release: releaseCounterparty.promise,
-            onTransactionError: (error) => {
-              reconciliationTransactionError = error;
-            },
-          });
-    await counterpartyLockHeld.promise;
-
-    // The deletion writer now takes the advisory before any users-row lock,
-    // so it must queue at the advisory while the counterparty holds it; the
-    // customer-read pause is pre-released because it happens under the lock.
-    const releaseDeletion = createDeferred<void>();
-    releaseDeletion.resolve();
-    const deletionPid = createDeferred<number>();
-    const deletionPromise = runDeletionWriter({
-      clerkUserId: storedUser.clerkUserId,
-      eventId: clerkEventId,
-      backendPid: (pid) => deletionPid.resolve(pid),
-      customerRead: () => undefined,
-      release: releaseDeletion.promise,
-    });
-
-    const deletionState = await waitForDeletionLockState(
-      await deletionPid.promise,
-    );
-    releaseCounterparty.resolve();
-
-    const [counterpartyResult, deletionResult] = await Promise.allSettled([
-      counterpartyPromise,
-      deletionPromise,
-    ]);
-    const postgresErrorCodes = [
-      reconciliationTransactionError,
-      counterpartyResult.status === 'rejected'
-        ? counterpartyResult.reason
-        : null,
-      deletionResult.status === 'rejected' ? deletionResult.reason : null,
-    ]
-      .map(findPostgresErrorCode)
-      .filter((code): code is string => code !== null);
-
-    expect(postgresErrorCodes).not.toContain('40P01');
-    expect(deletionState).toBe('waiting-on-advisory');
-    expect(counterpartyResult.status).toBe('fulfilled');
-    expect(deletionResult.status).toBe('fulfilled');
-    if (writerKind === 'reconcile') {
-      expect(counterpartyResult).toMatchObject({
-        status: 'fulfilled',
-        value: { updated: 1, failed: 0 },
+  it.each(['webhook', 'reconcile'] as const)(
+    'serializes the deletion writer and %s writer without a 40P01 deadlock',
+    async (writerKind) => {
+      const user = await createUser(control.db, cleanup);
+      const storedUser = await control.db.query.users.findFirst({
+        columns: { clerkUserId: true },
+        where: eq(schema.users.id, user.id),
       });
-    }
-  });
+      if (!storedUser) throw new Error('Failed to reload integration user');
+
+      const externalCustomerId = `cus_${randomUUID().replaceAll('-', '')}`;
+      const externalSubscriptionId = `sub_${randomUUID().replaceAll('-', '')}`;
+      const stripeEventId = `evt_${randomUUID().replaceAll('-', '')}`;
+      const clerkEventId = `evt_${randomUUID().replaceAll('-', '')}`;
+      if (writerKind === 'webhook') {
+        cleanup.stripeEventIds.push(stripeEventId);
+      }
+      clerkEventIds.push(clerkEventId);
+      deletedClerkUserIds.push(storedUser.clerkUserId);
+
+      await new DrizzleStripeCustomerRepository(control.db).insert(
+        user.id,
+        externalCustomerId,
+      );
+      await new DrizzleSubscriptionRepository(control.db, priceIds).upsert({
+        userId: user.id,
+        externalSubscriptionId,
+        plan: 'monthly',
+        status: 'active',
+        expectedVersion: null,
+        currentPeriodEnd: new Date('2029-01-01T00:00:00.000Z'),
+        cancelAtPeriodEnd: false,
+      });
+
+      const counterpartyLockHeld = createDeferred<void>();
+      const releaseCounterparty = createDeferred<void>();
+      let reconciliationTransactionError: unknown;
+      const counterpartyPromise =
+        writerKind === 'webhook'
+          ? runWebhookWriter({
+              userId: user.id,
+              externalCustomerId,
+              externalSubscriptionId,
+              eventId: stripeEventId,
+              lockHeld: () => counterpartyLockHeld.resolve(),
+              release: releaseCounterparty.promise,
+              deletionCounterparty: true,
+            })
+          : runReconciliationWriter({
+              userId: user.id,
+              externalCustomerId,
+              externalSubscriptionId,
+              lockHeld: () => counterpartyLockHeld.resolve(),
+              release: releaseCounterparty.promise,
+              onTransactionError: (error) => {
+                reconciliationTransactionError = error;
+              },
+            });
+      await counterpartyLockHeld.promise;
+
+      // The deletion writer now takes the advisory before any users-row lock,
+      // so it must queue at the advisory while the counterparty holds it; the
+      // customer-read pause is pre-released because it happens under the lock.
+      const releaseDeletion = createDeferred<void>();
+      releaseDeletion.resolve();
+      const deletionPid = createDeferred<number>();
+      const deletionPromise = runDeletionWriter({
+        clerkUserId: storedUser.clerkUserId,
+        eventId: clerkEventId,
+        backendPid: (pid) => deletionPid.resolve(pid),
+        customerRead: () => undefined,
+        release: releaseDeletion.promise,
+      });
+
+      const deletionState = await waitForDeletionLockState(
+        await deletionPid.promise,
+      );
+      releaseCounterparty.resolve();
+
+      const [counterpartyResult, deletionResult] = await Promise.allSettled([
+        counterpartyPromise,
+        deletionPromise,
+      ]);
+      const postgresErrorCodes = [
+        reconciliationTransactionError,
+        counterpartyResult.status === 'rejected'
+          ? counterpartyResult.reason
+          : null,
+        deletionResult.status === 'rejected' ? deletionResult.reason : null,
+      ]
+        .map(findPostgresErrorCode)
+        .filter((code): code is string => code !== null);
+
+      expect(postgresErrorCodes).not.toContain('40P01');
+      expect(deletionState).toBe('waiting-on-advisory');
+      expect(counterpartyResult.status).toBe('fulfilled');
+      expect(deletionResult.status).toBe('fulfilled');
+      if (writerKind === 'reconcile') {
+        expect(counterpartyResult).toMatchObject({
+          status: 'fulfilled',
+          value: { updated: 1, failed: 0 },
+        });
+      }
+    },
+  );
 
   it('serializes the deletion writer and a first-insert webhook writer at the advisory lock', async () => {
     const user = await createUser(control.db, cleanup);
@@ -815,122 +815,125 @@ describe('Stripe subscription writer lock order', () => {
     });
   });
 
-  it.each([
-    'webhook',
-    'checkout-success',
-  ] as const)('serializes the %s and reconcile writers without a 40P01 deadlock', async (writerKind) => {
-    const user = await createUser(control.db, cleanup);
-    const externalCustomerId = `cus_${randomUUID().replaceAll('-', '')}`;
-    const externalSubscriptionId = `sub_${randomUUID().replaceAll('-', '')}`;
-    const eventId = `evt_${randomUUID().replaceAll('-', '')}`;
-    if (writerKind === 'webhook') cleanup.stripeEventIds.push(eventId);
+  it.each(['webhook', 'checkout-success'] as const)(
+    'serializes the %s and reconcile writers without a 40P01 deadlock',
+    async (writerKind) => {
+      const user = await createUser(control.db, cleanup);
+      const externalCustomerId = `cus_${randomUUID().replaceAll('-', '')}`;
+      const externalSubscriptionId = `sub_${randomUUID().replaceAll('-', '')}`;
+      const eventId = `evt_${randomUUID().replaceAll('-', '')}`;
+      if (writerKind === 'webhook') cleanup.stripeEventIds.push(eventId);
 
-    await new DrizzleStripeCustomerRepository(control.db).insert(
-      user.id,
-      externalCustomerId,
-    );
+      await new DrizzleStripeCustomerRepository(control.db).insert(
+        user.id,
+        externalCustomerId,
+      );
 
-    const writerLockHeld = createDeferred<void>();
-    const releaseWriter = createDeferred<void>();
-    const reconciliationPid = createDeferred<number>();
-    let customerLockObserved = false;
-    let reconciliationTransactionError: unknown;
+      const writerLockHeld = createDeferred<void>();
+      const releaseWriter = createDeferred<void>();
+      const reconciliationPid = createDeferred<number>();
+      let customerLockObserved = false;
+      let reconciliationTransactionError: unknown;
 
-    const writerPromise =
-      writerKind === 'webhook'
-        ? runWebhookWriter({
-            userId: user.id,
-            externalCustomerId,
-            externalSubscriptionId,
-            eventId,
-            lockHeld: () => writerLockHeld.resolve(),
-            release: releaseWriter.promise,
-          })
-        : runCheckoutSuccessWriter({
-            userId: user.id,
-            email: user.email,
-            externalCustomerId,
-            externalSubscriptionId,
-            lockHeld: () => writerLockHeld.resolve(),
-            release: releaseWriter.promise,
-          });
-
-    await writerLockHeld.promise;
-
-    const normalizedSubscription = stripeSubscription({
-      userId: user.id,
-      externalCustomerId,
-      externalSubscriptionId,
-    });
-    const stripe = createReconciliationStripeClient(normalizedSubscription);
-
-    const reconciliationPromise = reconcileStripeSubscriptions(
-      { limit: 1, offset: 0, dryRun: true, concurrency: 1 },
-      {
-        stripe,
-        priceIds,
-        logger: new FakeLogger(),
-        now: () => new Date('2026-08-07T12:00:00.000Z'),
-        listLocalSubscriptions: async () => [
-          {
-            userId: user.id,
-            stripeSubscriptionId: externalSubscriptionId,
-            version: null,
-          },
-        ],
-        transaction: async (fn) => {
-          try {
-            return await reconciliationWriter.db.transaction(async (tx) => {
-              await configureFastDeadlockWriter(tx);
-              reconciliationPid.resolve(await getBackendPid(tx));
-              return fn({
-                subscriptions: new DrizzleSubscriptionRepository(tx, priceIds),
-                stripeCustomers: new ObservedStripeCustomerRepository(
-                  tx,
-                  () => {
-                    customerLockObserved = true;
-                  },
-                ),
-                renewalConsentRecords:
-                  new DrizzleRenewalConsentRecordRepository(tx),
-              });
+      const writerPromise =
+        writerKind === 'webhook'
+          ? runWebhookWriter({
+              userId: user.id,
+              externalCustomerId,
+              externalSubscriptionId,
+              eventId,
+              lockHeld: () => writerLockHeld.resolve(),
+              release: releaseWriter.promise,
+            })
+          : runCheckoutSuccessWriter({
+              userId: user.id,
+              email: user.email,
+              externalCustomerId,
+              externalSubscriptionId,
+              lockHeld: () => writerLockHeld.resolve(),
+              release: releaseWriter.promise,
             });
-          } catch (error) {
-            reconciliationTransactionError = error;
-            throw error;
-          }
-        },
-      },
-    );
 
-    const pid = await reconciliationPid.promise;
-    let state: Awaited<ReturnType<typeof waitForReconciliationState>>;
-    try {
-      state = await waitForReconciliationState({
-        pid,
-        customerLockObserved: () => customerLockObserved,
+      await writerLockHeld.promise;
+
+      const normalizedSubscription = stripeSubscription({
+        userId: user.id,
+        externalCustomerId,
+        externalSubscriptionId,
       });
-    } finally {
-      releaseWriter.resolve();
-    }
+      const stripe = createReconciliationStripeClient(normalizedSubscription);
 
-    const [writerResult, reconciliationResult] = await Promise.allSettled([
-      writerPromise,
-      reconciliationPromise,
-    ]);
-    const postgresErrorCodes = [
-      reconciliationTransactionError,
-      writerResult.status === 'rejected' ? writerResult.reason : null,
-    ]
-      .map(findPostgresErrorCode)
-      .filter((code): code is string => code !== null);
+      const reconciliationPromise = reconcileStripeSubscriptions(
+        { limit: 1, offset: 0, dryRun: true, concurrency: 1 },
+        {
+          stripe,
+          priceIds,
+          logger: new FakeLogger(),
+          now: () => new Date('2026-08-07T12:00:00.000Z'),
+          listLocalSubscriptions: async () => [
+            {
+              userId: user.id,
+              stripeSubscriptionId: externalSubscriptionId,
+              version: null,
+            },
+          ],
+          transaction: async (fn) => {
+            try {
+              return await reconciliationWriter.db.transaction(async (tx) => {
+                await configureFastDeadlockWriter(tx);
+                reconciliationPid.resolve(await getBackendPid(tx));
+                return fn({
+                  subscriptions: new DrizzleSubscriptionRepository(
+                    tx,
+                    priceIds,
+                  ),
+                  stripeCustomers: new ObservedStripeCustomerRepository(
+                    tx,
+                    () => {
+                      customerLockObserved = true;
+                    },
+                  ),
+                  renewalConsentRecords:
+                    new DrizzleRenewalConsentRecordRepository(tx),
+                });
+              });
+            } catch (error) {
+              reconciliationTransactionError = error;
+              throw error;
+            }
+          },
+        },
+      );
 
-    expect(postgresErrorCodes).toEqual([]);
-    expect(state).toBe('waiting-on-advisory');
-    expect(writerResult.status).toBe('fulfilled');
-    expect(reconciliationResult).toMatchObject({
-      status: 'fulfilled',
-      value: { updated: 1, failed: 0 },
-    });
-  });
+      const pid = await reconciliationPid.promise;
+      let state: Awaited<ReturnType<typeof waitForReconciliationState>>;
+      try {
+        state = await waitForReconciliationState({
+          pid,
+          customerLockObserved: () => customerLockObserved,
+        });
+      } finally {
+        releaseWriter.resolve();
+      }
+
+      const [writerResult, reconciliationResult] = await Promise.allSettled([
+        writerPromise,
+        reconciliationPromise,
+      ]);
+      const postgresErrorCodes = [
+        reconciliationTransactionError,
+        writerResult.status === 'rejected' ? writerResult.reason : null,
+      ]
+        .map(findPostgresErrorCode)
+        .filter((code): code is string => code !== null);
+
+      expect(postgresErrorCodes).toEqual([]);
+      expect(state).toBe('waiting-on-advisory');
+      expect(writerResult.status).toBe('fulfilled');
+      expect(reconciliationResult).toMatchObject({
+        status: 'fulfilled',
+        value: { updated: 1, failed: 0 },
+      });
+    },
+  );
 });

--- a/tests/integration/user-repository.integration.test.ts
+++ b/tests/integration/user-repository.integration.test.ts
@@ -52,66 +52,66 @@ afterAll(async () => {
 });
 
 describe('DrizzleUserRepository', () => {
-  it.each([
-    'upsertByClerkId',
-    'updateEmailByClerkId',
-  ] as const)('ignores a stale existing-identity write to a foreign-owned email through %s', async (operation) => {
-    const repo = new DrizzleUserRepository(db);
-    const staleObservedAt = new Date('2026-02-01T00:00:00.000Z');
-    const currentObservedAt = new Date('2026-02-02T00:00:00.000Z');
-    const ownerClerkId = `user_${randomUUID().replaceAll('-', '')}`;
-    const incomingClerkId = `user_${randomUUID().replaceAll('-', '')}`;
-    const ownedEmail = `it-${randomUUID()}@example.com`;
-    const incomingEmail = `it-${randomUUID()}@example.com`;
-    const owner = await repo.upsertByClerkId(ownerClerkId, ownedEmail, {
-      observedAt: currentObservedAt,
-    });
-    const incoming = await repo.upsertByClerkId(
-      incomingClerkId,
-      incomingEmail,
-      { observedAt: currentObservedAt },
-    );
-    cleanup.userIds.push(owner.id, incoming.id);
+  it.each(['upsertByClerkId', 'updateEmailByClerkId'] as const)(
+    'ignores a stale existing-identity write to a foreign-owned email through %s',
+    async (operation) => {
+      const repo = new DrizzleUserRepository(db);
+      const staleObservedAt = new Date('2026-02-01T00:00:00.000Z');
+      const currentObservedAt = new Date('2026-02-02T00:00:00.000Z');
+      const ownerClerkId = `user_${randomUUID().replaceAll('-', '')}`;
+      const incomingClerkId = `user_${randomUUID().replaceAll('-', '')}`;
+      const ownedEmail = `it-${randomUUID()}@example.com`;
+      const incomingEmail = `it-${randomUUID()}@example.com`;
+      const owner = await repo.upsertByClerkId(ownerClerkId, ownedEmail, {
+        observedAt: currentObservedAt,
+      });
+      const incoming = await repo.upsertByClerkId(
+        incomingClerkId,
+        incomingEmail,
+        { observedAt: currentObservedAt },
+      );
+      cleanup.userIds.push(owner.id, incoming.id);
 
-    await expect(
-      repo[operation](incomingClerkId, ownedEmail, {
-        observedAt: staleObservedAt,
-      }),
-    ).resolves.toEqual(incoming);
-    await expect(repo.findByClerkId(incomingClerkId)).resolves.toEqual(
-      incoming,
-    );
-  });
+      await expect(
+        repo[operation](incomingClerkId, ownedEmail, {
+          observedAt: staleObservedAt,
+        }),
+      ).resolves.toEqual(incoming);
+      await expect(repo.findByClerkId(incomingClerkId)).resolves.toEqual(
+        incoming,
+      );
+    },
+  );
 
-  it.each([
-    'upsertByClerkId',
-    'updateEmailByClerkId',
-  ] as const)('stores the newer observation timestamp for a same-email write through %s', async (operation) => {
-    const repo = new DrizzleUserRepository(db);
-    const initialObservedAt = new Date('2026-02-01T00:00:00.000Z');
-    const newerObservedAt = new Date('2026-02-02T00:00:00.000Z');
-    const clerkUserId = `user_${randomUUID().replaceAll('-', '')}`;
-    const email = `it-${randomUUID()}@example.com`;
-    const existing = await repo.upsertByClerkId(clerkUserId, email, {
-      observedAt: initialObservedAt,
-    });
-    cleanup.userIds.push(existing.id);
+  it.each(['upsertByClerkId', 'updateEmailByClerkId'] as const)(
+    'stores the newer observation timestamp for a same-email write through %s',
+    async (operation) => {
+      const repo = new DrizzleUserRepository(db);
+      const initialObservedAt = new Date('2026-02-01T00:00:00.000Z');
+      const newerObservedAt = new Date('2026-02-02T00:00:00.000Z');
+      const clerkUserId = `user_${randomUUID().replaceAll('-', '')}`;
+      const email = `it-${randomUUID()}@example.com`;
+      const existing = await repo.upsertByClerkId(clerkUserId, email, {
+        observedAt: initialObservedAt,
+      });
+      cleanup.userIds.push(existing.id);
 
-    await expect(
-      repo[operation](clerkUserId, email, {
-        observedAt: newerObservedAt,
-      }),
-    ).resolves.toMatchObject({
-      id: existing.id,
-      email,
-      updatedAt: newerObservedAt,
-    });
-    await expect(repo.findByClerkId(clerkUserId)).resolves.toMatchObject({
-      id: existing.id,
-      email,
-      updatedAt: newerObservedAt,
-    });
-  });
+      await expect(
+        repo[operation](clerkUserId, email, {
+          observedAt: newerObservedAt,
+        }),
+      ).resolves.toMatchObject({
+        id: existing.id,
+        email,
+        updatedAt: newerObservedAt,
+      });
+      await expect(repo.findByClerkId(clerkUserId)).resolves.toMatchObject({
+        id: existing.id,
+        email,
+        updatedAt: newerObservedAt,
+      });
+    },
+  );
 
   it('throws when scripted time is drawn more times than configured', () => {
     const observedAt = new Date('2026-02-01T00:00:00.000Z');

--- a/tests/shared/subscription-observation-version-contract.ts
+++ b/tests/shared/subscription-observation-version-contract.ts
@@ -209,10 +209,11 @@ export function runSubscriptionObservationVersionContract(
   createHarness: () => Promise<SubscriptionObservationVersionContractHarness>,
 ): void {
   describe(`${adapterName} subscription observation-version contract`, () => {
-    it.each(
-      subscriptionObservationVersionContractScenarios,
-    )('$name', async (scenario) => {
-      await scenario.run(await createHarness());
-    });
+    it.each(subscriptionObservationVersionContractScenarios)(
+      '$name',
+      async (scenario) => {
+        await scenario.run(await createHarness());
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- upgrade `@biomejs/biome` from resolved 2.5.3 to 2.5.6, reproducing Dependabot PR #718
- migrate the config schema to 2.5.6 and disable the newly enforced `noExcessiveLinesPerFile` rule for test globs; test suites stay intentionally cohesive
- apply Biome 2.5.6 formatter output and remove three now-obsolete per-file suppressions

## Scope checks
- lockfile movement is Biome-only (the core package plus platform binaries)
- the 27 formatted files are mechanical output from `pnpm exec biome format --write .`
- zero file overlap with PR #740 (`fix/debt-414-round2-audit`)
- `@biomejs/biome@2.5.6` published 2026-07-28T09:53:25.098Z, aged past the seven-day gate on 2026-08-07

## Validation
- cold `pnpm install --frozen-lockfile` with the original `node_modules` absent
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test --run` (3,821)
- `pnpm test:browser` (398)
- `pnpm test:integration` (243 passed, 2 skipped)
- `pnpm build`
- `pnpm test:e2e` (38/38)

Supersedes #718.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reformatted parameterized tests across unit, integration, and end-to-end test suites for improved readability.
  * Removed unnecessary lint suppression comments.
* **Tests**
  * Added coverage ensuring invalid checkout data does not start a transaction.
  * Preserved existing coverage for idempotency, subscriptions, pricing, retries, repositories, and workflows.
* **Chores**
  * Updated code-quality tooling and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->