### PR TITLE
Promote @noble/hashes 2.3.0 compatibility migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@clerk/nextjs": "^7.4.1",
     "@clerk/ui": "^1.13.1",
-    "@noble/hashes": "1.8.0",
+    "@noble/hashes": "2.3.0",
     "@sentry/nextjs": "^10.53.1",
     "@tailwindcss/postcss": "4.3.3",
     "@typescript/native": "npm:typescript@^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^1.13.1
         version: 1.27.2(@solana/web3.js@1.98.4(@typescript/typescript6@6.0.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(bs58@6.0.0)(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-native@0.84.1(@babel/core@7.29.7)(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(utf-8-validate@6.0.6))(react@19.2.8)(utf-8-validate@6.0.6)
       '@noble/hashes':
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 2.3.0
+        version: 2.3.0
       '@sentry/nextjs':
         specifier: ^10.53.1
         version: 10.69.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(webpack@5.105.0(esbuild@0.28.1))
@@ -1057,6 +1057,10 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -6776,6 +6780,8 @@ snapshots:
       '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.3.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/src/adapters/gateways/noble-sha256-hasher.ts
+++ b/src/adapters/gateways/noble-sha256-hasher.ts
@@ -1,5 +1,5 @@
-import { sha256 } from '@noble/hashes/sha2';
-import { bytesToHex } from '@noble/hashes/utils';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 import type { Sha256Hasher } from '@/src/application/ports';
 
 export class NobleSha256Hasher implements Sha256Hasher {

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -15,8 +15,8 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       '@clerk/nextjs/server',
-      '@noble/hashes/sha2',
-      '@noble/hashes/utils',
+      '@noble/hashes/sha2.js',
+      '@noble/hashes/utils.js',
       '@sentry/nextjs',
       'drizzle-orm',
       'drizzle-orm/pg-core',


### PR DESCRIPTION
## Summary

Promote the `@noble/hashes` v2 compatibility migration from `dev` to `main`.

This promotion contains exactly one rider:

- #784 — direct `@noble/hashes` 1.8.0 -> 2.3.0, explicit v2 `.js` subpaths in the SHA-256 adapter and Vitest Browser prebundle config, with jsdom's transitive v1 peer context preserved

## Rider evidence

- authored head: `e712d30bca1e9ade760d289dd743b4cc557a524f`
- squash merge on dev: `aaf7b9b50abfb24c70902cb1c14110443bae5530`
- CodeRabbit: formal APPROVED on exact authored head, review `4931116274`, zero review threads
- CI: run `31733138835`, `test` passed on the exact authored head
- Vercel Preview and Codecov patch checks passed

## Final dev validation

Validated in a fresh detached worktree at exact dev SHA `aaf7b9b50abfb24c70902cb1c14110443bae5530`:

- cold `pnpm install --frozen-lockfile` — passed, 969 packages
- lockfile — direct `@noble/hashes@2.3.0`; independent jsdom peer line remains `@noble/hashes@1.8.0`
- `pnpm typecheck` — passed
- `pnpm lint` — passed with one pre-existing unused-suppression warning
- `pnpm test --run` — 436 files / 3,853 tests passed
- `pnpm test:browser` — 64 files / 398 tests passed
- `pnpm test:integration` — 38 passed + 1 skipped files / 244 passed + 2 skipped tests
- `pnpm build` — Turbopack compiled and generated all 23 routes
- `pnpm test:e2e` — 38/38 passed, including trial start on the isolated origin

## Promotion semantics

- merge commit only
- never delete `dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the cryptographic hashing library to a newer version.
  * Improved compatibility for browser-based testing and module resolution.
  * No user-facing functionality or public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->