### PR TITLE
Upgrade Stripe SDK to 22.4.0 and Dahlia API contract

### DIFF
--- a/lib/stripe-api-version.ts
+++ b/lib/stripe-api-version.ts
@@ -1,1 +1,1 @@
-export const STRIPE_API_VERSION = '2026-06-24.dahlia';
+export const STRIPE_API_VERSION = '2026-07-29.dahlia';

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -18,7 +18,7 @@ export function getStripe(): Stripe {
      * - Verifying webhooks + checkout flows in a staging environment
      *
      * Reference: https://stripe.com/docs/upgrades#api-versions
-     * Last reviewed: 2026-06-04
+     * Last reviewed: 2026-08-07
      */
     apiVersion: STRIPE_API_VERSION,
     typescript: true,

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "remark-gfm": "^4.0.1",
     "resend": "6.18.0",
     "server-only": "^0.0.1",
-    "stripe": "^22.3.0",
+    "stripe": "^22.4.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "4.3.3",
     "tw-animate-css": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,8 +101,8 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
       stripe:
-        specifier: ^22.3.0
-        version: 22.3.1(@types/node@24.13.3)
+        specifier: ^22.4.0
+        version: 22.4.0(@types/node@24.13.3)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.6.0
@@ -5402,8 +5402,8 @@ packages:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
-  stripe@22.3.1:
-    resolution: {integrity: sha512-6XSLN0KK0IdfXqDHqMg6CDoO3eO62ye9dhzw0fZp55AUOzHR1YRJOqYHTsuCi4QJ4Ni/usEmXtq69c9ghKDmYw==}
+  stripe@22.4.0:
+    resolution: {integrity: sha512-LVJ+tcSYeqOSnXr3i+Kz2tZ7y0crLLdP2uwD/4wccrmEVyn0g/Heo0pF7as7rxS/sOjJzrb1lxgZY0Y0Dx1pSA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -11665,7 +11665,7 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
-  stripe@22.3.1(@types/node@24.13.3):
+  stripe@22.4.0(@types/node@24.13.3):
     optionalDependencies:
       '@types/node': 24.13.3
 

--- a/src/adapters/gateways/stripe/index.ts
+++ b/src/adapters/gateways/stripe/index.ts
@@ -1,3 +1,4 @@
+export { isValidStripeSubscriptionStatus } from '@/src/adapters/shared/stripe-types';
 export {
   createStripeCheckoutSession,
   createStripeTrialPaymentMethodSetupSession,
@@ -26,7 +27,6 @@ export {
   retrieveAndNormalizeStripeSubscription,
 } from './stripe-subscription-normalizer';
 export {
-  isValidStripeSubscriptionStatus,
   stripeSubscriptionStatusToSubscriptionStatus,
   subscriptionStatusToStripeSubscriptionStatus,
 } from './stripe-subscription-status';

--- a/src/adapters/gateways/stripe/stripe-checkout-sessions.test.ts
+++ b/src/adapters/gateways/stripe/stripe-checkout-sessions.test.ts
@@ -322,6 +322,29 @@ describe('createStripeCheckoutSession', () => {
     });
   });
 
+  it('fails closed when Stripe returns an unrecognized subscription status', async () => {
+    const { stripe, sessionsList, sessionsCreate } = createStripeMock({
+      subscriptionsListData: [
+        { id: 'sub_future_status', status: 'future_status' },
+      ],
+    });
+
+    await expect(
+      createStripeCheckoutSession({
+        stripe,
+        input,
+        priceIds,
+        logger,
+      }),
+    ).rejects.toMatchObject({
+      code: 'STRIPE_ERROR',
+      message: 'Stripe subscription status is invalid',
+    });
+
+    expect(sessionsList).not.toHaveBeenCalled();
+    expect(sessionsCreate).not.toHaveBeenCalled();
+  });
+
   it('reuses an existing open checkout session when plan price matches and expires after the injected nowMs boundary', async () => {
     const { stripe, sessionsCreate, sessionsRetrieve } = createStripeMock({
       openSessionsData: [

--- a/src/adapters/gateways/stripe/stripe-checkout-sessions.ts
+++ b/src/adapters/gateways/stripe/stripe-checkout-sessions.ts
@@ -18,6 +18,7 @@ import type { Logger } from '@/src/application/ports/logger';
 import { MS_PER_SECOND } from '@/src/domain/services';
 import { createStripeConsentStateSignature } from './stripe-consent-state';
 import { callStripeWithRetry } from './stripe-retry';
+import { isValidStripeSubscriptionStatus } from './stripe-subscription-status';
 
 export const SUBSCRIPTION_LIST_LIMIT = 10;
 export const OPEN_CHECKOUT_SESSION_RECONCILE_LIMIT = 10;
@@ -207,6 +208,7 @@ function getBlockingSubscriptionStatus(
 ): StripeSubscriptionStatus | null {
   if (!subscription) return null;
   if (!subscription.status) return null;
+  if (!isValidStripeSubscriptionStatus(subscription.status)) return null;
   if (!BLOCKING_SUBSCRIPTION_STATUSES.has(subscription.status)) return null;
   return subscription.status;
 }

--- a/src/adapters/gateways/stripe/stripe-checkout-sessions.ts
+++ b/src/adapters/gateways/stripe/stripe-checkout-sessions.ts
@@ -2,12 +2,13 @@
 import { createHash } from 'node:crypto';
 import type { StripePriceIds } from '@/src/adapters/config/stripe-prices';
 import { getStripePriceId } from '@/src/adapters/config/stripe-prices';
-import type {
-  CheckoutSessionCreateParams,
-  StripeCheckoutSession,
-  StripeClient,
-  StripeListedSubscription,
-  StripeSubscriptionStatus,
+import {
+  type CheckoutSessionCreateParams,
+  isValidStripeSubscriptionStatus,
+  type StripeCheckoutSession,
+  type StripeClient,
+  type StripeListedSubscription,
+  type StripeSubscriptionStatus,
 } from '@/src/adapters/shared/stripe-types';
 import { ApplicationError } from '@/src/application/errors';
 import type {
@@ -18,7 +19,6 @@ import type { Logger } from '@/src/application/ports/logger';
 import { MS_PER_SECOND } from '@/src/domain/services';
 import { createStripeConsentStateSignature } from './stripe-consent-state';
 import { callStripeWithRetry } from './stripe-retry';
-import { isValidStripeSubscriptionStatus } from './stripe-subscription-status';
 
 export const SUBSCRIPTION_LIST_LIMIT = 10;
 export const OPEN_CHECKOUT_SESSION_RECONCILE_LIMIT = 10;
@@ -208,7 +208,12 @@ function getBlockingSubscriptionStatus(
 ): StripeSubscriptionStatus | null {
   if (!subscription) return null;
   if (!subscription.status) return null;
-  if (!isValidStripeSubscriptionStatus(subscription.status)) return null;
+  if (!isValidStripeSubscriptionStatus(subscription.status)) {
+    throw new ApplicationError(
+      'STRIPE_ERROR',
+      'Stripe subscription status is invalid',
+    );
+  }
   if (!BLOCKING_SUBSCRIPTION_STATUSES.has(subscription.status)) return null;
   return subscription.status;
 }

--- a/src/adapters/gateways/stripe/stripe-subscription-normalizer.ts
+++ b/src/adapters/gateways/stripe/stripe-subscription-normalizer.ts
@@ -10,16 +10,16 @@ import {
   STRIPE_SUBSCRIPTION_METADATA_E2E_OWNER_FIELD,
   STRIPE_SUBSCRIPTION_METADATA_USER_ID_FIELD,
 } from '@/src/adapters/shared/stripe-subscription-errors';
-import type { StripeClient } from '@/src/adapters/shared/stripe-types';
+import {
+  isValidStripeSubscriptionStatus,
+  type StripeClient,
+} from '@/src/adapters/shared/stripe-types';
 import { ApplicationError, isApplicationError } from '@/src/application/errors';
 import type { WebhookEventResult } from '@/src/application/ports/gateways';
 import type { Logger } from '@/src/application/ports/logger';
 import { MS_PER_SECOND } from '@/src/domain/services';
 import { callStripeWithRetry } from './stripe-retry';
-import {
-  isValidStripeSubscriptionStatus,
-  stripeSubscriptionStatusToSubscriptionStatus,
-} from './stripe-subscription-status';
+import { stripeSubscriptionStatusToSubscriptionStatus } from './stripe-subscription-status';
 import {
   type StripeSubscriptionRef,
   stripeSubscriptionSchema,

--- a/src/adapters/gateways/stripe/stripe-subscription-status.test.ts
+++ b/src/adapters/gateways/stripe/stripe-subscription-status.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { isValidStripeSubscriptionStatus } from '@/src/adapters/shared/stripe-types';
 import {
-  isValidStripeSubscriptionStatus,
   stripeSubscriptionStatusToSubscriptionStatus,
   subscriptionStatusToStripeSubscriptionStatus,
 } from './stripe-subscription-status';

--- a/src/adapters/gateways/stripe/stripe-subscription-status.ts
+++ b/src/adapters/gateways/stripe/stripe-subscription-status.ts
@@ -1,7 +1,4 @@
-import {
-  STRIPE_SUBSCRIPTION_STATUSES,
-  type StripeSubscriptionStatus,
-} from '@/src/adapters/shared/stripe-types';
+import type { StripeSubscriptionStatus } from '@/src/adapters/shared/stripe-types';
 import type { SubscriptionStatus } from '@/src/domain/value-objects';
 
 const stripeToDomain: Record<StripeSubscriptionStatus, SubscriptionStatus> = {
@@ -25,12 +22,6 @@ const domainToStripe: Record<SubscriptionStatus, StripeSubscriptionStatus> = {
   unpaid: 'unpaid',
   paused: 'paused',
 };
-
-export function isValidStripeSubscriptionStatus(
-  value: string,
-): value is StripeSubscriptionStatus {
-  return (STRIPE_SUBSCRIPTION_STATUSES as readonly string[]).includes(value);
-}
 
 export function stripeSubscriptionStatusToSubscriptionStatus(
   status: StripeSubscriptionStatus,

--- a/src/adapters/shared/stripe-types.test.ts
+++ b/src/adapters/shared/stripe-types.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import {
   STRIPE_SUBSCRIPTION_STATUSES,
+  type StripeCheckoutSessionMode,
+  type StripeCheckoutSessionPaymentMethodCollection,
+  type StripeSubscriptionResponseStatus,
   type StripeSubscriptionStatus,
 } from './stripe-types';
 
@@ -31,5 +34,24 @@ describe('StripeSubscriptionStatus', () => {
       'trialing',
       'unpaid',
     ]);
+  });
+});
+
+describe('Stripe response enums', () => {
+  type OtherString = string & Record<never, never>;
+
+  it('preserves known checkout values while allowing future values', () => {
+    expectTypeOf<StripeCheckoutSessionMode>().toEqualTypeOf<
+      'payment' | 'setup' | 'subscription' | OtherString
+    >();
+    expectTypeOf<StripeCheckoutSessionPaymentMethodCollection>().toEqualTypeOf<
+      'always' | 'if_required' | OtherString
+    >();
+  });
+
+  it('preserves known subscription statuses while allowing future values', () => {
+    expectTypeOf<StripeSubscriptionResponseStatus>().toEqualTypeOf<
+      StripeSubscriptionStatus | OtherString
+    >();
   });
 });

--- a/src/adapters/shared/stripe-types.ts
+++ b/src/adapters/shared/stripe-types.ts
@@ -50,6 +50,16 @@ export type CheckoutSessionCreateParams =
     });
 
 export type StripeCheckoutSessionStatus = 'open' | 'complete' | 'expired';
+type StripeOtherString = string & Record<never, never>;
+export type StripeCheckoutSessionPaymentMethodCollection =
+  | 'always'
+  | 'if_required'
+  | StripeOtherString;
+export type StripeCheckoutSessionMode =
+  | 'subscription'
+  | 'payment'
+  | 'setup'
+  | StripeOtherString;
 
 export type StripeCheckoutSession = {
   id: string;
@@ -58,9 +68,8 @@ export type StripeCheckoutSession = {
   status?: StripeCheckoutSessionStatus | null | undefined;
   expires_at?: number | undefined;
   metadata?: Record<string, string> | null;
-  // Stripe response enums are open; request params remain narrowed above.
-  payment_method_collection?: string | null;
-  mode?: string;
+  payment_method_collection?: StripeCheckoutSessionPaymentMethodCollection | null;
+  mode?: StripeCheckoutSessionMode;
   setup_intent?: string | { id: string } | null;
   consent?: { terms_of_service?: 'accepted' | 'required' | null } | null;
 };
@@ -105,9 +114,19 @@ export const STRIPE_SUBSCRIPTION_STATUSES = [
 ] as const;
 export type StripeSubscriptionStatus =
   (typeof STRIPE_SUBSCRIPTION_STATUSES)[number];
+export type StripeSubscriptionResponseStatus =
+  | StripeSubscriptionStatus
+  | StripeOtherString;
+
+export function isValidStripeSubscriptionStatus(
+  value: string,
+): value is StripeSubscriptionStatus {
+  return (STRIPE_SUBSCRIPTION_STATUSES as readonly string[]).includes(value);
+}
+
 export type StripeListedSubscription = {
   id?: string;
-  status?: string;
+  status?: StripeSubscriptionResponseStatus;
 };
 export type StripeSubscriptionListParams = {
   customer: string;

--- a/src/adapters/shared/stripe-types.ts
+++ b/src/adapters/shared/stripe-types.ts
@@ -58,8 +58,9 @@ export type StripeCheckoutSession = {
   status?: StripeCheckoutSessionStatus | null | undefined;
   expires_at?: number | undefined;
   metadata?: Record<string, string> | null;
-  payment_method_collection?: 'always' | 'if_required' | null;
-  mode?: 'subscription' | 'payment' | 'setup';
+  // Stripe response enums are open; request params remain narrowed above.
+  payment_method_collection?: string | null;
+  mode?: string;
   setup_intent?: string | { id: string } | null;
   consent?: { terms_of_service?: 'accepted' | 'required' | null } | null;
 };
@@ -106,7 +107,7 @@ export type StripeSubscriptionStatus =
   (typeof STRIPE_SUBSCRIPTION_STATUSES)[number];
 export type StripeListedSubscription = {
   id?: string;
-  status?: StripeSubscriptionStatus;
+  status?: string;
 };
 export type StripeSubscriptionListParams = {
   customer: string;


### PR DESCRIPTION
## Summary

- upgrade stripe from the 22.3 line to 22.4.0
- advance the pinned API contract from 2026-06-24.dahlia to 2026-07-29.dahlia
- keep request enums narrowed while treating Stripe response enums as open, with explicit runtime validation before subscription-status policy logic

This compatibility change is intentionally excluded from the current production promotion. It is for the next dev-to-main promo only. Close #719 as superseded after this PR merges.

## Dahlia compatibility audit

Sources:
- API changelog: https://docs.stripe.com/changelog/dahlia
- stripe-node 22.4.0 release: https://github.com/stripe/stripe-node/releases/tag/v22.4.0

The API interval is 2026-06-24.dahlia to 2026-07-29.dahlia. The July 29 Dahlia entries are additive on the repository's used surfaces. stripe-node 22.4.0 removes the limited-use dynamic_tax_rates field from the Checkout line-item type; repository search found no dynamic_tax_rates usage.

Used-surface review:

- Webhooks: checkout.session.completed/expired; invoice payment failed/succeeded/action_required; customer.subscription created/updated/deleted/paused/resumed/trial_will_end/pending_update_applied/pending_update_expired. The July changes add unrelated Financial Connections events and do not alter these handlers.
- Checkout Sessions: create/list/retrieve/expire in subscription and setup modes. No behavioral change; dynamic_tax_rates is unused.
- Subscriptions: retrieve/list/cancel/update default payment method. No behavioral change in this API interval.
- Billing portal: sessions.create only. No behavioral change in this API interval.

## Age gate

npm publish timestamp for stripe@22.4.0: 2026-07-29T23:38:17.675Z. This is beyond the repository's seven-day minimum release age as of 2026-08-08.

## Validation

- cold pnpm install --frozen-lockfile from an empty node_modules tree: passed
- pnpm typecheck: passed
- pnpm lint: passed (one pre-existing unused-suppression warning)
- pnpm test --run: 436 files / 3,847 tests passed
- pnpm test:browser: 64 files / 398 tests passed
- pnpm test:integration: 38 files passed, 1 skipped / 244 tests passed, 2 skipped
- pnpm build: passed on Next.js 16.2.12
- authenticated billing E2E: clean rerun 38/38 passed. The preceding run completed 37 passed plus 1 Clerk-handshake retry, then its interactive HTML reporter was terminated; the CI-mode rerun exited 0 with all 38 passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for subscription statuses to prevent unrecognized values from being treated as valid.
  - Improved handling of evolving Stripe checkout and subscription response values.

- **Maintenance**
  - Updated Stripe API compatibility to the latest supported version.
  - Upgraded the Stripe integration dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->