### PR TITLE
Pin pnpm setup action to immutable commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.10
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11.3.0
           run_install: false


### PR DESCRIPTION
## Summary

- Pin `pnpm/action-setup` v6.0.10 to its immutable commit.
- Address CodeRabbit's blocking review on promo #774 without changing the action version.
- Use the dereferenced commit `0977fd99725f1db4007ccb2928dbb4e90d06cc86`; `ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3` is the signed annotated tag object, not the commit.

## Verification

Exact head: `39ab4e73b8c23c15049c1ca1bc2473360801ebfc`

- `pnpm typecheck`
- `pnpm lint` (passes with one pre-existing unused-suppression warning)
- `pnpm test --run`: 3,853 passed
- `pnpm test:browser`: 398 passed
- `pnpm test:integration`: 244 passed, 2 skipped
- `pnpm build`
- `pnpm test:e2e`: 38 passed

The action tag was verified through GitHub's refs/tags APIs and the successful #768 CI download log.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration setup to use a fixed, verified action version for more consistent and reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->