### PR TITLE
Promote nanoid 3.3.18 security override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   brace-expansion@5: 5.0.9
   brace-expansion@1: 1.1.18
   fast-uri: 3.1.5
-  nanoid@3: 3.3.17
+  nanoid@3: 3.3.18
   sharp: 0.35.3
 
 importers:
@@ -4795,8 +4795,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10914,7 +10914,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   negotiator@1.0.0: {}
 
@@ -11098,7 +11098,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,11 +54,12 @@ overrides:
   # 2026-08-07 (published 2026-07-31).
   fast-uri: 3.1.5
   # Security: GHSA-2v37-7h3g-55p8 — custom nanoid generators can loop
-  # indefinitely when size is zero. Transitive via postcss@8.5.23 (build-time
-  # CSS tooling under Tailwind/Next); no direct usage, so defense-in-depth.
-  # Scoped to the 3.x line; 3.3.17 satisfies postcss's ^3.3.16. Aged past the
-  # 7-day gate 2026-08-10 (published 2026-08-03).
-  'nanoid@3': 3.3.17
+  # indefinitely when size is zero. The 2026-08-14 advisory revision moved the
+  # patched floor to 3.3.18. Transitive via postcss@8.5.23 (build-time CSS
+  # tooling under Tailwind/Next); no direct usage, so defense-in-depth. Scoped
+  # to the 3.x line; 3.3.18 satisfies postcss's ^3.3.16. Aged past the 7-day
+  # gate 2026-08-14T16:41:05Z (published 2026-08-07T16:41:05Z).
+  'nanoid@3': 3.3.18
   # Security: GHSA-f88m-g3jw-g9cj — sharp < 0.35.0 bundles a libvips affected by
   # four inherited CVEs (memory-safety on untrusted image input): CVE-2026-33327
   # (VIPS dimension overflow), CVE-2026-33328 (GIF integer overflow, 32-bit),


### PR DESCRIPTION
## Promotion scope

Promote the single dev rider since main's last promotion:

- #787 — bump the scoped `nanoid@3` override from 3.3.17 to 3.3.18 for Dependabot alert #50 / GHSA-2v37-7h3g-55p8

No other workstream commits are present between main and dev.

## Rider evidence

### #787 — nanoid 3.3.18 security override

- authored head: `44a8c6c0120891b0d6834626075f7c9c9be64731`
- dev squash SHA: `bf5a2c15f6550f823397cc2b91d8a197eb1bda99`
- squash body verified to contain `Closes #786`
- CodeRabbit formal APPROVED on exact authored head with zero unresolved threads: https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/pull/787#pullrequestreview-4940464881
- GitHub `test` passed on exact authored head in 9m35s: https://github.com/The-Obstacle-Is-The-Way/naltrexone-university/actions/runs/31824822592
- Vercel Preview and Codecov patch checks passed

## Exact promo-tree validation

Promo head: `bf5a2c15f6550f823397cc2b91d8a197eb1bda99`

- empty-tree `pnpm install --frozen-lockfile` — pass; 969 packages
- supply-chain validation over the changed lockfile — pass; 1,127 entries
- `pnpm typecheck` — pass
- `pnpm lint` — pass (one pre-existing unused-suppression warning)
- `pnpm test --run` — 436 files / 3,853 tests passed
- `pnpm test:browser` — 64 files / 398 tests passed
- `pnpm test:integration` — 38 files passed + 1 skipped / 244 tests passed + 2 skipped
- `pnpm build` — pass; Turbopack generated 23 routes
- `pnpm test:e2e` on a newly created isolated DB/app origin — 38/38 passed, including Stripe trial checkout

The first final-dev E2E attempt passed 37/38 but the trial checkout hit the known generic `checkout=error` path. The exact tree had passed the same trial earlier. Per the repository rail, the suite was reproduced from a fresh local test instance (new DB at port 56329 and new app origin); all 38 tests then passed without a code change, identifying test-account/origin residue rather than a regression.

## Lockfile and security result

- final lockfile diff is limited to nanoid 3.3.17 → 3.3.18 in the scoped override, package record, snapshot, and postcss edge
- 3.3.18 was published 2026-08-07T16:41:05.696Z and aged past the strict seven-day gate
- expected default-branch effects: alert #50 resolves and issue #786 closes when this promotion reaches main

## Merge semantics

Merge commit only. Never delete `dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `nanoid` dependency to version 3.3.18.
  * Refreshed related security advisory and release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->