### PR TITLE
Migrate @noble/hashes to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@clerk/nextjs": "^7.4.1",
     "@clerk/ui": "^1.13.1",
-    "@noble/hashes": "1.8.0",
+    "@noble/hashes": "2.3.0",
     "@sentry/nextjs": "^10.53.1",
     "@tailwindcss/postcss": "4.3.3",
     "@typescript/native": "npm:typescript@^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^1.13.1
         version: 1.27.2(@solana/web3.js@1.98.4(@typescript/typescript6@6.0.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(bs58@6.0.0)(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-native@0.84.1(@babel/core@7.29.7)(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(utf-8-validate@6.0.6))(react@19.2.8)(utf-8-validate@6.0.6)
       '@noble/hashes':
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 2.3.0
+        version: 2.3.0
       '@sentry/nextjs':
         specifier: ^10.53.1
         version: 10.69.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(webpack@5.105.0(esbuild@0.28.1))
@@ -1057,6 +1057,10 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -6776,6 +6780,8 @@ snapshots:
       '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.3.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/src/adapters/gateways/noble-sha256-hasher.ts
+++ b/src/adapters/gateways/noble-sha256-hasher.ts
@@ -1,5 +1,5 @@
-import { sha256 } from '@noble/hashes/sha2';
-import { bytesToHex } from '@noble/hashes/utils';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 import type { Sha256Hasher } from '@/src/application/ports';
 
 export class NobleSha256Hasher implements Sha256Hasher {

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -15,8 +15,8 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       '@clerk/nextjs/server',
-      '@noble/hashes/sha2',
-      '@noble/hashes/utils',
+      '@noble/hashes/sha2.js',
+      '@noble/hashes/utils.js',
       '@sentry/nextjs',
       'drizzle-orm',
       'drizzle-orm/pg-core',


### PR DESCRIPTION
## Summary

- migrate the direct `@noble/hashes` dependency from 1.8.0 to 2.3.0
- use v2's explicit `.js` export specifiers in the SHA-256 adapter
- keep jsdom's optional peer context on `@noble/hashes@1.8.0`
- update Vite Browser's matching optimize-dependency specifiers so browser tests can resolve the ESM-only v2 exports

Closes #779.

## Evidence

- npm publish time: `@noble/hashes@2.3.0` was published `2026-08-06T06:26:47.068Z`; execution began after the seven-day gate at `2026-08-13T18:39:35Z`
- runtime requirement: v2 requires Node `>=20.19.0`; the repository runs Node 24
- characterization: `src/adapters/gateways/noble-sha256-hasher.test.ts` is unchanged and passes, proving the same input still produces the same lowercase SHA-256 hex digest
- lockfile: only the root importer moves 1.8.0 -> 2.3.0 and the v2 package/snapshot records are added; the existing v1 package and `jsdom@30.0.1(@noble/hashes@1.8.0)` graph remain unchanged
- cold frozen install: passed for 969 packages; the first cold verification rechecked all 1,127 lock entries against the supply-chain policy
- Turbopack: production build compiled successfully and generated all 23 routes, covering the subpath-resolution failure that blocked #770

## Scope note

Issue #779 correctly identified the sole first-party runtime consumer. The first full browser gate additionally failed during Vite startup because `vitest.browser.config.ts` explicitly prebundled the same two extensionless subpaths. That red gate was the characterization proof for the two matching `.js` config changes; the rerun passed 64 files / 398 tests.

## Verification

- `pnpm typecheck`
- `pnpm lint` (green with one pre-existing unused-suppression warning)
- `pnpm test --run` — 436 files / 3,853 tests
- `pnpm test:browser` — 64 files / 398 tests
- `pnpm test:integration` — 38 passed + 1 skipped files / 244 passed + 2 skipped tests
- `pnpm build` — Turbopack success, 23 routes
- `pnpm test:e2e` — 38/38 passed, including trial start on the isolated origin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with updated cryptographic hashing packages.
  * Preserved existing SHA-256 hashing behavior while ensuring browser-based tests continue to run correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->