### PR TITLE
Bump nanoid override to 3.3.18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   brace-expansion@5: 5.0.9
   brace-expansion@1: 1.1.18
   fast-uri: 3.1.5
-  nanoid@3: 3.3.17
+  nanoid@3: 3.3.18
   sharp: 0.35.3
 
 importers:
@@ -4795,8 +4795,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10914,7 +10914,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   negotiator@1.0.0: {}
 
@@ -11098,7 +11098,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,7 +58,7 @@ overrides:
   # patched floor to 3.3.18. Transitive via postcss@8.5.23 (build-time CSS
   # tooling under Tailwind/Next); no direct usage, so defense-in-depth. Scoped
   # to the 3.x line; 3.3.18 satisfies postcss's ^3.3.16. Aged past the 7-day
-  # gate 2026-08-14 (published 2026-08-07T16:41:05Z).
+  # gate 2026-08-14T16:41:05Z (published 2026-08-07T16:41:05Z).
   'nanoid@3': 3.3.18
   # Security: GHSA-f88m-g3jw-g9cj — sharp < 0.35.0 bundles a libvips affected by
   # four inherited CVEs (memory-safety on untrusted image input): CVE-2026-33327

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,11 +54,12 @@ overrides:
   # 2026-08-07 (published 2026-07-31).
   fast-uri: 3.1.5
   # Security: GHSA-2v37-7h3g-55p8 — custom nanoid generators can loop
-  # indefinitely when size is zero. Transitive via postcss@8.5.23 (build-time
-  # CSS tooling under Tailwind/Next); no direct usage, so defense-in-depth.
-  # Scoped to the 3.x line; 3.3.17 satisfies postcss's ^3.3.16. Aged past the
-  # 7-day gate 2026-08-10 (published 2026-08-03).
-  'nanoid@3': 3.3.17
+  # indefinitely when size is zero. The 2026-08-14 advisory revision moved the
+  # patched floor to 3.3.18. Transitive via postcss@8.5.23 (build-time CSS
+  # tooling under Tailwind/Next); no direct usage, so defense-in-depth. Scoped
+  # to the 3.x line; 3.3.18 satisfies postcss's ^3.3.16. Aged past the 7-day
+  # gate 2026-08-14 (published 2026-08-07T16:41:05Z).
+  'nanoid@3': 3.3.18
   # Security: GHSA-f88m-g3jw-g9cj — sharp < 0.35.0 bundles a libvips affected by
   # four inherited CVEs (memory-safety on untrusted image input): CVE-2026-33327
   # (VIPS dimension overflow), CVE-2026-33328 (GIF integer overflow, 32-bit),


### PR DESCRIPTION
## Summary

- bump the existing scoped `nanoid@3` override from 3.3.17 to 3.3.18
- update the house comment for the 2026-08-14 GHSA-2v37-7h3g-55p8 advisory revision
- retain postcss 8.5.23's 3.x dependency line and defense-in-depth rationale

## Security and age-gate evidence

- Dependabot alert #50 now reports `nanoid < 3.3.18` with first patched version 3.3.18
- `npm view nanoid@3.3.18 time` reports `2026-08-07T16:41:05.696Z`
- the strict seven-day gate cleared at 2026-08-14T16:41:05Z; execution began at 2026-08-14T16:57:04Z
- 3.3.18 satisfies postcss's `^3.3.16` range and remains scoped to the 3.x line
- no `minimumReleaseAgeExclude` was added

## Lockfile proof

- the final lockfile diff contains only `nanoid` 3.3.17 → 3.3.18 in the override, package record, snapshot, and postcss edge
- pnpm initially attempted unrelated jsdom optional-peer re-keying and deprecated-metadata refreshes; those generated changes were restored because they are outside this issue
- an empty-tree `pnpm install --frozen-lockfile` accepted the final lockfile and verified all 1,127 entries against the supply-chain policy

## Validation

- `pnpm typecheck` — pass
- `pnpm lint` — pass (one pre-existing unused-suppression warning)
- `pnpm test --run` — 436 files / 3,853 tests passed
- `pnpm test:browser` — 64 files / 398 tests passed
- `pnpm test:integration` — 38 files passed + 1 skipped / 244 tests passed + 2 skipped
- `pnpm build` — pass; Turbopack generated 23 routes
- `pnpm test:e2e` — 38/38 passed, including the Stripe trial flow

## Merge requirement

The squash commit body must retain the exact closing keyword below so the issue closes when the commit reaches the default branch:

Closes #786


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled nanoid 3.x version to 3.3.18.
  * Refreshed related security and release metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->