### PR TITLE
fix(deps): pin nanoid 3 to patched release

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   brace-expansion@5: 5.0.9
   brace-expansion@1: 1.1.18
   fast-uri: 3.1.5
+  nanoid@3: 3.3.17
   sharp: 0.35.3
 
 importers:
@@ -4790,8 +4791,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10907,7 +10908,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   negotiator@1.0.0: {}
 
@@ -11091,7 +11092,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,6 +53,12 @@ overrides:
   # 3.1.4 to 3.1.5, which satisfies ajv's ^3.0.1. Aged past the 7-day gate as of
   # 2026-08-07 (published 2026-07-31).
   fast-uri: 3.1.5
+  # Security: GHSA-2v37-7h3g-55p8 — custom nanoid generators can loop
+  # indefinitely when size is zero. Transitive via postcss@8.5.23 (build-time
+  # CSS tooling under Tailwind/Next); no direct usage, so defense-in-depth.
+  # Scoped to the 3.x line; 3.3.17 satisfies postcss's ^3.3.16. Aged past the
+  # 7-day gate 2026-08-10 (published 2026-08-03).
+  'nanoid@3': 3.3.17
   # Security: GHSA-f88m-g3jw-g9cj — sharp < 0.35.0 bundles a libvips affected by
   # four inherited CVEs (memory-safety on untrusted image input): CVE-2026-33327
   # (VIPS dimension overflow), CVE-2026-33328 (GIF integer overflow, 32-bit),


### PR DESCRIPTION
## Problem

Dependabot alert #47 (GHSA-2v37-7h3g-55p8) affects nanoid before 3.3.17: custom generators can loop indefinitely when called with size zero. The dependency is transitive through `postcss@8.5.23` under Tailwind/Next build tooling and is not imported directly, so this is a defense-in-depth pin.

## Solution

- Add the scoped override `'nanoid@3': 3.3.17`.
- Keep the override within postcss's declared `^3.3.16` range.
- Update only nanoid in the lockfile (`3.3.16` → `3.3.17`); no unrelated package versions move.

## Release-age evidence

- `nanoid@3.3.17` published `2026-08-03T10:39:22.487Z` and cleared the strict seven-day gate at `2026-08-10T10:39:22.487Z`.
- This change resolved successfully at `2026-08-10T16:09:06Z`, without a `minimumReleaseAgeExclude`.
- `nanoid@3.3.18` exists (published `2026-08-07T16:41:05.696Z`) but does not age in until `2026-08-14T16:41:05.696Z`; 3.3.17 is the patched floor.

## Verification

- Cold `pnpm install --frozen-lockfile`: passed from an absent `node_modules`.
- `pnpm typecheck`: passed.
- `pnpm lint`: passed with one pre-existing unused-suppression warning.
- `pnpm test --run`: 436 files / 3,853 tests passed.
- `pnpm test:browser`: 64 files / 398 tests passed.
- `pnpm test:integration`: 38 passed, 1 skipped files / 244 passed, 2 skipped tests.
- `pnpm build`: passed.
- `pnpm test:e2e`: 38/38 passed.

Closes #762


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated the bundled `nanoid` dependency to a secure patched version, preventing potential infinite loops when generating zero-size custom identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->